### PR TITLE
Fix up win/loss colours so they are intuitive in both themes (#603)

### DIFF
--- a/src/components/RatingsChart/RatingsChart.styl
+++ b/src/components/RatingsChart/RatingsChart.styl
@@ -119,25 +119,24 @@ rating-chart-height=380px;
     /* Bright for strong, darker for weak
        green for win, red for loss ... */
     .weak-wins {
-        themed-darken fill win 25%
-        themed-darken background-color win 25%
+        themed fill weak-win
+        themed background-color weak-win
     }
     .strong-wins {
-        themed-lighten fill win 25%
-        themed-lighten background-color win 25%
+        themed fill strong-win
+        themed background-color strong-win
     }
     .strong-losses {
-        themed-lighten fill loss 25%
-        themed-lighten background-color loss 25%
+        themed fill strong-loss
+        themed background-color strong-loss
     }
     .weak-losses {
-        themed-darken fill loss 25%
-        themed-darken background-color loss 25%
+        themed fill weak-loss
+        themed background-color weak-loss
     }
     .transparent {
         fill: transparent;
     }
-
     .win-loss-stats {
         font-size: font-size-small;
         margin-bottom: 1rem;

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -125,9 +125,15 @@ light.teacher                           = #27AD49
 light.chat-mentions                     = #DB397A // pink
 light.chat-self-message                 = #0449C4
 light.chat-system                       = #1CA760
+
 light.win                               = #73D355
 light.loss                              = #BC4B9A
 
+light.weak-win                          = lighten(light.win, 25%)
+light.weak-loss                         = lighten(light.loss, 25%)
+
+light.strong-win                        = darken(light.win, 25%)
+light.strong-loss                       = darken(light.loss, 25%)
 
 light.shade0                            = lighten(light.fg, 20%)
 light.shade1                            = lighten(light.fg, 40%)
@@ -226,8 +232,17 @@ dark.shade5                             = lighten(dark.bg, 13%)
 dark.chat-mentions                      = #E36497 // pink
 dark.chat-self-message                  = #8AB1E6
 dark.chat-system                        = lighten(light.chat-system, 20%)
+
+
 dark.win                                = desaturate(darken(light.win, 30%), 20%)
 dark.loss                               = desaturate(darken(light.loss, 30%), 20%)
+
+dark.strong-win                         = lighten(dark.win, 25%)
+dark.strong-loss                        = lighten(dark.loss, 25%)
+
+dark.weak-win                           = darken(dark.win, 25%)
+dark.weak-loss                          = darken(dark.loss, 25%)
+
 
 /** Navbar **/
 


### PR DESCRIPTION
Rejigged the theming of win/loss colours for the RatingChart so the strongest looking colour is always the one for stronger opponents.

Had to push this back into the theme itself.
