### PR TITLE
Make WebAssembly feature detection more robust

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -218,10 +218,12 @@
         try {
             var script = document.createElement('script');
             script.id = "ogs_score_estimator_script";
-            if (typeof WebAssembly === "object")  {
+            try {
+                new WebAssembly.Memory({ initial: 0 });
                 console.log("WASM support detected, score estimator will be fast"); 
                 script.src = "/OGSScoreEstimator/OGSScoreEstimator-0.7.0.js";
-            } else {
+            } catch (error) {
+                console.warn(error);
                 console.log("No WASM support detected, score estimator falling back to ASM.js mode"); 
                 script.src = "/OGSScoreEstimator/OGSScoreEstimator-0.7.0.asm.js";
             }


### PR DESCRIPTION
When running Chromium with WebAssembly disabled, the `WebAssembly`
global is still defined, and so a `typeof` check isn't quite enough.
Instead, let's try to allocate a Memory region. This operation will
fail with `RangeError` if WebAssembly is disabled.

See: https://github.com/openbsd/ports/blob/77b70736cf794ac0ff7c420e4321017471799f6d/www/chromium/files/chrome#L57
