### PR TITLE
Focus on symmetry for scaled stones rather than center placement.

### DIFF
--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -2956,7 +2956,7 @@ export abstract class Goban extends EventEmitter {
     abstract getSelectedThemes();
 
     private computeThemeStoneRadius(metrics) {{{
-        return Math.max(1, this.square_size * 0.48);
+        return Math.max(1, this.square_size * 0.488);
     }}}
     private setThemes(themes, dont_redraw) { /* {{{ */
         if (this.no_display) {


### PR DESCRIPTION
This fix I'm happy with. Hope you like it as well 😀 

https://github.com/online-go/online-go.com/issues/193

I thought about it for a while before understanding that the problem is in symmetry. For the higher resolution of mobile devices I can ignore the centre alignment (as the pixels are so small) and focus on a simple stone symmetry to make them look nicer. Visually this should revert the look and feel for mobile to before my original change, while keeping centre positioning for non-scaled devices. 

I believe that visually this is the best solution. Here are the examples:

![screen shot 2017-04-02 at 14 23 32](https://cloud.githubusercontent.com/assets/12175058/24587524/48e505da-17b0-11e7-9f92-a379f78732f4.png)
![screen shot 2017-04-02 at 14 23 42](https://cloud.githubusercontent.com/assets/12175058/24587525/48e5cccc-17b0-11e7-8e23-eb4b0dab1dd5.png)
![screen shot 2017-04-02 at 14 23 52](https://cloud.githubusercontent.com/assets/12175058/24587526/48e6e382-17b0-11e7-9d55-d2a4262f091f.png)
![screen shot 2017-04-02 at 14 24 13](https://cloud.githubusercontent.com/assets/12175058/24587528/48e74e44-17b0-11e7-9a75-29f893f5f56c.png)
![screen shot 2017-04-02 at 14 24 30](https://cloud.githubusercontent.com/assets/12175058/24587527/48e7556a-17b0-11e7-9528-1a18a174700f.png)
![screen shot 2017-04-02 at 14 24 44](https://cloud.githubusercontent.com/assets/12175058/24587529/48e9586a-17b0-11e7-9630-de9c9d691973.png)
