### PR TITLE
A better rule for detecting troublesome time settings

### DIFF
--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -19,8 +19,6 @@ import * as data from "data";
 import {_, pgettext, interpolate} from "translate";
 import {TimeControl, TimeControlTypes} from "./TimeControl";
 
-const QUESTIONABLE_SECONDS_PER_MOVE = 5;  // less than this gets alerted to players about to accept
-
 const times = [ /* {{{ */
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12,
     15, 20, 25, 30, 35, 40, 45, 50, 55, 60,
@@ -408,27 +406,42 @@ export function shortShortTimeControl(time_control) { /* {{{ */
     }
 }  /* }}} */
 
+const QUESTIONABLE_SECONDS_PER_MOVE = 4;  // less than this gets flagged as may be cheaty.
+const QUESTIONABLE_ABSOLUTE_TIME = 900; // Arguably absolute time cheaters don't use > 10 min.  I've seen reports complaining about abuse at 10min though, so set this a bit higher.
+
 export function usedForCheating(time_control) {
     if (typeof(time_control) !== "object" || time_control === null) {
         return false;
     }
 
+    // either there has to be enough time for the whole game or
+    // a sensible ongoing per-move allocation
     switch (time_control.system || time_control.time_control) {
 
         case "simple":
             return time_control.per_move < QUESTIONABLE_SECONDS_PER_MOVE;
 
         case "absolute":
-            return time_control.total_time <= 900; // Arguably absolute time cheaters don't use > 10 min.  I've seen reports complaining about abuse at 10min though, so set this a bit higher.
+            return time_control.total_time <= QUESTIONABLE_ABSOLUTE_TIME;
 
         case "canadian":
-            return time_control.main_time < QUESTIONABLE_SECONDS_PER_MOVE && time_control.period_time / time_control.stones_per_period < QUESTIONABLE_SECONDS_PER_MOVE;
+            return !(
+                time_control.main_time > QUESTIONABLE_ABSOLUTE_TIME ||
+                time_control.period_time / time_control.stones_per_period > QUESTIONABLE_SECONDS_PER_MOVE
+            );
 
         case "byoyomi":
-            return time_control.main_time < QUESTIONABLE_SECONDS_PER_MOVE && time_control.period_time < QUESTIONABLE_SECONDS_PER_MOVE;
+            return !(
+                time_control.main_time > QUESTIONABLE_ABSOLUTE_TIME ||
+                time_control.period_time > QUESTIONABLE_SECONDS_PER_MOVE
+            );
 
-        // haven't seen silliness, not sure about sensible criteria
         case "fischer":
+            return !(
+                time_control.initial_time > QUESTIONABLE_ABSOLUTE_TIME ||
+                time_control.time_increment > QUESTIONABLE_SECONDS_PER_MOVE
+            );
+
         case "none":
         default:
             return false;


### PR DESCRIPTION
Either there has to be enough time for a game, or enough time for each move ongoing.