### PR TITLE
Fix timecop notification

### DIFF
--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -702,7 +702,7 @@ class NotificationEntry extends React.Component<{notification}, any> { /* {{{ */
 
             case "timecop":
                 let now = (Date.now()) / 1000;
-                let left = Math.floor(notification.expiration / 1000 - now);
+                let left = Math.floor(notification.time / 1000 - now);
                 return <div>{interpolate(_("You have {{time_left}} to make your move!"), {"time_left": formatTime(left)})}</div>;
 
             case "gameEnteredStoneRemoval":


### PR DESCRIPTION
Notification showed "You have timeout to make your move" instead of e.g. "You have 12 hours to make your move".