### PR TITLE
fix cheat-alert alignment style issue

### DIFF
--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -246,8 +246,11 @@
 
         .cheat-alert {
             color: chocolate;
-            margin-left: 1em;
             cursor: help;
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            margin-left: .5em;
         }
 
         .cell .cheat-alert-tooltiptext {


### PR DESCRIPTION
Fixes  #845 by changing some styles on the cheat-alert class. See screenshot below.

![Screenshot from 2019-07-25 11-39-48](https://user-images.githubusercontent.com/35127144/61892284-0e21ba00-aed1-11e9-82e4-12c4a7c5cb06.png)
