### PR TITLE
Add server time display

### DIFF
--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.styl
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.styl
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2012-2019  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.ServerTimeDisplay {
+    div {
+        padding-top: 50px;
+        padding-bottom: 50px;
+    }
+}
+

--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
@@ -17,32 +17,38 @@
 
 import * as React from "react";
 import * as moment from "moment";
-import {_, pgettext, interpolate} from "translate";
+import {_, interpolate} from "translate";
 
 interface ServerTimeDisplayProperties {}
 
 export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperties, any> {
+
     intervalID;
+
     constructor(props) {
         super(props);
         this.state = {
-            time: moment().utcOffset(0).format('dddd, LT')
+            time: moment().utcOffset(0)
         };
     }
+
     componentDidMount() {
         this.intervalID = setInterval(
             () => this.tick(),
             1000
         );
     }
+
     componentWillUnmount() {
         clearInterval(this.intervalID);
     }
+
     tick() {
         this.setState({
-            time: moment().utcOffset(0).format('dddd, LT')
+            time: moment().utcOffset(0)
         });
     }
+
     isWeekend() {
         if (new Date().getUTCDay() === 6) {
             return _(" It is the weekend!");
@@ -57,12 +63,13 @@ export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperti
             return _(" It is not the weekend.");
         }
     }
+
     render() {
         return (
             <div className="server-time-display">
                 <p>
                     <b>
-                    {_("Current Server Time is: ")}{this.state.time}.{this.isWeekend()}
+                    {_("Current Server Time is: ")}{this.state.time.format('dddd, LT')}.{this.isWeekend()}
                     </b>
                 </p>
             </div>

--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2012-2019  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import * as moment from "moment";
+
+interface ServerTimeDisplayProperties {}
+
+export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperties, any> {
+    intervalID;
+    constructor(props) {
+        super(props);
+        this.state = {
+            time: moment().utcOffset(0).format('dddd, HH:mm:ss')
+        };
+    }
+    componentDidMount() {
+        this.intervalID = setInterval(
+            () => this.tick(),
+            1000
+        );
+    }
+    componentWillUnmount() {
+        clearInterval(this.intervalID);
+    }
+    tick() {
+        this.setState({
+            time: moment().utcOffset(0).format('dddd, HH:mm:ss')
+        });
+    }
+    isWeekend() {
+        if (this.state.time.startsWith("Saturday") || this.state.time.startsWith("Sunday")) {
+            return " It is the weekend!";
+        }
+        else {
+            return " It is not the weekend.";
+        }
+    }
+    render() {
+        return (
+            <div className="server-time-display">
+                <p>
+                    <b>
+                    Current Server Time is: {this.state.time}.{this.isWeekend()}
+                    </b>
+                </p>
+            </div>
+        );
+    }
+}

--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
@@ -43,8 +43,14 @@ export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperti
         });
     }
     isWeekend() {
-        if (this.state.time.startsWith("Saturday") || this.state.time.startsWith("Sunday")) {
+        if (this.state.time.startsWith("Saturday")) {
             return " It is the weekend!";
+        }
+        else if (this.state.time.startsWith("Sunday")) {
+            return " Weekend ends " + moment().utcOffset(0).endOf('day').fromNow() + ".";
+        }
+        else if (this.state.time.startsWith("Friday")) {
+            return " Weekend starts " + moment().utcOffset(0).endOf('day').fromNow() + ".";
         }
         else {
             return " It is not the weekend.";

--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
@@ -26,7 +26,7 @@ export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperti
     constructor(props) {
         super(props);
         this.state = {
-            time: moment().utcOffset(0).format('dddd, HH:mm:ss')
+            time: moment().utcOffset(0).format('dddd, LT')
         };
     }
     componentDidMount() {
@@ -40,7 +40,7 @@ export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperti
     }
     tick() {
         this.setState({
-            time: moment().utcOffset(0).format('dddd, HH:mm:ss')
+            time: moment().utcOffset(0).format('dddd, LT')
         });
     }
     isWeekend() {

--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 import * as moment from "moment";
+import {_, pgettext, interpolate} from "translate";
 
 interface ServerTimeDisplayProperties {}
 
@@ -43,17 +44,17 @@ export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperti
         });
     }
     isWeekend() {
-        if (this.state.time.startsWith("Saturday")) {
-            return " It is the weekend!";
+        if (new Date().getUTCDay() == 6) {
+            return _(" It is the weekend!");
         }
-        else if (this.state.time.startsWith("Sunday")) {
-            return " Weekend ends " + moment().utcOffset(0).endOf('day').fromNow() + ".";
+        else if (new Date().getUTCDay() == 0) {
+            return _(" Weekend ends ") + moment().utcOffset(0).endOf('day').fromNow() + ".";
         }
-        else if (this.state.time.startsWith("Friday")) {
-            return " Weekend starts " + moment().utcOffset(0).endOf('day').fromNow() + ".";
+        else if (new Date().getUTCDay() == 5) {
+            return _(" Weekend starts ") + moment().utcOffset(0).endOf('day').fromNow() + ".";
         }
         else {
-            return " It is not the weekend.";
+            return _(" It is not the weekend.");
         }
     }
     render() {
@@ -61,7 +62,7 @@ export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperti
             <div className="server-time-display">
                 <p>
                     <b>
-                    Current Server Time is: {this.state.time}.{this.isWeekend()}
+                    {_("Current Server Time is: ")}{this.state.time}.{this.isWeekend()}
                     </b>
                 </p>
             </div>

--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
@@ -44,13 +44,13 @@ export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperti
         });
     }
     isWeekend() {
-        if (new Date().getUTCDay() == 6) {
+        if (new Date().getUTCDay() === 6) {
             return _(" It is the weekend!");
         }
-        else if (new Date().getUTCDay() == 0) {
+        else if (new Date().getUTCDay() === 0) {
             return _(" Weekend ends ") + moment().utcOffset(0).endOf('day').fromNow() + ".";
         }
-        else if (new Date().getUTCDay() == 5) {
+        else if (new Date().getUTCDay() === 5) {
             return _(" Weekend starts ") + moment().utcOffset(0).endOf('day').fromNow() + ".";
         }
         else {

--- a/src/components/ServerTimeDisplay/index.ts
+++ b/src/components/ServerTimeDisplay/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2019  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./ServerTimeDisplay";

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -39,6 +39,7 @@ import {EmailBanner} from "EmailBanner";
 import {SupporterGoals} from "SupporterGoals";
 import {ProfileCard} from "ProfileCard";
 import {notification_manager} from "Notifications";
+import {ActiveAnnouncements} from "Announcements:;
 import {FabX, FabCheck} from "material";
 import {ServerTimeDisplay} from "ServerTimeDisplay";
 
@@ -123,6 +124,7 @@ export class Overview extends React.Component<{}, any> {
             <div id="Overview">
                 <div className="left">
                     <EmailBanner />
+                    <ActiveAnnouncements />
                     <ServerTimeDisplay />
                     <ChallengesList onAccept={() => this.refresh()} />
 

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -125,9 +125,10 @@ export class Overview extends React.Component<{}, any> {
                 <div className="left">
                     <EmailBanner />
                     <ActiveAnnouncements  />
-                    <ServerTimeDisplay />
                     <ChallengesList onAccept={() => this.refresh()} />
 
+
+                    <ServerTimeDisplay />
 
                     {((user && user.provisional) || null) &&
                         <DismissableNotification

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -40,6 +40,7 @@ import {SupporterGoals} from "SupporterGoals";
 import {ProfileCard} from "ProfileCard";
 import {notification_manager} from "Notifications";
 import {FabX, FabCheck} from "material";
+import {ServerTimeDisplay} from "ServerTimeDisplay";
 
 
 
@@ -122,6 +123,7 @@ export class Overview extends React.Component<{}, any> {
             <div id="Overview">
                 <div className="left">
                     <EmailBanner />
+                    <ServerTimeDisplay />
                     <ChallengesList onAccept={() => this.refresh()} />
 
 

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -39,7 +39,7 @@ import {EmailBanner} from "EmailBanner";
 import {SupporterGoals} from "SupporterGoals";
 import {ProfileCard} from "ProfileCard";
 import {notification_manager} from "Notifications";
-import {ActiveAnnouncements} from "Announcements:;
+import {ActiveAnnouncements} from "Announcements";
 import {FabX, FabCheck} from "material";
 import {ServerTimeDisplay} from "ServerTimeDisplay";
 
@@ -124,7 +124,7 @@ export class Overview extends React.Component<{}, any> {
             <div id="Overview">
                 <div className="left">
                     <EmailBanner />
-                    <ActiveAnnouncements />
+                    <ActiveAnnouncements  />
                     <ServerTimeDisplay />
                     <ChallengesList onAccept={() => this.refresh()} />
 

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -759,7 +759,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                     </Card>
                 }
 
-                <ServerTimeDisplay></ServerTimeDisplay>
+                <ServerTimeDisplay />
 
                 {(this.state.active_games.length > 0 || null) && <h2>{_("Active Games")}</h2>}
                 <GameList list={this.state.active_games} player={user}/>

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -74,7 +74,6 @@ let inlineBlock = {display: "inline-block"};
 let marginRight0 = {marginRight: "0"};
 let marginBottom0 = {marginBottom: "0"};
 let nowrapAlignTop = {whiteSpace: "nowrap", verticalAlign: "top"};
-let time = new Date().toLocaleString();
 
 export class User extends React.PureComponent<UserProperties, any> {
     refs: {

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -44,6 +44,7 @@ import {Flag} from "Flag";
 import {Markdown} from "Markdown";
 import {RatingsChart} from 'RatingsChart';
 import {UIPush} from "UIPush";
+import {ServerTimeDisplay} from "ServerTimeDisplay";
 
 declare let swal;
 
@@ -73,6 +74,7 @@ let inlineBlock = {display: "inline-block"};
 let marginRight0 = {marginRight: "0"};
 let marginBottom0 = {marginBottom: "0"};
 let nowrapAlignTop = {whiteSpace: "nowrap", verticalAlign: "top"};
+let time = new Date().toLocaleString();
 
 export class User extends React.PureComponent<UserProperties, any> {
     refs: {
@@ -757,6 +759,8 @@ export class User extends React.PureComponent<UserProperties, any> {
                         </div>
                     </Card>
                 }
+
+                <ServerTimeDisplay></ServerTimeDisplay>
 
                 {(this.state.active_games.length > 0 || null) && <h2>{_("Active Games")}</h2>}
                 <GameList list={this.state.active_games} player={user}/>


### PR DESCRIPTION
Display current server time above active games on profile page as per [Issue #849](https://github.com/online-go/online-go.com/issues/849)