### PR TITLE
Iframe support

### DIFF
--- a/iframe_test.html
+++ b/iframe_test.html
@@ -1,4 +1,4 @@
 <iframe src="http://dev.beta.online-go.com:8080/game/18588826" width=600 height=663 ></iframe>
-<iframe src="http://dev.beta.online-go.com:8080/game/18588826" ></iframe>
+<!-- <iframe src="http://dev.beta.online-go.com:8080/game/18588826" ></iframe>
 <iframe src="http://dev.beta.online-go.com:8080/game/18588826" width=600 height=400 ></iframe>
-<iframe src="http://dev.beta.online-go.com:8080/game/18588826" width=230 height=300 ></iframe>
+<iframe src="http://dev.beta.online-go.com:8080/game/18588826" width=230 height=300 ></iframe> -->

--- a/iframe_test.html
+++ b/iframe_test.html
@@ -1,3 +1,4 @@
-<iframe src="https://online-go.com/game/18588826" width=600 height=800 ></iframe>
-<iframe src="https://online-go.com/game/18588826" ></iframe>
-<iframe src="https://online-go.com/game/18588826" width=600 height=400 ></iframe>
+<iframe src="http://dev.beta.online-go.com:8080/game/18588826" width=600 height=663 ></iframe>
+<iframe src="http://dev.beta.online-go.com:8080/game/18588826" ></iframe>
+<iframe src="http://dev.beta.online-go.com:8080/game/18588826" width=600 height=400 ></iframe>
+<iframe src="http://dev.beta.online-go.com:8080/game/18588826" width=230 height=300 ></iframe>

--- a/iframe_test.html
+++ b/iframe_test.html
@@ -1,0 +1,3 @@
+<iframe src="https://online-go.com/game/18588826" width=600 height=800 ></iframe>
+<iframe src="https://online-go.com/game/18588826" ></iframe>
+<iframe src="https://online-go.com/game/18588826" width=600 height=400 ></iframe>

--- a/src/components/IFrame/IFrame.styl
+++ b/src/components/IFrame/IFrame.styl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2012-2019  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+.ogs-nav-logo-container {
+    flex-shrink: 0;
+    flex-wrap: nowrap;
+    display: flex;
+    align-items: center;
+    align-content: center;
+    height: navbar-height;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    margin-right: 1rem;
+    cursor: pointer;
+}

--- a/src/components/IFrame/IFrame.tsx
+++ b/src/components/IFrame/IFrame.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2012-2019  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+import * as React from "react";
+
+
+export class OGS_iframe_logo extends React.PureComponent<{}, any> {
+
+    constructor(props) {
+        super(props);
+    }
+
+    openInNewTab() {
+        window.open(document.URL)
+    }
+
+    render () {
+        return (
+            <span className="ogs-iframe-logo-container" onClick={this.openInNewTab}>
+                <i className="fa fa-bars"/>
+                <span className="ogs-nav-logo"/>
+            </span>
+        )
+    }
+}
+
+export function isIframe() {
+    try {
+        return window.self !== window.top;
+    } catch (e) {
+        return true;
+    }
+}

--- a/src/components/IFrame/IFrame.tsx
+++ b/src/components/IFrame/IFrame.tsx
@@ -18,24 +18,22 @@
 
 import * as React from "react";
 
-
-export class OGS_iframe_logo extends React.PureComponent<{}, any> {
+export class OGSIframeLogo extends React.PureComponent<{}, any> {
 
     constructor(props) {
         super(props);
     }
 
     openInNewTab() {
-        window.open(document.URL)
+        window.open(document.URL);
     }
 
-    render () {
+    render() {
         return (
             <span className="ogs-iframe-logo-container" onClick={this.openInNewTab}>
-                <i className="fa fa-bars"/>
                 <span className="ogs-nav-logo"/>
             </span>
-        )
+        );
     }
 }
 

--- a/src/components/IFrame/index.ts
+++ b/src/components/IFrame/index.ts
@@ -15,10 +15,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function isIframe() {
-    try {
-        return window.self !== window.top;
-    } catch (e) {
-        return true;
-    }
-}
+export * from "./IFrame";

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -37,6 +37,7 @@ import {Player} from "Player";
 import * as player_cache from "player_cache";
 import * as preferences from "preferences";
 import cached from 'cached';
+import {isIframe} from "IFrame";
 
 let body = $(document.body);
 
@@ -237,6 +238,7 @@ export class NavBar extends React.PureComponent<{}, any> {
 
 
     render() {
+
         let user = this.state.user.anonymous ? null : this.state.user;
         let anon = this.state.user.anonymous;
         let tournament_invites = this.state.tournament_invites;
@@ -261,6 +263,10 @@ export class NavBar extends React.PureComponent<{}, any> {
             this.state.omnisearch_tournaments.length +
             this.state.omnisearch_groups.length +
             this.state.omnisearch_sitemap.length ;
+
+        if (isIframe()) {
+            return (<div id="" className=""></div>);
+        }
 
         return (
         <div id="NavBar" className={(this.state.left_nav_active || this.state.right_nav_active) ? "active" : ""}>

--- a/src/lib/iframe.ts
+++ b/src/lib/iframe.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2012-2019  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export function isIframe() {
+    try {
+        return window.self !== window.top;
+    }
+    catch (e) {
+        return true;
+    }
+}

--- a/src/lib/iframe.ts
+++ b/src/lib/iframe.ts
@@ -18,8 +18,7 @@
 export function isIframe() {
     try {
         return window.self !== window.top;
-    }
-    catch (e) {
+    } catch (e) {
         return true;
     }
 }

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -24,6 +24,10 @@
     left: 0;
 }
 
+.Game.iframe {
+    top: 0;
+}
+
 .outer-banner {
     .Game, .Dock {
         top: below-navbar + 5.4 !important;
@@ -80,6 +84,10 @@ goban-view-bar-width=400px
     //justify-content: stretch;
 
     // .players is handled in Players.styl
+
+    .horizontal {
+        display: flex;
+    }
 
     .play-controls { /* {{{ */
         flex-grow: 0;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -52,6 +52,7 @@ import {GameChat} from "./Chat";
 import {setActiveGameView} from "./Chat";
 import {CountDown} from "./CountDown";
 import {toast} from "toast";
+import {isIframe, OGSIframeLogo} from "IFrame";
 
 declare var swal;
 
@@ -1778,6 +1779,25 @@ export class Game extends React.PureComponent<GameProperties, any> {
 
 
     render() {
+        if (isIframe()) {
+            return (
+                <div>
+                    <div className={"Game MainGobanView iframe " + this.state.view_mode + " " + (this.state.squashed ? "squashed" : "")}>
+                        <div className="center-col">
+                            <div className="horizontal">
+                                <OGSIframeLogo></OGSIframeLogo>
+                                {this.frag_players(true)}
+                            </div>
+                            <div ref={el => this.ref_goban_container = el} className="goban-container">
+                                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                                <PersistentElement className="Goban" elt={this.goban_div}/>
+                            </div>
+                            {this.frag_below_board_controls()}
+                        </div>
+                    </div>
+                </div>);
+        }
+
         const CHAT = <GameChat ref={el => this.ref_chat = el} chatlog={this.chat_log} onChatLogChanged={this.setChatLog}
                          gameview={this} userIsPlayer={this.state.user_is_player}
                          channel={this.game_id ? `game-${this.game_id}` : `review-${this.review_id}`} />;
@@ -2404,7 +2424,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
           </div>
         );
     }
-    frag_players() {
+    frag_players(iframe?) {
         let goban = this.goban;
         if (!goban) {
             return null;
@@ -2414,7 +2434,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
 
 
         return (
-            <div ref={el => this.ref_players = el} className="players">
+            <div ref={el => this.ref_players = el} className={"players" + (iframe ? " iframe" : "")}>
               {["black", "white"].map((color, idx) => {
                   let player_bg: any = {};
                   if (this.state[`historical_${color}`]) {
@@ -2423,7 +2443,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                   }
 
                   return (
-                  <div key={idx} className={`${color} player-container`}>
+                  <div key={idx} className={`${color} player-container` + (iframe ? " iframe" : "")}>
                       {this.state[`${color}_auto_resign_expiration`] &&
                           <div className={`auto-resign-overlay`}>
                               <i className='fa fa-bolt' />
@@ -2439,7 +2459,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                               </div>
                           }
 
-                          {(goban.engine.phase !== "finished" && !goban.review_id || null) &&
+                          {(!iframe) && (goban.engine.phase !== "finished" && !goban.review_id || null) &&
                               this.frag_clock(color)
                           }
                       </div>
@@ -2449,6 +2469,8 @@ export class Game extends React.PureComponent<GameProperties, any> {
                              <Player user={ this.state[`historical_${color}`] || goban.engine.players[color] } disableCacheUpdate />
                           </div>
                       }
+
+                      {iframe && this.frag_clock(color)}
 
                       {((!goban.engine.players[color]) || null) &&
                           <span className="player-name-plain">{color === "black" ? _("Black") : _("White")}</span>

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -114,6 +114,10 @@
         }
     }
 
+    .player-container.iframe {
+        flex-direction: row;
+    }
+
 
     .white.player-container {
         box-shadow: 0 2px 5px rgba(50,50,50,.51);
@@ -403,5 +407,46 @@
         .periods, .period-time {
             font-size: font-size-extra-small;
         }
+    }
+}
+
+
+.MainGobanView .players.iframe {
+    flex-shrink: 1;
+    flex-grow: 1;
+    min-height: 1rem;
+
+    .captures, .points, .komi, .hidden {
+        display: none;
+    }
+
+    .player-container {
+        margin-top: 0;
+    }
+
+    .player-icon-container {
+        flex-grow: 0;
+        flex-shrink: 1;
+        width: 100%;
+        min-height: 1rem;
+        min-width: 1rem;
+    }
+
+    .player-icon-clock-row{
+        display: contents;
+    }
+
+    .main-time {
+        text-align: left;
+        flex-grow: 0;
+    }
+
+    .byo-yomi-periods {
+        flex-grow: 1;
+        text-align: left;
+    }
+
+    .player-name-container {
+
     }
 }


### PR DESCRIPTION
# Summary

This is a try to make OGS nice looking when it's embedded in an iframe on another website. 

This pr serves as discussion thread. I'll create separate pull requests for individual working parts.

# TODOs
## checklist (todo or nice to have)
This is a collection of everything what could be nice to have
### General 
- [x] find out if we are in an iframe
- [ ] disable sound
- [ ] prevent links from opening in the iframe (open them in new tab?) Player profiles for example
- [ ] do we need to communicate with the parent site? For example to return a preferred size depending on width/hight? https://stackoverflow.com/questions/9153445/how-to-communicate-between-iframe-and-the-parent-site
- [ ] prevent the need for scroll bars (they are ugly in iframes)
- [ ] make background transparent?
- [ ] don't show notification popups

### NavBar
- [x] show only the OGS logo
- [x] when clicking on the OGS logo, open the iframed page in a new tab
- [x] shrink to width of OGS logo, so player-containers fit on the right

### Game View
- [ ] Player-container:
    - [x] make 1 line
    - [x] show on the right of OGS logo
    - [ ] handle time for active games
- [ ] Goban:
    - [ ] disable mouse interaction with goban (placing stones, ...)
    - [ ] disable all keyboard interaction, but back and forth
    - [ ] make it possible to show only a part of the board (tsumego mode) (puzzles do it, do we need it for demo boards in iframes?)
    - [ ] make it possible to link to any move number, not only the last move
- [ ] right-col:
    basically hide everything but player-container
    - [ ] don't show ai-panels
    - [ ] don't show reviews list
    - [ ] don't show chat
    - [ ] don't show dock
- [ ] game-chat:
    - [ ] don't connect to game-chat if it's hidden
### reviews
- [ ] show review comment box
- [ ] show move-tree-container (reduce height)
### joseki
### puzzles
- [ ] make it possible to show specific puzzle
### tournaments
### profile page

## first step
this should be done to get a usable state.
### General 
- [x] find out if we are in an iframe
- [ ] disable sound
- [ ] prevent links from opening in the iframe (open them in new tab?)
- [ ] don't show notification popups

### NavBar
- [x] show only the OGS logo
- [x] when clicking on the OGS logo, open the iframed page in a new tab
- [x] shrink to width of OGS logo, so player-containers fit on the right

### Game View:
- [ ] Player-container:
    - [x] make 1 line
    - [x] show on the right of OGS logo
    - [ ] handle time for active games
- [ ] Goban:
    - [ ] disable mouse interaction with goban (placing stones, ...)
    - [ ] disable all keyboard interaction, but back and forth
- [x] right-col:
    basically hide everything but player-container
    - [x] don't show ai-panels
    - [x] don't show reviews list
    - [x] don't show chat
    - [x] don't show dock

- [ ] do tests
- [ ] do tests
- [ ] do tests