### PR TITLE
Add "always-disable-analysis" preference

### DIFF
--- a/src/lib/goban.ts
+++ b/src/lib/goban.ts
@@ -85,13 +85,14 @@ export class Goban extends OGSGoban {
     }
 
     isAnalysisDisabled(perGameSettingAppliesToNonPlayers = false):boolean {
-        if (preferences.get("always-disable-analysis")) {
-            // Player's settings to always disable analysis overrides the per-game setting.
+        // The player's preference setting to always disable analysis overrides the per-game setting for
+        // their own games.
+        if (preferences.get("always-disable-analysis") && this.isParticipatingPlayer()) {
             return true;
         }
 
-        // If the user hasn't enabled the always-disable-analysis option we check the per-game
-        // setting.
+        // If the user hasn't enabled the always-disable-analysis option (or they do not participate in this game),
+        // we check the per-game setting.
         if (perGameSettingAppliesToNonPlayers) {
             // This is used for the SGF download which is disabled even for users that are not
             // participating in the game (or not signed in)

--- a/src/lib/goban.ts
+++ b/src/lib/goban.ts
@@ -84,9 +84,21 @@ export class Goban extends OGSGoban {
         return preferences.get("show-variation-move-numbers");
     }
 
-    isAnalysisDisabled():boolean {
-        // Player's settings to always disable analysis overrides the per-game setting.
-        return this.engine.config.disable_analysis || preferences.get("always-disable-analysis");
+    isAnalysisDisabled(perGameSettingAppliesToNonPlayers = false):boolean {
+        if (preferences.get("always-disable-analysis")) {
+            // Player's settings to always disable analysis overrides the per-game setting.
+            return true;
+        }
+
+        // If the user hasn't enabled the always-disable-analysis option we check the per-game
+        // setting.
+        if (perGameSettingAppliesToNonPlayers) {
+            // This is used for the SGF download which is disabled even for users that are not
+            // participating in the game (or not signed in)
+            return this.engine.config.original_disable_analysis;
+        } else {
+            return this.engine.config.disable_analysis;
+        }
     }
 
     watchSelectedThemes(cb) {

--- a/src/lib/goban.ts
+++ b/src/lib/goban.ts
@@ -84,6 +84,10 @@ export class Goban extends OGSGoban {
         return preferences.get("show-variation-move-numbers");
     }
 
+    isAnalysisDisabled():boolean {
+        // Player's settings to always disable analysis overrides the per-game setting.
+        return this.engine.config.disable_analysis || preferences.get("always-disable-analysis");
+    }
 
     watchSelectedThemes(cb) {
         return watchSelectedThemes(cb);

--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -4514,9 +4514,15 @@ export abstract class Goban extends TypedEventEmitter<Events> {
     protected getShouldPlayVoiceCountdown():boolean {{{
         return false;
     }}}
+    /**
+     * Returns true if the user has signed in and if the signed in user is a participating player in this game
+     * (and not only spectating), that is, if they are either white or black.
+     */
+    public isParticipatingPlayer():boolean { /* {{{ */
+        return this.engine.black_player_id === this.player_id ||
+               this.engine.white_player_id === this.player_id;
+    } /* }}} */
 }
-
-
 function plurality(num, single, plural) {{{
     if (num > 0) {
         if (num === 1) {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -33,6 +33,7 @@ let defaults = {
     "autoplay-delay": 10000,
     "desktop-notifications": true,
     "asked-to-enable-desktop-notifications": false,
+    "always-disable-analysis": false,
 
     "sound-enabled": true,
     "sound-volume": 0.5,

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2340,12 +2340,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
         let game_id = null;
         let sgf_download_enabled = false;
         try {
-            // This used this.goban.engine.config.original_disable_analysis
-            // before. Thus, you could not download the SGF even when you are
-            // not one of the participating players, or, if you are not signed
-            // in at all. I wonder why? More importantly: Is this a feature that
-            // we want to keep as it was before?
-            sgf_download_enabled = this.goban.engine.phase === 'finished' || !this.goban.isAnalysisDisabled();
+            sgf_download_enabled = this.goban.engine.phase === 'finished' || !this.goban.isAnalysisDisabled(true);
             game_id = this.goban.engine.config.game_id;
 
         } catch (e) {}

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -695,7 +695,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
     }}}
 
     checkAndEnterAnalysis(move?:MoveTree) {{{
-        if (this.goban.mode === "play" && this.goban.engine.phase !== "stone removal" && (!this.goban.engine.config.disable_analysis || this.goban.engine.phase === "finished")) {
+        if (this.goban.mode === "play" && this.goban.engine.phase !== "stone removal" && (!this.goban.isAnalysisDisabled() || this.goban.engine.phase === "finished")) {
             this.setState({variation_name: ""});
             this.goban.setMode("analyze");
             if (move) {
@@ -902,7 +902,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
     }}}
     gameAnalyze() {{{
         let user = data.get("user");
-        if (this.goban.engine.disable_analysis && this.goban.engine.phase !== "finished") {
+        if (this.goban.isAnalysisDisabled() && this.goban.engine.phase !== "finished") {
             //swal(_("Analysis mode has been disabled for this game"));
         } else {
             let last_estimate_move = this.stopEstimatingScore();
@@ -914,7 +914,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
         }
     }}}
     fork() {{{
-        if (this.goban.engine.disable_analysis && this.goban.engine.phase !== "finished") {
+        if (this.goban.isAnalysisDisabled() && this.goban.engine.phase !== "finished") {
             //swal(_("Game forking has been disabled for this game since analysis mode has been disabled"));
         } else {
             challengeFromBoardPosition(this.goban);
@@ -1350,7 +1350,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
     }}}
     enterConditionalMovePlanner() {{{
             //if (!auth) { return; }
-        if (this.goban.engine.disable_analysis && this.goban.engine.phase !== "finished") {
+        if (this.goban.isAnalysisDisabled() && this.goban.engine.phase !== "finished") {
             //swal(_("Conditional moves have been disabled for this game."));
         } else {
             this.stashed_conditional_moves = this.goban.conditional_tree.duplicate();
@@ -1364,7 +1364,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
         let user = data.get("user");
         let is_player = user.id === this.goban.engine.players.black.id || user.id === this.goban.engine.players.white.id;
 
-        if (this.goban.engine.disable_analysis && this.goban.engine.phase !== "finished" && is_player) {
+        if (this.goban.isAnalysisDisabled() && this.goban.engine.phase !== "finished" && is_player) {
             //swal(_("Analysis mode has been disabled for this game, you can start a review after the game has concluded."));
 
         } else {
@@ -1782,7 +1782,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     {(state.mode === "play" && state.phase === "play" && state.cur_move_number >= state.official_move_number || null) &&
                         this.frag_play_buttons(show_cancel_button)
                     }
-                    {(state.mode === "play" && state.phase === "play" && this.goban.engine.disable_analysis && state.cur_move_number < state.official_move_number || null) &&
+                    {(state.mode === "play" && state.phase === "play" && this.goban.isAnalysisDisabled() && state.cur_move_number < state.official_move_number || null) &&
                         <span>
                             <button className="sm primary bold" onClick={this.goban_setModeDeferredPlay}>{_("Back to Game")}</button>
                         </span>
@@ -2340,7 +2340,12 @@ export class Game extends React.PureComponent<GameProperties, any> {
         let game_id = null;
         let sgf_download_enabled = false;
         try {
-            sgf_download_enabled = this.goban.engine.phase === 'finished' || !this.goban.engine.config.original_disable_analysis;
+            // This used this.goban.engine.config.original_disable_analysis
+            // before. Thus, you could not download the SGF even when you are
+            // not one of the participating players, or, if you are not signed
+            // in at all. I wonder why? More importantly: Is this a feature that
+            // we want to keep as it was before?
+            sgf_download_enabled = this.goban.engine.phase === 'finished' || !this.goban.isAnalysisDisabled();
             game_id = this.goban.engine.config.game_id;
 
         } catch (e) {}
@@ -2379,13 +2384,13 @@ export class Game extends React.PureComponent<GameProperties, any> {
                 <a onClick={this.toggleCoordinates}><i className="ogs-coordinates"></i> {_("Toggle coordinates")}</a>
                 <a onClick={this.showGameInfo}><i className="fa fa-info"></i> {_("Game information")}</a>
                 {game &&
-                    <a onClick={this.gameAnalyze} className={goban && goban.engine.phase !== "finished" && goban.engine.disable_analysis ? "disabled" : ""} >
+                    <a onClick={this.gameAnalyze} className={goban && goban.engine.phase !== "finished" && goban.isAnalysisDisabled() ? "disabled" : ""} >
                         <i className="fa fa-sitemap"></i> {_("Analyze game")}
                     </a>
                 }
                 {(goban && this.state.user_is_player && goban.engine.phase !== "finished" || null) &&
                     <a style={{visibility: goban.mode === "play" && goban && goban.engine.playerToMove() !== data.get("user").id ? "visible" : "hidden"}}
-                       className={goban && goban.engine.phase !== "finished" && goban.engine.disable_analysis ? "disabled" : ""}
+                       className={goban && goban.engine.phase !== "finished" && goban.isAnalysisDisabled() ? "disabled" : ""}
                        onClick={this.enterConditionalMovePlanner}>
                        <i className="fa fa-exchange"></i> {_("Plan conditional moves")}
                     </a>
@@ -2394,7 +2399,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     <a onClick={this.pauseGame}><i className="fa fa-pause"></i> {_("Pause game")}</a>
                 }
                 {game &&
-                    <a onClick={this.startReview} className={goban && goban.engine.phase !== "finished" && goban.engine.disable_analysis ? "disabled" : ""}>
+                    <a onClick={this.startReview} className={goban && goban.engine.phase !== "finished" && goban.isAnalysisDisabled() ? "disabled" : ""}>
                         <i className="fa fa-refresh"></i> {_("Review this game")}
                     </a>
                 }
@@ -2913,14 +2918,14 @@ export class GameChatLine extends React.Component<GameChatLineProperties, any> {
        let goban = this.props.gameview.goban;
 
        if ("move_number" in line) {
-           if (!goban.engine.config.disable_analysis) {
+           if (!goban.isAnalysisDisabled()) {
                goban.setMode("analyze");
            }
 
             goban.engine.followPath(line.move_number, "");
             goban.redraw();
 
-            if (goban.engine.config.disable_analysis) {
+            if (goban.isAnalysisDisabled()) {
                 goban.updatePlayerToMoveTitle();
             }
 
@@ -2934,7 +2939,7 @@ export class GameChatLine extends React.Component<GameChatLineProperties, any> {
                 ct += mvs[i].edited ? 0 : 1;
             }
 
-            if (goban.engine.config.disable_analysis) {
+            if (goban.isAnalysisDisabled()) {
                 goban.setMode("analyze");
             }
 

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -67,6 +67,7 @@ export class Settings extends React.PureComponent<{}, any> {
             game_list_threshold: preferences.get("game-list-threshold"),
             autoadvance: preferences.get("auto-advance-after-submit"),
             autoplay_delay: preferences.get("autoplay-delay") / 1000,
+            always_disable_analysis: preferences.get("always-disable-analysis"),
             desktop_notifications_enabled: desktop_notifications_enabled,
             desktop_notifications_enableable: typeof(Notification) !== "undefined",
             hide_ui_class: false,
@@ -225,6 +226,10 @@ export class Settings extends React.PureComponent<{}, any> {
     setAutoAdvance = (ev) => {{{
         preferences.set("auto-advance-after-submit", ev.target.checked),
         this.setState({autoadvance: preferences.get("auto-advance-after-submit")});
+    }}}
+    setAlwaysDisableAnalysis = (ev) => {{{
+        preferences.set("always-disable-analysis", ev.target.checked),
+        this.setState({always_disable_analysis: preferences.get("always-disable-analysis")});
     }}}
     updateDesktopNotifications = (ev) => {{{
         let enabled = ev.target.checked;
@@ -536,6 +541,14 @@ export class Settings extends React.PureComponent<{}, any> {
                     <dd>
                         <input type="number" step="0.1" min="0.1" onChange={this.updateAutoplayDelay} value={this.state.autoplay_delay} />
                     </dd>
+                    <dt><label htmlFor="always-disable-analysis">{_("Always disable analysis")}</label></dt>
+                    <dd>
+                        <input id="always-disable-analysis" type="checkbox" checked={this.state.always_disable_analysis} onChange={this.setAlwaysDisableAnalysis} />
+                        <div><i>
+                        {_("This will disable the analysis mode and conditional moves for you in all games, even if it is not disabled in the game's settings.")}
+                        </i></div>
+                    </dd>
+
                 </dl>
             </Card>
             {/* }}} */}


### PR DESCRIPTION
This new setting would disable the analysis mode (and conditional moves) in all of your games for you, no matter if the game was created with analysis enabled or not. By default, this setting is off, so everything works as before unless you change the setting for yourself.

This setting would only affect yourself, of course - that is, if the game has been created with analysis enabled, your opponent can still use the analysis feature, but you can't.

See <https://forums.online-go.com/t/option-to-always-disable-analysis-for-yourself/13408> for the motivation behind this setting. There has been some positive feedback (from two users) about the suggestion, not sure if that is enough or what the criteria for adding a new feature are?

Assuming for a moment, that this feature is considered useful, let's talk about the implementation: I'm not familiar with the online-go.com code base at all, this was the first time I did anything with it. So the changes could be all in the wrong place or whatever. If that is so, I'm happy to redo them from scratch or improve on the existing changes.

I encountered one weird thing: It seems GoEngine has an `disable_analysis` attribute, which it takes from the config object that is being passed around. Some places use `go_engine.config.disable_analysis` while others use `go_engine.disable_analysis`. This looks a bit like duplicated state, which is usually a bad thing. Also, I'm not entirely sure what the `config.original_disable_analysis` is for.