### PR TITLE
Update layout of buttons on Game Page to avoid misclicks (and improve consistency)

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -110,6 +110,19 @@ goban-view-bar-width=400px
             text-align: center;
         }
 
+        .analyze-mode-buttons {
+            display: flex;
+            justify-content: center;
+            margin: 5px;
+            button {
+                // this works in both light and dark theme
+                background: green;
+                border: darkgreen;
+            }
+            button:hover {
+                background: darkgreen;
+            }
+        }
         .pause-controls {
             text-align: center;
         }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1686,25 +1686,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     {(state.mode === "play" && state.phase === "play" && state.cur_move_number >= state.official_move_number || null) &&
                         this.frag_play_buttons(show_cancel_button)
                     }
-                    {(state.mode === "play" && state.phase === "play" && this.goban.isAnalysisDisabled() && state.cur_move_number < state.official_move_number || null) &&
-                        <span>
-                            <button className="sm primary bold" onClick={this.goban_setModeDeferredPlay}>{_("Back to Game")}</button>
-                        </span>
-                    }
-
-                    {(state.mode === "analyze" && !this.goban.engine.config.original_sgf || null) &&
-                        <span>
-                            <button className="sm primary bold" onClick={this.goban_setModeDeferredPlay}>{_("Back to Game")}</button>
-                            <button className="sm primary bold pass-button" onClick={this.analysis_pass}>{_("Pass")}</button>
-                        </span>
-                    }
-
-                    {(state.mode === "score estimation" || null) &&
-                        <span>
-                            <button className="sm primary bold" onClick={this.stopEstimatingScore}>{_("Back to Game")}</button>
-                        </span>
-                    }
-
                     {/* (this.state.view_mode === 'portrait' || null) && <i onClick={this.togglePortraitTab} className={'tab-icon fa fa-commenting'}/> */}
                 </div>
                 {/* }}} */}
@@ -1798,7 +1779,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     </div>
                 }{/* }}} */}
                 {(this.state.phase === "finished" || null) &&  /* {{{ */
-                    <div>
+                    <div className="analyze-mode-buttons">     {/* not really analyze mode, but equivalent button position and look*/}
                         {(this.state.user_is_player && this.state.mode !== "score estimation" || null) &&
                             <button
                                 onClick={this.rematch}
@@ -1895,7 +1876,8 @@ export class Game extends React.PureComponent<GameProperties, any> {
                        }
 
                     </div>
-                }{/* }}} */}
+                }
+                {/* }}} */}
                 {(this.state.mode === "conditional" || null) &&  /* {{{ */
                     <div className="conditional-move-planner">
                       <div className="buttons">
@@ -1933,16 +1915,21 @@ export class Game extends React.PureComponent<GameProperties, any> {
                         </div>
                     </div>
                 }{/* }}} */}
-
-                {/*
-                    (this.goban.engine.config.original_sgf || null) &&
-                    <div style={{paddingLeft: '0.5em', paddingRight: '0.5em'}}>
-                        <textarea id='game-move-node-text' placeholder={_("Move comments...")}
-                            rows={5}
-                            className='form-control'
-                            disabled={true}></textarea>
-                    </div>
-                */}
+                {(state.mode === "play" && state.phase === "play" && this.goban.isAnalysisDisabled() && state.cur_move_number < state.official_move_number || null) &&
+                   <div className="analyze-mode-buttons">
+                    <span>
+                        <button className="sm primary bold"
+                                onClick={this.goban_setModeDeferredPlay}>{_("Back to Game")}</button>
+                    </span>
+                   </div>
+                }
+                {(state.mode === "score estimation" || null) &&
+                <div className="analyze-mode-buttons">
+                    <span>
+                        <button className="sm primary bold" onClick={this.stopEstimatingScore}>{_("Back to Game")}</button>
+                    </span>
+                </div>
+                }
             </div>
         );
     }}}
@@ -2010,6 +1997,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
         );
     }}}
     frag_analyze_button_bar() {{{
+        let state = this.state;
         return (
         <div className="game-analyze-button-bar">
             {/*
@@ -2077,7 +2065,14 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     <i className="ogs-label-x"></i>
                 </button>
             </div>
-
+             <div className="analyze-mode-buttons">
+                 {(state.mode === "analyze" && !this.goban.engine.config.original_sgf || null) &&
+                 <span>
+                     <button className="sm primary bold" onClick={this.goban_setModeDeferredPlay}>{_("Back to Game")}</button>
+                     <button className="sm primary bold pass-button" onClick={this.analysis_pass}>{_("Pass")}</button>
+                 </span>
+                 }
+             </div>
         </div>
         );
     }}}


### PR DESCRIPTION
In this change, buttons that are not for actually manipulating the current game are now green instead of blue.   Blue buttons actually affect the game.

Also, they are moved to the bottom of that general area above the chat window, away from where the game-affecting buttons are (at the top of that area).

Unchanged: it's my turn, I have not placed a stone.  Here is the "Pass" button.  Note that it is blue, because it affects this game.

<img width="1440" alt="screenshot 2018-03-28 20 39 42 2" src="https://user-images.githubusercontent.com/61894/38023671-7ec93514-32ca-11e8-9715-b795ec7307a4.png">

Now I placed a stone.  Also unchanged, here is the "Submit" button:

<img width="1440" alt="screenshot 2018-03-28 20 40 02" src="https://user-images.githubusercontent.com/61894/38023757-a823fc46-32ca-11e8-9b17-e8677cfbce7f.png">

I submitted the move, then hit the arrow keys in disabled-analyze-mode.   This takes me back one move, so I have "back to game", but no analysis tree.   The "Back to Game" button is green and below the status.

<img width="1440" alt="screenshot 2018-03-28 20 40 14 2" src="https://user-images.githubusercontent.com/61894/38024001-4a6fa248-32cb-11e8-9d9e-17e181938970.png">

I resigned, so now I have "Rematch".  Also green, and now centered, like the others:

<img width="1440" alt="screenshot 2018-03-28 20 40 37" src="https://user-images.githubusercontent.com/61894/38024061-6f1d3484-32cb-11e8-9a51-247878570941.png">

At last the one we were all really interested in.  I started a new game with Analysis enabled, and went into Analysis mode:

![Uploading Screenshot 2018-03-28 20.40.55(2).png…]()

Note that the buttons are both green, and they are significantly differently placed than the Back To Game button.






