### PR TITLE
Don't jump to last move when disable AI reveiw

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -970,7 +970,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
             this.goban.setHeatmap(null);
             this.goban.setColoredCircles(null);
             this.goban.engine.cur_move.clearMarks();
-            this.goban.setMode("play");
+            this.goban.redraw();
         }
         this.setState({ ai_review_enabled: !this.state.ai_review_enabled });
     }


### PR DESCRIPTION
Don't switch "Play" mode after the user disabled AI review.

When using "Disable AI review" we shouldn't change the game mode, since the user probably want to keep doing what they were on.

Fix for https://github.com/online-go/online-go.com/issues/858