### PR TITLE
Apply a delay to the pop-out-on-hover of the Dock (implements #618)

### DIFF
--- a/src/components/Dock/Dock.styl
+++ b/src/components/Dock/Dock.styl
@@ -33,15 +33,22 @@ dock-inline-height=500px
     padding-bottom: 1rem;
     z-index: z.dock;
 
-    -webkit-transition: all 0.1s ease-in;
-    -moz-transition: all 0.1s ease-in;
-    -o-transition: all 0.1s ease-in;
-    transition: all 0.1s ease-in;
+    -webkit-transition: all 0.1s ease-in 0s;
+    -moz-transition: all 0.1s ease-in 0s;
+    -o-transition: all 0.1s ease-in 0s;
+    transition: all 0.1s ease-in 0s;
+
     box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.26);
 
     &:hover {
         right: 0;
         box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.26);
+
+        -webkit-transition: all 0.1s ease-in 2s;
+        -moz-transition: all 0.1s ease-in 2s;
+        -o-transition: all 0.1s ease-in 2s;
+        transition: all 0.1s ease-in 2s;
+
     }
 
     div.line-item {


### PR DESCRIPTION
As per #618, it is irritating having the Dock pop out when the mouse strays on to it.

This PR delays the opening of the Dock by 2 seconds, enough for someone to click an icon if they know what it is without the Dock opening, and not too long to have to wait if you want to confirm what the items are.

