### PR TITLE
Pronounce countdown only when counter decreases

### DIFF
--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -125,7 +125,7 @@ export abstract class Goban extends EventEmitter {
     private last_phase;
     private last_review_message;
     private last_sent_move;
-    private last_sound_played;
+    private last_countdown_registered;
     private last_sound_played_for_a_stone_placement;
     private last_stone_sound;
     private layer_offset_left;
@@ -3645,7 +3645,7 @@ export abstract class Goban extends EventEmitter {
         if (this.last_sound_played_for_a_stone_placement === this.engine.cur_move.x + "," + this.engine.cur_move.y) {
             return;
         }
-        this.last_sound_played_for_a_stone_placement = this.last_sound_played = this.engine.cur_move.x + "," + this.engine.cur_move.y;
+        this.last_sound_played_for_a_stone_placement = this.engine.cur_move.x + "," + this.engine.cur_move.y;
 
         let idx;
         do {
@@ -3983,8 +3983,6 @@ export abstract class Goban extends EventEmitter {
         let use_short_format = this.config.use_short_format_clock;
         //let now_delta = Date.now() - clock.now;
 
-        this.last_sound_played = null;
-
         let formatTime = (clock_div, time, base_time: number, player_id?: number) => { /* {{{ */
             let ms;
             let time_suffix = "";
@@ -4122,12 +4120,15 @@ export abstract class Goban extends EventEmitter {
                     if (seconds % 2 === 0) {
                         cls += " low_time";
                     }
+                }
+            }
 
-                    let sound_to_play = null;
+            // extra cues react only to current player time updates
+            if (this.on_game_screen && player_id && window["user"] && player_id === window["user"].id) {
+                if (player_id === this.engine.playerToMove()) {
+                    if (days === 0 && hours === 0 && minutes === 0 && seconds > 0 && seconds <= 11) {
 
-                    if (this.on_game_screen && player_id) {
-                        sound_to_play = seconds;
-                        if (window["user"] && player_id === window["user"].id && window["user"].id === this.engine.playerToMove()) {
+                        if (seconds <= 10) {
                             this.byoyomi_label = "" + seconds;
                             let last_byoyomi_label = this.byoyomi_label;
                             if (this.last_hover_square) {
@@ -4142,16 +4143,14 @@ export abstract class Goban extends EventEmitter {
                                 }
                             }, 1100);
                         }
-                        if (sound_to_play && window["user"].id === this.engine.playerToMove() && player_id === window["user"].id) {
-                            if (this.last_sound_played !== sound_to_play) {
-                                this.last_sound_played = sound_to_play;
 
-
-                                if (this.getShouldPlayVoiceCountdown()) {
-                                    sfx.play(sound_to_play);
-                                }
+                        // play sound
+                        if (seconds < this.last_countdown_registered) {
+                            if (this.getShouldPlayVoiceCountdown()) {
+                                sfx.play(seconds);
                             }
                         }
+                        this.last_countdown_registered = seconds;
                     }
                 }
             }


### PR DESCRIPTION
Simple fix for https://github.com/online-go/online-go.com/issues/11

Compared to https://github.com/online-go/online-go.com/pull/15 this approach does not try to proactively detect turn changes. This one simply pronounces countdown only when the observed counter decreases. 

As a result, fix is much simpler, but in case of byo-yomi timer it doesn't pronounce the maximum counter.