### PR TITLE
Better challenge cheat warnings

### DIFF
--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -136,9 +136,9 @@
         i {
             padding-right: 0.25rem;
         }
-    } 
+    }
 
-    .automatch-settings-corr { 
+    .automatch-settings-corr {
         flex: 0;
         text-align: justify;
         font-size: 1rem;
@@ -210,12 +210,6 @@
         cursor: help;
     }
 
-    .cheat-alert {
-        color: chocolate;
-        margin-left: 1em;
-        cursor: help;
-    }
-
     // Flex to escape from the table
     .custom-games-list-header-row {
         display: flex;
@@ -240,14 +234,44 @@
         }
         .head.time-control-header {
             padding-left: 4em;
-            text-align: left;    
+            text-align: left;
         }
-        
+
         .cell {
             padding-left: 0.5em;
             display: table-cell;
             text-align: left;
+            position: relative;
         }
+
+        .cheat-alert {
+            color: chocolate;
+            margin-left: 1em;
+            cursor: help;
+        }
+
+        .cell .cheat-alert-tooltiptext {
+            visibility: hidden;
+            background-color: chocolate;
+            color: #fff;
+            text-align: center;
+            border-radius: 6px;
+            padding: 5px;
+
+            /* Position the tooltip */
+            position: absolute;
+            z-index: 1;
+            bottom: 1em;
+            left: 75%;
+
+            width: 10em;
+            white-space: normal;
+        }
+
+        .cell:hover .cheat-alert-tooltiptext {
+            visibility: visible;
+        }
+
         .break {
             border-top: 1px solid #888;
             border-bottom: 1px solid #888;

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -37,7 +37,6 @@ import {bot_count} from "bots";
 import {SupporterGoals} from "SupporterGoals";
 import {boundedRankString} from "rank_utils";
 import * as player_cache from "player_cache";
-import { join } from "path";
 
 const CHALLENGE_LIST_FREEZE_PERIOD = 1000; // Freeze challenge list for this period while they move their mouse on it
 
@@ -605,7 +604,7 @@ export class Play extends React.Component<PlayProperties, any> {
                             {(C.user_challenge || null) && <button onClick={this.cancelOpenChallenge.bind(this, C)} className="btn reject xs">{_("Remove")}</button>}
 
                             { /* Mark eligible suspect games with a warning icon and warning explanation popup.
-                                 We do let user's see the warning for their own challenges. */
+                                 We do let users see the warning for their own challenges. */
                                 (((C.eligible || C.user_challenge) && !C.removed) &&
                                  (C.komi ||
                                   usedForCheating(C.time_control_parameters) ||


### PR DESCRIPTION
Folk are still missing the warning that they are joining a game with tricky settings.

This change:

1) Moves the warning triangle icon over next to the accept button
2) Causes a popup as they mouse over the cell with the button in it, so they can't press the button without seeing the warning details popup.

![Screenshot 2019-06-10 00 30 28](https://user-images.githubusercontent.com/61894/59160655-66fee400-8b17-11e9-8385-d8eb365419af.png)
