### PR TITLE
Improved text contrast for player name and score (especially dark theme)

### DIFF
--- a/src/components/Player/Player.styl
+++ b/src/components/Player/Player.styl
@@ -16,7 +16,6 @@
  */
 
 .Player {
-    themed color user
     cursor: pointer;
     white-space: nowrap;
     

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -161,9 +161,10 @@ light.player-black-background           = linear-gradient(to bottom, #7d7e7d 0%,
 light.player-white-background           = linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
 light.player-black-fg                   = #eeeeee
 light.player-white-fg                   = light.fg
-light.player-black-name                 = lighten(light.user, 50%)
+light.player-black-name                 = lighten(light.user, 60%)
 light.player-white-name                 = light.user
-
+light.player-black-clock                = lighten(light.player-black-fg, 50%)
+light.player-whitw-clock                = light.player-white-fg
 
 /************/
 /*** DARK ***/
@@ -180,7 +181,7 @@ dark.spectator-text-color               = #8987FC
 dark.text-color-active                  = lighten(dark.text-color, 50%)
 dark.toast-bg                           = dark.fg
 dark.toast-fg                           = dark.bg
-dark.link-color                         = #0068F7
+dark.link-color                         = #539bff
 dark.link-color-active                  = darken(dark.link-color, 20%)
 
 
@@ -235,24 +236,24 @@ dark.input-fg                           = dark.fg
 
 /** MiniBoards **/
 
-dark.goban-shadow                      = none
-dark.goban-shadow-borderless           = none
-dark.miniboard-to-move                 = #2B4029
-dark.miniboard-to-move-border          = darken(dark.miniboard-to-move, 60%)
-dark.miniboard-hover                   = #578588
-dark.miniboard-hover-border            = darken(dark.miniboard-hover, 30%)
-dark.miniboard-stone-removal           = #5B4810
-dark.miniboard-stone-removal-border    = darken(dark.miniboard-stone-removal, 45%)
-dark.miniboard-stone-removal-hover     = darken(dark.miniboard-stone-removal, 45%)
+dark.goban-shadow                       = none
+dark.goban-shadow-borderless            = none
+dark.miniboard-to-move                  = #2B4029
+dark.miniboard-to-move-border           = darken(dark.miniboard-to-move, 60%)
+dark.miniboard-hover                    = #578588
+dark.miniboard-hover-border             = darken(dark.miniboard-hover, 30%)
+dark.miniboard-stone-removal            = #5B4810
+dark.miniboard-stone-removal-border     = darken(dark.miniboard-stone-removal, 45%)
+dark.miniboard-stone-removal-hover      = darken(dark.miniboard-stone-removal, 45%)
 dark.miniboard-stone-removal-hover-border= darken(dark.miniboard-stone-removal-hover, 45%)
-dark.player-black-background           = linear-gradient(to bottom, #7d7d7d 0%, #333333 50%, #0c0c0c 100%);
-dark.player-white-background           = linear-gradient(to bottom, #dddddd 0%, #666666 50%, #333333 101%);
-dark.player-black-fg                   = dark.fg
-dark.player-white-fg                   = lighten(dark.fg, 20%)
-dark.player-black-name                 = lighten(dark.user, 50%)
-dark.player-white-name                 = lighten(dark.user, 50%)
-
-
+dark.player-black-background            = linear-gradient(to bottom, #7d7d7d 0%, #333333 50%, #0c0c0c 100%);
+dark.player-white-background            = linear-gradient(to bottom, #dddddd 0%, #666666 50%, #333333 101%);
+dark.player-black-fg                    = dark.fg
+dark.player-white-fg                    = lighten(dark.fg, 20%)
+dark.player-black-name                  = lighten(dark.user, 50%)
+dark.player-white-name                  = lighten(dark.user, 50%)
+dark.player-black-clock                 = lighten(dark.player-black-fg, 50%)
+dark.player-white-clock                 = #000
 
 
 /************/

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -161,7 +161,8 @@ light.player-black-background           = linear-gradient(to bottom, #7d7e7d 0%,
 light.player-white-background           = linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
 light.player-black-fg                   = #eeeeee
 light.player-white-fg                   = light.fg
-
+light.player-black-name                 = lighten(light.user, 50%)
+light.player-white-name                 = light.user
 
 
 /************/
@@ -244,11 +245,12 @@ dark.miniboard-stone-removal           = #5B4810
 dark.miniboard-stone-removal-border    = darken(dark.miniboard-stone-removal, 45%)
 dark.miniboard-stone-removal-hover     = darken(dark.miniboard-stone-removal, 45%)
 dark.miniboard-stone-removal-hover-border= darken(dark.miniboard-stone-removal-hover, 45%)
-dark.player-black-background           = linear-gradient(to bottom, #7d7e7d 0%,#0e0e0e 100%);
-dark.player-white-background           = linear-gradient(to bottom, darken(#ffffff, 15%) 0%, darken(#e5e5e5, 45%) 100%);
-dark.player-black-fg                   = #fff
-dark.player-white-fg                   = #fff
-
+dark.player-black-background           = linear-gradient(to bottom, #7d7d7d 0%, #333333 50%, #0c0c0c 100%);
+dark.player-white-background           = linear-gradient(to bottom, #dddddd 0%, #666666 50%, #333333 101%);
+dark.player-black-fg                   = dark.fg
+dark.player-white-fg                   = lighten(dark.fg, 20%)
+dark.player-black-name                 = lighten(dark.user, 50%)
+dark.player-white-name                 = lighten(dark.user, 50%)
 
 
 

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2159,7 +2159,7 @@ export class Game extends OGSComponent<GameProperties, any> {
                       </div>
 
                       {((goban.engine.players[color] && goban.engine.players[color].rank !== -1) || null) &&
-                          <div className="player-name-container">
+                          <div className={`${color} player-name-container`}>
                              <Player user={goban.engine.players[color]}/>
                           </div>
                       }

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -252,6 +252,14 @@
         }
     }
     
+    #game-black-clock{
+        themed color player-black-clock
+    }
+
+    #game-white-clock{
+        themed color player-white-clock
+    }
+
     #game-black-clock .out_of_time, #game-white-clock .out_of_time {
         color: #f44;
     }

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -43,7 +43,7 @@
         text-align: center;
         padding: 0.2em;
         margin-top: 0.2em;
-        border: 1px solid transparent;
+        /*border: 1px solid transparent;*/
         .komi {
             flex-grow: 0;
             text-align: right;
@@ -142,6 +142,12 @@
     .player-name-container {
         overflow: hidden;
         text-align: left;
+    }
+    .black.player-name-container{
+            themed color player-black-name;
+    }
+    .white.player-name-container{
+            themed color player-white-name;
     }
 
 


### PR DESCRIPTION
### Issue I am trying to fix
In light theme, the black player's name and rank are hard to read. In the dark theme, the White player's name and rank are almost impossible to read. Those are the main points.

### Method
I made a black and white name color in each theme. I made the player-name-container div also  subclass the color (I think that's how you describe it. It has been  a while since I did anything web). The color style attribute for `.[color] .player-name-container` is then themed. This implies removing the color responsibility from the `Player` class.

### Other Minor Tweaks
I removed the transparent border as it was creating an unsightly white line under the player boxes while in the dark theme. Also, I lessened the contrast between the score text and the background while in the dark theme.