### PR TITLE
Fix logic around play buttons in analysis disabled mode (fixes #643)

### DIFF
--- a/src/lib/goban.ts
+++ b/src/lib/goban.ts
@@ -42,6 +42,21 @@ export class Goban extends OGSGoban {
         };
     }
 
+    showNext(dont_update_display?) {
+        /* This is a workaround for a bug (?) in ogs-goban where a showNext to the
+           lastOfficialMove plus 1 does not set move_selected.  But at least in
+           analysis disabled mode, you would expect to be able to submit that move
+           Easiest thing is to just not let them "next" forwards to a previously submitted
+           speculative move that they went back from.  The (?) is because ogs-goban doesn't
+           know about isAnalysisDisabled, so how does it know whether to set move_selected?
+           Meanwhile, sidestep the issue :)
+         */
+        if (this.isAnalysisDisabled() && this.isLastOfficialMove()) {
+            return;
+        }
+        super.showNext(dont_update_display);
+    }
+
     getClockDrift() {
         return get_clock_drift();
     }

--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -3516,7 +3516,7 @@ export abstract class Goban extends TypedEventEmitter<Events> {
         this.engine.setLastOfficialMove();
         this.updateTitleAndStonePlacement();
     } /* }}} */
-    public isLastOfficialMove() { /* {{{ */
+    protected isLastOfficialMove() { /* {{{ */
         return this.engine.isLastOfficialMove();
     } /* }}} */
 

--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -3436,6 +3436,7 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                 this.followConditionalPath(prev_path);
             }
         } else {
+            this.setSubmit(null); // once you go back, you can't be submitting, the Pass button should show.
             if (this.move_selected) {
                 this.jumpToLastOfficialMove();
                 return;

--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -3516,7 +3516,7 @@ export abstract class Goban extends TypedEventEmitter<Events> {
         this.engine.setLastOfficialMove();
         this.updateTitleAndStonePlacement();
     } /* }}} */
-    private isLastOfficialMove() { /* {{{ */
+    public isLastOfficialMove() { /* {{{ */
         return this.engine.isLastOfficialMove();
     } /* }}} */
 

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -578,26 +578,13 @@ export class Game extends React.PureComponent<GameProperties, any> {
         this.goban.showPrevious();
         this.goban.syncReviewMove();
     }}}
-    /* This is a workaround for a bug (?) in ogs-goban where a showNext to the
-       lastOfficialMove plus 1 does not set move_selected.  But at least in
-       analysis disabled mode, you would expect to be able to submit that move
-       Easiest thing is to just not let them "next" forwards to a previously submitted
-       speculative move that they went back from.  The (?) is because ogs-goban doesn't
-       know about analysis mode, so how does it know to set move_selected? Meanwhile,
-       sidestep the issue :)
-     */
-    goban_show_next() {{{
-        if (!(this.goban.isAnalysisDisabled() && this.goban.isLastOfficialMove())) {
-            this.goban.showNext();
-        }
-    }}}
     nav_next(event?: React.MouseEvent<any>, dont_stop_autoplay?: boolean) {{{
         let last_estimate_move = this.stopEstimatingScore();
         if (!dont_stop_autoplay) {
             this.stopAutoplay();
         }
         this.checkAndEnterAnalysis(last_estimate_move);
-        this.goban_show_next();
+        this.goban.showNext();
         this.goban.syncReviewMove();
     }}}
     nav_next_10() {{{
@@ -605,7 +592,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
         this.stopAutoplay();
         this.checkAndEnterAnalysis(last_estimate_move);
         for (let i = 0; i < 10; ++i) {
-            this.goban_show_next();
+            this.goban.showNext();
         }
         this.goban.syncReviewMove();
     }}}

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -578,13 +578,26 @@ export class Game extends React.PureComponent<GameProperties, any> {
         this.goban.showPrevious();
         this.goban.syncReviewMove();
     }}}
+    /* This is a workaround for a bug (?) in ogs-goban where a showNext to the
+       lastOfficialMove plus 1 does not set move_selected.  But at least in
+       analysis disabled mode, you would expect to be able to submit that move
+       Easiest thing is to just not let them "next" forwards to a previously submitted
+       speculative move that they went back from.  The (?) is because ogs-goban doesn't
+       know about analysis mode, so how does it know to set move_selected? Meanwhile,
+       sidestep the issue :)
+     */
+    goban_show_next() {{{
+        if (!(this.goban.isAnalysisDisabled() && this.goban.isLastOfficialMove())) {
+            this.goban.showNext();
+        }
+    }}}
     nav_next(event?: React.MouseEvent<any>, dont_stop_autoplay?: boolean) {{{
         let last_estimate_move = this.stopEstimatingScore();
         if (!dont_stop_autoplay) {
             this.stopAutoplay();
         }
         this.checkAndEnterAnalysis(last_estimate_move);
-        this.goban.showNext();
+        this.goban_show_next();
         this.goban.syncReviewMove();
     }}}
     nav_next_10() {{{
@@ -592,7 +605,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
         this.stopAutoplay();
         this.checkAndEnterAnalysis(last_estimate_move);
         for (let i = 0; i < 10; ++i) {
-            this.goban.showNext();
+            this.goban_show_next();
         }
         this.goban.syncReviewMove();
     }}}


### PR DESCRIPTION
There were two underlying problem here.

The first is easy: when you go back from placing a stone speculatively on the board, you should get the pass button back again, so setSubmit(null) needs to be called in showPrevious(), so that we tell the Game to not display the Submit button.

The second is not so easy: when you go forwards again, you would want to be able to Submit that stone.  But - goban does not update move_selected when you go from the LastOfficialMove to the next move past that.  And I'm not sure this would always be correct.   It's correct in disabledAnalysis mode, but maybe not others.   And goban doesn't know about that.  Can of worms.

Therefore, the second part of this fix is that if you go back from a speculative placement, you've lost it.  If you want it back, you have to place it again: you can't go forwards past LastOfficialMove with the showNext() in disabledAnalysis mode.   This seems solid, and not too bad experience.
