### PR TITLE
Correct stronger/weaker labels in game history and rating graph

### DIFF
--- a/src/components/RatingsChart/RatingEntry.ts
+++ b/src/components/RatingsChart/RatingEntry.ts
@@ -125,9 +125,9 @@ export function makeRatingEntry(d:any):RatingEntry {
         count              : d.opponent_id > 0 ? 1 : 0,
         wins               : won,
         losses             : lost,
-        strong_wins        : (played_black ? outcome.black_effective_stronger : outcome.white_effective_stronger) ? won : 0,
-        strong_losses      : (played_black ? outcome.black_effective_stronger : outcome.white_effective_stronger) ? lost : 0,
-        weak_wins          : (played_black ? outcome.white_effective_stronger : outcome.black_effective_stronger) ? won : 0,
-        weak_losses        : (played_black ? outcome.white_effective_stronger : outcome.black_effective_stronger) ? lost : 0,
+        strong_wins        : (played_black ? outcome.white_effective_stronger : outcome.black_effective_stronger) ? won : 0,
+        strong_losses      : (played_black ? outcome.white_effective_stronger : outcome.black_effective_stronger) ? lost : 0,
+        weak_wins          : (played_black ? outcome.black_effective_stronger : outcome.white_effective_stronger) ? won : 0,
+        weak_losses        : (played_black ? outcome.black_effective_stronger : outcome.white_effective_stronger) ? lost : 0,
     });
 }

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -539,6 +539,8 @@ export class User extends React.PureComponent<UserProperties, any> {
                 item.width = r.width;
                 item.height = r.height;
                 item.date = r.ended ? new Date(r.ended) : null;
+                item.ranked = r.ranked;
+                item.handicap = r.handicap;
                 item.black = r.players.black;
                 item.black_won = !r.black_lost && r.white_lost;
                 item.black_class = item.black_won ? (item.black.id === this.user_id ? "library-won" : "library-lost") : "";
@@ -550,21 +552,25 @@ export class User extends React.PureComponent<UserProperties, any> {
                 let outcome = effective_outcome(item.historical.black.ratings.overall.rating, item.historical.white.ratings.overall.rating, item.handicap);
                 if ((r.white_lost && r.black_lost) || (!r.white_lost && !r.black_lost) || r.annulled) {
                     item.result_class = "library-tie-result";
-                } else if (item.white_won) {
-                    if (item.white.id === this.user_id && r.ranked) {
-                        item.result_class = outcome.white_effective_stronger ? "library-won-result-vs-weaker" : "library-won-result-vs-stronger";
-                    } else if (r.ranked) {
-                        item.result_class = outcome.white_effective_stronger ? "library-lost-result-vs-stronger" : "library-lost-result-vs-weaker";
+                } else if (item.white.id === this.user_id) /* played white */ {
+                    if (item.ranked) {
+                        if (item.white_won) /* player won */ {
+                            item.result_class = outcome.white_effective_stronger ? "library-won-result-vs-weaker" : "library-won-result-vs-stronger";
+                        } else if (item.black_won) /* player lost */ {
+                            item.result_class = outcome.white_effective_stronger ? "library-lost-result-vs-weaker" : "library-lost-result-vs-stronger";
+                        }
                     } else {
-                        item.result_class = item.white.id === this.user_id ? "library-won-result-unranked" : "library-lost-result-unranked";
+                        item.result_class = item.white_won ? "library-won-result-unranked" : "library-lost-result-unranked"; /* tie catched above */
                     }
-                } else {
-                    if (item.white.id === this.user_id && r.ranked) {
-                        item.result_class = outcome.white_effective_stronger ? "library-lost-result-vs-weaker" : "library-lost-result-vs-stronger";
-                    } else if (r.ranked) {
-                        item.result_class = outcome.white_effective_stronger ? "library-won-result-vs-stronger" : "library-won-result-vs-weaker";
+                } else if (item.black.id === this.user_id) /* played black */ {
+                    if (item.ranked) {
+                        if (item.black_won) /* player won */ {
+                            item.result_class = outcome.black_effective_stronger ? "library-won-result-vs-weaker" : "library-won-result-vs-stronger";
+                        } else if (item.white_won) /* player black */ {
+                            item.result_class = outcome.black_effective_stronger ? "library-lost-result-vs-weaker" : "library-lost-result-vs-stronger";
+                        }
                     } else {
-                        item.result_class = item.white.id === this.user_id ? "library-lost-result-unranked" : "library-won-result-unranked";
+                        item.result_class = item.black_won ? "library-won-result-unranked" : "library-lost-result-unranked"; /* tie catched above */
                     }
                 }
 


### PR DESCRIPTION
I confused the stronger/weaker labels. The coloring of all games in history and graph where reversed. 

This changes the colors back to the right ones.