### PR TITLE
Fix bug in handicap adjustment for rating graph

### DIFF
--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -16,6 +16,7 @@
  */
 
 import {_, interpolate, pgettext} from "translate";
+import { Interface } from "readline";
 
 interface IRankInfo {
     rank: number;
@@ -269,3 +270,33 @@ export function allRanks() { return rankList().concat( proRankList()); }
 export function humble_rating(rating:number, deviation:number):number {
     return rating - ((Math.min(350, Math.max(PROVISIONAL_RATING_CUTOFF, deviation)) - PROVISIONAL_RATING_CUTOFF) / (350 - PROVISIONAL_RATING_CUTOFF)) * deviation;
 }
+
+export interface EffectiveOutcome {
+    black_real_rating: number;
+    white_real_rating: number;
+    black_real_stronger: boolean;
+    white_real_stronger: boolean;
+    handicap: number;
+    black_effective_rating: number;
+    white_effective_rating: number;
+    black_effective_stronger: boolean;
+    white_effective_stronger: boolean;
+}
+
+export function effective_outcome(black_rating: number, white_rating: number, handicap: number):EffectiveOutcome {
+    //let res: EffectiveOutcome = new EffectiveOutcome;
+    let black_effective_rating: number = black_rating + get_handicap_adjustment(black_rating, handicap);
+    let white_effective_rating: number = white_rating;
+    return {
+        black_real_rating: black_rating,
+        white_real_rating: white_rating,
+        handicap: handicap,
+        black_effective_rating: black_effective_rating,
+        white_effective_rating: white_effective_rating,
+        black_real_stronger: black_rating > white_rating,
+        black_effective_stronger: black_effective_rating > white_effective_rating,
+        white_real_stronger: white_rating >= black_rating,
+        white_effective_stronger: white_effective_rating >= black_effective_rating
+    };
+}
+

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -28,7 +28,7 @@ import {PlayerIcon} from 'PlayerIcon';
 import {GameList} from "GameList";
 import {Player} from "Player";
 import {updateDup, alertModerator, getGameResultText, ignore} from "misc";
-import {longRankString, rankString, getUserRating, humble_rating} from "rank_utils";
+import {longRankString, rankString, getUserRating, humble_rating, effective_outcome} from "rank_utils";
 import {durationString, daysOnlyDurationString} from "TimeControl";
 import {openModerateUserModal} from "ModerateUser";
 import {openSupporterAdminModal} from "SupporterAdmin";
@@ -547,24 +547,25 @@ export class User extends React.PureComponent<UserProperties, any> {
                 item.white_class = item.white_won ? (item.white.id === this.user_id ? "library-won" : "library-lost") : "";
                 item.historical = r.historical_ratings;
 
+                let outcome = effective_outcome(item.historical.black.ratings.overall.rating, item.historical.white.ratings.overall.rating, item.handicap);
                 if ((r.white_lost && r.black_lost) || (!r.white_lost && !r.black_lost) || r.annulled) {
                     item.result_class = "library-tie-result";
                 } else if (item.white_won) {
-                  if (item.white.id === this.user_id && r.ranked) {
-                    item.result_class = item.historical.white.ratings.overall.rating > item.historical.black.ratings.overall.rating ? "library-won-result-vs-weaker" : "library-won-result-vs-stronger";
-                  } else if (r.ranked) {
-                    item.result_class = item.historical.white.ratings.overall.rating > item.historical.black.ratings.overall.rating ? "library-lost-result-vs-stronger" : "library-lost-result-vs-weaker";
-                  } else {
-                    item.result_class = item.white.id === this.user_id ? "library-won-result-unranked" : "library-lost-result-unranked";
-                  }
+                    if (item.white.id === this.user_id && r.ranked) {
+                        item.result_class = outcome.white_effective_stronger ? "library-won-result-vs-weaker" : "library-won-result-vs-stronger";
+                    } else if (r.ranked) {
+                        item.result_class = outcome.white_effective_stronger ? "library-lost-result-vs-stronger" : "library-lost-result-vs-weaker";
+                    } else {
+                        item.result_class = item.white.id === this.user_id ? "library-won-result-unranked" : "library-lost-result-unranked";
+                    }
                 } else {
-                  if (item.white.id === this.user_id && r.ranked) {
-                    item.result_class = item.historical.white.ratings.overall.rating > item.historical.black.ratings.overall.rating ? "library-lost-result-vs-weaker" : "library-lost-result-vs-stronger";
-                  } else if (r.ranked) {
-                    item.result_class = item.historical.white.ratings.overall.rating > item.historical.black.ratings.overall.rating ? "library-won-result-vs-stronger" : "library-won-result-vs-weaker";
-                  } else {
-                    item.result_class = item.white.id === this.user_id ? "library-lost-result-unranked" : "library-won-result-unranked";
-                  }
+                    if (item.white.id === this.user_id && r.ranked) {
+                        item.result_class = outcome.white_effective_stronger ? "library-lost-result-vs-weaker" : "library-lost-result-vs-stronger";
+                    } else if (r.ranked) {
+                        item.result_class = outcome.white_effective_stronger ? "library-won-result-vs-stronger" : "library-won-result-vs-weaker";
+                    } else {
+                        item.result_class = item.white.id === this.user_id ? "library-lost-result-unranked" : "library-won-result-unranked";
+                    }
                 }
 
                 if ("time_control_parameters" in r) {


### PR DESCRIPTION
Fixes https://forums.online-go.com/t/wins-losses-against-stronger-weaker-opponents-again/23952?u=flovo

In 
https://github.com/online-go/online-go.com/blob/ac381c26f952e344574b5a69e7e8d3d340b12c7f/src/components/RatingsChart/RatingEntry.ts#L106
handicap is passed as string, resulting the math going wrong. (effective rating ~ real rating)

Besides the coloring on the game history used the real ratings to determine stronger/weaker.

## Proposed Changes

  - move the code to determine the effective outcome to rank_utils.ts
  - use the new code for rating graph
  - use the new code for game history
