### PR TITLE
Pre-render stones in canvas resolution

### DIFF
--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -2956,7 +2956,7 @@ export abstract class Goban extends EventEmitter {
     abstract getSelectedThemes();
 
     private computeThemeStoneRadius(metrics) {{{
-        return Math.max(1, this.square_size * 0.48);
+        return Math.max(1, this.square_size * 0.49);
     }}}
     private setThemes(themes, dont_redraw) { /* {{{ */
         if (this.no_display) {

--- a/src/lib/ogs-goban/themes/rendered_stones.ts
+++ b/src/lib/ogs-goban/themes/rendered_stones.ts
@@ -218,7 +218,6 @@ function clearAboveColor(ctx, width, height, r, g, b) { /* {{{ */
     ctx.putImageData(image, 0, 0);
 } /* }}} */
 function preRenderStone(radius, seed, options) { /* {{{ */
-    radius *= deviceCanvasScalingRatio();
 
     //var ss = radius*2; /* Square size */
     let ss = square_size(radius);
@@ -359,24 +358,17 @@ function preRenderStone(radius, seed, options) { /* {{{ */
     return [{"stone": stone[0], "shadow": shadow[0]}];
 } /* }}} */
 function placeRenderedStone(ctx, shadow_ctx, stone, cx, cy, radius) {{{
-    let ss = square_size(radius);
+
     let center = stone_center_in_square(radius);
 
     let sx = cx - center;
     let sy = cy - center;
 
-    let dcsr = deviceCanvasScalingRatio();
-    if (dcsr !== 1.0) {
-        if (shadow_ctx) {
-            shadow_ctx.drawImage(stone.shadow, sx, sy, radius * 2.5, radius * 2.5);
-        }
-        ctx.drawImage(stone.stone, sx, sy, ss, ss);
-    } else {
-        if (shadow_ctx) {
-            shadow_ctx.drawImage(stone.shadow, sx, sy);
-        }
-        ctx.drawImage(stone.stone, sx, sy);
+    if (shadow_ctx) {
+        shadow_ctx.drawImage(stone.shadow, sx, sy);
     }
+    ctx.drawImage(stone.stone, sx, sy);
+
 }}}
 function stoneCastsShadow(radius) {{{
     return radius >= 10;


### PR DESCRIPTION
Quick fix for https://github.com/online-go/online-go.com/issues/193

Pre-renders stones in canvas resolution.

![screen shot 2017-04-01 at 14 46 22](https://cloud.githubusercontent.com/assets/12175058/24579289/427df614-16ea-11e7-936c-f76de6099fbd.png)
![screen shot 2017-04-01 at 14 46 33](https://cloud.githubusercontent.com/assets/12175058/24579291/4299a7f6-16ea-11e7-8444-648cbcf86702.png)
![screen shot 2017-04-01 at 14 46 44](https://cloud.githubusercontent.com/assets/12175058/24579290/4297ea4c-16ea-11e7-9421-a623adcde3e7.png)
![screen shot 2017-04-01 at 14 46 59](https://cloud.githubusercontent.com/assets/12175058/24579292/42a91a10-16ea-11e7-926f-cc639876a972.png)
![screen shot 2017-04-01 at 14 47 14](https://cloud.githubusercontent.com/assets/12175058/24579293/42ac5874-16ea-11e7-9f0b-dd6b34382e12.png)
![screen shot 2017-04-01 at 14 47 26](https://cloud.githubusercontent.com/assets/12175058/24579288/427cb6c8-16ea-11e7-8186-24d4b921e11c.png)