### PR TITLE
Add Size column to game screen #506

### DIFF
--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -188,7 +188,8 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                             white={game.white}
                             player={this.props.player}
                             gobanref={(goban) => game.goban = goban}
-                            size={game.height}
+                            width={game.width}
+                            height={game.height}
                             />)}
                 </div>
             );

--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -158,6 +158,7 @@ export class GameList extends React.PureComponent<GameListProps, any> {
             let opponent_sort         = sort_order === 'opponent'       ? 'sorted-desc' : sort_order === '-opponent'       ? 'sorted-asc' : '';
             let clock_sort            = sort_order === 'clock'          ? 'sorted-desc' : sort_order === '-clock'          ? 'sorted-asc' : '';
             let opponent_clock_sort   = sort_order === 'opponent-clock' ? 'sorted-desc' : sort_order === '-opponent-clock' ? 'sorted-asc' : '';
+            let size                  = sort_order === 'size'           ? 'sorted-desc' : sort_order === '-size'           ? 'sorted-asc' : '';
 
             return (
                 <div className="GameList GobanLineSummaryContainer">
@@ -168,6 +169,7 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                               <div onClick={this.sortBy("opponent")} className={sortable + opponent_sort + " text-align-left"}>{_("Opponent")}</div>
                               <div onClick={this.sortBy("clock")} className={sortable + clock_sort}>{_("Clock")}</div>
                               <div onClick={this.sortBy("opponent-clock")} className={sortable + opponent_clock_sort}>{_("Opponent's Clock")}</div>
+                              <div onClick={this.sortBy("size")} className={sortable + size}>{_("Size")}</div>
                           </div>
                         : <div className="GobanLineSummaryContainerHeader">
                               <div >{pgettext("Game list move number", "Move")}</div>
@@ -176,6 +178,7 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                               <div></div>
                               <div className="text-align-left">{_("White")}</div>
                               <div></div>
+                              <div className="text-align-left">{_("Size")}</div>
                           </div>
                     }
                     {lst.map((game) =>
@@ -185,6 +188,7 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                             white={game.white}
                             player={this.props.player}
                             gobanref={(goban) => game.goban = goban}
+                            size={game.height}
                             />)}
                 </div>
             );

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -30,7 +30,8 @@ interface GobanLineSummaryProps {
     white: any;
     player?: any;
     gobanref?: (goban:Goban) => void;
-    size?: number;
+    width?: number;
+    height?: number;
 }
 
 export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any> {
@@ -176,7 +177,7 @@ export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any
                         <PersistentElement className={`clock ${this.state.paused}`} elt={this.white_clock} />
                     </div>
                 }
-                <div className="size">{this.props.size}</div>
+                <div className="size">{this.props.width + "x" + this.props.width}</div>
             </Link>
         );
     }

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -30,6 +30,7 @@ interface GobanLineSummaryProps {
     white: any;
     player?: any;
     gobanref?: (goban:Goban) => void;
+    size?: number;
 }
 
 export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any> {
@@ -175,6 +176,7 @@ export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any
                         <PersistentElement className={`clock ${this.state.paused}`} elt={this.white_clock} />
                     </div>
                 }
+                <div className="size">{this.props.size}</div>
             </Link>
         );
     }


### PR DESCRIPTION
Add a column displaying the board size to game lists in Observe Games, Overview, and Profile.