### PR TITLE
fixed variable name typo

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -164,7 +164,7 @@ light.player-white-fg                   = light.fg
 light.player-black-name                 = lighten(light.user, 60%)
 light.player-white-name                 = light.user
 light.player-black-clock                = lighten(light.player-black-fg, 50%)
-light.player-whitw-clock                = light.player-white-fg
+light.player-white-clock                = light.player-white-fg
 
 /************/
 /*** DARK ***/


### PR DESCRIPTION
So sorry for not being more careful originally. It would appear I am a bit rusty with this web stuff. Anyway, one of the color names had a typo. This didn't effect the look since at the moment what it defaulted to was essentially correct. Anyway this should be the last of it.