### PR TITLE
Always floor/ceil rank

### DIFF
--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -185,7 +185,7 @@ export function rankString(r, with_tenths?:boolean) {
 
     if (r < 30) {
         if (with_tenths) {
-            r = Math.ceil((30 - r) * 10) / 10;
+            r = (Math.ceil((30 - r) * 10) / 10).toFixed(1);
         } else {
             r = Math.ceil(30 - r);
         }
@@ -193,7 +193,7 @@ export function rankString(r, with_tenths?:boolean) {
     }
 
     if (with_tenths) {
-        r = Math.floor((r - 29) * 10) / 10;
+        r = (Math.floor((r - 29) * 10) / 10).toFixed(1);
     } else {
         r = Math.floor(r - 29);
     }

--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -185,7 +185,7 @@ export function rankString(r, with_tenths?:boolean) {
 
     if (r < 30) {
         if (with_tenths) {
-            r = (30 - r).toFixed(1);
+            r = Math.ceil((30 - r) * 10) / 10;
         } else {
             r = Math.ceil(30 - r);
         }
@@ -193,7 +193,7 @@ export function rankString(r, with_tenths?:boolean) {
     }
 
     if (with_tenths) {
-        r = (r - 29).toFixed(1);
+        r = Math.floor((r - 29) * 10) / 10;
     } else {
         r = Math.floor(r - 29);
     }


### PR DESCRIPTION
When the rank of a player is near threshold, there is a discrepancy between the PlayerDetails (rank rounded to 1 decimal point) and the rank displayed in [] behind the players name (rank ceiled with no decimal places)

This came up in the [forum](https://forums.online-go.com/t/rank-wrong-presentation-calculation-solved-rounding/23343) for a player whose precise rank would be (7.0301…k). His rank is shown as [8k] and 7.0k in PlayerDetails, which led to enough irritation to create a forum post.

My proposal is to floor/ceil the decimal rank as well (to 7.1k in this case). It's more consistent and should mitigate such inconsistencies in the future.

Before:
![Before](https://user-images.githubusercontent.com/4864182/67192655-42374900-f3f4-11e9-8b16-486ac2d55df5.png)
After:
![After](https://user-images.githubusercontent.com/4864182/67192754-6a26ac80-f3f4-11e9-8f0c-8d7b561001c7.png)

