### PR TITLE
Adding clocks to zen mode

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -392,12 +392,65 @@ goban-view-bar-width=400px
 
     &.zen {
         themed background-color bg
-        .left-col, .right-col {
+        .left-col {
             display: none;
+        }
+        .right-col {
+            padding-right: 0.5rem;
+            min-width: 150px;
+            max-width: 300px;
+            padding-top: 2.8rem;
+            justify-content: start;
+
+            .game-state {
+                display: none;
+            }
+            .play-controls {
+                display: block;
+                flex-grow: 0;
+            }
+            .players {
+                flex-direction: column-reverse;
+            }
+            .player-container {
+                width: 100%;
+            }
+            .black.player-container {
+                background: #333 !important;
+            }
+            .white.player-container {
+                background: #ddd !important;
+                .score-container {
+                    color: #000;   
+                }
+            }
         }
 
         .leave-zen-mode-button {
             display: inline-block;
+        }
+        .Dock {
+            display: none;
+        }
+    }
+
+    &.portrait.zen {
+        .center-col {
+            padding-top: 2.8rem
+            display: block;
+
+            .game-state {
+                display: none;
+            }
+            .black.player-container {
+                background: #333 !important;
+            }
+            .white.player-container {
+                background: #ddd !important;
+                .score-container {
+                    color: #000;   
+                }
+            }
         }
     }
 

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -72,7 +72,7 @@ interface GameProperties {
 /* TODO: Implement giving voice and control over to players in Reviews */
 /* TODO: Implement mobile interface for reviews */
 
-export type ViewMode = "portrait"|"wide"|"square"|"zen";
+export type ViewMode = "portrait"|"wide"|"square";
 type AdClass = 'no-ads' | 'block' | 'goban-banner' | 'outer-banner' | 'mobile-banner';
 
 export class Game extends React.PureComponent<GameProperties, any> {
@@ -131,7 +131,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
         this.game_id = this.props.match.params.game_id ? parseInt(this.props.match.params.game_id) : 0;
         this.review_id = this.props.match.params.review_id ? parseInt(this.props.match.params.review_id) : 0;
         this.state = {
-            view_mode: "wide" as ViewMode,
+            view_mode: this.computeViewMode(),
             squashed: goban_view_squashed(),
             undo_requested: false,
             estimating_score: false,
@@ -155,7 +155,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
             ai_review_enabled: preferences.get('ai-review-enabled'),
         };
 
-        (this.state as any).view_mode = this.computeViewMode(); /* needs to access this.state.zen_mode, so can't be set above */
 
         this.conditional_move_tree = $("<div class='conditional-move-tree-container'/>")[0];
         this.goban_div = $("<div class='Goban'>");
@@ -904,11 +903,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
             }
         }
     }
-    computeViewMode(ignore_zen_mode?): ViewMode {
-        if (!ignore_zen_mode && this.state.zen_mode) {
-            return "zen";
-        }
-
+    computeViewMode(): ViewMode {
         return goban_view_mode();
     }
     computeSquashed(): boolean {
@@ -974,14 +969,14 @@ export class Game extends React.PureComponent<GameProperties, any> {
             body.classList.remove("zen");   //remove the class
             this.setState({
                 zen_mode: false,
-                view_mode: this.computeViewMode(true),
+                view_mode: this.computeViewMode(),
             });
         } else {
             let body = document.getElementsByTagName('body')[0];
             body.classList.add("zen");   //add the class
             this.setState({
                 zen_mode: true,
-                view_mode: "zen",
+                view_mode: this.computeViewMode(),
             });
         }
         this.onResize();
@@ -1808,7 +1803,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
 
         return (
             <div>
-             <div className={"Game MainGobanView " + this.state.view_mode + " " + (this.state.squashed ? "squashed" : "")}>
+             <div className={"Game MainGobanView " + this.state.view_mode + (this.state.zen_mode ? " zen" : "") + " " + (this.state.squashed ? "squashed" : "")}>
                 {this.frag_kb_shortcuts()}
                 <i onClick={this.toggleZenMode} className="leave-zen-mode-button ogs-zen-mode"></i>
 

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -19,7 +19,6 @@
     50% { color: #888; }
 }
 
-
 .MainGobanView .players {
     flex-shrink: 0;
     flex-grow: 0;
@@ -372,6 +371,19 @@
 
 }
 
+&.zen .MainGobanView .players {
+    div.in-game-clock {
+        &.paused .main-time {
+            animation-iteration-count: 0
+        }
+        .pause-text {
+            display: none;
+        }
+    }
+    .player-name-container, .player-icon-container, .score-details {
+        display: none;
+    }
+}
 
 .MainGobanView.portrait .players {
     .player-icon-container {
@@ -403,5 +415,20 @@
         .periods, .period-time {
             font-size: font-size-extra-small;
         }
+    }
+}
+
+&.zen .MainGobanView.portrait .players {
+    div.in-game-clock {
+        &.paused .main-time {
+            animation-iteration-count: 0
+        }
+        .pause-text {
+            display: none;
+        }
+    }
+
+    .player-name-container, .player-icon-container, .score-details {
+        display: none;
     }
 }


### PR DESCRIPTION
Fixes #484 

## Proposed Changes

  - Adding clocks to zen mode
  - Introduce a separate portrait layout for zen mode
  - move controls to the right (below clocks), to make goban as big as possible
  - some related layout changes

I changed the background color of the clocks to be monochrome in zen mode. The linear-gradient attracts too much attention in zen.

![zen landscape](https://user-images.githubusercontent.com/4864182/66073658-ca45d380-e557-11e9-8a02-1db1b856a920.png)
![zen portrait](https://user-images.githubusercontent.com/4864182/66074010-8ef7d480-e558-11e9-8d54-28aac094a692.png)