### PR TITLE
Fix &nbsp; added to quickchat messages #613

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2605,7 +2605,7 @@ export class GameChat extends React.PureComponent<GameChatProperties, any> {
     saveEdit = () => {{{
         let user = data.get("user");
         this.qc_editableMsgs.map((li, index) => {
-            user.qc_phrases[index] = li.innerHTML;
+            user.qc_phrases[index] = li.innerText.trim();
         });
         localStorage.setItem("ogs.qc.messages", JSON.stringify(user.qc_phrases));
         this.finishEdit();


### PR DESCRIPTION
Use innerText instead of innerHTML to retrieve edited messages.