### PR TITLE
Add a setting to show/hide the tournament indicator

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -35,6 +35,7 @@ import {TournamentIndicator} from "Announcements";
 import {FriendIndicator} from "FriendList";
 import {Player} from "Player";
 import * as player_cache from "player_cache";
+import * as preferences from "preferences";
 
 let body = $(document.body);
 
@@ -298,7 +299,7 @@ export class NavBar extends React.PureComponent<{}, any> {
                 :
                 <section className="right">
                     <IncidentReportTracker />
-                    <TournamentIndicator />
+                    { preferences.get("show-tournament-indicator") && <TournamentIndicator /> }
                     <FriendIndicator />
                     <TurnIndicator />
                     <span className="icon-container" onClick={this.toggleRightNav}>

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -64,6 +64,7 @@ let defaults = {
     "translation-dialog-dismissed": 0,
     "translation-dialog-never-show": false,
     "unicode-filter": false,
+    "show-tournament-indicator": true,
 };
 
 defaults['profanity-filter'][current_language] = true;

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -78,6 +78,7 @@ export class Settings extends React.PureComponent<{}, any> {
             board_labeling: preferences.get("board-labeling"),
             translation_dialog_never_show: preferences.get("translation-dialog-never-show"),
             dock_delay: preferences.get("dock-delay"),
+            show_tournament_indicator: preferences.get("show-tournament-indicator"),
         };
     }
 
@@ -266,6 +267,10 @@ export class Settings extends React.PureComponent<{}, any> {
     setShowOfflineFriends = (ev) => {{{
         preferences.set("show-offline-friends", ev.target.checked),
         this.setState({show_offline_friends: preferences.get("show-offline-friends")});
+    }}}
+    setShowTournamentIndicator = (ev) => {{{
+        preferences.set("show-tournament-indicator", ev.target.checked),
+        this.setState({show_tournament_indicator: preferences.get("show-tournament-indicator")});
     }}}
     setUnicodeFilterUsernames = (ev) => {{{
         preferences.set("unicode-filter", ev.target.checked),
@@ -522,6 +527,11 @@ export class Settings extends React.PureComponent<{}, any> {
                                     </label>
                                 </dd>
                             }
+
+                            <dt><label htmlFor="show-tournament-indicator">{_("Show tournament indicator")}</label></dt>
+                            <dd>
+                                <input id="show-tournament-indicator" type="checkbox" checked={this.state.show_tournament_indicator} onChange={this.setShowTournamentIndicator} />
+                            </dd>
                         </dl>
                     </Card>
 


### PR DESCRIPTION
## Add a general setting to show/hide the tournament indicator in the nav bar.

I never play tournaments and the tournament countdown in the top right gives me a little anxiety every time I look at it.

![image](https://user-images.githubusercontent.com/337627/40285749-8c00bae6-5c54-11e8-8fd3-6bb87e3eda3d.png)


What about a setting to toggle the indicator on/off? It would look like this:

![image](https://user-images.githubusercontent.com/337627/40285722-43f4da7a-5c54-11e8-98df-6610a23861ba.png)

By default the tournament indicator is shown, but you can disable it if you really want to.
