### PR TITLE
Fix mid-word line breaks in PaginatedTables

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -35,7 +35,6 @@
 
     .name, .player {
         word-wrap: break-word;
-        word-break: break-all;
         white-space: normal;
     }
 


### PR DESCRIPTION
Lines frequently broke mid-word on pages like /groups and /puzzles. This was due
to the word-break property being set to break-all. This commit fixes the issue
by removing the setting of this property. word-wrap is still set to break-word,
so extremely long words should still break.