### PR TITLE
limit the visible AI suggestions to well explored variations

### DIFF
--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -872,7 +872,7 @@ export class AIReview extends React.Component<AIReviewProperties, any> {
                         });
                     }
 
-                    let visits = this.state.selected_ai_review.visits;
+                    let visits = move_ai_review.max_visits[0];
 
                     for (let i = 0 ; i < variations.length; ++i) {
                         if (variations[i].moves.length > 2 || variations[i].move === next_move_pretty_coords) {

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -872,6 +872,8 @@ export class AIReview extends React.Component<AIReviewProperties, any> {
                         });
                     }
 
+                    let visits = this.state.selected_ai_review.visits;
+
                     for (let i = 0 ; i < variations.length; ++i) {
                         if (variations[i].moves.length > 2 || variations[i].move === next_move_pretty_coords) {
                             let delta = 0;
@@ -905,7 +907,11 @@ export class AIReview extends React.Component<AIReviewProperties, any> {
                                 key = "0";
                             }
                             let mv = this.props.game.goban.engine.decodeMoves(variations[i].move)[0];
-                            if (mv) {
+                            // only show numbers for well explored moves
+                            // show number for AI choice and played move as well
+                            if (mv && ((i === 0) ||
+                                       (variations[i].move === next_move_pretty_coords) ||
+                                       (variations[i].visits >= Math.min(50, 0.1 * visits)))) {
                                 if (parseFloat(key).toPrecision(2).length < key.length) {
                                     key = parseFloat(key).toPrecision(2);
                                 }


### PR DESCRIPTION
The AI review is sometimes full of move suggestions (percent points). Many are only poorly explored.

This is a suggestion to limit the shown variations to variations on which leela spend more than 10% of her total visits.

At this point the pps are only shown if it's
- the played move,
- the AIs top suggestion, or
- at least 10% of the total visits were spent on the particular variation (or 50 visits)
    - 26 visits for Supporter (250 total),
    - 50 visits for Kyu Supporter (1000 total), 
    - 50 visits for Dan Supporter (800 total), or 
    - 50 for Pro Supporter (2000 total).

Tested for [Kyu Supporter](http://online-go.com/game/18734180), [Pro Supporter](https://online-go.com/game/18588826) and [Basic Supporter](https://online-go.com/game/19093854) level. There are still many visible variations left.

<details>
<summary>Screenshots (Pro Supporter) https://online-go.com/game/18588826</summary>
<br>
Before: <br>

<img src="https://user-images.githubusercontent.com/4864182/62939753-43d00980-bdd2-11e9-8e56-44d0d5ec766c.png">

<br>
After: <br>

<img src="https://user-images.githubusercontent.com/4864182/62939762-4a5e8100-bdd2-11e9-81d9-d546d0c68fb5.png">

</details>


<details>
<summary>Screenshots (Kyu Supporter) https://online-go.com/game/18734180</summary>
<br>
Before: <br>

<img src="https://user-images.githubusercontent.com/4864182/62939622-fbb0e700-bdd1-11e9-98c5-74cca73216fb.png">

<br>
After: <br>

<img src="https://user-images.githubusercontent.com/4864182/62939663-0f5c4d80-bdd2-11e9-9c60-40cfcdee9020.png">

</details>


<details>
<summary>Screenshots (Basic Supporter) https://online-go.com/game/19093854</summary>
<br>
Before: <br>

<img src="https://user-images.githubusercontent.com/4864182/62939274-2ea6ab00-bdd1-11e9-9456-6ca73e073da2.png">
<br>
After: <br>

<img src="https://user-images.githubusercontent.com/4864182/62939306-40884e00-bdd1-11e9-8f9f-7d61360a4d5f.png">

</details>