### PR TITLE
Support page: improved UX

### DIFF
--- a/src/views/Supporter/Supporter.styl
+++ b/src/views/Supporter/Supporter.styl
@@ -25,7 +25,7 @@
     padding: 1rem;
 
     .main-paragraph {
-        max-width: 30rem;
+        max-width: 1110px;
         text-align: justify;
 
         .p {
@@ -71,6 +71,9 @@
             border-radius: 0.3rem;
             padding: 0.3rem;
             themed background-color shade4
+        }
+        .primary {
+            margin-top: 1rem;
         }
     }
 

--- a/src/views/Supporter/Supporter.tsx
+++ b/src/views/Supporter/Supporter.tsx
@@ -493,9 +493,13 @@ export class Supporter extends React.PureComponent<SupporterProperties, any> {
 
         return (
         <div className="Supporter">
-            <SupporterGoals alwaysShow={true} />
-
+        <div className="row">
+            <div className="col-sm-7">
+            <h2><i className="fa fa-star"></i> {_("Support OGS")}</h2>
             {supporter_text}
+            </div>
+
+            <div className="col-sm-5">
             {processing
                 ? <h1 style={{textAlign: "center", marginTop: "5em"}}>{_("Processing")}</h1>
                 : !this.state.is_supporter
@@ -611,6 +615,8 @@ export class Supporter extends React.PureComponent<SupporterProperties, any> {
 
                       </div>
             }
+            </div>
+        </div>
         </div>
         );
     }


### PR DESCRIPTION
No ad on support page.
Standard max-width
Added page title
Moved donation box to the top for improved visibility (on 2nd columns)
Added margin on button.

Current look:
![support-current](https://user-images.githubusercontent.com/880119/31484998-324402b2-aee7-11e7-9062-482f5f64a02b.png)

Proposed change:
![support-new](https://user-images.githubusercontent.com/880119/31485012-3b3359d6-aee7-11e7-837d-c491f98204bd.png)

