### PR TITLE
Use number value handicap instead of sting d.handicap

### DIFF
--- a/src/components/RatingsChart/RatingEntry.ts
+++ b/src/components/RatingsChart/RatingEntry.ts
@@ -103,7 +103,7 @@ export function makeRatingEntry(d:any):RatingEntry {
         if (played_black) {
             effective_rating += get_handicap_adjustment(effective_rating, handicap);
         } else {
-            effective_opponent_rating += get_handicap_adjustment(effective_opponent_rating, d.handicap);
+            effective_opponent_rating += get_handicap_adjustment(effective_opponent_rating, handicap);
         }
     }
 


### PR DESCRIPTION
Fixes https://forums.online-go.com/t/wins-losses-against-stronger-weaker-opponents-again/23952?u=flovo

btw: Is it possible to turn this kind of type conversion off in javascript?