### PR TITLE
Hide captures/points while score estimator active

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2451,13 +2451,13 @@ export class Game extends React.PureComponent<GameProperties, any> {
                       <div className="score-container" onMouseEnter={this.score_popups[`popup_${color}`]} onMouseLeave={this.score_popups[`hide_${color}`]}>
                           {((goban.engine.phase === "finished" || goban.engine.phase === "stone removal" || null) && goban.mode !== "analyze" &&
                             goban.engine.outcome !== "Timeout" && goban.engine.outcome !== "Resignation" && goban.engine.outcome !== "Cancellation") &&
-                              <div className="points">
+                              <div className={"points" + (this.state.estimating_score ? " hidden" : "")} >
                                   {interpolate(_("{{total}} {{unit}}"), {"total": this.state.score[color].total, "unit": ngettext("point", "points", this.state.score[color].total)})}
                               </div>
                           }
                           {((goban.engine.phase !== "finished" && goban.engine.phase !== "stone removal" || null) || goban.mode === "analyze" ||
                             goban.engine.outcome === "Timeout" || goban.engine.outcome === "Resignation" || goban.engine.outcome === "Cancellation") &&
-                              <div className="captures">
+                              <div className={"captures" + (this.state.estimating_score ? " hidden" : "")}>
                                   {interpolate(_("{{captures}} {{unit}}"), {"captures": this.state.score[color].prisoners, "unit": ngettext("capture", "captures", this.state.score[color].prisoners)})}
                               </div>
                           }

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -56,6 +56,9 @@
             background-image: none;
             font-size: 1.1rem;
         }
+        .hidden {
+            visibility: hidden;
+        }
 
         .auto-resign-overlay {
             position: absolute;


### PR DESCRIPTION
resolves gh-882

The captures/points don't reflect the result of the SE, so best is to hide it.