### PR TITLE
Fix for incorrect custom handicap warning

### DIFF
--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -609,7 +609,7 @@ export class Play extends React.Component<PlayProperties, any> {
                                 (((C.eligible || C.user_challenge) && !C.removed) &&
                                  (C.komi !== null ||
                                   usedForCheating(C.time_control_parameters) ||
-                                  (C.handicap_text !== "Auto" && C.handicap_text !== "No"))
+                                  (C.handicap > 0))
                                    || null) &&
                                 <React.Fragment>
                                  <i className="cheat-alert fa fa-exclamation-triangle fa-xs"/>
@@ -617,7 +617,7 @@ export class Play extends React.Component<PlayProperties, any> {
                                     {
                                         (C.komi !== null ? "Custom komi: " + C.komi + ". " : "") +
                                         (usedForCheating(C.time_control_parameters) ? "Unusual time setting. " : "" ) +
-                                        ((C.handicap_text !== "Auto" && C.handicap_text !== "No") ? "Custom handicap: " + C.handicap_text : "")
+                                        ((C.handicap > 0) ? "Custom handicap: " + C.handicap_text : "")
                                     }
                                 </p>
                                 </React.Fragment>

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -609,7 +609,7 @@ export class Play extends React.Component<PlayProperties, any> {
                                 (((C.eligible || C.user_challenge) && !C.removed) &&
                                  (C.komi !== null ||
                                   usedForCheating(C.time_control_parameters) ||
-                                  (C.handicap > 0))
+                                  ((C.handicap !== 0 && C.handicap !== -1)))
                                    || null) &&
                                 <React.Fragment>
                                  <i className="cheat-alert fa fa-exclamation-triangle fa-xs"/>
@@ -617,7 +617,7 @@ export class Play extends React.Component<PlayProperties, any> {
                                     {
                                         (C.komi !== null ? "Custom komi: " + C.komi + ". " : "") +
                                         (usedForCheating(C.time_control_parameters) ? "Unusual time setting. " : "" ) +
-                                        ((C.handicap > 0) ? "Custom handicap: " + C.handicap_text : "")
+                                        ((C.handicap !== 0 && C.handicap !== -1) ? "Custom handicap: " + C.handicap_text : "")
                                     }
                                 </p>
                                 </React.Fragment>


### PR DESCRIPTION
As discussed in https://forums.online-go.com/t/please-remove-that-for-games-without-handicap/22447?u=flovo there is a bug for the "Custom handicap" warning when using another language than English.

When using another language, every open challenge had the "Custom handicap" warning attached.

This should fix this.

<details>
<summary>Screenshot</summary>
Before:
<img src=https://user-images.githubusercontent.com/4864182/62581484-aa709700-b8a9-11e9-8c29-83da567d76b0.png>
After:
<img src=https://user-images.githubusercontent.com/4864182/62581589-fa4f5e00-b8a9-11e9-806e-3f4c36a33290.png>
</details>
