### PR TITLE
"Learning hub" view

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -300,6 +300,7 @@ export class NavBar extends OGSComponent<{}, any> {
                 {(!this.state.user.anonymous || null) && <Link to="/overview">{_("Home")}</Link>}
                 {user && <Link to="/play">{_("Play")}</Link>}
                 <Link to="/observe-games">{_("Watch")}</Link>
+                <Link to="/learn">{_("Learn")}</Link>
                 <Link to="/chat">{_("Chat")}</Link>
                 <Link to="/puzzles">{_("Puzzles")}</Link>
                 <Link to="/tournaments">{_("Tournaments")}</Link>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -65,6 +65,7 @@ import {LibraryPlayer} from "LibraryPlayer";
 import {Play} from "Play";
 import {Moderator} from "Moderator";
 import {ObserveGames} from "ObserveGames";
+import {Learn} from "Learn";
 import {Puzzle} from "Puzzle";
 import {PuzzleList} from "PuzzleList";
 import {PuzzleModify} from "PuzzleModify";
@@ -205,6 +206,7 @@ const routes = (
         <Route path="/play" component={Play}/>
         <Route path="/chat" component={ChatView}/>
         <Route path="/observe-games" component={ObserveGames}/>
+        <Route path="/learn" component={Learn}/>
         <Route path="/game/:game_id" component={Game}/>
         <Route path="/game/view/:game_id" component={Game}/>
         <Route path="/review/:review_id" component={Game}/>

--- a/src/views/Learn/Learn.styl
+++ b/src/views/Learn/Learn.styl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.Learn {
+    .news th.none {
+        display: none;
+    }
+
+    .Card {
+        overflow-x: auto;
+    }
+
+    h4 {
+        text-align: center;
+    }
+}

--- a/src/views/Learn/Learn.tsx
+++ b/src/views/Learn/Learn.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import {_, pgettext, interpolate} from "translate";
+import {get} from "requests";
+import {errorAlerter} from "misc";
+import data from "data";
+import {Card} from "components";
+import {Player, setExtraActionCallback} from "Player";
+import {PaginatedTable} from "PaginatedTable";
+import {Markdown} from "Markdown";
+import {UIPush} from "UIPush";
+import {close_all_popovers} from "popover";
+import player_cache from "player_cache";
+import * as moment from "moment";
+import {EmbeddedChat} from "Chat";
+import online_status from "online_status";
+
+
+/* The "OGS teachers" group we use to drive the learning hub. */
+const OGS_TEACHERS = 14;
+
+function shuffleArray(array) {
+    for (let i = array.length - 1; i >= 0; i--) {
+        let j = Math.floor(Math.random() * (i + 1));
+        let temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+    }
+    return array;
+}
+
+function scramble(...args) {
+    return shuffleArray(args);
+}
+
+function sortByOnlineStatus(lst) {{{
+    let ret = [].concat(lst);
+    ret.sort((a, b) => {
+        let a_online = online_status.is_player_online(a.id);
+        let b_online = online_status.is_player_online(b.id);
+        if (a_online && !b_online) {
+            return -1;
+        }
+        if (b_online && !a_online) {
+            return 1;
+        }
+        return a.username.localeCompare(b.username);
+    });
+    return ret;
+}}}
+
+
+interface LearnProperties {
+    params: any;
+}
+
+export class Learn extends React.PureComponent<LearnProperties, any> {
+    refs: {
+        members;
+        news;
+    };
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            group: {
+                id: OGS_TEACHERS,
+            },
+            group_loaded: false,
+            news: [],
+            members: [],
+            group_id: OGS_TEACHERS,
+        };
+    }
+
+    componentWillMount() {{{
+        setExtraActionCallback(null);
+    }}}
+
+    componentDidMount() {{{
+        this.resolve(OGS_TEACHERS);
+    }}}
+
+    componentWillUnmount() {{{
+        setExtraActionCallback(null);
+    }}}
+
+    resolve(group_id: number) {{{
+        let user = data.get("user");
+
+        get(`groups/${group_id}`).then((group) => {
+            this.setState({
+                group: group,
+                group_loaded: true,
+            });
+        }).catch(errorAlerter);
+        get(`groups/${group_id}/news/`).then((news) => {
+            this.setState({news: news.results});
+        }).catch(errorAlerter);
+    }}}
+
+    refreshGroup = () => {{{
+        this.resolve(this.state.group_id);
+    }}}
+
+    refreshPlayerList = () => {{{
+        this.refs.members.update();
+    }}}
+
+    render() {{{
+        let user = data.get("user");
+        let group = this.state.group;
+        let news = this.state.news;
+
+
+        return (
+        <div className="Learn container">
+            <UIPush event="players-updated" channel={`group-${group.id}`} action={this.refreshPlayerList} />
+            <UIPush event="reload-group" channel={`group-${group.id}`} action={this.refreshGroup}/>
+
+            <div className="row">
+                <div className="col-sm-9">
+                    <Card style={{minHeight: "3rem", position: "relative"}}>
+                        <div className="row">
+                            <div className="col-sm-10">
+                                <h2>Learning Hub</h2>
+                            </div>
+                        </div>
+                    </Card>
+                    <EmbeddedChat channel={`group-${group.id}`} />
+                    {(this.state.news.length > 0 || null) &&
+                        <Card style={{minHeight: "12rem"}}>
+                            <PaginatedTable
+                                ref="news"
+                                className="news"
+                                name="news"
+                                source={`groups/${group.id}/news`}
+                                pageSize={1}
+                                columns={[
+                                    {header: _("News"), className: "none", render: (entry) => (
+                                        <div>
+                                        <h2>{entry.title}</h2>
+                                        <i>{moment(entry.posted).format("llll")} - <Player icon user={entry.author} /></i>
+                                        <Markdown source={entry.content} />
+                                        </div>
+
+                                    )},
+                                ]}
+                            />
+                        </Card>
+                    }
+                </div>
+                <div className="col-sm-3">{/* Right column {{{ */}
+                    <Card style={{minHeight: "12rem"}}>
+                        <PaginatedTable
+                            ref="members"
+                            className="members"
+                            name="members"
+                            source={`groups/${group.id}/members`}
+                            groom={(u_arr) => sortByOnlineStatus(u_arr.map((u) => player_cache.update(u.user)))}
+                            columns={[
+                                {header: _("Teachers"), className: "", render: (X) => <Player user={X} online rank/>},
+                            ]}
+                        />
+                    </Card>
+                    <Card style={{minHeight: "12rem"}}>
+                        <h4>Resources</h4>
+                        <div>
+                          {scramble(
+                          <span><a href="http://www.playgo.to/iwtg/">The Interactive Way To Go</a></span>,
+                          <span><a href="http://www.josekipedia.com/">Josekipedia</a></span>,
+                          <span><a href="http://eidogo.com/#search">Eidogo's Pattern Search</a></span>,
+                          <span><a href="http://ps.waltheri.net/">Waltheri's Pattern Search</a></span>
+                          ).map((elt, idx) => <dd key={idx}>{elt}</dd>)
+                          }
+                        </div>
+                    </Card>
+                </div>
+                {/* }}} */}
+            </div>
+        </div>
+        );
+    }}}
+}

--- a/src/views/Learn/Learn.tsx
+++ b/src/views/Learn/Learn.tsx
@@ -143,7 +143,7 @@ export class Learn extends React.PureComponent<LearnProperties, any> {
                             </div>
                         </div>
                     </Card>
-                    <EmbeddedChat channel={`group-${group.id}`} />
+                    <EmbeddedChat channel={`group-${group.id}`} updateTitle={false} />
                     {(this.state.news.length > 0 || null) &&
                         <Card style={{minHeight: "12rem"}}>
                             <PaginatedTable

--- a/src/views/Learn/index.ts
+++ b/src/views/Learn/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+export * from "./Learn";


### PR DESCRIPTION
This is (the start of) an implementation of
https://forums.online-go.com/t/accessible-teaching/11039

The idea is to use a stripped down "Group" view so that we can drive the
content of the learning hub page (news, teachers) from existing
infrastructure.

We'll need to create an invite-only, private "OGS Teachers" group on the
main site to drive the page from, and presumably a `global-teaching`
channel to link with from `EmbeddedChat`.

Once we have this hashed out, next we'd like to create an interactive
tutorial that we'll link to from this page along with a player's
progress - that'll be more involved though.

There are some problems I know about with this initial stab:

*   `PaginatedTable` may not be the right thing to use for the list of
    teachers, given that we'd like to sort the whole group by online
    status, and keep it refreshed.
*   The "Resources" section is anaemic.

Any advice appreciated.

A screenshot running against the Beta server:

*   http://cian.furiousthinking.org/picture/ogs-learn-1.png