### PR TITLE
fix handicap stone color bug

### DIFF
--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -2312,7 +2312,8 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                         color = this.edit_color === "black" ? 2 : 1;
                     }
                 }
-                else if (this.move_selected) {
+                else if (this.move_selected && this.engine.handicapMovesLeft() <= 0) {
+
                     color = this.engine.otherPlayer();
                 }
                 else if (this.mode === "puzzle") {
@@ -2764,7 +2765,7 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                 else if (this.mode === "edit" || (this.mode === "analyze" && this.analyze_tool === "stone" && this.analyze_subtool !== "alternate")) {
                     color = this.edit_color === "black" ? 1 : 2;
                 }
-                else if (this.move_selected) {
+                else if (this.move_selected && this.engine.handicapMovesLeft() <= 0) {
                     color = this.engine.otherPlayer();
                 }
                 else {

--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -2312,9 +2312,12 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                         color = this.edit_color === "black" ? 2 : 1;
                     }
                 }
-                else if (this.move_selected && this.engine.handicapMovesLeft() <= 0) {
-
-                    color = this.engine.otherPlayer();
+                else if (this.move_selected) {
+                    if (this.engine.handicapMovesLeft() <= 0) {
+                        color = this.engine.otherPlayer();
+                    }   else {
+                            color = this.engine.player;
+                    }
                 }
                 else if (this.mode === "puzzle") {
                     if (this.getPuzzlePlacementSetting) {
@@ -2765,8 +2768,12 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                 else if (this.mode === "edit" || (this.mode === "analyze" && this.analyze_tool === "stone" && this.analyze_subtool !== "alternate")) {
                     color = this.edit_color === "black" ? 1 : 2;
                 }
-                else if (this.move_selected && this.engine.handicapMovesLeft() <= 0) {
-                    color = this.engine.otherPlayer();
+                else if (this.move_selected) {
+                    if (this.engine.handicapMovesLeft() <= 0) {
+                        color = this.engine.otherPlayer();
+                    }   else {
+                            color = this.engine.player;
+                    }
                 }
                 else {
                     color = this.engine.player;


### PR DESCRIPTION
Fixes #727. 

It looks like after placing a stone but before submitting it, `this.engine` refers to the game tree updated with this new move. 

Because of this, `this.engine.otherPlayer()` will actually refer to the current player after a stone has been placed but before submitted. However, if there are handicap stones left to place, the engine will know this and `this.engine.otherPlayer()` will now refer to the actual other player. So I have added an if-statement that checks if there are handicap moves left and if so sets color to `this.engine.player`. 