### PR TITLE
Correct Player id handling in Player React

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -72,7 +72,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
             }
 
             let player_id = typeof(this.props.user) !== "object" ? this.props.user : (this.props.user.id || this.props.user.player_id) ;
-            let username = typeof(this.props.user) !== "object" ? this.props.user : this.props.user.username ;
+            let username = typeof(this.props.user) !== "object" ? null : this.props.user.username ;
             if (player_id && player_id > 0) {
                 player_cache.fetch(player_id, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     let player_id = typeof(this.props.user) !== "object" ? this.props.user : (this.props.user.id || this.props.user.player_id) ;
@@ -128,7 +128,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
 
         if (!new_props.disableCacheUpdate) {
             let player_id = typeof(new_props.user) !== "object" ? new_props.user : (new_props.user.id || new_props.user.player_id) ;
-            let username = typeof(this.props.user) !== "object" ? this.props.user : this.props.user.username ;
+            let username = typeof(this.props.user) !== "object" ? null : this.props.user.username ;
 
             if (typeof(new_props.user) === "object" && new_props.user.id > 0) {
                 player_cache.update(new_props.user);

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -84,6 +84,9 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
                     errorLogger(user);
                 });
             }
+            else if (player_id && player_id <= 0) {
+                // do nothing
+            }
             else if (username) {
                 player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     if (username === user.username) {
@@ -144,6 +147,9 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
                     this.setState({user: {id: player_id, username: "?player" + player_id + "?", ui_class: "provisional", pro: false}});
                     errorLogger(user);
                 });
+            }
+            else if (player_id && player_id <= 0) {
+                // do nothing
             }
             else if (username) {
                 player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {


### PR DESCRIPTION
The joseki code is using -1 as fallback userid.

The changes I made earlier to [Player.tsx](https://github.com/flovo/online-go.com/blob/e7ca023e62d71641381f5355e9aeaa556798df49/src/components/Player/Player.tsx) caused notpositive ids to be interpreted as usernames and tried to fetch users with that name (what luckily failed).

This pr restores the original 'do nothing' behavior for invalid (not positive) userids again.