### PR TITLE
Show username in chat instead of player 123

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -940,6 +940,9 @@ export function chat_markup(body, extra_pattern_replacements?: Array<{split: Reg
         {split: /\b((?:player |user )?https?:\/\/online-go\.com\/(?:u|user(?!\/(?:view|settings|supporter|verifyEmail)))\/(?:[^\/<> ]+)(?:\/|\b))/gi,
             pattern: /\b((player |user )?https?:\/\/online-go\.com\/(?:u|user(?!\/(?:view|settings|supporter|verifyEmail)))\/([^\/<> ]+)(?:\/|\b))/gi,
             replacement: (m, idx) => (<Player user={{"id": -1, username: m[3]}} rank={false} noextracontrols />)},
+        {split: /(@"[^"]+")/gi,
+            pattern: /(@"([^"]+)")/gi,
+            replacement: (m, idx) => (<Player user={{"id": -1, username: m[2]}} rank={false} noextracontrols />)},
         // games
         {split: /(^#[0-9]{3,}|[ ]#[0-9]{3,})/gi, pattern: /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi,
             replacement: (m, idx) => (<Link key={idx} to={`/game/${m[2] || ""}${m[4] || ""}`}>{`${m[3] || ""}game ${m[2] || ""}${m[4] || ""}`}</Link>)},

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -940,9 +940,9 @@ export function chat_markup(body, extra_pattern_replacements?: Array<{split: Reg
         {split: /\b((?:player |user )?https?:\/\/online-go\.com\/(?:u|user(?!\/(?:view|settings|supporter|verifyEmail)))\/(?:[^\/<> ]+)(?:\/|\b))/gi,
             pattern: /\b((player |user )?https?:\/\/online-go\.com\/(?:u|user(?!\/(?:view|settings|supporter|verifyEmail)))\/([^\/<> ]+)(?:\/|\b))/gi,
             replacement: (m, idx) => (<Player user={{"id": -1, username: m[3]}} rank={false} noextracontrols />)},
-        {split: /(@"[^"]+")/gi,
-            pattern: /(@"([^"]+)")/gi,
-            replacement: (m, idx) => (<Player user={{"id": -1, username: m[2]}} rank={false} noextracontrols />)},
+        {split: /(@"[^"\/]+(?:\/[0-9]+)?")/gi,
+            pattern: /(@"([^"\/]+)(?:\/([0-9]+))?")/gi,
+            replacement: (m, idx) => (<Player user={(m[3] ? {id: Number(m[3])} : {username: m[2]})} rank={false} noextracontrols />)},
         // games
         {split: /(^#[0-9]{3,}|[ ]#[0-9]{3,})/gi, pattern: /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi,
             replacement: (m, idx) => (<Link key={idx} to={`/game/${m[2] || ""}${m[4] || ""}`}>{`${m[3] || ""}game ${m[2] || ""}${m[4] || ""}`}</Link>)},

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -933,13 +933,13 @@ export function chat_markup(body, extra_pattern_replacements?: Array<{split: Reg
             replacement: (m, idx) => (<a key={idx} target="_blank" href={m[1]}>{(m[2]).replace(/(\-)/gi, " ")}</a>)},
         // Match online-go links
         // user profiles
-        {split: /\b(player ?[0-9]+)\b/gi, pattern: /\b(player ?([0-9]+))\b/gi, replacement: (m, idx) => (<Link key={idx} to={`/user/view/${m[2]}`}>{m[1]}</Link>)},
+        {split: /\b(player ?[0-9]+)\b/gi, pattern: /\b(player ?([0-9]+))\b/gi, replacement: (m, idx) => (<Player user={{id: Number(m[2])}} rank={false} noextracontrols />)},
         {split: /\b((?:player |user )?https?:\/\/online-go\.com(?:\/player|\/user\/view)\/[0-9]+(?:\/[^\/<> ]+)*(?:\/|\b))/gi,
             pattern: /\b((player |user )?https?:\/\/online-go\.com(?:\/player|\/user\/view)\/([0-9]+)(?:\/[^\/<> ]+)*(?:\/|\b))/gi,
-            replacement: (m, idx) => (<Link key={idx} to={`/player/${m[3]}`}>{(m[2] ? m[2] : "player ") + m[3]}</Link>)},
+            replacement: (m, idx) => (<Player user={{id: Number(m[3])}} rank={false} noextracontrols />)},
         {split: /\b((?:player |user )?https?:\/\/online-go\.com\/(?:u|user(?!\/(?:view|settings|supporter|verifyEmail)))\/(?:[^\/<> ]+)(?:\/|\b))/gi,
             pattern: /\b((player |user )?https?:\/\/online-go\.com\/(?:u|user(?!\/(?:view|settings|supporter|verifyEmail)))\/([^\/<> ]+)(?:\/|\b))/gi,
-            replacement: (m, idx) => (<Link key={idx} to={`/u/${m[3]}`}>{(m[2] ? m[2] : "player ") + m[3]}</Link>)},
+            replacement: (m, idx) => (<Player user={{"id": -1, username: m[3]}} rank={false} noextracontrols />)},
         // games
         {split: /(^#[0-9]{3,}|[ ]#[0-9]{3,})/gi, pattern: /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi,
             replacement: (m, idx) => (<Link key={idx} to={`/game/${m[2] || ""}${m[4] || ""}`}>{`${m[3] || ""}game ${m[2] || ""}${m[4] || ""}`}</Link>)},

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -72,10 +72,18 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
             }
 
             let player_id = typeof(this.props.user) !== "object" ? this.props.user : (this.props.user.id || this.props.user.player_id) ;
+            let username = typeof(this.props.user) !== "object" ? this.props.user : this.props.user.username ;
             if (player_id && player_id > 0) {
                 player_cache.fetch(player_id, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     let player_id = typeof(this.props.user) !== "object" ? this.props.user : (this.props.user.id || this.props.user.player_id) ;
                     if (player_id === user.id) {
+                        this.setState({user: user});
+                    }
+                }).catch(errorLogger);
+            }
+            else if (username) {
+                player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
+                    if (username === user.username) {
                         this.setState({user: user});
                     }
                 }).catch(errorLogger);
@@ -114,6 +122,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
 
         if (!new_props.disableCacheUpdate) {
             let player_id = typeof(new_props.user) !== "object" ? new_props.user : (new_props.user.id || new_props.user.player_id) ;
+            let username = typeof(this.props.user) !== "object" ? this.props.user : this.props.user.username ;
 
             if (typeof(new_props.user) === "object" && new_props.user.id > 0) {
                 player_cache.update(new_props.user);
@@ -123,6 +132,13 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
                 player_cache.fetch(player_id, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     let player_id = typeof(this.props.user) !== "object" ? this.props.user : (this.props.user.id || this.props.user.player_id) ;
                     if (player_id === user.id) {
+                        this.setState({user: user});
+                    }
+                }).catch(errorLogger);
+            }
+            else if (username) {
+                player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
+                    if (username === user.username) {
                         this.setState({user: user});
                     }
                 }).catch(errorLogger);

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -79,14 +79,20 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
                     if (player_id === user.id) {
                         this.setState({user: user});
                     }
-                }).catch(errorLogger);
+                }).catch((user) => {
+                    this.setState({user: {id: player_id, username: "?player" + player_id + "?", ui_class: "provisional", pro: false}});
+                    errorLogger(user);
+                });
             }
             else if (username) {
                 player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     if (username === user.username) {
                         this.setState({user: user});
                     }
-                }).catch(errorLogger);
+                }).catch((user) => {
+                    this.setState({user: {id: null, username: username, ui_class: "provisional", pro: false}});
+                    errorLogger(user);
+                });
             }
         }
 
@@ -134,14 +140,20 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
                     if (player_id === user.id) {
                         this.setState({user: user});
                     }
-                }).catch(errorLogger);
+                }).catch((user) => {
+                    this.setState({user: {id: player_id, username: "?player" + player_id + "?", ui_class: "provisional", pro: false}});
+                    errorLogger(user);
+                });
             }
             else if (username) {
                 player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     if (username === user.username) {
                         this.setState({user: user});
                     }
-                }).catch(errorLogger);
+                }).catch((user) => {
+                    this.setState({user: {id: null, username: username, ui_class: "provisional", pro: false}});
+                    errorLogger(user);
+                });
             }
         }
 

--- a/src/lib/player_cache.ts
+++ b/src/lib/player_cache.ts
@@ -154,6 +154,27 @@ export function lookup_by_username(username: string): PlayerCacheEntry {
     return null;
 }
 
+
+export function fetch_by_username(username: string, required_fields?: Array<string>): Promise<PlayerCacheEntry> {
+    let user = lookup_by_username(username);
+    if (user) {
+        return fetch(user.id, required_fields);
+    }
+    else {
+        let res = get("players", {username: username})
+                    .then((res) => {
+                    if (res.results.length) {
+                        return fetch(res.results[0].id);
+                    } else {
+                        console.error("Attempted to fetch invalid player name: ", username);
+                        return Promise.reject("invalid player name");
+                    }
+                });
+        return res;
+    }
+}
+
+
 export function fetch(player_id: number, required_fields?: Array<string>): Promise<PlayerCacheEntry> {
     if (!player_id) {
         console.error("Attempted to fetch invalid player id: ", player_id);

--- a/src/lib/player_cache.ts
+++ b/src/lib/player_cache.ts
@@ -164,7 +164,7 @@ export function fetch_by_username(username: string, required_fields?: Array<stri
         let res = get("players", {username: username})
                     .then((res) => {
                     if (res.results.length) {
-                        return fetch(res.results[0].id);
+                        return fetch(res.results[0].id, required_fields);
                     } else {
                         console.error("Attempted to fetch invalid player name: ", username);
                         return Promise.reject("invalid player name");

--- a/src/lib/tabcomplete.ts
+++ b/src/lib/tabcomplete.ts
@@ -170,7 +170,7 @@ function onKeyPress(e, options) {
                      /* Space should not be added when there is only 1 match
                             or if there is already a space following the caret position */
                      let space = (match.matches.length > 1 || last.length && last.substr(0, 1) === " ") ? "" : (first.trim().length === 0 ? ": " : " ");
-                     $this.val(first + match.value + space + last);
+                     $this.val(first + '@"' + match.value + '"' + space + last);
                      setCaretToPos(this, sel.start - text.length + match.value.length + space.length);
                  }
 

--- a/src/lib/tabcomplete.ts
+++ b/src/lib/tabcomplete.ts
@@ -170,7 +170,7 @@ function onKeyPress(e, options) {
                      /* Space should not be added when there is only 1 match
                             or if there is already a space following the caret position */
                      let space = (match.matches.length > 1 || last.length && last.substr(0, 1) === " ") ? "" : (first.trim().length === 0 ? ": " : " ");
-                     $this.val(first + '@"' + match.value + '"' + space + last);
+                     $this.val(first + '@"' + match.value + '/' + player_cache.lookup_by_username(match.value).id + '"' + space + last);
                      setCaretToPos(this, sel.start - text.length + match.value.length + space.length);
                  }
 

--- a/src/lib/tabcomplete.ts
+++ b/src/lib/tabcomplete.ts
@@ -129,6 +129,40 @@ function matchName(input, nicknames) {
     return { value: "", matches: matches };
 }
 
+function matchFullName(input, nicknames) {
+    let matches = [];
+    let i = 0;
+    let letter;
+    let letters = "";
+    $.each(nicknames, (index, value) => {
+        if (input.lastIndexOf(value) === input.length - value.length) {
+            matches.push(value);
+        }
+    });
+
+    if (matches.length === 1) {
+        return { value: matches[0], matches: matches };
+    } else if (matches.length > 1) {
+        for (; i < matches[0].length - length; i = i + 1) {
+            letter = matches[0].toLowerCase().substr(length + i, 1);
+
+            $.each(matches, (index, value) => {
+                if (value.toLowerCase().substr(length + i, 1) !== letter) {
+                     letter = "";
+                     return false;
+                }
+            });
+            if (letter) {
+                letters += letter;
+            } else {
+                break;
+            }
+        }
+        return { value: input + letters, matches: matches };
+    }
+    return { value: "", matches: matches };
+}
+
 /* tslint:disable */
 function onKeyPress(e, options) {
     if (e.which === 9) {
@@ -170,7 +204,7 @@ function onKeyPress(e, options) {
                      /* Space should not be added when there is only 1 match
                             or if there is already a space following the caret position */
                      let space = (match.matches.length > 1 || last.length && last.substr(0, 1) === " ") ? "" : (first.trim().length === 0 ? ": " : " ");
-                     $this.val(first + '@"' + match.value + '/' + player_cache.lookup_by_username(match.value).id + '"' + space + last);
+                     $this.val(first + match.value + space + last);
                      setCaretToPos(this, sel.start - text.length + match.value.length + space.length);
                  }
 
@@ -178,6 +212,34 @@ function onKeyPress(e, options) {
 
                  // Part of a crazy hack for Opera
                  this.lastKey = 9;
+            }
+            else if (/( |: )$/.test(text)) {
+                let space = text.match(/( |: )$/)[1];
+                text = text.substring(0, text.length - space.length);
+                if (typeof(options.nicknames) === "function") {
+                    match = matchFullName(text, options.nicknames());
+                } else {
+                    match = matchFullName(text, options.nicknames);
+                }
+
+                completed_event = $.Event("nickname-complete");
+                $.extend(completed_event, match);
+                completed_event.caret = sel.start;
+                $this.trigger(completed_event);
+
+                if ((match.value && !completed_event.isDefaultPrevented()) || true) {
+                    first = val.substr(0, sel.start - match.value.length - space.length);
+                    last    = val.substr(sel.start);
+                    /* Space should not be added when there is only 1 match
+                           or if there is already a space following the caret position */
+                    $this.val(first + '@"' + match.value + '/' + player_cache.lookup_by_username(match.value).id + '"' + space + last);
+                    setCaretToPos(this, sel.start - match.value + match.value.length + space.length);
+                }
+
+                e.preventDefault();
+
+                // Part of a crazy hack for Opera
+                this.lastKey = 9;
             }
         }
     }
@@ -209,7 +271,7 @@ $.fn.nicknameTabComplete = function(options) {
 
 $.fn.nicknameTabComplete.defaults = {
   nicknames: () => player_cache.nicknames,
-  nick_match: /([-_a-z0-9]*)$/i,
+  nick_match: /([-_a-z0-9]+)$/i,
   on_complete: null // Pass in a function as an alternate way of binding to this event
 };
 


### PR DESCRIPTION
Instead of showing `player 1` when someone links a user profile, show the username instead.

This pull request needs a close review. I'm not sure if I broke anything in a subtle way (I encountered no obvious problems)

## Proposed Changes

  - Replace `<Link>` with `<Player>`: I had to enable CacheUpdate to get the username. (There are repeated requests if no user with id exists, else it looks like every user is requested only once)
  - Add another Chat shortcut `@" "` to allow link mentions by name. I had to modify [Player.tsx](src/components/Player/Player.tsx) and [player_cache.ts](src/lib/player_cache.ts) to allow for fetching of `user` by username.
  - Modify [tab-completion](src/lib/tabcomplete.ts) to automatically enclose completed usernames in `@" "`. 
(I tried to enclose every typed username after it's completely entered, but was not able to make it work for *all* usernames (special chars and spaces are problematic))

![image](https://user-images.githubusercontent.com/4864182/65975285-ae1a3780-e46e-11e9-8752-c186f01f05e4.png)

----

I tried to create a test account containing a 💖 to test for special characters, but it's not possible on the beta server. But on the main server users exist using this character https://online-go.com/player/85719/. Are special characters deprecated. And is somewhere a list which chars are allowed?