### PR TITLE
ChatUserList passing rank # not object, but pros aren't > 1000 any more

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -274,6 +274,7 @@ export class Chat extends React.Component<ChatProperties, any> {
             ui_class: obj.ui_class,
             country: obj.country,
             ranking: obj.ranking,
+            professional: obj.professional,
         }, true);
 
         c.chat_log.push(obj);
@@ -545,6 +546,7 @@ export class Chat extends React.Component<ChatProperties, any> {
             obj.username = user.username;
             obj.id = user.id;
             obj.ranking = user.ranking;
+            obj.professional = user.professional;
             obj.ui_class = user.ui_class;
             obj.message = {"i": obj.uuid, "t": Math.floor(Date.now() / 1000), "m": txt};
             this.onChatMessage(obj);

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -215,6 +215,7 @@ class ChatManager {
             ui_class: obj.ui_class,
             country: obj.country,
             ranking: obj.ranking,
+            professional: obj.professional,
         }, true);
 
         this.channels[obj.channel].handleChat(obj);

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -115,14 +115,6 @@ export function rankString(r) { /* {{{ */
     }
     if (r > 900) {
         return interpolate(pgettext("Pro", "%sp"), [(((r - 1000) - 36))]);
-    } else {
-        // ChatUserList.tsx isn't showing professionals correctly, shows 8D instead of 1P.
-        // Probably need to send an opject to rankString() but I can't figure that out. So,
-        // instead we could also test for > 36 when it isn't > 900.
-        //
-        if (r > 36) {
-            return interpolate(pgettext("Pro", "%sp"), [(r - 36)]);
-        }
     }
     if (r < -900) {
         return "?";

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -121,7 +121,7 @@ export function rankString(r) { /* {{{ */
         // instead we could also test for > 36 when it isn't > 900.
         //
         if (r > 36) {
-            return translate_1.interpolate(translate_1.pgettext("Pro", "%sp"), [(r - 36)]);
+            return interpolate(pgettext("Pro", "%sp"), [(r - 36)]);
         }
     }
     if (r < -900) {

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -115,6 +115,14 @@ export function rankString(r) { /* {{{ */
     }
     if (r > 900) {
         return interpolate(pgettext("Pro", "%sp"), [(((r - 1000) - 36))]);
+    } else {
+        // ChatUserList.tsx isn't showing professionals correctly, shows 8D instead of 1P.
+        // Probably need to send an opject to rankString() but I can't figure that out. So,
+        // instead we could also test for > 36 when it isn't > 900.
+        //
+        if (r > 36) {
+            return translate_1.interpolate(translate_1.pgettext("Pro", "%sp"), [(r - 36)]);
+        }
     }
     if (r < -900) {
         return "?";


### PR DESCRIPTION
It's probably better for ChatUserList to pass a ranking object, so the professional value can be tested for future compatibility. But I couldn't figure out what to change to pass the object instead of the rank. This work around also works.