### PR TITLE
Improve text visibility in private messaging title bar

### DIFF
--- a/src/components/PrivateChat/PrivateChat.styl
+++ b/src/components/PrivateChat/PrivateChat.styl
@@ -29,7 +29,7 @@
 
 
     .title {
-        themed background-color shade0
+        themed background-color shade5
         border-bottom: 1px solid #aaaaaa;
         padding-left: 0.1em;
         padding-right: 0.1em;


### PR DESCRIPTION
This pull request changes the title bar color of the private messaging window from "shade0" to "shade5" which is a lighter color in the light theme and a darker color in the dark theme. This improves the contrast between text and background.

Change was suggested on [this forum thread](https://forums.online-go.com/t/username-color-change-difficult-to-see-username-on-pm-box/14932/)

Screenshots of the title bars below

**Before:**

Light theme
![image](https://user-images.githubusercontent.com/6917205/33995756-eedd6008-e119-11e7-96f2-e3ee24ad70b7.png)
Dark theme
![image](https://user-images.githubusercontent.com/6917205/33995737-dfae57d6-e119-11e7-96fb-300005d4ca31.png)

**After:**

Light theme
![screenshot_20171214_215519](https://user-images.githubusercontent.com/6917205/33995683-adc0b2aa-e119-11e7-954d-8a3e2e0e6864.png)
Dark theme
![screenshot_20171214_215426](https://user-images.githubusercontent.com/6917205/33995687-b2568d6c-e119-11e7-9c75-30a35fd0be55.png)