### PR TITLE
Ensure that the player.rating.professional field is treated as a boolean in the PlayerDetails.

### DIFF
--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -215,7 +215,7 @@ export class PlayerDetails extends React.PureComponent<PlayerDetailsProperties, 
                         <div>
                             <Player user={this.state} nodetails rank={false} />
                         </div>
-                        {rating && rating.professional &&
+                        {rating && !!rating.professional &&
                             <div>
                                 <span className="rank">{rating.rank_label}</span>
                             </div>


### PR DESCRIPTION
Sometimes the backend uses an integer for the player.rating.professional field, and sometimes it uses a boolean. React displays integers literally, but treats false or null as a signal to not render the component. Hence, if the backend sends a zero to indicate that the player is not a professional, then that zero gets displayed literally.