### PR TITLE
Displays players' rankings at gametime in the games history table (fixes Issue #364/#542)

### DIFF
--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -513,6 +513,8 @@ export class User extends React.PureComponent<UserProperties, any> {
                 item.white_won = !r.white_lost && r.black_lost;
                 item.white_class = item.white_won ? (item.white.id === this.user_id ? "library-won" : "library-lost") : "";
                 item.result_class = (item.white_won && (item.white.id === this.user_id)) || (item.black_won && (item.black.id === this.user_id)) ? "library-won-result" : "library-lost-result";
+                item.historical = r.historical_ratings;
+
                 if ((r.white_lost && r.black_lost) || (!r.white_lost && !r.black_lost)) {
                     item.result_class = "";
                 }
@@ -550,6 +552,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                 item.white_class = item.white_won ? (item.white.id === this.user_id ? "library-won" : "library-lost") : "";
                 item.name = r.name;
                 item.href = "/review/" + item.id;
+                item.historical = r.game.historical_ratings;
 
                 if (!item.name || item.name.trim() === "") {
                     item.name = item.href;
@@ -770,8 +773,8 @@ export class User extends React.PureComponent<UserProperties, any> {
                                         {header: _("Date"),   className: () => "date",                            render: (X) => moment(X.date).format("YYYY-MM-DD")},
                                         {header: _("Size"),   className: () => "board_size",                      render: (X) => `${X.width}x${X.height}`},
                                         {header: _("Name"),   className: () => "name",                            render: (X) => <Link to={X.href}>{X.name || interpolate('{{black_username}} vs. {{white_username}}', {'black_username': X.black.username, 'white_username': X.white.username}) }</Link>},
-                                        {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <Player user={X.black}/>},
-                                        {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <Player user={X.white}/>},
+                                        {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <Player user={X.historical.black} disableCacheUpdate />},
+                                        {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <Player user={X.historical.white} disableCacheUpdate />},
                                         {header: _("Result"), className: (X) => (X ? X.result_class : ""),            render: (X) => X.result},
                                     ]}
                                 />
@@ -803,8 +806,8 @@ export class User extends React.PureComponent<UserProperties, any> {
                                         columns={[
                                             {header: _("Date"),   className: () => "date",                            render: (X) => moment(X.date).format("YYYY-MM-DD")},
                                             {header: _("Name"),   className: () => "name",                            render: (X) => <Link to={X.href}>{X.name}</Link>},
-                                            {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <Player user={X.black}/>},
-                                            {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <Player user={X.white}/>},
+                                            {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <Player user={X.historical.black} disableCacheUpdate />},
+                                            {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <Player user={X.historical.white} disableCacheUpdate />},
                                         ]}
                                     />
                                 </div>


### PR DESCRIPTION
Previously, the games history table and the review games tables would show the players current ranks, instead of the ranks they were at when they played the game. This pull request displays the old ranks.

![screenshot 2018-03-30 17 18 54](https://user-images.githubusercontent.com/6894860/38157742-83fe9c66-343e-11e8-9c2b-3e7e869297bf.png)
