### PR TITLE
Add chat window to group view

### DIFF
--- a/src/views/Group/Group.styl
+++ b/src/views/Group/Group.styl
@@ -88,4 +88,14 @@
     button {
         margin: 0 0.5rem 1rem 0;
     }
+
+    .EmbeddedChat {
+        flex-shrink: 0;
+        flex-grow: 1;
+        min-width: 15rem;
+        flex-basis: 15rem;
+        overflow: hidden;
+        .Chat {
+        }
+    }
 }

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -609,7 +609,7 @@ export class Group extends React.PureComponent<GroupProperties, any> {
                     }
 
                     {((!group.hide_details || group.is_member ) || null) && <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />}
-                    
+
                     <Card>
                         {(group.has_tournament_records || null) &&
                             <div>

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -37,6 +37,7 @@ import * as moment from "moment";
 import {PlayerAutocomplete} from "PlayerAutocomplete";
 import {EmbeddedChat} from "Chat";
 
+
 declare var swal;
 
 interface GroupProperties {
@@ -607,8 +608,8 @@ export class Group extends React.PureComponent<GroupProperties, any> {
                         </Card>
                     }
 
-                    <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />
-
+                    {((!group.hide_details || group.is_member ) || null) && <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />}
+                    
                     <Card>
                         {(group.has_tournament_records || null) &&
                             <div>

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -607,7 +607,7 @@ export class Group extends React.PureComponent<GroupProperties, any> {
                         </Card>
                     }
 
-		    <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />
+                    <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />
 
                     <Card>
                         {(group.has_tournament_records || null) &&

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -35,7 +35,7 @@ import * as Dropzone from "react-dropzone";
 import {image_resizer} from "image_resizer";
 import * as moment from "moment";
 import {PlayerAutocomplete} from "PlayerAutocomplete";
-
+import {EmbeddedChat} from "Chat";
 
 declare var swal;
 
@@ -607,6 +607,7 @@ export class Group extends React.PureComponent<GroupProperties, any> {
                         </Card>
                     }
 
+		    <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />
 
                     <Card>
                         {(group.has_tournament_records || null) &&

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -608,7 +608,7 @@ export class Group extends React.PureComponent<GroupProperties, any> {
                         </Card>
                     }
 
-                    {((!group.hide_details || group.is_member ) || null) && <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />}
+                    {(((group.is_public && !group.hide_details) || group.is_member ) || null) && <EmbeddedChat channel={`group-${this.state.group.id}`} updateTitle={false} />}
 
                     <Card>
                         {(group.has_tournament_records || null) &&


### PR DESCRIPTION
At the moment, the group chat is only accessible in the chat view. Adding a chat window to the group page could increase the usage of group chats and increase the activity of users within groups.

This pull request adds an EmbeddedChat window to the group page. 

It is basically a copy and paste of the implementation on the tournament page.

<details>
<summary>Screenshots</summary>
<img src=https://user-images.githubusercontent.com/4864182/62082942-145bc180-b256-11e9-80d3-ffdf93475197.png>
<!---![image](https://user-images.githubusercontent.com/4864182/62082942-145bc180-b256-11e9-80d3-ffdf93475197.png)--->
<img src=https://user-images.githubusercontent.com/4864182/62083333-fb074500-b256-11e9-8dfe-65d8701044f8.png>
<!---![image](https://user-images.githubusercontent.com/4864182/62083333-fb074500-b256-11e9-8dfe-65d8701044f8.png)--->
</details>