### PR TITLE
Working on bug #62.

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2468,9 +2468,13 @@ export class GameChat extends React.PureComponent<GameChatProperties, any> {
         this.autoscroll();
 
         setTimeout(() => {
-            this.setState({online_count: this.props.gameview.chat_proxy.channel.users_by_rank.length});
-            this.props.gameview.chat_proxy.on("join", this.updateOnlineCount);
-            this.props.gameview.chat_proxy.on("part", this.updateOnlineCount);
+            try {
+                this.setState({ online_count: this.props.gameview.chat_proxy.channel.users_by_rank.length });
+                this.props.gameview.chat_proxy.on("join", this.updateOnlineCount);
+                this.props.gameview.chat_proxy.on("part", this.updateOnlineCount);
+            } catch (e) {
+                console.error(e);
+            }
         }, 1);
     }}}
     componentDidUpdate() {{{


### PR DESCRIPTION
It appears that the function that updates the number of spectators in a match works correctly but is not being called when the number of spectators changes. I have a hunch that a setTimeout is throwing an exception that is silently dropped. Add code to log any exceptions thrown, and continue to watch for further occurrences of the bug.