### PR TITLE
Chat improvements

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -56,6 +56,7 @@ data.watch("config.user", (user) => {
     name_match_regex = new RegExp(
           "\\b"  + cleaned_username_regex + "([?:,.!*'\\s])"
         + "|\\b" + cleaned_username_regex + "$"
+        + "|player [0-9]+"
         , "i");
 });
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -54,8 +54,7 @@ let name_match_regex = /^loading...$/;
 data.watch("config.user", (user) => {
     let cleaned_username_regex = user.username.replace(/[\\^$*+.()|[\]{}]/g, "\\$&");
     name_match_regex = new RegExp(
-          "\\b"  + cleaned_username_regex + "([?:,.!*'’\\s])"
-        + "|\\b" + cleaned_username_regex + "$"
+          "\\b"  + cleaned_username_regex + "\\b"
         + "|player ?[0-9]+"
         , "i");
 });

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -54,7 +54,7 @@ let name_match_regex = /^loading...$/;
 data.watch("config.user", (user) => {
     let cleaned_username_regex = user.username.replace(/[\\^$*+.()|[\]{}]/g, "\\$&");
     name_match_regex = new RegExp(
-          "\\b"  + cleaned_username_regex + "([?:.!*\\s])"
+          "\\b"  + cleaned_username_regex + "([?:,.!*'\\s])"
         + "|\\b" + cleaned_username_regex + "$"
         , "i");
 });

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -55,7 +55,7 @@ data.watch("config.user", (user) => {
     let cleaned_username_regex = user.username.replace(/[\\^$*+.()|[\]{}]/g, "\\$&");
     name_match_regex = new RegExp(
           "\\b"  + cleaned_username_regex + "\\b"
-        + "|player ?[0-9]+"
+        + "|\\bplayer ?" + user.id + "\\b"
         , "i");
 });
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -56,7 +56,7 @@ data.watch("config.user", (user) => {
     name_match_regex = new RegExp(
           "\\b"  + cleaned_username_regex + "([?:,.!*'\\s])"
         + "|\\b" + cleaned_username_regex + "$"
-        + "|player [0-9]+"
+        + "|player ?[0-9]+"
         , "i");
 });
 
@@ -919,9 +919,9 @@ export function chat_markup(body, extra_pattern_replacements?: Array<{split: Reg
             replacement: (m, idx) => (<Link key={idx} to={`/review/${m[2] || ""}${m[4] || ""}`}>{`${m[3] || ""}##${m[2] || ""}${m[4] || ""}`}</Link>)},
         {split: /(^#[0-9]{3,}|[ ]#[0-9]{3,})/gi, pattern: /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi,
             replacement: (m, idx) => (<Link key={idx} to={`/game/${m[2] || ""}${m[4] || ""}`}>{`${m[3] || ""}#${m[2] || ""}${m[4] || ""}`}</Link>)},
-        {split: /(player [0-9]+)/gi, pattern: /(player ([0-9]+))/gi, replacement: (m, idx) => (<Link key={idx} to={`/user/view/${m[2]}`}>{m[1]}</Link>)},
-        {split: /(issue [0-9]+)/gi, pattern: /(issue ([0-9]+))/gi, replacement: (m, idx) => (<a key={idx} target="_blank" href={`https://github.com/online-go/online-go.com/issues/${m[2]}`}>{m[1]}</a>)},
-        {split: /(pr [0-9]+)/gi, pattern: /(pr ([0-9]+))/gi, replacement: (m, idx) => (<a key={idx} target="_blank" href={`https://github.com/online-go/online-go.com/pull/${m[2]}`}>{m[1]}</a>)},
+        {split: /(player ?[0-9]+)/gi, pattern: /(player ?([0-9]+))/gi, replacement: (m, idx) => (<Link key={idx} to={`/user/view/${m[2]}`}>{m[1]}</Link>)},
+        {split: /(issue ?[0-9]+)/gi, pattern: /(issue ?([0-9]+))/gi, replacement: (m, idx) => (<a key={idx} target="_blank" href={`https://github.com/online-go/online-go.com/issues/${m[2]}`}>{m[1]}</a>)},
+        {split: /(pr ?[0-9]+)/gi, pattern: /(pr ?([0-9]+))/gi, replacement: (m, idx) => (<a key={idx} target="_blank" href={`https://github.com/online-go/online-go.com/pull/${m[2]}`}>{m[1]}</a>)},
         {split: /(#group-[0-9]+)/gi, pattern: /(#group-([0-9]+))/gi, replacement: (m, idx) => (<Link key={idx} to={`/group/${m[2]}`}>{m[1]}</Link>)},
     ];
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -54,7 +54,7 @@ let name_match_regex = /^loading...$/;
 data.watch("config.user", (user) => {
     let cleaned_username_regex = user.username.replace(/[\\^$*+.()|[\]{}]/g, "\\$&");
     name_match_regex = new RegExp(
-          "\\b"  + cleaned_username_regex + "([?:,.!*'\\s])"
+          "\\b"  + cleaned_username_regex + "([?:,.!*'’\\s])"
         + "|\\b" + cleaned_username_regex + "$"
         + "|player ?[0-9]+"
         , "i");


### PR DESCRIPTION
Now the chat recognises when an username is followed by a `,` or a `'` as a mention of username.
If the user is mentioned as `player 1`, now this is a mentioning as well.

I also made the space between `player` and the player_id optional. 
Same for `issue` and `pr`.

This still leaves some mentions undetected:
In German `Adam's` would be `Adams` (without Apostrophe). I don't know if there is any language which adds letters at the beginning of a name to indicate anything.
It could be better to remove the checks for word boundaries entirely.