### PR TITLE
Change player color names+order : nigiri - strength

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -128,7 +128,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
             initialized: false,
             min_ranking: 5,
             max_ranking: 36,
-            challenger_color: "automatic",
+            challenger_color: "random",
             game: {
                 name: "",
                 rules: "japanese",
@@ -858,10 +858,10 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                     <div className="controls">
                         <div className="checkbox">
                             <select value={this.state.challenge.challenger_color} onChange={this.update_challenge_color} id="challenge-color" className="challenge-dropdown form-control">
-                                <option value="automatic">{_("Automatic")}</option>
+                                <option value="random">{_("Nigiri")}</option>                                
+                                <option value="automatic">{_("Strength")}</option>
                                 <option value="black">{_("Black")}</option>
                                 <option value="white">{_("White")}</option>
-                                <option value="random">{_("Random")}</option>
                             </select>
                         </div>
                     </div>
@@ -1166,7 +1166,7 @@ export let blitz_config = { /* {{{ */
         restrict_rank: true,
     },
     challenge: {
-        challenger_color: "automatic",
+        challenger_color: "random",
         game: {
             name: "",
             rules: "japanese",
@@ -1192,7 +1192,7 @@ export let live_config = { /* {{{ */
         restrict_rank: true,
     },
     challenge: {
-        challenger_color: "automatic",
+        challenger_color: "random",
         game: {
             name: "",
             rules: "japanese",
@@ -1218,7 +1218,7 @@ export let correspondence_config = { /* {{{ */
         restrict_rank: true,
     },
     challenge: {
-        challenger_color: "automatic",
+        challenger_color: "random",
         game: {
             name: "",
             rules: "japanese",

--- a/src/components/GameAcceptModal/GameAcceptModal.tsx
+++ b/src/components/GameAcceptModal/GameAcceptModal.tsx
@@ -70,8 +70,8 @@ export class GameAcceptModal extends Modal<Events, GameAcceptModalProperties, {}
 
         if (challenge.challenger_color === "black")          { player_color = _("White");     }
         else if (challenge.challenger_color === "white")     { player_color = _("Black");     }
-        else if (challenge.challenger_color === "automatic") { player_color = _("Automatic"); }
-        else if (challenge.challenger_color === "random")    { player_color = _("Random");    }
+        else if (challenge.challenger_color === "random")    { player_color = _("Nigiri");    }
+        else if (challenge.challenger_color === "automatic") { player_color = _("Strength"); }
 
         return (
           <div className="Modal GameAcceptModal" ref="modal">


### PR DESCRIPTION
hi :smiley: 

so since i started go i noticed i was almost always forced to pick black color, due to the current "automatic" mode giving white to the strongest player

but there are some issues with that !

## 1) (winrate fairness)

this default behaviour made sense in the past in the pre-komi era, but now all bots agree that white has a higher win chance with komi 

this is especially true for beginners who find the 9x9 5.5 komi impossible to overcome, and hate having black

## 2) (diversity)

also, i got too used to playing black and almost never got the opportunity to learn how it feels to play as white, since i was never playing as black (it's important to learn how different you have to play depending on your color, white generally tries to simplify the game, which is easier for the strongest player btw)

## 3)  (clearer names)

and, simply when creating a custom challenge, the "automatic" name feels to the average user like a thing that should not be replaced, so i suggested to modify them with these new names
Color names : 

- Automatic -> Strength
- Random -> Nigiri

Most go players are familiar with the name "nigiri" rather (just like "komi", "ko", "hoshi", "komoku", "sente", etc...) , and if not it's easy to google it

Also, "Strength" is something more intuitive to understand, and it's also true for handicap (strongest player will get white color which has no handicap stones)


## 4) (tournaments)

finally, recently i set up the OGS AI tournament, and i noticed the higher ranked player almost always gets white, which is not desirable for game diversity and enjoyment 

ultimately, i would like a color setting under the rules setting in tournaments (nigiri/strength , adding black/white doesnt make sense since there are many players)

So this is what motivates me to create this PR

i tested this new branch on dev:880 and it works as intended

- nigiri is now shown first in challenge creation (not strength which is now in 2nd position)
- nigiri is the default color for automatch (see handicap notes below)
- Nigiri = "random" color
- Strength = "automatic" color
- when starting a game with "nigiri", arround half of the games between player A and B are black color, and half are white color

if we are not sure about it, we can start just with showing the color setting nigiri first, to see the people's feedback, but keeping automatic color as the default for automatch

see : 

![nigiri1](https://user-images.githubusercontent.com/38690718/51108855-b43e8a00-17f3-11e9-8f8a-6b73e1b1a01d.png)
![nigiri2](https://user-images.githubusercontent.com/38690718/51108853-b43e8a00-17f3-11e9-9a0a-7652d5949895.png)

## notes : 

the expected change is that auto handicap is now broken (i didnt it yet, but i assume it is possible that the strongest player can be given

@anoek @GreenAsJade @schambers 