### PR TITLE
Different layout of Game Creation Card for improved intuition about what does what

### DIFF
--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -71,6 +71,7 @@
         justify-content: space-around;
         align-content: stretch
         width: 100%;
+        flex-wrap: wrap;
 
         button {
             font-size: 1.1rem;
@@ -79,7 +80,8 @@
             flex-basis: 13rem;
             height: 4rem;
             margin: 0.9rem;
-            min-width: 160px; // so none shrink less wider than the widest
+            min-width: 155px; // to stop shrinking and expanding differently to others
+            max-width: 155px;
 
             .fa, .ogs-turtle {
                 //font-size: 1.2rem;
@@ -123,6 +125,8 @@
             flex-basis: 13rem;
             height: 3rem;
             margin: 1rem;
+            min-width: 155px; // to stop shrinking and expanding differently to others
+            max-width: 155px;
 
             .fa {
             //font-size: 1.2rem;

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -79,6 +79,7 @@
             flex-basis: 13rem;
             height: 4rem;
             margin: 0.9rem;
+            min-width: 160px; // so none shrink less wider than the widest
 
             .fa, .ogs-turtle {
                 //font-size: 1.2rem;

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -167,9 +167,16 @@
         cursor: help;
     }
 
-    .custom-games-list-header {
-        padding-bottom: 0.5rem;
+    .custom-games-list-header-row {
+        display: table-row;
         font-weight: bold;
+        white-space: nowrap;
+
+        .cell {
+            padding-left: 0.5em;
+            display: table-cell;
+            padding-bottom: 0.5rem;
+        }
     }
 
     .challenge-row {

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -78,7 +78,7 @@
             flex-grow: 1;
             flex-basis: 13rem;
             height: 4rem;
-            margin: 1rem;
+            margin: 0.9rem;
 
             .fa, .ogs-turtle {
                 //font-size: 1.2rem;
@@ -86,7 +86,7 @@
             }
             .ogs-turtle{
                 vertical-align: middle;
-                font-size: 1.3rem;
+                font-size: 1.2rem;
                 margin-bottom: 0;
             }
 
@@ -97,14 +97,50 @@
     }
 
     .automatch-settings {
+        font: 1rem;
         flex: 0;
         text-align: right;
+        align-content: right;
+        width: 100%
         margin-right: 0.5em;
         .automatch-settings-link {
             cursor: pointer;
             user-select: none;
         }
     }
+
+    .custom-game-row {
+        display: flex;
+        justify-content: space-around;
+        align-content: stretch
+        width: 50%;
+
+        button {
+            font-size: 1.1rem;
+            font-weight: bold;
+            flex-grow: 1;
+            flex-basis: 13rem;
+            height: 3rem;
+            margin: 1rem;
+
+            .fa {
+            //font-size: 1.2rem;
+                margin: 0.2rem;
+            }
+        }
+    }
+
+    .custom-game-header {
+        display: flex;
+        justify-content: space-around;
+        align-content: stretch
+        width: 100%;
+        justify-content: space-between;
+        align-items: left;
+        font-size: 1.3rem;
+        margin-top: 0.5rem;
+    }
+
 }
 
 
@@ -129,6 +165,11 @@
         font-size: 0.9em;
         vertical-align: middle;
         cursor: help;
+    }
+
+    .custom-games-list-header {
+        padding-bottom: 0.5rem;
+        font-weight: bold;
     }
 
     .challenge-row {

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -80,8 +80,8 @@
             flex-basis: 13rem;
             height: 4rem;
             margin: 0.9rem;
-            min-width: 155px; // to stop shrinking and expanding differently to others
-            max-width: 155px;
+            min-width: 165px; // to stop shrinking and expanding differently to others
+            max-width: 165px;
 
             .fa, .ogs-turtle {
                 //font-size: 1.2rem;
@@ -109,6 +109,10 @@
         .automatch-settings-link {
             cursor: pointer;
             user-select: none;
+        }
+
+        i {
+            padding-right: 0.25rem;
         }
     }
 

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -297,7 +297,7 @@ export class Play extends React.Component<PlayProperties, any> {
 
                         {/* kinda brute force tr/td to get this centred - urk! My table-fu is weak! */}
                         <tr className='custom-games-list-header'>
-                            <td colSpan="8">{_("Custom Games")}</td>
+                            <td colSpan={8}>{_("Custom Games")}</td>
                         </tr>
 
                         <div className="challenge-row">

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -398,7 +398,7 @@ export class Play extends React.Component<PlayProperties, any> {
                             </button>
                         </div>
                         <div className='automatch-settings'>
-                            <span className='automatch-settings-link fake-link' onClick={openAutomatchSettings}>{_("Settings ")}<i className='fa fa-gear'/></span>
+                            <span className='automatch-settings-link fake-link' onClick={openAutomatchSettings}><i className='fa fa-gear'/>{_("Settings ")}</span>
                         </div>
                         <div className='custom-game-header'>
                             <div>{_("Custom Game")}</div>

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -295,10 +295,14 @@ export class Play extends React.Component<PlayProperties, any> {
 
                         <div style={{marginTop: "2em"}}></div>
 
-                        {/* kinda brute force tr/td to get this centred - urk! My table-fu is weak! */}
-                        <tr className='custom-games-list-header'>
-                            <td colSpan={8}>{_("Custom Games")}</td>
-                        </tr>
+                        {/* There must be a better way to get the header in the centre! At least this doesn't cause warnings :) */}
+                        <div className='custom-games-list-header-row'>
+                            <span className='cell'></span>
+                            <span className='cell'></span>
+                            <span className='cell'></span>
+                            <span className='cell'>{_("Custom Games")}</span>
+                        </div>
+
 
                         <div className="challenge-row">
                             <span className="cell break">{_("Short Games")}</span>

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -295,6 +295,11 @@ export class Play extends React.Component<PlayProperties, any> {
 
                         <div style={{marginTop: "2em"}}></div>
 
+                        {/* kinda brute force tr/td to get this centred - urk! My table-fu is weak! */}
+                        <tr className='custom-games-list-header'>
+                            <td colSpan="8">{_("Custom Games")}</td>
+                        </tr>
+
                         <div className="challenge-row">
                             <span className="cell break">{_("Short Games")}</span>
                             {this.cellBreaks(7)}
@@ -380,12 +385,6 @@ export class Play extends React.Component<PlayProperties, any> {
                             <button className='primary' onClick={this.newComputerGame}>
                                 <i className="fa fa-desktop" /> {_("Computer")}
                             </button>
-                            <button className='primary' onClick={this.newCustomGame}>
-                                <i className="fa fa-cog" /> {_("Custom")}
-                            </button>
-                        </div>
-
-                        <div className='automatch-row'>
                             <button className='primary' disabled={this.state.disableCorrespondenceButton} onClick={() => this.findMatch("correspondence")}>
                                 {this.state.disableCorrespondenceButton
                                     ? <span><i className="fa fa-check" /> {_("Correspondence")}</span>
@@ -394,11 +393,19 @@ export class Play extends React.Component<PlayProperties, any> {
                                 <br/><span className='time-per-move'>{pgettext("Automatch average time per move", "~1 day per move")}</span>
                             </button>
                         </div>
+                        <div className='automatch-settings'>
+                            <span className='automatch-settings-link fake-link' onClick={openAutomatchSettings}>{_("Settings ")}<i className='fa fa-gear'/></span>
+                        </div>
+                        <div className='custom-game-header'>
+                            <div>{_("Custom Game")}</div>
+                        </div>
+                        <div className='custom-game-row'>
+                            <button className='primary' onClick={this.newCustomGame}>
+                                <i className="fa fa-cog" /> {_("Create")}
+                            </button>
+                        </div>
                     </div>
 
-                    <div className='automatch-settings'>
-                        <span className='automatch-settings-link fake-link' onClick={openAutomatchSettings}><i className='fa fa-gear'/> {_("Settings")}</span>
-                    </div>
                 </div>
             );
         }


### PR DESCRIPTION
In this thread, some time ago, I suggested an alternative layout for the Game Creation Card:

https://forums.online-go.com/t/clearer-layout-of-game-finder-pane/12354

This PR implements that suggestion.

The rationale is explained in the thread.

As noted in the thread, the "computer" button is not a perfect fit for the layout logic, but close enough I think.