### PR TITLE
Always save a volume setting change

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1569,6 +1569,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
     }
     setVolume = (ev) => {
         this._setVolume(parseFloat(ev.target.value));
+        this.saveVolume();
     }
     _setVolume(volume) {
         let enabled = volume > 0;
@@ -2414,7 +2415,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     /> <input type="range"
                         onChange={this.setVolume}
                         value={this.state.volume} min={0} max={1.0} step={0.01}
-                    /> <i className="fa fa-save" onClick={this.saveVolume} style={{cursor: "pointer"}}/>
+                    />
                 </a>
 
                 <a onClick={this.toggleZenMode}><i className="ogs-zen-mode"></i> {_("Zen mode")}</a>


### PR DESCRIPTION
Background: whenever Dwyrin plays on OGS he opens the settings and turns down the volume.

Sometimes he mutters about how it's always too loud.

Although I have mentioned it, he doesn't seem to catch on that you can save the setting using the archaic "save" icon.

So that got me thinking "Why do we need a save option?  Why would you change it and _not_ want it to persist".

Hence this PR: just persist the volume setting.
