### PR TITLE
Turn-indicator: theme update

### DIFF
--- a/src/components/Notifications/Notifications.styl
+++ b/src/components/Notifications/Notifications.styl
@@ -89,10 +89,8 @@ indiciator-size=1.5rem
         height: indiciator-size;
         border-radius: 50%;
         text-align: center;
-        border: 2px solid #fff;
+        border: 2px transparent;
         font-weight: 700;
-        background-color: #000;
-        color: #fff;
     }
 
     .active.count {
@@ -100,6 +98,19 @@ indiciator-size=1.5rem
     }
 }
 
+body.light #NavBar .turn-indicator {
+    .count {
+        background-color: #101010;
+        color: #fff;
+    }
+}
+
+body.dark #NavBar .turn-indicator {
+    .count {
+        background-color: #bbb;
+        color: #252525;
+    }
+}
 
 notification-list-height=14rem
 

--- a/src/components/Notifications/Notifications.styl
+++ b/src/components/Notifications/Notifications.styl
@@ -96,6 +96,9 @@ indiciator-size=1.5rem
     .active.count {
         visibility: visible;
     }
+    .inactive.count {
+        visibility: visible;
+    }
 }
 
 body.light #NavBar .turn-indicator {
@@ -103,12 +106,18 @@ body.light #NavBar .turn-indicator {
         background-color: #101010;
         color: #fff;
     }
+    .inactive.count {
+        background-color: #d2d2d2;
+    }
 }
 
 body.dark #NavBar .turn-indicator {
     .count {
         background-color: #bbb;
         color: #252525;
+    }
+    .inactive.count {
+        background-color: #535353;
     }
 }
 

--- a/src/components/Notifications/Notifications.styl
+++ b/src/components/Notifications/Notifications.styl
@@ -68,8 +68,7 @@ indiciator-size=1.5rem
     }
 }
 
-
- .turn-indicator {
+.turn-indicator {
     width: 3rem;
 
     flex: 1;

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -497,7 +497,7 @@ export class TurnIndicator extends React.Component<{}, any> { /* {{{ */
     render() {
         return (
             <span className="turn-indicator" onClick={this.advanceToNextBoard}>
-                <span className={this.state.total > 0 ? "active count" : "count"}><span>{this.state.count}</span></span>
+                <span className={this.state.total > 0 ? (this.state.count > 0 ? "active count" : "inactive count") : "count"}><span>{this.state.count}</span></span>
             </span>
        );
     }


### PR DESCRIPTION
I added a dark theme for the turn indicator
and a grayed version if the turn counter shows `0`

On the dark theme the turn-indicator had a bright white border (#fff). That's much brighter than everything else on the dark theme (text color #ddd)

I changed the color of the turn-indicator circle to match the text-color of the theme. The number within the turn-indicator now has the same color as the top bar.

Since the border would have the same color as the background for both themes, it's now just set to be transparent.

When the turn-indicator  shows `0` it has the same color as the friends icon when no friends are online.

![turn-indicator](https://user-images.githubusercontent.com/4864182/64485177-73313500-d21d-11e9-8e4b-91473c4603d0.png)
