### PR TITLE
Added option to turn off countdown in main time for byo-yomi and canadian

### DIFF
--- a/src/lib/goban.ts
+++ b/src/lib/goban.ts
@@ -54,8 +54,20 @@ export class Goban extends OGSGoban {
         return window.location.pathname;
     }
 
-    protected getShouldPlayVoiceCountdown():boolean {
-        return preferences.get("sound-voice-countdown");
+    protected getShouldPlayVoiceCountdown(timing_type: string, in_overtime: boolean):boolean {
+        // Don't play voice countdown in byo-yomi or canadian main time unless they really asked for it.
+
+        if (preferences.get("sound-voice-countdown")) {
+            if (timing_type === "byo-yomi" || timing_type === "canadian") {
+                if (preferences.get("sound-voice-countdown-main") || in_overtime) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+
+        }
+        return false;
     }
 
     protected getCoordinateDisplaySystem():'A1'|'1-1' {{{

--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -4237,10 +4237,14 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                 clock_div = clock_div.children(".full-time");
             }
 
+            // Prepare to be able to not-play the voice countdown in main time of byo-yomi
+            let timing_type = null;
+            let in_overtime = false;
 
             if (typeof(time) === "object") {
                 ms = (base_time + (time.thinking_time) * 1000) - now;
                 if ("moves_left" in time) { /* canadian */
+                    timing_type = "canadian";
                     if ("block_time" in time) {
                         if (time.moves_left) {
                             time_suffix = "<span class='time_suffix'> + " + shortDurationString(time.block_time) + "/" + time.moves_left + "</span>";
@@ -4269,9 +4273,11 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                     }
                 }
                 if ("periods" in time) { /* byo yomi */
+                    timing_type = 'byo-yomi';
                     let period_offset = 0;
                     if (ms < 0 || time.thinking_time === 0) {
                         if (overtime_parent_div) {
+                            in_overtime = true;
                             overtime_parent_div.addClass("in-overtime");
                         }
 
@@ -4372,7 +4378,8 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                             if (this.last_sound_played !== sound_to_play) {
                                 this.last_sound_played = sound_to_play;
 
-                                if (this.getShouldPlayVoiceCountdown()) {
+                                if (this.getShouldPlayVoiceCountdown(timing_type, in_overtime)) {
+                                    //console.log("Playing sound", sound_to_play);
                                     sfx.play(sound_to_play);
                                 }
                             }
@@ -4597,7 +4604,7 @@ export abstract class Goban extends TypedEventEmitter<Events> {
 
         return ret;
     } /* }}} */
-    protected getShouldPlayVoiceCountdown():boolean {{{
+    protected getShouldPlayVoiceCountdown(timing_type: string, in_overtime: boolean):boolean {{{
         return false;
     }}}
     /**

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -59,6 +59,7 @@ let defaults = {
     "show-variation-move-numbers": false,
     "sound-enabled": true,
     "sound-voice-countdown": true,
+    "sound-voice-countdown-main" : false,
     "sound-volume": 0.5,
     "supporter.currency": "auto",
     "supporter.interval": "month",

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -57,6 +57,7 @@ export class Settings extends React.PureComponent<{}, any> {
             volume: preferences.get("sound-volume"),
             automatch_alert_volume: preferences.get("automatch-alert-volume"),
             voice_countdown: preferences.get("sound-voice-countdown"),
+            voice_countdown_main: preferences.get("sound-voice-countdown-main"),
             sound_enabled: preferences.get("sound-enabled"),
             live_submit_mode: this.getSubmitMode("live"),
             corr_submit_mode: this.getSubmitMode("correspondence"),
@@ -172,6 +173,12 @@ export class Settings extends React.PureComponent<{}, any> {
         preferences.set("sound-voice-countdown", ev.target.checked);
         this.setState({"voice_countdown": ev.target.checked});
     }}}
+
+    setVoiceCountdownMain = (ev) => {{{
+        preferences.set("sound-voice-countdown-main", ev.target.checked);
+        this.setState({"voice_countdown_main": ev.target.checked});
+    }}}
+
     toggleVolume = (ev) => {{{
         this._setVolume(this.state.volume > 0 ? 0 : 0.5);
     }}}
@@ -601,8 +608,12 @@ export class Settings extends React.PureComponent<{}, any> {
                                         : interpolate(_("{{number_of}} seconds"), { number_of:  this.state.dock_delay}) /* translators: Indicates the number of seconds to delay the slide out of the panel of game buttons on the right side of the game page */
                                 }</span>
                             </dd>
+
                             <dt><label htmlFor="voice-countdown">{_("Voice countdown")}</label></dt>
                             <dd><input type="checkbox" id="voice-countdown" checked={this.state.voice_countdown} onChange={this.setVoiceCountdown}/></dd>
+                            <dt><label htmlFor="voice-countdown-main">{_("Voice countdown on main time")}</label></dt>
+                            <dd><input type="checkbox" id="voice-countdown-main" checked={this.state.voice_countdown_main} onChange={this.setVoiceCountdownMain}/></dd>
+
                             <dt>{_("Board labeling")}</dt>
                             <dd>
                                 <select value={this.state.board_labeling} onChange={this.setBoardLabeling}>


### PR DESCRIPTION
As recently discussed, and comes up from time to time, it irritates some players to have voice countdown during main time for Byo-yomi and Canadian.

So here is an option to turn that off. 

Because Dwyrin and Collosiuss both complained about this, and they are not great setters-of-settings, I have made it the default to have it turned off, so they get to experience the change for good without effort on their part.
