### PR TITLE
Modal: Increased space b/w the buttons and the edges of the modal.

### DIFF
--- a/src/components/Modal/Modal.styl
+++ b/src/components/Modal/Modal.styl
@@ -85,7 +85,7 @@
 
     .buttons {
         flex: 0;
-        padding: 0.5rem;
+        padding: 0.5rem 1rem;
         display: flex;
         justify-content: space-between;
         align-items: center;


### PR DESCRIPTION
Increased the space b/w the buttons and the sides of the modal.

Current & proposed looks:
![31157707-9fe7f5d4-a871-11e7-8010-946cf5981503](https://user-images.githubusercontent.com/880119/31158772-10068748-a879-11e7-8070-8db7ccfe6d23.png)

For comparison, Facebook buttons are placed at the same distance from both edges of the modal:
![facebook-buttons](https://user-images.githubusercontent.com/880119/31157712-aaae97a2-a871-11e7-8a11-3f9d9f370121.png)

same w/ Bootstrap:
![screen shot 2017-10-03 at 8 22 31 pm](https://user-images.githubusercontent.com/880119/31158725-ae25a1ee-a878-11e7-9203-499c0de244fe.png)



