### PR TITLE
Put the popup above the target element if it doesn't fit below - fixes #607

### DIFF
--- a/src/lib/popover.ts
+++ b/src/lib/popover.ts
@@ -93,19 +93,29 @@ export function popover(config: PopoverConfig): PopOver {
     if (config.at) {
         x = config.at.x;
         y = config.at.y;
+
+        x = Math.min(x, bounds.x - minWidth);
+
+        if (y < bounds.y - minHeight) {
+            container.css({minWidth: minWidth, top: y, left: x});
+        } else {
+            container.css({minWidth: minWidth, bottom: $(window).height() - y, left: x});
+        }
     }
     else if (config.below) {
         let rectangle = ReactDOM.findDOMNode(config.below).getBoundingClientRect();
         x = rectangle.left + window.scrollX;
+        x = Math.min(x, bounds.x - minWidth);
+
         y = rectangle.bottom + window.scrollY;
-    }
 
-    x = Math.min(x, bounds.x - minWidth);
-
-    if (y < bounds.y - minHeight) {
-        container.css({minWidth: minWidth, top: y, left: x});
-    } else {
-        container.css({minWidth: minWidth, bottom: $(window).height() - y, left: x});
+        if (y < bounds.y - minHeight) {
+            container.css({minWidth: minWidth, top: y, left: x});
+        } else {
+            // Don't overlap the element we were supposed to be below.
+            // If there is no space below, just go above it instead.
+            container.css({minWidth: minWidth, bottom:$(window).height() - rectangle.top, left: x});
+        }
     }
 
     $(document.body).append(backdrop);

--- a/src/lib/popover.ts
+++ b/src/lib/popover.ts
@@ -114,7 +114,7 @@ export function popover(config: PopoverConfig): PopOver {
         } else {
             // Don't overlap the element we were supposed to be below.
             // If there is no space below, just go above it instead.
-            container.css({minWidth: minWidth, bottom:$(window).height() - rectangle.top, left: x});
+            container.css({minWidth: minWidth, bottom: $(window).height() - rectangle.top - window.scrollY, left: x});
         }
     }
 


### PR DESCRIPTION
As simple as the summary: put popups above a target element if they don't fit below as requested by config.bottom.

Before:

<img width="946" alt="screenshot 2018-03-29 10 46 23" src="https://user-images.githubusercontent.com/61894/38063291-d98bf228-333f-11e8-9c22-2ed4e1a9e0eb.png">

After:

<img width="905" alt="screenshot 2018-03-29 10 25 14" src="https://user-images.githubusercontent.com/61894/38063296-e4267186-333f-11e8-92ad-889a34c35ce2.png">


