### PR TITLE
Moved Settings icon to the left (for consistency w/ buttons).

### DIFF
--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -99,6 +99,7 @@
     .automatch-settings {
         flex: 0;
         text-align: right;
+        margin-right: 0.5em;
         .automatch-settings-link {
             cursor: pointer;
             user-select: none;

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -397,7 +397,7 @@ export class Play extends React.Component<PlayProperties, any> {
                     </div>
 
                     <div className='automatch-settings'>
-                        <span className='automatch-settings-link fake-link' onClick={openAutomatchSettings}>{_("Settings")} <i className='fa fa-gear'/></span>
+                        <span className='automatch-settings-link fake-link' onClick={openAutomatchSettings}><i className='fa fa-gear'/> {_("Settings")}</span>
                     </div>
                 </div>
             );


### PR DESCRIPTION
Because all buttons have their icon on the left, "settings" should do too.

Current:
![settings-current](https://user-images.githubusercontent.com/880119/31155176-08322cd8-a861-11e7-9325-908b6b0d3228.png)

Proposed change:
![settings-new2](https://user-images.githubusercontent.com/880119/31156547-eaba2008-a869-11e7-8bb5-4697553bb496.png)
