### PR TITLE
Account for device canvas scale when repositioning pre-rendered stone.

### DIFF
--- a/src/lib/ogs-goban/themes/rendered_stones.ts
+++ b/src/lib/ogs-goban/themes/rendered_stones.ts
@@ -359,24 +359,35 @@ function preRenderStone(radius, seed, options) { /* {{{ */
     return [{"stone": stone[0], "shadow": shadow[0]}];
 } /* }}} */
 function placeRenderedStone(ctx, shadow_ctx, stone, cx, cy, radius) {{{
-    let ss = square_size(radius);
-    let center = stone_center_in_square(radius);
-
-    let sx = cx - center;
-    let sy = cy - center;
 
     let dcsr = deviceCanvasScalingRatio();
     if (dcsr !== 1.0) {
+        let pre_radius = radius * dcsr;
+        let pre_ss = square_size(pre_radius);
+        let pre_center = stone_center_in_square(pre_radius);
+
+        let ss = pre_ss / dcsr;
+        let center = pre_center / dcsr;
+
+        let sx = cx - center;
+        let sy = cy - center;
+
         if (shadow_ctx) {
             shadow_ctx.drawImage(stone.shadow, sx, sy, radius * 2.5, radius * 2.5);
         }
         ctx.drawImage(stone.stone, sx, sy, ss, ss);
     } else {
+        let center = stone_center_in_square(radius);
+
+        let sx = cx - center;
+        let sy = cy - center;
+
         if (shadow_ctx) {
             shadow_ctx.drawImage(stone.shadow, sx, sy);
         }
         ctx.drawImage(stone.stone, sx, sy);
     }
+
 }}}
 function stoneCastsShadow(radius) {{{
     return radius >= 10;


### PR DESCRIPTION
Another quick fix proposition for:
https://github.com/online-go/online-go.com/issues/193

This one keeps the stone render at high res and makes necessary adjustment during rendering.

![screen shot 2017-04-01 at 20 29 08](https://cloud.githubusercontent.com/assets/12175058/24581785/0c133212-171a-11e7-9827-8672ac14ee25.png)
![screen shot 2017-04-01 at 20 29 21](https://cloud.githubusercontent.com/assets/12175058/24581786/0c2d5944-171a-11e7-86c5-d2722f0a7bcc.png)
![screen shot 2017-04-01 at 20 29 31](https://cloud.githubusercontent.com/assets/12175058/24581787/0c3d6f1e-171a-11e7-8812-3e733611477f.png)
![screen shot 2017-04-01 at 20 30 02](https://cloud.githubusercontent.com/assets/12175058/24581788/0c414d50-171a-11e7-9768-227b6c28b3da.png)
![screen shot 2017-04-01 at 20 29 41](https://cloud.githubusercontent.com/assets/12175058/24581789/0c419530-171a-11e7-93ec-3cca4daf6908.png)
![screen shot 2017-04-01 at 20 29 50](https://cloud.githubusercontent.com/assets/12175058/24581790/0c42bec4-171a-11e7-82c6-660990ea9816.png)
