### PR TITLE
Render stones in 2x res for scaled devices.

### DIFF
--- a/src/lib/ogs-goban/themes/rendered_stones.ts
+++ b/src/lib/ogs-goban/themes/rendered_stones.ts
@@ -218,7 +218,10 @@ function clearAboveColor(ctx, width, height, r, g, b) { /* {{{ */
     ctx.putImageData(image, 0, 0);
 } /* }}} */
 function preRenderStone(radius, seed, options) { /* {{{ */
-    radius *= deviceCanvasScalingRatio();
+    let dcsr = deviceCanvasScalingRatio();
+    if (dcsr !== 1.0) {
+        radius *= 2 * dcsr;
+    }
 
     //var ss = radius*2; /* Square size */
     let ss = square_size(radius);
@@ -359,24 +362,30 @@ function preRenderStone(radius, seed, options) { /* {{{ */
     return [{"stone": stone[0], "shadow": shadow[0]}];
 } /* }}} */
 function placeRenderedStone(ctx, shadow_ctx, stone, cx, cy, radius) {{{
-    let ss = square_size(radius);
-    let center = stone_center_in_square(radius);
-
-    let sx = cx - center;
-    let sy = cy - center;
 
     let dcsr = deviceCanvasScalingRatio();
     if (dcsr !== 1.0) {
+        let ss = square_size(radius * dcsr) / dcsr;
+
+        let sx = Math.round(cx - radius);
+        let sy = Math.round(cy - radius);
+
         if (shadow_ctx) {
             shadow_ctx.drawImage(stone.shadow, sx, sy, radius * 2.5, radius * 2.5);
         }
         ctx.drawImage(stone.stone, sx, sy, ss, ss);
     } else {
+        let center = stone_center_in_square(radius);
+
+        let sx = cx - center;
+        let sy = cy - center;
+
         if (shadow_ctx) {
             shadow_ctx.drawImage(stone.shadow, sx, sy);
         }
         ctx.drawImage(stone.stone, sx, sy);
     }
+
 }}}
 function stoneCastsShadow(radius) {{{
     return radius >= 10;


### PR DESCRIPTION
Yet another fix proposition for https://github.com/online-go/online-go.com/issues/193

I've had this extra idea that allows keeping the pre-rendering with affixed centre spot, while reverting the handling of scaled devices to before my change. By simply pre-rendering the stones in 2x resolution we get few pleasant advantages:

  - pre-rendered stone fills almost 100% of the image so radius becomes the valid offset again as rounding becomes negligible
  - manual rounding to full pixels can be avoided and a sub-pixel smoothing can be left to the browser

The result looks pretty good while maintaining sharpness of the image:

![screen shot 2017-04-02 at 12 03 52](https://cloud.githubusercontent.com/assets/12175058/24586583/95dc7454-179c-11e7-8dea-389f53da295d.png)
![screen shot 2017-04-02 at 12 03 19](https://cloud.githubusercontent.com/assets/12175058/24586584/95dd9b36-179c-11e7-9a58-fdde5181687f.png)
![screen shot 2017-04-02 at 12 04 05](https://cloud.githubusercontent.com/assets/12175058/24586586/95e2df06-179c-11e7-9144-51d74d0cf7cf.png)
![screen shot 2017-04-02 at 12 04 18](https://cloud.githubusercontent.com/assets/12175058/24586585/95e24294-179c-11e7-8fc3-5a408c7b3559.png)
![screen shot 2017-04-02 at 12 04 31](https://cloud.githubusercontent.com/assets/12175058/24586588/95e3abe8-179c-11e7-85af-5f9b28773e84.png)
![screen shot 2017-04-02 at 12 04 40](https://cloud.githubusercontent.com/assets/12175058/24586587/95e35878-179c-11e7-88cd-39e268c3e406.png)
