### PR TITLE
Text contrast

### DIFF
--- a/src/components/Player/Player.styl
+++ b/src/components/Player/Player.styl
@@ -15,7 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 .Player {
+    themed color user
     cursor: pointer;
     white-space: nowrap;
     
@@ -128,4 +130,8 @@
     .PlayerIcon {
         margin-right: 0.5em;
     }
+}
+
+.player-name-container span.Player{
+    color: inherit;
 }

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -197,7 +197,7 @@ dark.malkovich-bg                       = #597053
 dark.variation                          = #00aaff
 dark.variation-hover                    = #1A93D0
 
-dark.user                               = #3C8DFF
+dark.user                               = #9dc6ff
 dark.supporter                          = #FFCC00;
 dark.bot                                = light.bot
 dark.moderator                          = lighten(light.moderator, 20%)
@@ -250,8 +250,8 @@ dark.player-black-background            = linear-gradient(to bottom, #7d7d7d 0%,
 dark.player-white-background            = linear-gradient(to bottom, #dddddd 0%, #666666 50%, #333333 101%);
 dark.player-black-fg                    = dark.fg
 dark.player-white-fg                    = lighten(dark.fg, 20%)
-dark.player-black-name                  = lighten(dark.user, 50%)
-dark.player-white-name                  = lighten(dark.user, 50%)
+dark.player-black-name                  = dark.user
+dark.player-white-name                  = lighten(dark.user, 10%)
 dark.player-black-clock                 = lighten(dark.player-black-fg, 50%)
 dark.player-white-clock                 = #000
 


### PR DESCRIPTION
Whoops, looks like I missed something. I realized they way I did it before removed coloration from the chat window. So I added the color back to the .Player style, but then just made it override if inside a plyer-name-container class. 