### PR TITLE
Left navigation: Black icons on hover.

### DIFF
--- a/src/components/NavBar/NavBar.styl
+++ b/src/components/NavBar/NavBar.styl
@@ -290,6 +290,10 @@ navbar-width= 17rem;
                 themed color fg
             }
         }
+
+        a:hover i {
+            color: black;
+        }
     }
 }
 


### PR DESCRIPTION
This change is barely noticeable but I think it is nice to have.

Current:
![grey-icon](https://user-images.githubusercontent.com/880119/32470760-a5fcbf2e-c30e-11e7-9841-bb7fd2619ce6.png)

Proposed:
![black-icon](https://user-images.githubusercontent.com/880119/32470765-adba61ee-c30e-11e7-92d2-dd182bb1a0f3.png)