### PR TITLE
Add a setting to hide ranks and ratings

### DIFF
--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -113,8 +113,8 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
             black_score: interpolate("%s points", [(score.black.prisoners + score.black.komi)]),
             white_score: interpolate("%s points", [(score.white.prisoners + score.white.komi)]),
 
-            black_name: (typeof(black) === "object" ? (black.username + " [" + getUserRating(black).bounded_rank_label + "]") : black),
-            white_name: (typeof(white) === "object" ? (white.username + " [" + getUserRating(white).bounded_rank_label + "]") : white),
+            black_name: (typeof(black) === "object" ? (black.username + (preferences.get('hide-ranks') ? "" : (" [" + getUserRating(black).bounded_rank_label + "]"))) : black),
+            white_name: (typeof(white) === "object" ? (white.username + (preferences.get('hide-ranks') ? "" : (" [" + getUserRating(white).bounded_rank_label + "]"))) : white),
             paused: this.state.black_pause_text ? "paused" : "",
 
             current_users_move: player_to_move === data.get("config.user").id,

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -27,6 +27,7 @@ import {PlayerDetails} from "./PlayerDetails";
 import {Flag} from "Flag";
 import {PlayerIcon} from "PlayerIcon";
 import * as player_cache from "player_cache";
+import * as preferences from "preferences";
 import online_status from "online_status";
 import {pgettext} from "translate";
 
@@ -241,7 +242,9 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
                 rank_text = rating.bounded_rank_label;
             }
 
-            rank = <span className='Player-rank'>[{rank_text}]</span>;
+            if (!preferences.get("hide-ranks")) {
+                rank = <span className='Player-rank'>[{rank_text}]</span>;
+            }
         }
 
         if (props.flare) {

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -34,6 +34,7 @@ import {challenge} from "ChallengeModal";
 import {getPrivateChat} from "PrivateChat";
 import {openBlockPlayerControls} from "BlockPlayer";
 import {Player} from "./Player";
+import * as preferences from "preferences";
 import {close_friend_list} from 'FriendList/FriendIndicator';
 import cached from 'cached';
 
@@ -228,7 +229,7 @@ export class PlayerDetails extends React.PureComponent<PlayerDetailsProperties, 
     render() {
         let user = data.get("user");
 
-        let rating = this.state.ratings ? getUserRating(this.state, 'overall', 0) : null;
+        let rating = !preferences.get("hide-ranks") && (this.state.ratings ? getUserRating(this.state, 'overall', 0) : null);
 
         return (
             <div className="PlayerDetails">

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -20,6 +20,7 @@ import {Link} from "react-router-dom";
 import {getUserRating, is_novice, is_provisional, humble_rating} from "rank_utils";
 import {Player} from "Player";
 import {PlayerIcon} from "PlayerIcon";
+import * as preferences from "preferences";
 
 
 
@@ -37,7 +38,7 @@ export class ProfileCard extends React.Component<ProfileCardInterface, any> {
 
     render() {
         let user = this.props.user;
-        let rating = user ? getUserRating(user, 'overall', 0) : null;
+        let rating = !preferences.get("hide-ranks") && user ? getUserRating(user, 'overall', 0) : null;
 
         return (
             <div className='ProfileCard'>

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -59,6 +59,7 @@ let defaults = {
     "show-all-challenges": false,
     "show-move-numbers": true,
     "show-offline-friends": true,
+    "hide-ranks": false,
     "show-tournament-indicator": true,
     "show-variation-move-numbers": false,
     "sound-enabled": true,

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -99,6 +99,7 @@ export class Settings extends React.PureComponent<{}, any> {
             translation_dialog_never_show: preferences.get("translation-dialog-never-show"),
             dock_delay: preferences.get("dock-delay"),
             show_tournament_indicator: preferences.get("show-tournament-indicator"),
+            hide_ranks: preferences.get("hide-ranks"),
             disable_ai_review: !preferences.get("ai-review-enabled"),
             disable_variations_in_chat: !preferences.get("variations-in-chat-enabled"),
         };
@@ -314,6 +315,10 @@ export class Settings extends React.PureComponent<{}, any> {
     setShowTournamentIndicator = (ev) => {
         preferences.set("show-tournament-indicator", ev.target.checked),
         this.setState({show_tournament_indicator: preferences.get("show-tournament-indicator")});
+    }
+    setHideRanks = (ev) => {
+        preferences.set("hide-ranks", ev.target.checked),
+        this.setState({hide_ranks: preferences.get("hide-ranks")});
     }
     setUnicodeFilterUsernames = (ev) => {
         preferences.set("unicode-filter", ev.target.checked),
@@ -572,6 +577,11 @@ export class Settings extends React.PureComponent<{}, any> {
                             <dd>
                                 <input id="show-tournament-indicator" type="checkbox" checked={this.state.show_tournament_indicator} onChange={this.setShowTournamentIndicator} />
                             </dd>
+                            <dt><label htmlFor="hide-ranks">{_("Hide ranks and ratings")}</label></dt>
+                            <dd>
+                                <input id="hide-ranks" type="checkbox" checked={this.state.hide_ranks} onChange={this.setHideRanks} />
+                            </dd>
+
 
                             {(user.is_moderator || null) &&
                                 <dt><label htmlFor="incident-report-notifications">{_("Notify me when an incident is submitted for moderation")}</label></dt>

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -472,4 +472,9 @@
             }
         }
     }
+
+    button.toggle-ratings {
+        display: block;
+        margin: 10px auto;
+    }
 }


### PR DESCRIPTION
Some players (including me) find it more relaxing to not see their opponents' or their own rank and rating.

This commit adds a setting called "Hide ranks and ratings".
When the setting is activated:
* Ranks next to player names are hidden
* Ranks in the mini goban are hidden
* Ranks and ratings in the player details and profile card are hidden
* Ratings in the rating table on the profile page are hidden
* The rating chart on the profile page is hidden
* There is a button on the profile page that toggles the visibility of the rating chart and rating table, as well as the rank next to the player name.