### PR TITLE
Use strict in Gulpfile and webpack.config

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const spawn        = require('child_process').spawn;
 const fs           = require('fs');
 const gulp         = require('gulp');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 console.log(process.env.NODE_PATH)
 
 var path = require('path');


### PR DESCRIPTION
Adds ```'use strict';``` to the head of Gulpfile.js and webpack.config.js.

Currently, developers running ```make``` will receive an error similar to the following when the script tries to load the application:

```
Running node-supervisor with
  program ''
  --watch 'Gulpfile.js'
  --extensions 'node,js'
  --exec 'gulp'

Starting child process with 'gulp '
Watching directory '/home/mark/dev/websites/online-go.com/Gulpfile.js' for changes.
Press rs for restarting the process.
/home/mark/dev/websites/online-go.com/Gulpfile.js:18
let ts_sources = ['src/**/*.ts', 'src/**/*.tsx'];
^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Liftoff.handleArguments (/home/mark/dev/websites/online-go.com/node_modules/gulp/bin/gulp.js:116:3)
    at Liftoff.<anonymous> (/home/mark/dev/websites/online-go.com/node_modules/liftoff/index.js:198:16)
    at module.exports (/home/mark/dev/websites/online-go.com/node_modules/flagged-respawn/index.js:17:3)
Program gulp  exited with code 1
```

The changes allow developers to run the application successfully using the Makefile (after https://github.com/online-go/online-go.com/pull/20).