### PR TITLE
Quick fix for Play mode, broken with caching

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -233,7 +233,7 @@ export class Joseki extends React.Component<JosekiProps, any> {
     }
 
     initializeBoard = (target_position: string = "root") => {
-        console.log("Resetting board...");
+        // console.log("Resetting board...");
         this.next_moves = [];
         this.played_mistake = false;
         this.computer_turn = false;
@@ -374,7 +374,7 @@ export class Joseki extends React.Component<JosekiProps, any> {
             this.processNewMoves(node_id, this.cached_positions[node_id]);
         }
         else {
-            console.log("fetching position for node", node_id);
+            // console.log("fetching position for node", node_id);
             fetch(position_url(node_id, variation_filter), {
                 mode: 'cors',
                 headers: godojo_headers
@@ -430,7 +430,7 @@ export class Joseki extends React.Component<JosekiProps, any> {
             else if (dto.next_moves.length > 0 && this.state.move_string !== "") {
                 // the computer plays both good and bad moves
                 const next_play = dto.next_moves[Math.floor(Math.random() * dto.next_moves.length)];
-                console.log("Will play: ", next_play);
+                // console.log("Will play: ", next_play);
 
                 this.computer_turn = true;
                 if (next_play.placement === "pass") {

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -367,7 +367,8 @@ export class Joseki extends React.Component<JosekiProps, any> {
 
         // Because of tricky sequencing of state update from server responses, only
         // explore mode works with this caching ... the others need processNewMoves to happen after completion
-        // of fetchNextFilteredMovesFor (this routine), which doesn't work with caching...
+        // of fetchNextFilteredMovesFor (this routine), which doesn't work with caching... needs some reorganisation
+        // to make that work
         if (this.state.mode === PageMode.Explore && this.cached_positions.hasOwnProperty(node_id)) {
             console.log("cached position:", node_id);
             this.processNewMoves(node_id, this.cached_positions[node_id]);


### PR DESCRIPTION
Caching broke Play mode.

This disables caching except for Explore more, where it's most useful anyhow.

Some code resequencing needed to make Play mode work with caching (due to cache causing move processing in-line instead of after call to server).
