### PR TITLE
fixes margin of page-controls

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -58,6 +58,7 @@
     .page-controls {
         display: flex;
         align-items: flex-end;
+        margin-top: 1rem;
 
         .left {
             display: inline-block;


### PR DESCRIPTION
Adds a bit of margin to the top of `.page-controls`.

Fixes issue #63.
