### PR TITLE
fixes #915 - Vacation Day Accrued not displaying for 0 Days

### DIFF
--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -605,9 +605,7 @@ export function daysOnlyDurationString(seconds): string { /* {{{ */
     let days = Math.floor(seconds / 86400);
 
     let ret: string = "";
-    if (days) {
-        ret += interpolate(_("{{number_of_days}} {{day_or_days_plurality}}"), {number_of_days: days, day_or_days_plurality: ngettext("Day", "Days", days)});
-    }
+    ret += interpolate(_("{{number_of_days}} {{day_or_days_plurality}}"), {number_of_days: days, day_or_days_plurality: ngettext("Day", "Days", days)});
     return ret.trim();
 } /* }}} */
 export function shortDurationString(seconds) { /* {{{ */


### PR DESCRIPTION
Fixes #915 

## Proposed Changes

  -removed if(days) which was returning false when days===0
