### PR TITLE
Improve left navbar styling and delete whitespace

### DIFF
--- a/src/components/NavBar/NavBar.styl
+++ b/src/components/NavBar/NavBar.styl
@@ -116,7 +116,7 @@ navbar-width= 17rem;
     .sign-in {
         padding-right: 1.0rem;
     }
-        
+
 
     .nav-menu-modal-backdrop {
         display: none;
@@ -229,6 +229,11 @@ navbar-width= 17rem;
 
         ul.nav-items {
             box-shadow: 2px 0px 2px 0px rgba(0, 0, 0, 0.16);
+        }
+
+        ul#items {
+            margin-left: 0.75rem;
+            width: initial;
         }
 
         li {


### PR DESCRIPTION
From first image:
![2fa1d2f2f5acf7435f836861c32c4f29cd31f085](https://cloud.githubusercontent.com/assets/5705052/23569140/b1b11e7e-0012-11e7-9ee8-b4a43ec6c1ff.png)

To second image:
![66974c94ffb3b81b1b4fe27b2384ea9f79bee130](https://cloud.githubusercontent.com/assets/5705052/23569136/af33381c-0012-11e7-8112-dfe3da2e71b0.png)

Tested in Chrome and Firefox

