### PR TITLE
Improved placement for Waiting For Opponent (implements #615)

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.styl
+++ b/src/components/ChallengeModal/ChallengeModal.styl
@@ -15,6 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+.waiting-for-opponent-container {
+    themed background-color card-background-color;
+    themed color text-color;
+
+    text-align: center;
+}
+
 .ChallengeModal {
     width: 50rem;
     max-width: 100%;
@@ -48,8 +55,6 @@
     label {
         user-select: none;
     }
-
-
 
     .left-pane {
         margin-right: 0.5rem;

--- a/src/global_styl/misc-ui.styl
+++ b/src/global_styl/misc-ui.styl
@@ -108,7 +108,7 @@
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background-color: #333;
+  themed background-color toast-bg;
   opacity: 0.6;
   position: absolute;
   top: 0;

--- a/src/lib/popover.ts
+++ b/src/lib/popover.ts
@@ -126,7 +126,7 @@ export function popover(config: PopoverConfig): PopOver {
 
         y = rectangle.top + window.scrollY;
 
-        container.css({top:y, left: x, width: rectangle.right - x, height: rectangle.bottom - y});
+        container.css({top:y, left: x, width: rectangle.right - x, height: rectangle.bottom - y + window.scrollY});
     }
 
     if (config.container_class) {

--- a/src/lib/popover.ts
+++ b/src/lib/popover.ts
@@ -29,11 +29,13 @@ interface PopupCoordinates {
 }
 
 interface PopoverConfig {
-    elt: React.ReactElement<any>;
-    at?: PopupCoordinates;
-    below?: React.ReactInstance;
+    elt: React.ReactElement<any>; // the contents of the popover
+    at?: PopupCoordinates; // the position to place the popover
+    below?: React.ReactInstance; // the element to place the popover below
+    cover?: React.ReactInstance; // an element to cover up with the popover
     minWidth?: number;
     minHeight?: number;
+    container_class?: string; // className attribute to add to the popover container
     //above?:HTMLElement;;
     //below?:HTMLElement;;
     //left?:HTMLElement;;
@@ -116,6 +118,19 @@ export function popover(config: PopoverConfig): PopOver {
             // If there is no space below, just go above it instead.
             container.css({minWidth: minWidth, bottom:$(window).height() - rectangle.top, left: x});
         }
+    }
+    else if (config.cover) {
+        let rectangle = ReactDOM.findDOMNode(config.cover).getBoundingClientRect();
+        x = rectangle.left + window.scrollX;
+        //x = Math.min(x, bounds.x - minWidth);
+
+        y = rectangle.top + window.scrollY;
+
+        container.css({top:y, left: x, width: rectangle.right - x, height: rectangle.bottom - y});
+    }
+
+    if (config.container_class) {
+        container[0].className += " " + config.container_class;
     }
 
     $(document.body).append(backdrop);

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -209,7 +209,8 @@ export class Play extends React.Component<PlayProperties, any> {
     }}}
 
     newCustomGame = () => {{{
-        challenge(null);
+        challenge(undefined, undefined, undefined, undefined,
+            document.getElementsByClassName('automatch-container')[0]);
     }}}
 
     toggleSize(size) {{{


### PR DESCRIPTION
This branch implements the "Waiting for opponent" dialog as a popover instead of a swal, allowing it to be placed directly over the automatch Card, where it obscures only that card.  Sending the message that those controls aren't really intended to be used while waiting for a live match, but not obscuring anything else.

It pulls in improve-popup-location branch because I needed to extend the popover functionality, and wanted to build on that change.

This branch also themes the double-bounce spinner.

![screenshot 2018-04-02 21 54 32](https://user-images.githubusercontent.com/61894/38196400-0c4fe914-36c2-11e8-806c-148aff0e5fb9.png)
