### PR TITLE
How to point at the beta joseki explorer server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,13 @@ npm run dev
 If you're on linux, you can simply type `make` and it will do all this for you as well.
 
 Once running, you can then navigate to [http://dev.beta.online-go.com:8080/](http://dev.beta.online-go.com:8080/)
-which loads the interface from your local server that you just started with gulp, and 
+which loads the interface from your local server that you just started with gulp, and
 connects to the beta server for testing.
+
+If you want to work on Joseki Explorer front-end code, you also need to point to the beta Joseki Explorer server.
+
+Do this by executing `data.set("joseki-url", "https:beta.online-go.com/godojo/")` in the javascript console of your browser,
+after confirming that the dev server loaded as above.
 
 ## Getting Started
 * Sign up for a [GitHub account](https://github.com/signup/free).


### PR DESCRIPTION
Instructions about how to point a local OGS client environment at the beta Joseki Explorer server.