### PR TITLE
Fix incorrect user id being used when a player component's user chang…

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -107,7 +107,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
             this.setState({user: new_props.user});
         }
 
-        let player_id = typeof(this.props.user) !== "object" ? this.props.user : (this.props.user.id || this.props.user.player_id) ;
+        let player_id = typeof(new_props.user) !== "object" ? new_props.user : (new_props.user.id || new_props.user.player_id) ;
         if (player_id && player_id > 0) {
             player_cache.fetch(player_id, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                 this.setState({user: user});


### PR DESCRIPTION
…es. (Mostly) fixes #336.

Please note that while I did monkey-patch the client-side code (in prod) to confirm that this indeed fixes the issue, I have *not* installed a dev environment locally; in particular, the literal code in this PR is untested.

There are two somewhat related issues that aren't addressed in this PR:

- There's a potential for race conditions in [this code](https://github.com/online-go/online-go.com/blob/82346dd691c79a7a0ab5131ad24515620a8e0650/src/components/Player/Player.tsx#L112); it may asynchronously update a Player component after that component no longer refers to the user that was being fetched.
- The `key` in [this line](https://github.com/online-go/online-go.com/blob/212dd9736004f9c66e7d027d59ece19bac388afa/src/views/Play/Play.tsx#L417) should arguably be the challenge id (which might have prevented #336 as well, although it would really only have hidden the symptoms).