### PR TITLE
Align stone and line centers

### DIFF
--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -2957,7 +2957,7 @@ export abstract class Goban extends EventEmitter {
     abstract getSelectedThemes();
 
     private computeThemeStoneRadius(metrics) {{{
-        return Math.round(Math.max(1, metrics.mid - 1.0));
+        return Math.max(1, this.square_size * 0.48);
     }}}
     private setThemes(themes, dont_redraw) { /* {{{ */
         if (this.no_display) {


### PR DESCRIPTION
Fix proposition for https://github.com/online-go/online-go.com/issues/140

The change acknowledges specific position of stone inside of rendered square. Pre-renders all stones shifted 0.5 pixel to the left, which aligns with the way goban lines are printed. 

Also, since the stone alignment is done correctly, prerender function is able to accept fractional radius parameter. I used that opportunity to make radius scale proportionally to board size instead of leaving 1 pixel of margin at all times.