### PR TITLE
Overview page: Links on titles (rather than repeating) + added icons …

### DIFF
--- a/src/views/Overview/Overview.styl
+++ b/src/views/Overview/Overview.styl
@@ -22,6 +22,10 @@
     flex-wrap: wrap;
     justify-content: center;
 
+    h3 >i {
+        margin-right: 1rem;
+    }
+
     .actions {
         display: flex;
         justify-content: center;
@@ -73,16 +77,14 @@
             width: 15px;
         }
     }
+    .overview-categories {
+        padding-top: 1rem;
 
-
-    .right-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: bottom;
-        margin-bottom: 1rem;
-        margin-top: 1rem;
-        h3 {
-            margin: 0;
+        a > i {
+            margin-right: 0.5rem;
+        }
+        > div {
+            margin-left: 2rem;
         }
     }
 
@@ -98,9 +100,8 @@
             flex: 1;
             display: flex;
             flex-direction: column;
-            padding-left: 10px;
+            padding-left: 1rem;
             justify-content: space-between;
-            text-align: right;
         }
         .PlayerIcon{
             width: 80px;

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -108,7 +108,7 @@ export class Overview extends React.Component<{}, any> {
                         <PlayerIcon id={user.id} size={80} />
 
                         <div className="profile-right">
-                            <div>
+                            <div style={{fontSize: '1.2em'}}>
                                 <Player user={user} nodetails rank={false} />
                             </div>
                             {rating && rating.professional &&
@@ -128,33 +128,27 @@ export class Overview extends React.Component<{}, any> {
                             }
                         </div>
                     </div>
-                    <div className="right-header" style={{justifyContent: 'center'}}>
+
+                    <div style={{justifyContent: 'center'}}>
                         <AdUnit unit='cdm-zone-02' />
                     </div>
-                    <div className="right-header">
-                        <h3>{_("Tournaments")}</h3>
-                        <Link to="/tournaments">{_("All tournaments") /* translators: Link to view all tournaments */} &gt;</Link>
-                    </div>
-                    <TournamentList />
 
-                    <div className="right-header">
-                        <h3>{_("Ladders")}</h3>
-                        <Link to="/ladders">{_("All ladders") /* translators: Link to view all ladders */} &gt;</Link>
-                    </div>
-                    <LadderList />
+                    <div className="overview-categories">
+                        <h3><Link to="/tournaments"><i className="fa fa-trophy"></i> {_("Tournaments")}</Link></h3>
+                        <TournamentList />
 
-                    <div className="right-header">
-                        <h3>{_("Groups")}</h3>
-                        <Link to="/groups">{_("Find Groups") /* translators: Link to view all groups */} &gt;</Link>
-                    </div>
-                    <GroupList />
+                        <h3><Link to="/ladders"><i className="fa fa-list-ol"></i> {_("Ladders")}</Link></h3>
+                        <LadderList />
 
-                    <div className="right-header">
-                        <h3>{_("Friends")}</h3>
-                        <Link to="/chat">{_("Meet some in Chat!") /* translators: Meet some friends in chat */} &gt;</Link>
+                        <h3><Link to="/groups"><i className="fa fa-users"></i> {_("Groups")}</Link></h3>
+                        <GroupList />
+
+                        <h3><Link to="/chat"><i className="fa fa-comment-o"></i> {_("Chat with friends")}</Link></h3>
+                        <FriendList />
                     </div>
-                    <FriendList />
+
                 </div>
+
             </div>
         </div>
         );


### PR DESCRIPTION
Overview page: 

- Links on titles (rather than repeating)
- using icons
- indentation of summaries
- made user name more prominent (bigger font + left justified)

Current look:
![overview-current](https://user-images.githubusercontent.com/880119/31305632-22c43d36-aaf3-11e7-91ac-5d4eace7f3f6.png)

Proposed change:
![overview-new](https://user-images.githubusercontent.com/880119/31305607-b0affcda-aaf2-11e7-93ab-6b6c400b21e5.png)






