### PR TITLE
Fix the ChatPresenceIndicator.

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2210,7 +2210,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                       }
 
                       <div className="player-icon-clock-row">
-                          {(goban.engine.players[color] || null) &&
+                          {((engine.players[color] && engine.players[color].id) || null) &&
                               <div className="player-icon-container" style={player_bg}>
                                  <div className="player-flag"><Flag country={engine.players[color].country}/></div>
                                  <ChatPresenceIndicator channel={this.game_id ? `game-${this.game_id}` : `review-${this.review_id}`} userId={engine.players[color].id} />


### PR DESCRIPTION
The Game view would attempt to display a ChatPresenceIndicator before the engine is initialised, causing the indicator to receive an undefined user id. We fix this by performing more checks before rendering the indicator.
Fixes #263.