### PR TITLE
Revome marks from all moves when AI review disabled

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -969,7 +969,8 @@ export class Game extends React.PureComponent<GameProperties, any> {
         if (this.state.ai_review_enabled) {
             this.goban.setHeatmap(null);
             this.goban.setColoredCircles(null);
-            this.goban.engine.cur_move.clearMarks();
+            let move_tree = this.goban.engine.move_tree;
+            while (move_tree.next(true)) { move_tree = move_tree.next(true); move_tree.clearMarks(); }
             this.goban.setMode("play");
         }
         this.setState({ ai_review_enabled: !this.state.ai_review_enabled });


### PR DESCRIPTION
This is a fix for https://github.com/online-go/online-go.com/issues/856

When the user disables AI review in Game view, the AI marks are only deleted for the current move. For other moves the marks are still visible.

To remove the AI marks for all moves we have to go over the whole tree.