### PR TITLE
Custom colors

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.styl
+++ b/src/components/GobanThemePicker/GobanThemePicker.styl
@@ -40,5 +40,14 @@
             themed border-color primary
             opacity: 1.0;
         }
+
+        input[type=color] {
+            border: 0;
+        }
+
+        .color-reset {
+            vertical-align: top;
+            margin-top: 0.4rem;
+        }
     }
 }

--- a/src/lib/ogs-goban/GoTheme.ts
+++ b/src/lib/ogs-goban/GoTheme.ts
@@ -16,8 +16,10 @@
 
 export default class GoTheme {
     public name: string;
+    protected parent: GoTheme; // An optional parent theme
 
-    constructor() {
+    constructor(parent) {
+        this.parent = parent;
     }
 
     /* Returns an array of black stone objects. The structure
@@ -37,7 +39,7 @@ export default class GoTheme {
     /* Places a pre rendered stone onto the canvas, centered at cx, cy */
     public placeWhiteStone(ctx, shadow_ctx, stone, cx, cy, radius) {
         //if (shadow_ctx) do something
-        ctx.fillStyle = "#fff";
+        ctx.fillStyle = this.getWhiteStoneColor();
         ctx.beginPath();
         ctx.arc(cx, cy, radius, 0, 2 * Math.PI, true);
         ctx.fill();
@@ -45,7 +47,7 @@ export default class GoTheme {
 
     public placeBlackStone(ctx, shadow_ctx, stone, cx, cy, radius) {
         //if (shadow_ctx) do something
-        ctx.fillStyle = "#000";
+        ctx.fillStyle = this.getBlackStoneColor();
         ctx.beginPath();
         ctx.arc(cx, cy, radius, 0, 2 * Math.PI, true);
         ctx.fill();
@@ -57,17 +59,25 @@ export default class GoTheme {
         return false;
     };
 
+    /* Returns the color that should be used for white stones */
+    public getWhiteStoneColor() {
+        return "#ffffff";
+    }
+
+    /* Returns the color that should be used for black stones */
+    public getBlackStoneColor() {
+        return "#000000";
+    }
+
     /* Returns the color that should be used for text over white stones */
     public getWhiteTextColor(color) {
         return "#000000";
     };
 
-
     /* Returns the color that should be used for text over black stones */
     public getBlackTextColor(color) {
         return "#ffffff";
     };
-
 
     /* Returns a set of CSS styles that should be applied to the background layer (ie the board) */
     public getBackgroundCSS() {

--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -2437,6 +2437,7 @@ export abstract class Goban extends EventEmitter {
         {{{
             let transparent = letter_was_drawn;
             let hovermark = null;
+            let symbol_color = stone_color === 1 ? this.theme_black_text_color : stone_color === 2 ? this.theme_white_text_color : text_color;
 
             if (this.analyze_tool === "label" && (this.last_hover_square && this.last_hover_square.x === i && this.last_hover_square.y === j)) {
                 if (this.analyze_subtool === "triangle" || this.analyze_subtool === "square" || this.analyze_subtool === "cross" || this.analyze_subtool === "circle") {
@@ -2454,7 +2455,7 @@ export abstract class Goban extends EventEmitter {
                 if (transparent) {
                     ctx.globalAlpha = 0.6;
                 }
-                ctx.strokeStyle = stone_color === 1 ? this.theme_black_text_color : this.theme_white_text_color;
+                ctx.strokeStyle = symbol_color;
                 ctx.lineWidth = this.square_size * 0.075;
                 ctx.arc(cx, cy, this.square_size * 0.25, 0, 2 * Math.PI, false);
                 ctx.stroke();
@@ -2468,7 +2469,7 @@ export abstract class Goban extends EventEmitter {
                 if (transparent) {
                     ctx.globalAlpha = 0.6;
                 }
-                ctx.strokeStyle = stone_color === 1 ? this.theme_black_text_color : this.theme_white_text_color;
+                ctx.strokeStyle = symbol_color;
                 if (pos.chat_triangle) {
                     ctx.strokeStyle = "#00aaFF";
                 }
@@ -2496,7 +2497,7 @@ export abstract class Goban extends EventEmitter {
                 ctx.lineTo(cx + r, cy + r);
                 ctx.moveTo(cx + r, cy - r);
                 ctx.lineTo(cx - r, cy + r);
-                ctx.strokeStyle = stone_color === 1 ? this.theme_black_text_color : this.theme_white_text_color;
+                ctx.strokeStyle = symbol_color;
                 ctx.stroke();
                 ctx.restore();
                 draw_last_move = false;
@@ -2516,7 +2517,7 @@ export abstract class Goban extends EventEmitter {
                 ctx.lineTo(cx + r, cy + r);
                 ctx.lineTo(cx - r, cy + r);
                 ctx.lineTo(cx - r, cy - r);
-                ctx.strokeStyle = stone_color === 1 ? this.theme_black_text_color : this.theme_white_text_color;
+                ctx.strokeStyle = symbol_color;
                 ctx.stroke();
                 ctx.restore();
                 draw_last_move = false;
@@ -2960,8 +2961,8 @@ export abstract class Goban extends EventEmitter {
         this.themes = themes;
 
         this.theme_board = new (GoThemes["board"][themes.board])();
-        this.theme_white = new (GoThemes["white"][themes.white])();
-        this.theme_black = new (GoThemes["black"][themes.black])();
+        this.theme_white = new (GoThemes["white"][themes.white])(this.theme_board);
+        this.theme_black = new (GoThemes["black"][themes.black])(this.theme_board);
 
         if (!this.metrics) {
             this.metrics = this.computeMetrics();

--- a/src/lib/ogs-goban/themes/board_plain.ts
+++ b/src/lib/ogs-goban/themes/board_plain.ts
@@ -16,7 +16,22 @@
 
 import GoTheme from "../GoTheme";
 import {_} from "../translate";
+import data from "data";
 
+data.setDefault("custom.board", "#DCB35C");
+data.setDefault("custom.line", "#000000");
+
+// Converts a six-digit hex string to rgba() notation
+function hexToRgba(raw: string, alpha: number = 1): string {
+    let hex = raw.replace("#", "");
+    if (hex.length !== 6) {
+        return raw;
+    }
+    let r = parseInt(`0x${hex.substr(0, 2)}`);
+    let g = parseInt(`0x${hex.substr(2, 2)}`);
+    let b = parseInt(`0x${hex.substr(4, 2)}`);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
 
 export default function(GoThemes) {
 
@@ -24,16 +39,16 @@ export default function(GoThemes) {
         sort() { return 0; }
         getBackgroundCSS() {
             return {
-                "background-color": "#DCB35C",
+                "background-color": data.get("custom.board"),
                 "background-image": ""
             };
         };
-        getLineColor() { return "#000000"; };
-        getFadedLineColor() { return "#888888"; };
-        getStarColor() { return "#000000"; };
-        getFadedStarColor() { return "#888888"; };
-        getBlankTextColor() { return "#000000"; };
-        getLabelTextColor() { return "#444444"; };
+        getLineColor() { return data.get("custom.line"); };
+        getFadedLineColor() { return hexToRgba(data.get("custom.line"), 0.5); };
+        getStarColor() { return data.get("custom.line"); };
+        getFadedStarColor() { return hexToRgba(data.get("custom.line"), 0.5); };
+        getBlankTextColor() { return data.get("custom.line"); };
+        getLabelTextColor() { return hexToRgba(data.get("custom.line"), 0.75); };
     }
 
 

--- a/src/lib/ogs-goban/themes/disc.ts
+++ b/src/lib/ogs-goban/themes/disc.ts
@@ -16,49 +16,71 @@
 
 import GoTheme from "../GoTheme";
 import {_} from "../translate";
+import data from "data";
+
+data.setDefault("custom.black", "#000000");
+data.setDefault("custom.white", "#FFFFFF");
 
 export default function(GoThemes) {
-    class White extends GoTheme {
+    class Stone extends GoTheme {
         sort() { return  0; }
 
-        preRenderBlack(radius, seed): any {
-            return true;
-        };
-
-        placeBlackStone(ctx, shadow_ctx, stone, cx, cy, radius) {
-            ctx.fillStyle = "#000";
-            ctx.beginPath();
-            ctx.arc(cx, cy, radius, 0.001, 2 * Math.PI, false); /* 0.001 to workaround fucked up chrome bug */
-            ctx.fill();
-        };
-    }
-
-    class Black extends GoTheme {
-        sort() { return  0; }
-
-        preRenderWhite(radius, seed): any {
-            return true;
-        };
-
-        placeWhiteStone(ctx, shadow_ctx, stone, cx, cy, radius) {
+        placePlainStone(ctx, cx, cy, radius, color) {
             let lineWidth = radius * 0.10;
             if (lineWidth < 0.3) {
                 lineWidth = 0;
             }
-            ctx.fillStyle = "#fff";
-            ctx.strokeStyle = "#000";
+            ctx.fillStyle = color;
+            ctx.strokeStyle = this.parent ? this.parent.getLineColor() : this.getLineColor();
             if (lineWidth > 0) {
                 ctx.lineWidth = lineWidth;
             }
             ctx.beginPath();
             ctx.arc(cx, cy, radius - lineWidth / 2, 0.001, 2 * Math.PI, false); /* 0.001 to workaround fucked up chrome bug */
-                    if (lineWidth > 0) {
+            if (lineWidth > 0) {
                 ctx.stroke();
             }
             ctx.fill();
-        };
+        }
     }
 
-    GoThemes["black"]["Plain"] = White;
-    GoThemes["white"]["Plain"] = Black;
+    class Black extends Stone {
+        preRenderBlack(radius, seed): any {
+            return true;
+        };
+
+        placeBlackStone(ctx, shadow_ctx, stone, cx, cy, radius) {
+            this.placePlainStone(ctx, cx, cy, radius, this.getBlackStoneColor());
+        };
+
+        public getBlackStoneColor() {
+            return data.get("custom.black");
+        }
+
+        public getBlackTextColor() {
+            return data.get("custom.white");
+        }
+    }
+
+    class White extends Stone {
+        preRenderWhite(radius, seed): any {
+            return true;
+        };
+
+        placeWhiteStone(ctx, shadow_ctx, stone, cx, cy, radius) {
+            this.placePlainStone(ctx, cx, cy, radius, this.getWhiteStoneColor());
+        };
+
+        public getWhiteStoneColor() {
+            return data.get("custom.white");
+        }
+
+        public getWhiteTextColor() {
+            return data.get("custom.black");
+        }
+    }
+
+    GoThemes["black"]["Plain"] = Black;
+    GoThemes["white"]["Plain"] = White;
+
 }


### PR DESCRIPTION
This PR allows for customization of the Plain themes' colors, using standard HTML5 `color` inputs. It fulfills [this feature request](https://ogs.uservoice.com/forums/277766-online-go-com-suggestions-and-feature-requests/suggestions/8182245-custom-colors-for-plain-board-and-stones). 