### PR TITLE
allow mods to use Auto-Score button

### DIFF
--- a/src/lib/ogs-goban/Goban.ts
+++ b/src/lib/ogs-goban/Goban.ts
@@ -4245,7 +4245,7 @@ export abstract class Goban extends TypedEventEmitter<Events> {
     } /* }}} */
     public autoScore() { /* {{{ */
         try {
-            if (!window["user"] || !this.on_game_screen  || !this.engine || (window["user"].id !== this.engine.black_player_id && window["user"].id !== this.engine.white_player_id)) {
+            if (!window["user"] || !this.on_game_screen  || !this.engine || (window["user"].id !== this.engine.black_player_id && window["user"].id !== this.engine.white_player_id && window["user"].is_moderator !== true)) {
                 return;
             }
         } catch (e) {

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2095,7 +2095,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                        <br/>
 
                        <div style={{textAlign: "center"}}>
-                           {(this.state.user_is_player || null) &&
+                           {(this.state.user_is_player || user.is_moderator || null) &&
                                <button id="game-stone-removal-auto-score" onClick={this.onStoneRemovalAutoScore}>
                                    {_("Auto-score")}
                                </button>


### PR DESCRIPTION
Partial implementation for #792 

This PR implements the ability for mods to interact with the Auto-Score button to return the board back to a neutral position to better identify living or dead groups in the event of trolls erroneously marking groups alive/dead.

There is room for more to be done in this area, such as enabling mods to mark stones alive/dead and disabling players from being able to mark stones, but I feel what I have already done would be a huge help in such cases.