### PR TITLE
Don't display PlayerDetails for guest players.

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -227,7 +227,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
     }
 
     display_details = (event) => {
-        if (this.props.nolink || !(this.state.user.id || this.state.user.player_id) || this.state.guest) {
+        if (this.props.nolink || !(this.state.user.id || this.state.user.player_id) || this.state.user.anonymous || (this.state.user.id || this.state.user.player_id) < 0) {
             return;
         }
         else {


### PR DESCRIPTION
We were displaying PlayerDetails for guest players. (This kind of bug could have been prevented by the type system.)