### PR TITLE
Use visits for heatmap instead of policy network

### DIFF
--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -2290,7 +2290,7 @@ export abstract class Goban extends TypedEventEmitter<Events> {
                 ctx.lineCap = "square";
                 ctx.save();
                 ctx.beginPath();
-                ctx.globalAlpha = this.heatmap[j][i] * 0.5;
+                ctx.globalAlpha = Math.min(this.heatmap[j][i], 0.5);
                 let r = Math.floor(this.square_size * 0.5) - 0.5;
                 ctx.moveTo(cx - r, cy - r);
                 ctx.lineTo(cx + r, cy - r);

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -874,7 +874,20 @@ export class AIReview extends React.Component<AIReviewProperties, any> {
 
                     let visits = move_ai_review.max_visits[0];
 
+                    heatmap = [];
+                    for (let y = 0; y < this.props.game.goban.engine.height; y++) {
+                        let r = [];
+                        for (let x = 0; x < this.props.game.goban.engine.width; x++) {
+                            r.push(0);
+                        }
+                        heatmap.push(r);
+                    }
+
                     for (let i = 0 ; i < variations.length; ++i) {
+
+                        let mv = this.props.game.goban.engine.decodeMoves(variations[i].move)[0];
+                        heatmap[mv.y][mv.x] = variations[i].visits / visits;
+
                         if (variations[i].moves.length > 2 || variations[i].move === next_move_pretty_coords) {
                             let delta = 0;
 
@@ -906,7 +919,6 @@ export class AIReview extends React.Component<AIReviewProperties, any> {
                             if (key === "0.0" || key === "-0.0") {
                                 key = "0";
                             }
-                            let mv = this.props.game.goban.engine.decodeMoves(variations[i].move)[0];
                             // only show numbers for well explored moves
                             // show number for AI choice and played move as well
                             if (mv && ((i === 0) ||
@@ -949,7 +961,7 @@ export class AIReview extends React.Component<AIReviewProperties, any> {
                         marks["sub_triangle"] = GoMath.encodeMove(next_move.x, next_move.y);
                     }
                     */
-                    heatmap = this.normalizeHeatmap(move_ai_review.heatmap);
+                    heatmap = this.normalizeHeatmap(heatmap);
                 }
             }
             else { // !cur_move.trunk

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -961,7 +961,6 @@ export class AIReview extends React.Component<AIReviewProperties, any> {
                         marks["sub_triangle"] = GoMath.encodeMove(next_move.x, next_move.y);
                     }
                     */
-                    heatmap = this.normalizeHeatmap(heatmap);
                 }
             }
             else { // !cur_move.trunk


### PR DESCRIPTION
resolves online-go/online-go.com#874

I also changed the normalization of the heatmap to be relative to total visits. With this it's easier to see how many visits the AI spent on a variation. 

1) Policy network:
    ![image](https://user-images.githubusercontent.com/4864182/64253816-64e1d100-cf1e-11e9-959b-57200b5d6c14.png)

2) Visits:
    ![image](https://user-images.githubusercontent.com/4864182/64253464-a45bed80-cf1d-11e9-9103-b554be6432c3.png)

3) Visity / total visits
    ![image](https://user-images.githubusercontent.com/4864182/64253768-424fb800-cf1e-11e9-8fb3-d7976691665f.png)
