### PR TITLE
Added the PWA service worker.

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -194,6 +194,25 @@ browserHistory.listen(location => {
 
 });
 
+/*** Progressive Web App ***/
+
+try {
+  // This API is available only over HTTPS.
+  navigator.serviceWorker.register('/pwa.js').then(
+    res => console.log('PWA handler registered.'),
+    err => console.warn('PWA registration failed:', err));
+
+  let deferredPrompt;
+
+  window.addEventListener('beforeinstallprompt', e => {
+    console.log('Got the PWA beforeinstallprompt event.');
+    e.preventDefault();
+    // Now we can invoke e.prompt(), but Chrome already has
+    // the Install PWA button in the settings.
+  });
+} catch (err) {
+  console.warn('PWA registration failed:', err);
+}
 
 /*** Some finial initializations ***/
 init_tabcomplete();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -202,8 +202,6 @@ try {
     res => console.log('PWA handler registered.'),
     err => console.warn('PWA registration failed:', err));
 
-  let deferredPrompt;
-
   window.addEventListener('beforeinstallprompt', e => {
     console.log('Got the PWA beforeinstallprompt event.');
     e.preventDefault();

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+self.addEventListener('fetch', () => {});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = {
     mode: production ? 'production' : 'development',
     entry: {
         'ogs': './src/main.tsx',
+        'pwa': './src/pwa.ts',
     },
     resolve: {
         modules: [


### PR DESCRIPTION
Given that /manifest.json is already
served by OGS, we only need to add
this dummy service worker to enable
the Install PWA button in the Chrome's
settings.

Important note for testing: PWAs work
only over HTTPS with a valid cert or
from localhost.