### PR TITLE
Stop firefox from collapsing editable quick chat lines (fixes #724)

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -530,8 +530,12 @@ goban-view-bar-width=400px
     }
 }
 
-
-
+.chat-container {
+    /* Prevent silly Firefox from collapsing empty editable lines */
+    .qc-option[contenteditable=true]{
+        min-height: 1 em;
+    }
+}
 
 .ad.large-rectangle,
 .ad.medium-rectangle,


### PR DESCRIPTION
As per #724

AdamR identified what was going on - nice work.

Idea for solution found here

https://bugzilla.mozilla.org/show_bug.cgi?id=1098151

