### PR TITLE
Adds left padding to items in navbar's drawer

### DIFF
--- a/src/components/NavBar/NavBar.styl
+++ b/src/components/NavBar/NavBar.styl
@@ -206,6 +206,7 @@ navbar-width= 17rem;
             list-style-type: none;
             list-style: none;
             padding: 0;
+            padding-left: 0.75em;
             vertical-align: top;
             width: 100%;
         }


### PR DESCRIPTION
Adds left padding to items in navbar's drawer. Please see the red and green bars in the image below to see the change in padding.

![add_padding](https://user-images.githubusercontent.com/19355185/43985284-1eb6c6ae-9cd4-11e8-8952-f63cb4831893.png)
