### PR TITLE
goban size fix for webkit2-based browsers such as midori, ps4 browser

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -249,8 +249,8 @@ goban-view-bar-width=400px
     /* }}} */
 
     .goban-container { /* {{{ */
-        //flex-grow: 1;
-        flex-shrink: 1;
+        flex-grow: 1;
+        //flex-shrink: 1;
         flex-basis: 100%;
         display: flex;
         align-items: center;


### PR DESCRIPTION
Simple style change causes the goban offsetHeight to report correctly and fixes the issue displayed below. Tested in Chrome and Firefox, goban still works as expected after the change.

![sshot](https://cloud.githubusercontent.com/assets/623830/23346463/8704c372-fc68-11e6-9b70-f0ef09bba8ee.png)
