### PR TITLE
hide private-chat in zen mode

### DIFF
--- a/src/components/PrivateChat/PrivateChat.styl
+++ b/src/components/PrivateChat/PrivateChat.styl
@@ -102,6 +102,13 @@
     }
 }
 
+&.zen .private-chat-window {
+    display: none;
+}
+
+&.zen .private-chat-window .superchat {
+    display: inline-block;
+}
 
 .private-chat-window.open {
     //background-color: @ogs-private-chat-bg;

--- a/src/components/PrivateChat/PrivateChat.styl
+++ b/src/components/PrivateChat/PrivateChat.styl
@@ -106,7 +106,7 @@
     display: none;
 }
 
-&.zen .private-chat-window .superchat {
+&.zen .private-chat-window.superchat {
     display: inline-block;
 }
 

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -114,7 +114,7 @@ class PrivateChat {
                 this.superchat_enabled = !this.superchat_enabled;
                 if (this.superchat_enabled) {
                     superchat.addClass("enabled");
-                    this.dom.addChat("superchat");
+                    this.dom.addClass("superchat");
 
                     comm_socket.send("chat/pm/superchat", {
                         "player_id": this.user_id,

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -114,6 +114,7 @@ class PrivateChat {
                 this.superchat_enabled = !this.superchat_enabled;
                 if (this.superchat_enabled) {
                     superchat.addClass("enabled");
+                    this.dom.addChat("superchat");
 
                     comm_socket.send("chat/pm/superchat", {
                         "player_id": this.user_id,
@@ -123,6 +124,7 @@ class PrivateChat {
                     });
                 } else {
                     superchat.removeClass("enabled");
+                    this.dom.removeClass("superchat");
                     comm_socket.send("chat/pm/superchat", {
                         "player_id": this.user_id,
                         "username": this.player.username,

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -293,6 +293,8 @@ export class Game extends React.PureComponent<GameProperties, any> {
         setExtraActionCallback(null);
         $(window).off("focus", this.onFocus);
         window.document.title = "OGS";
+        let body = document.getElementsByTagName('body')[0];
+        body.classList.remove("zen");   //remove the class
     }
     getLocation():string {
         return window.location.pathname;
@@ -968,11 +970,15 @@ export class Game extends React.PureComponent<GameProperties, any> {
     }
     toggleZenMode() {
         if (this.state.zen_mode) {
+            let body = document.getElementsByTagName('body')[0];
+            body.classList.remove("zen");   //remove the class
             this.setState({
                 zen_mode: false,
                 view_mode: this.computeViewMode(true),
             });
         } else {
+            let body = document.getElementsByTagName('body')[0];
+            body.classList.add("zen");   //add the class
             this.setState({
                 zen_mode: true,
                 view_mode: "zen",


### PR DESCRIPTION
In the forum it was mentioned that the private-chat window is disturbing the zen experience (minimal disturbance). 

https://forums.online-go.com/t/hide-messages-while-being-in-zen-mode/23026

This should hide the private-chat window while Zen mode is active. 
Hopefully superchat still shows up. (If I interpret it correctly superchat means a moderator wants to talk to you officially). Obviously I haven't tested if moderator chat is still visible.