### PR TITLE
misc(build): add an npm script for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ then simply clone the repository and within the working directory run the follow
 npm install
 
 # Run this to start the development server and build system
-node_modules/.bin/gulp
+npm run dev
 ```
 
 If you're on linux, you can simply type `make` and it will do all this for you as well.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "url": "https://github.com/online-go/online-go.com/issues",
   "license": "AGPL-3.0",
   "private": true,
+  "scripts": {
+    "dev": "gulp"
+  },
   "devDependencies": {
     "autoprefixer": "^6.4.1",
     "babel-core": "^6.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5355,6 +5355,10 @@ stylus@^0.54.0, stylus@^0.54.5:
     sax "0.5.x"
     source-map "0.1.x"
 
+supervisor@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/supervisor/-/supervisor-0.12.0.tgz#de7e6337015b291851c10f3538c4a7f04917ecc1"
+
 supports-color@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"


### PR DESCRIPTION
This works because npm scripts have node_modules/.bin in their
environment as bin.