### PR TITLE
Add semi-transparent, non-gray shadow to message box

### DIFF
--- a/src/lib/ogs-goban/Goban.styl
+++ b/src/lib/ogs-goban/Goban.styl
@@ -82,7 +82,7 @@
 
     .GobanMessage table td div {
         border-radius: 3px;
-        box-shadow: 5px 5px 3px #888888;
+        box-shadow: 5px 5px 3px rgba(0, 0, 0, 0.26);
         color: #FF5500;
         background-color: #262626;
         padding: .3em;


### PR DESCRIPTION
The gray shadow in the "Loading..." (and other messages) has bugged me, since it's lighter than the thing casting the shadow, and solid. This makes it a semi-transparent, dark shadow.
It's super minor and doesn't affect any functionality, but it's something that I've noticed for a while and I decided to finally do something about it. 😄 