### PR TITLE
Fix game history speed icon for no timelimit

### DIFF
--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -567,15 +567,25 @@ export class User extends React.PureComponent<UserProperties, any> {
                   }
                 }
 
-                if (r.time_per_move >= 3600) {
-                  item.speed = "Correspondence";
-                  item.speed_icon_class = "speed-icon ogs-turtle";
-                } else if (r.time_per_move < 10) {
-                  item.speed = "Blitz";
-                  item.speed_icon_class = "speed-icon fa fa-bolt";
+                if (!item.speed) { // fallback
+                    if (r.time_per_move >= 3600 || r.time_per_move === 0) {
+                        item.speed = "Correspondence";
+                    } else if (r.time_per_move < 10 && r.time_per_move > 0) {
+                        item.speed = "Blitz";
+                    } else if (r.time_per_move < 3600 && r.time_per_move >= 10) {
+                        item.speed = "Live";
+                    } else {
+                        console.log("time_per_move < 0");
+                    }
+                }
+                if (item.speed === "Correspondence") {
+                    item.speed_icon_class = "speed-icon ogs-turtle";
+                } else if (item.speed === "Blitz") {
+                    item.speed_icon_class = "speed-icon fa fa-bolt";
+                } else if (item.speed === "Live") {
+                    item.speed_icon_class = "speed-icon fa fa-clock-o";
                 } else {
-                  item.speed = "Live";
-                  item.speed_icon_class = "speed-icon fa fa-clock-o";
+                    console.log("unsupported speed setting: " + item.speed);
                 }
 
                 item.name = r.name;

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -567,6 +567,12 @@ export class User extends React.PureComponent<UserProperties, any> {
                   }
                 }
 
+                if ("time_control_parameters" in r) {
+                    let tcp = JSON.parse(r.time_control_parameters);
+                    if ("speed" in tcp) {
+                        item.speed = tcp.speed[0].toUpperCase() + tcp.speed.slice(1); // capitalize string
+                    }
+                }
                 if (!item.speed) { // fallback
                     if (r.time_per_move >= 3600 || r.time_per_move === 0) {
                         item.speed = "Correspondence";


### PR DESCRIPTION
Games with no time limit (`time_per_move===0`) were accidentally shown as blitz games in the game history on the profile page. This pr should fix it, showing it as correspondence.

Using `time_control_parameters.speed` as default source should improve the detection of the right game speed further.

Additionally, I added checks to ensure that negative `time_per_move` isn't interpreted as “Live”, but I doubt we get negative values. If neither corr, live nor blitz is detected, no icon will be displayed for game speed. 