### PR TITLE
Player-container colour tweaks for improved "white" container

### DIFF
--- a/src/components/Clock/Clock.styl
+++ b/src/components/Clock/Clock.styl
@@ -37,10 +37,6 @@
             animation-iteration-count: infinite
         }
 
-        &.paused-correspondence {
-            color: #888;
-        }
-
         .overtime-container {
             flex-grow: 1;
             display: inline-block;

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -188,7 +188,7 @@ light.miniboard-stone-removal-border    = darken(light.miniboard-stone-removal, 
 light.miniboard-stone-removal-hover     = lighten(light.miniboard-stone-removal, 45%)
 light.miniboard-stone-removal-hover-border= darken(light.miniboard-stone-removal-hover, 45%)
 light.player-black-background           = linear-gradient(to bottom, #7d7e7d 0%, #0e0e0e 100%);
-light.player-white-background           = linear-gradient(to bottom, #ffffff 0%, #e5e5e5 100%);
+light.player-white-background           = linear-gradient(to bottom, #e5e5e5e5 0%, #ffffff 100%);
 light.inactive-support-gradient         = linear-gradient(to bottom, #ffffff 0%, #e5e5e5 100%);
 light.active-support-gradient           = linear-gradient(to bottom, #ffffff 0%, lighten(light.supporter, 70%) 100%);
 light.player-black-fg                   = #eeeeee
@@ -197,6 +197,8 @@ light.player-black-name                 = lighten(light.user, 60%)
 light.player-white-name                 = light.user
 light.player-black-clock                = lighten(light.player-black-fg, 50%)
 light.player-white-clock                = light.player-white-fg
+light.player-black-paused-clock          = #ABA8AD;
+light.player-white-paused-clock          = #928A99;
 
 /************/
 /*** DARK ***/
@@ -301,17 +303,20 @@ dark.miniboard-stone-removal-border     = darken(dark.miniboard-stone-removal, 4
 dark.miniboard-stone-removal-hover      = darken(dark.miniboard-stone-removal, 45%)
 dark.miniboard-stone-removal-hover-border= darken(dark.miniboard-stone-removal-hover, 45%)
 dark.player-black-background            = linear-gradient(to bottom, #7d7d7d 0%, #333333 50%, #0c0c0c 100%);
-dark.player-white-background            = linear-gradient(to bottom, #dddddd 0%, #666666 50%, #333333 101%);
+dark.player-white-background            = linear-gradient(to bottom, #888888 0%, #888888 60%, #999999 101%);
 dark.inactive-support-gradient          = linear-gradient(to bottom, #7d7d7d 0%, #333333 100%);
 dark.active-support-gradient            = linear-gradient(to bottom, darken(dark.supporter, 30%) 0%, darken(dark.supporter, 60%) 100%);
 dark.player-black-fg                    = dark.fg
-dark.player-white-fg                    = lighten(dark.fg, 20%)
+dark.player-white-fg                    = darken(dark.fg, 90%)
 dark.player-black-name                  = dark.user
 dark.player-white-name                  = lighten(dark.user, 10%)
 dark.player-black-clock                 = lighten(dark.player-black-fg, 50%)
 dark.player-white-clock                 = #000
+dark.player-white-paused-clock          = #5F4A71;
+dark.player-black-paused-clock          = #928A99;
 
 dark.joseki-ideal                       = #DBAF00;
+
 
 /************/
 /************/

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -119,6 +119,10 @@
         box-shadow: 0 2px 5px rgba(50,50,50,.51);
         themed background player-white-background
         themed color player-white-fg
+
+        .paused-correspondence {
+            themed color player-white-paused-clock
+        }
     }
 
     .black.player-container {
@@ -126,6 +130,10 @@
         themed color player-black-fg
         border-top: 1px solid #202020;
         box-shadow: 0 2px 5px rgba(20,20,20,.71);
+
+        .paused-correspondence {
+            themed color player-black-paused-clock
+        }
 
         .player-name {
             color: #00B8FF;


### PR DESCRIPTION
Fixes #1005 

## Proposed Changes

Make the "white player container" have more whiteness, and be whiter at the bottom where the player name and score is, so it is more obvious which container is for "white"


Current dark game underway
<img width="416" alt="old-dark" src="https://user-images.githubusercontent.com/61894/70228277-feca4b80-17a3-11ea-8c6e-cce3822e8f21.png"> 

New dark game underway
<img width="412" alt="new-dark" src="https://user-images.githubusercontent.com/61894/70228285-02f66900-17a4-11ea-892b-4eeb1c64c08d.png">

Current dark game paused
<img width="415" alt="old-dark-paused" src="https://user-images.githubusercontent.com/61894/70228352-21f4fb00-17a4-11ea-90e6-0920a227ba82.png">

New dark game paused
<img width="414" alt="new-dark-paused" src="https://user-images.githubusercontent.com/61894/70228372-2ae5cc80-17a4-11ea-8d1b-dee73b367144.png">

Current light game underway

<img width="413" alt="old-light" src="https://user-images.githubusercontent.com/61894/70228387-33d69e00-17a4-11ea-9660-2404dc640640.png">

New light game underway

<img width="397" alt="new-light" src="https://user-images.githubusercontent.com/61894/70228403-3afdac00-17a4-11ea-9fa6-dd7f0d95e42e.png">


Current light game paused

<img width="415" alt="old-light-paused" src="https://user-images.githubusercontent.com/61894/70228421-40f38d00-17a4-11ea-9f11-374dcac8f879.png">


New light game paused

<img width="415" alt="new-light-paused" src="https://user-images.githubusercontent.com/61894/70228435-47820480-17a4-11ea-86ce-99a2380b0e8a.png">


