### PR TITLE
Do away with waiting dialog for live custom challenges.

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -432,7 +432,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                 notification_manager.event_emitter.on("notification", checkForReject);
 
                 if (open_now) {
-                    swal({
+                    /* swal({
                         title: _("Waiting for opponent"),
                         html: '<div class="spinner"><div class="double-bounce1"></div><div class="double-bounce2"></div></div>',
                         confirmButtonClass: "btn-danger",
@@ -442,7 +442,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                     })
                     .then(() => {
                         off();
-                        /* cancel challenge */
+                        // cancel challenge
                         del((this.props.mode === "open" ? "challenges/%%" : "me/challenges/%%"), challenge_id)
                         .then(ignore)
                         .catch(ignore);
@@ -451,7 +451,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                         off();
                     });
 
-
+                     */
                     active_check();
                 } else {
                     if (this.props.mode === "open") {

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -432,26 +432,32 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                 notification_manager.event_emitter.on("notification", checkForReject);
 
                 if (open_now) {
-                    /* swal({
-                        title: _("Waiting for opponent"),
-                        html: '<div class="spinner"><div class="double-bounce1"></div><div class="double-bounce2"></div></div>',
-                        confirmButtonClass: "btn-danger",
-                        confirmButtonText: "Cancel",
-                        allowOutsideClick: false,
-                        allowEscapeKey: false,
-                    })
-                    .then(() => {
-                        off();
-                        // cancel challenge
-                        del((this.props.mode === "open" ? "challenges/%%" : "me/challenges/%%"), challenge_id)
-                        .then(ignore)
-                        .catch(ignore);
-                    })
-                    .catch(() => {
-                        off();
-                    });
+                    if (this.props.mode !== "open") {
+                        /* This is a direct challenge, which can be made in any context (not necessarily one showing challenges)
+                           so it needs a dialog to let them know that we made the challenge.
 
-                     */
+                           This doesn't _have to be_ a modal, but currently is a modal pending a different design.
+                         */
+                        swal({
+                            title: _("Waiting for opponent"),
+                            html: '<div class="spinner"><div class="double-bounce1"></div><div class="double-bounce2"></div></div>',
+                            confirmButtonClass: "btn-danger",
+                            confirmButtonText: "Cancel",
+                            allowOutsideClick: false,
+                            allowEscapeKey: false,
+                        })
+                            .then(() => {
+                                off();
+                                // cancel challenge
+                                del("me/challenges/%%", challenge_id)
+                                    .then(ignore)
+                                    .catch(ignore);
+                            })
+                            .catch(() => {
+                                off();
+                            });
+                    }
+
                     active_check();
                 } else {
                     if (this.props.mode === "open") {

--- a/src/global_styl/misc-ui.styl
+++ b/src/global_styl/misc-ui.styl
@@ -108,7 +108,7 @@
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background-color: #333;
+  themed background-color toast-bg;
   opacity: 0.6;
   position: absolute;
   top: 0;

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -137,6 +137,15 @@ export class Play extends React.Component<PlayProperties, any> {
         del("challenges/%%", challenge.challenge_id).then(() => 0).catch(errorAlerter);
     }}}
 
+    cancelActiveLiveChallenges = () => {{{
+        // In theory there should only be one, but cancel them all anyhow...
+        this.state.live_list.forEach((c) => {
+           if (c.user_challenge) {
+               this.cancelOpenChallenge(c);
+           }
+        });
+    }}}
+
     extractUser(challenge) {{{
         return {
             id: challenge.user_id,
@@ -238,6 +247,11 @@ export class Play extends React.Component<PlayProperties, any> {
         return this.state.show_all_challenges && challengeList.length || challengeList.reduce( (prev, current) => {
             return prev || current.eligible || current.user_challenge;
         }, false );
+    }}}
+
+    liveOwnChallengePending = () => {{{
+        let locp = this.state.live_list.some((c) => (c.user_challenge));
+        return locp;
     }}}
 
     render() {
@@ -383,6 +397,24 @@ export class Play extends React.Component<PlayProperties, any> {
                     </div>
                     <div className='automatch-settings'>
                         <button className='danger sm' onClick={this.cancelActiveAutomatch}>{pgettext("Cancel automatch", "Cancel")}</button>
+                    </div>
+                </div>
+            );
+        }
+        else if (this.liveOwnChallengePending()) {
+            return(
+                <div className='automatch-container'>
+                    <div className='automatch-header'>
+                        {_("Waiting for opponent..")}
+                    </div>
+                    <div className='automatch-row-container'>
+                        <div className="spinner">
+                            <div className="double-bounce1"></div>
+                            <div className="double-bounce2"></div>
+                        </div>
+                    </div>
+                    <div className='automatch-settings'>
+                        <button className='danger sm' onClick={this.cancelActiveLiveChallenges}>{pgettext("Cancel challenge", "Cancel")}</button>
                     </div>
                 </div>
             );


### PR DESCRIPTION
@anoek  How about this approach?

It seems to work, simplistically testing. 

I'm not sure what gotchas there are.

I'm not sure what "active_check()" is doing in ChallengeModal - I left it there.

I can see that there is a case in ChallengeModal after the user cancels:

(this.props.mode === "open" ? "challenges/%%" : "me/challenges/%%"),

where I don't know what the false side is for.

That is to say, I cancel the challenge in Play.tsx the same way the "Remove" button does, which always uses challenges/%% not me/challenges/%%

