### PR TITLE
Extended columns for games list

### DIFF
--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -23,6 +23,7 @@ import {termination_socket} from "sockets";
 import {MiniGoban} from "MiniGoban";
 import {GobanLineSummary} from "GobanLineSummary";
 import * as data from "data";
+import {rulesText} from "misc";
 
 interface GameListProps {
     list: Array<any>;
@@ -140,6 +141,78 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                         }
                     });
                     break;
+
+                case '-rules':
+                case 'rules':
+                    lst.sort((a, b) => {
+                        try {
+                            return rulesText(a.rules).localeCompare(rulesText(b.rules));
+                        } catch (e) {
+                            console.error(a, b, e);
+                            return 0;
+                        }
+                    });
+                    break;
+
+                case '-analysis' :
+                case 'analysis' :
+                    lst.sort((a, b) => {
+                        try {
+                            let a_analysis = a.json.disable_analysis;
+                            let b_analysis = b.json.disable_analysis;
+
+                            return a_analysis;
+                        } catch (e) {
+                            console.error(a, b, e);
+                            return 0;
+                        }
+                    });
+                    break;
+
+                case '-ranked' :
+                case 'ranked' :
+                    lst.sort((a, b) => {
+                        try {
+                            let a_ranked = a.json.ranked;
+                            let b_ranked = b.json.ranked;
+
+                            return a_ranked;
+                        } catch (e) {
+                            console.error(a, b, e);
+                            return 0;
+                        }
+                    });
+                    break;
+
+                case '-handicap' :
+                case 'handicap' :
+                    lst.sort((a, b) => {
+                        try {
+                            let a_handicap = a.json.handicap;
+                            let b_handicap = b.json.handicap;
+
+                            return a_handicap - b_handicap;
+                        } catch (e) {
+                            console.error(a, b, e);
+                            return 0;
+                        }
+                    });
+                    break;
+
+                case '-weekendpause' :
+                case 'weekendpause' :
+                    lst.sort((a, b) => {
+                        try {
+                            let a_weekendpause = a.json.pause_on_weekends;
+                            let b_weekendpause = b.json.pause_on_weekends;
+
+                            return a_weekendpause;
+                        } catch (e) {
+                            console.error(a, b, e);
+                            return 0;
+                        }
+                    });
+                    break;
             }
 
             if (this.state.sort_order[0] === '-') {
@@ -159,6 +232,12 @@ export class GameList extends React.PureComponent<GameListProps, any> {
             let clock_sort            = sort_order === 'clock'          ? 'sorted-desc' : sort_order === '-clock'          ? 'sorted-asc' : '';
             let opponent_clock_sort   = sort_order === 'opponent-clock' ? 'sorted-desc' : sort_order === '-opponent-clock' ? 'sorted-asc' : '';
             let size                  = sort_order === 'size'           ? 'sorted-desc' : sort_order === '-size'           ? 'sorted-asc' : '';
+            let columns = preferences.get("extended-columns").reduce((columns, column) => {
+                columns[column] =  sort_order === column ? `${column}-desc` : sort_order === `-${column}` ? 'sorted-asc' : '';
+                return columns;
+              },
+              {}
+            );
 
             return (
                 <div className="GameList GobanLineSummaryContainer">
@@ -170,6 +249,21 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                               <div onClick={this.sortBy("clock")} className={sortable + clock_sort}>{_("Clock")}</div>
                               <div onClick={this.sortBy("opponent-clock")} className={sortable + opponent_clock_sort}>{_("Opponent's Clock")}</div>
                               <div onClick={this.sortBy("size")} className={sortable + size}>{_("Size")}</div>
+                              {columns.rules != undefined &&
+                                <div onClick={this.sortBy("rules")} className={sortable + columns.rules}>{_("Rules")}</div>
+                              }
+                              {columns.analysis != undefined &&
+                                <div onClick={this.sortBy("analysis")} className={sortable + columns.analysis}>{_("Analysis")}</div>
+                              }
+                              {columns.ranked != undefined &&
+                                <div onClick={this.sortBy("ranked")} className={sortable + columns.ranked}>{_("Rank")}</div>
+                              }
+                              {columns.handicap != undefined &&
+                                <div onClick={this.sortBy("handicap")} className={sortable + columns.handicap}>{_("Handicap")}</div>
+                              }
+                              {columns.weekendpause != undefined &&
+                                <div onClick={this.sortBy("weekendpause")} className={sortable + columns.weekendpause}>{_("Pauses on weekends")}</div>
+                              }
                           </div>
                         : <div className="GobanLineSummaryContainerHeader">
                               <div >{pgettext("Game list move number", "Move")}</div>
@@ -190,6 +284,8 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                             gobanref={(goban) => game.goban = goban}
                             width={game.width}
                             height={game.height}
+                            columns={columns}
+                            game={game.json}
                             />)}
                 </div>
             );

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -23,6 +23,7 @@ import * as data from "data";
 import {PersistentElement} from "PersistentElement";
 import {rankString} from "rank_utils";
 import {Player} from "Player";
+import {rulesText} from "misc";
 
 interface GobanLineSummaryProps {
     id: number;
@@ -32,6 +33,8 @@ interface GobanLineSummaryProps {
     gobanref?: (goban:Goban) => void;
     width?: number;
     height?: number;
+    game?: any;
+    columns?: any;
 }
 
 export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any> {
@@ -178,6 +181,21 @@ export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any
                     </div>
                 }
                 <div className="size">{this.props.width + "x" + this.props.height}</div>
+                {this.props.columns.rules != undefined &&
+                  <div className="size">{rulesText(this.props.game.rules)}</div>
+                }
+                {this.props.columns.analysis != undefined &&
+                  <div className="size">{!this.props.game.disable_analysis ? _("Yes") : _("No")}</div>
+                }
+                {this.props.columns.ranked != undefined &&
+                  <div className="size">{this.props.game.ranked ? _("Yes") : _("No")}</div>
+                }
+                {this.props.columns.handicap != undefined &&
+                  <div className="size">{this.props.game.handicap}</div>
+                }
+                {this.props.columns.weekendpause != undefined &&
+                  <div className="size">{this.props.game.pause_on_weekends ? _("Yes") : _("No")}</div>
+                }
             </Link>
         );
     }

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -63,6 +63,7 @@ let defaults = {
     "translation-dialog-dismissed": 0,
     "translation-dialog-never-show": false,
     "unicode-filter": false,
+    "extended-columns": []
 };
 
 defaults['profanity-filter'][current_language] = true;

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -64,6 +64,7 @@ export class Settings extends React.PureComponent<{}, any> {
             email_changed: false,
             email_message: null,
             profanity_filter: Object.keys(preferences.get("profanity-filter")),
+            extended_columns: preferences.get("extended-columns"),
             game_list_threshold: preferences.get("game-list-threshold"),
             autoadvance: preferences.get("auto-advance-after-submit"),
             autoplay_delay: preferences.get("autoplay-delay") / 1000,
@@ -245,6 +246,11 @@ export class Settings extends React.PureComponent<{}, any> {
         Array.prototype.filter.apply(ev.target.options, [x => x.selected]).map(opt => new_profanity_settings[opt.value] = true);
         preferences.set("profanity-filter", new_profanity_settings);
         this.setState({profanity_filter: Object.keys(new_profanity_settings)});
+    }}}
+    updateExtendedColumns = (ev) => {{{
+        const new_extended_columns = Array.prototype.filter.apply(ev.target.options, [x => x.selected]).map(opt => opt.value);
+        preferences.set("extended-columns", new_extended_columns);
+        this.setState({extended_columns: new_extended_columns});
     }}}
     setAutoAdvance = (ev) => {{{
         preferences.set("auto-advance-after-submit", ev.target.checked),
@@ -455,6 +461,17 @@ export class Settings extends React.PureComponent<{}, any> {
                                     {Object.keys(languages).filter(lang => lang in profanity_regex).map((lang) => (
                                         <option key={lang} value={lang}>{languages[lang]}</option>
                                     ))}
+                                </select>
+                            </dd>
+
+                            <dt>{_("Extended columns")}</dt>
+                            <dd>
+                                <select multiple onChange={this.updateExtendedColumns} value={this.state.extended_columns} >
+                                  <option key="rules" value="rules">{_('Rules')}</option>
+                                  <option key="analysis" value="analysis">{_('Analysis')}</option>
+                                  <option key="ranked" value="ranked">{_('Rank')}</option>
+                                  <option key="handicap" value="handicap">{_('Handicap')}</option>
+                                  <option key="weekendpause" value="weekendpause">{_('Pauses on weekends')}</option>
                                 </select>
                             </dd>
 


### PR DESCRIPTION
I noticed that each Friday I want to know which games have the pause on weekends enabled.
Also, time to time I'm interested in some additional information like if the analysis is enabled or which games are ranked.
So I decided it will be useful for a user to be able to configure which columns should be shown on the overview page when games are represented as a table.

Note: at the moment it's more like proof of concept.