### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting Security Issues
+
+The OGS team and community take security bugs in OGS seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, email [anoek@online-go.com](mailto:anoek@online-go.com) and include the word "SECURITY" in the subject line.
+
+The OGS team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining the module.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 The OGS team and community take security bugs in OGS seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, email [anoek@online-go.com](mailto:anoek@online-go.com) and include the word "SECURITY" in the subject line.
+To report a security issue, email [security@online-go.com](mailto:security@online-go.com) and include the word "SECURITY" in the subject line.
 
 The OGS team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 


### PR DESCRIPTION
**Feature requested**

GitHub has released the Security Policy feature, by writing the SECURITY.md file a new tab with security information should appear in the repository.

It will improve people trusting in open source security standards.