### PR TITLE
User Activity: added vertical space b/w activity types.

### DIFF
--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -93,6 +93,10 @@
         }
     }
 
+    .activity-card > div {
+        margin-bottom: 1em;
+    }
+
     .profile-card {
         position: relative;
         .row {

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -923,7 +923,7 @@ export class User extends React.PureComponent<UserProperties, any> {
 
 
                     <h2>{_("Activity")}</h2>
-                    <Card>
+                    <Card className="activity-card">
                         <h4>{_("Ladders")}</h4>
                         {(this.state.ladders.length > 0) && <div >
                             <dl className="activity-dl">


### PR DESCRIPTION
On the user profile page, organizing content w/ vertical spaces makes it easier to read.

Current: 
![activity-current](https://user-images.githubusercontent.com/880119/31152553-9038d83a-a851-11e7-9a00-c0d1ac975a63.png)

Proposed change:
![activity-new](https://user-images.githubusercontent.com/880119/31152560-981c70d4-a851-11e7-8e0f-6bcc23f5d124.png)




