### PR TITLE
I believe I've nailed the bug that causes the number of players in a …

### DIFF
--- a/src/components/ChatUserList/ChatUserList.tsx
+++ b/src/components/ChatUserList/ChatUserList.tsx
@@ -22,23 +22,25 @@ import {errorAlerter} from "misc";
 import {chat_manager, ChatChannelProxy} from "chat_manager";
 import preferences from "preferences";
 import {Player} from "Player";
+import {GameChat} from "Game";
 
 interface ChatUserListProperties {
     channel: string;
     display_name?: string;
 }
 
-export class ChatUserList extends React.PureComponent<ChatUserListProperties, any> {
+interface ChatUserCountProperties extends ChatUserListProperties {
+    chat: GameChat;
+    active: boolean;
+}
+
+export class ChatUsers<T extends ChatUserListProperties> extends React.PureComponent<T, any> {
     proxy: ChatChannelProxy;
 
     constructor(props) {
         super(props);
-        this.state = {
-            tick: 0,
-            user_sort_order: preferences.get("chat.user-sort-order"),
-        };
+        this.state = {tick: 0};
     }
-
     componentWillMount() {
         this.init(this.props.channel, this.props.display_name);
     }
@@ -62,6 +64,14 @@ export class ChatUserList extends React.PureComponent<ChatUserListProperties, an
         this.proxy.part();
         this.proxy = null;
     }
+}
+
+export class ChatUserList extends ChatUsers<ChatUserListProperties> {
+    constructor(props) {
+        super(props);
+        this.state.user_sort_order = preferences.get("chat.user-sort-order");
+    }
+
     toggleSortOrder = () => {{{
         let new_sort_order = preferences.get("chat.user-sort-order") === "rank" ? "alpha" : "rank";
         preferences.set("chat.user-sort-order", new_sort_order);
@@ -83,6 +93,19 @@ export class ChatUserList extends React.PureComponent<ChatUserListProperties, an
 
                 {sorted_users.map((user) => <div key={user.id}><Player user={user} flag rank /></div>)}
             </div>
+        );
+    }
+}
+
+export class ChatUserCount extends ChatUsers<ChatUserCountProperties> {
+    render () {
+        return (
+            <button
+                onClick={this.props.chat.togglePlayerList}
+                className={"chat-input-player-list-toggle sm" + (this.props.active ? " active" : "")}
+                >
+                <i className="fa fa-users" /> {this.proxy ? this.proxy.channel.users_by_name.length : ""}
+            </button>
         );
     }
 }

--- a/src/components/ChatUserList/ChatUserList.tsx
+++ b/src/components/ChatUserList/ChatUserList.tsx
@@ -98,7 +98,7 @@ export class ChatUserList extends ChatUsers<ChatUserListProperties> {
 }
 
 export class ChatUserCount extends ChatUsers<ChatUserCountProperties> {
-    render () {
+    render() {
         return (
             <button
                 onClick={this.props.chat.togglePlayerList}

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -40,7 +40,7 @@ import {PersistentElement} from "PersistentElement";
 import {close_all_popovers} from "popover";
 import {Resizable} from "Resizable";
 import {TabCompleteInput} from "TabCompleteInput";
-import {ChatUserList} from "ChatUserList";
+import {ChatUserList, ChatUserCount} from "ChatUserList";
 import {ChatPresenceIndicator} from "ChatPresenceIndicator";
 import {chat_manager} from "chat_manager";
 import {openGameInfoModal} from "./GameInfoModal";
@@ -2444,8 +2444,6 @@ export class GameChat extends React.PureComponent<GameChatProperties, any> {
         this.state = {
             chat_log: "main",
             show_player_list: false,
-            online_count: 0,
-            tick: 0,
         };
         this.chat_log_filter = this.chat_log_filter.bind(this);
         this.onKeyPress = this.onKeyPress.bind(this);
@@ -2466,33 +2464,9 @@ export class GameChat extends React.PureComponent<GameChatProperties, any> {
 
     componentDidMount() {{{
         this.autoscroll();
-
-        setTimeout(() => {
-            try {
-                this.setState({ online_count: this.props.gameview.chat_proxy.channel.users_by_rank.length });
-                this.props.gameview.chat_proxy.on("join", this.updateOnlineCount);
-                this.props.gameview.chat_proxy.on("part", this.updateOnlineCount);
-            } catch (e) {
-                console.error(e);
-            }
-        }, 1);
     }}}
     componentDidUpdate() {{{
         this.autoscroll();
-    }}}
-    componentWillMount() {{{
-    }}}
-    componentWillUnmount() {{{
-        if (this.props.gameview.chat_proxy) {
-            this.props.gameview.chat_proxy.off("join", this.updateOnlineCount);
-            this.props.gameview.chat_proxy.off("part", this.updateOnlineCount);
-        }
-    }}}
-    updateOnlineCount = () => {{{
-        this.setState({
-            online_count: this.props.gameview.chat_proxy.channel.users_by_rank.length,
-            tick: this.state.tick + 1
-        });
     }}}
 
     updateScrollPosition() {{{
@@ -2531,7 +2505,7 @@ export class GameChat extends React.PureComponent<GameChatProperties, any> {
     render() {{{
         let last_line = null;
         let user = data.get("user");
-
+        let channel = this.props.gameview.game_id ? `game-${this.props.gameview.game_id}` : `review-${this.props.gameview.review_id}`;
 
         return (
             <div className="chat-container">
@@ -2548,7 +2522,7 @@ export class GameChat extends React.PureComponent<GameChatProperties, any> {
                         </div>
                     </div>
                     {(this.state.show_player_list || null) &&
-                        <ChatUserList channel={this.props.gameview.game_id ? `game-${this.props.gameview.game_id}` : `review-${this.props.gameview.review_id}`} />
+                        <ChatUserList channel={channel} />
                     }
                 </div>
                 <div className="chat-input-container input-group">
@@ -2571,12 +2545,11 @@ export class GameChat extends React.PureComponent<GameChatProperties, any> {
                         }
                         onKeyPress={this.onKeyPress}
                     />
-                    <button
-                        onClick={this.togglePlayerList}
-                        className={"chat-input-player-list-toggle sm" + (this.state.show_player_list ? " active" : "")}
-                        >
-                        <i className="fa fa-users" /> {this.state.online_count}
-                    </button>
+                    <ChatUserCount
+                        chat={this}
+                        active={this.state.show_player_list}
+                        channel={channel}
+                    />
                 </div>
             </div>
         );


### PR DESCRIPTION
…game to be different to the number of players listed. It was caused by the GameChat object subscribing to the wrong chat_proxy. The Game object can initially contain the wrong game_id. The game_id gets corrected at a later stage, but after the GameChat has initialised. I corrected this by making the user count follow the method used by the user list.