### PR TITLE
Page control improvements

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -88,7 +88,7 @@
             }
 
             .fa {
-                //font-size: 0.7em;
+                font-size: 0.9em;
                 width: 0.7rem;
                 cursor: pointer;
             }

--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -64,9 +64,9 @@
             display: inline-block;
             flex:1;
             input {
-                font-size: 0.7em;
+                //font-size: 0.7em;
                 padding: 0;
-                width: 1rem;
+                width: 2rem;
                 text-align: left;
                 border: 0;
                 margin-left: 0.5rem;
@@ -76,19 +76,19 @@
             }
 
             .of {
-                font-size: 0.7em;
+                //font-size: 0.7em;
             }
 
             .total {
                 display: inline-block;
-                font-size: 0.7em;
+                //font-size: 0.7em;
                 min-width: 0.8rem;
                 text-align: right;
                 margin-right: 0.5rem;
             }
 
             .fa {
-                font-size: 0.7em;
+                //font-size: 0.7em;
                 width: 0.7rem;
                 cursor: pointer;
             }
@@ -101,6 +101,6 @@
     }
 
     select {
-        font-size: 0.7em;
+        //font-size: 0.7em;
     }
 }

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -280,7 +280,7 @@ export class PaginatedTable extends OGSComponent<PaginatedTableProperties, any> 
                                 onChange={this._setPage}
                                 onFocus={this._select}
                                 value={this.state.page}/>
-                                <span className="of"> of </span><span className="total">{this.state.num_pages}</span>
+                                <span className="of"> {_("of")} </span><span className="total">{this.state.num_pages}</span>
                             {this.state.page < this.state.num_pages ? <i className="fa fa-step-forward" onClick={() => this.setPage(this.state.page + 1)}/> : <i className="fa"/>}
                         </div>
                         <div className="right">

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -195,6 +195,10 @@ export class PaginatedTable extends OGSComponent<PaginatedTableProperties, any> 
     }
 
     _setPage = (ev) => {
+        if ((ev.target as any).value === "") {
+            this.setState({page: ""});
+            return;
+        }
         let n = parseInt(ev.target.value);
         if (isNaN(n)) {
             if (ev.target.value.trim() === "") {

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -200,12 +200,6 @@ export class PaginatedTable extends OGSComponent<PaginatedTableProperties, any> 
             return;
         }
         let n = parseInt(ev.target.value);
-        if (isNaN(n)) {
-            if (ev.target.value.trim() === "") {
-                this.setPage(1);
-            }
-            return;
-        }
         this.setPage(n);
     }
     _select = (ev) => {

--- a/src/views/ObserveGames/ObserveGames.styl
+++ b/src/views/ObserveGames/ObserveGames.styl
@@ -86,7 +86,7 @@
             }
 
             .fa {
-                //font-size: 0.7em;
+                font-size: 0.9em;
                 width: 0.7rem;
                 cursor: pointer;
             }

--- a/src/views/ObserveGames/ObserveGames.styl
+++ b/src/views/ObserveGames/ObserveGames.styl
@@ -60,9 +60,9 @@
             flex:1;
             margin-right: 1rem;
             input {
-                font-size: 0.7em;
+                //font-size: 0.7em;
                 padding: 0;
-                width: 1rem;
+                width: 2rem;
                 text-align: left;
                 border: 0;
                 margin-left: 0.5rem;
@@ -72,21 +72,21 @@
             }
 
             .of {
-                font-size: 0.7em;
+                //font-size: 0.7em;
                 margin-right: 0.5rem;
                 margin-left: 0.5rem;
             }
 
             .total {
                 display: inline-block;
-                font-size: 0.7em;
-                width: 0.8rem;
+                //font-size: 0.7em;
+                min-width: 0.8rem;
                 text-align: right;
                 margin-right: 0.5rem;
             }
 
             .fa {
-                font-size: 0.7em;
+                //font-size: 0.7em;
                 width: 0.7rem;
                 cursor: pointer;
             }
@@ -99,6 +99,6 @@
     }
 
     select {
-        font-size: 0.7em;
+        //font-size: 0.7em;
     }
 }

--- a/src/views/ObserveGames/ObserveGames.tsx
+++ b/src/views/ObserveGames/ObserveGames.tsx
@@ -120,7 +120,11 @@ export class ObserveGames extends React.PureComponent<ObserveGamesProperties, an
         this.setPage(this.state.page + 1);
     }}}
     setPage = (ev_or_page) => {{{
-        let page = parseInt(typeof(ev_or_page) === "number" ? ev_or_page : (ev_or_page.target as any).value) || 1;
+        if ((ev_or_page.target as any).value === "") {
+            this.setState({page: ""});
+            return;
+        }
+        let page = parseInt(typeof(ev_or_page) === "number" ? ev_or_page : (ev_or_page.target as any).value);
         page = Math.max(1, Math.min(Math.ceil(
             (this.state.viewing === "live" ? this.state.live_game_count : this.state.corr_game_count)
                 / this.state.page_size), page));

--- a/src/views/ObserveGames/ObserveGames.tsx
+++ b/src/views/ObserveGames/ObserveGames.tsx
@@ -120,7 +120,7 @@ export class ObserveGames extends React.PureComponent<ObserveGamesProperties, an
         this.setPage(this.state.page + 1);
     }}}
     setPage = (ev_or_page) => {{{
-        let page = parseInt(typeof(ev_or_page) === "number" ? ev_or_page : (ev_or_page.target as any).value);
+        let page = parseInt(typeof(ev_or_page) === "number" ? ev_or_page : (ev_or_page.target as any).value) || 1;
         page = Math.max(1, Math.min(Math.ceil(
             (this.state.viewing === "live" ? this.state.live_game_count : this.state.corr_game_count)
                 / this.state.page_size), page));
@@ -160,7 +160,7 @@ export class ObserveGames extends React.PureComponent<ObserveGamesProperties, an
                             <div className="left">
                                 {this.state.page > 1 ? <i className="fa fa-step-backward" onClick={this.prevPage}/> : <i className="fa"/>}
                                 <input onChange={this.setPage} value={this.state.page}/>
-                                <span className="of"> of </span>
+                                <span className="of"> {_("of")} </span>
                                 <span className="total">{this.state.num_pages.toString()}</span>
                                 {this.state.page < this.state.num_pages ? <i className="fa fa-step-forward" onClick={this.nextPage}/> : <i className="fa"/>}
                             </div>

--- a/src/views/ObserveGames/ObserveGames.tsx
+++ b/src/views/ObserveGames/ObserveGames.tsx
@@ -117,14 +117,18 @@ export class ObserveGames extends React.PureComponent<ObserveGamesProperties, an
         this.setPage(this.state.page - 1);
     }}}
     nextPage = () => {{{
-        this.setPage(this.state.page + 1);
+        if (typeof(this.state.page) === "number") {
+            this.setPage(this.state.page + 1);
+        } else {
+            this.setPage(1);
+        }
     }}}
     setPage = (ev_or_page) => {{{
-        if ((ev_or_page.target as any).value === "") {
+        let page = parseInt(typeof(ev_or_page) === "number" ? ev_or_page : (ev_or_page.target as any).value);
+        if (isNaN(page)) {
             this.setState({page: ""});
             return;
         }
-        let page = parseInt(typeof(ev_or_page) === "number" ? ev_or_page : (ev_or_page.target as any).value);
         page = Math.max(1, Math.min(Math.ceil(
             (this.state.viewing === "live" ? this.state.live_game_count : this.state.corr_game_count)
                 / this.state.page_size), page));


### PR DESCRIPTION
- Larger font size, this way buttons are easier to access on mobile and numbers are more legible.
- Fix overlap betweeen Total Pages and Next Page button on /observe-games:
![screenshot-2017-03-07-12h44m09s](https://cloud.githubusercontent.com/assets/10748063/23663972/038fedb0-0333-11e7-8313-f7f1cd6d8845.jpg)
- Make "**of**" string translatable.
- Fix #88