### PR TITLE
Reenable context menu when right-click on usernames

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -286,6 +286,14 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
             return;
         }
 
+        if ( ("buttons" in event && (event.buttons & 2)) ||
+             ("button" in event && event.button === 2) ) {
+            /* on click with right mouse button do nothing.
+               buttons uses on bit per button, alowing for multiple buttons pressed at the same time. The bit with value 2 is the right mouse button. https://www.w3schools.com/jsref/event_buttons.asp
+               buttons isn't supported in all browsers, so we have to check button as fallback. */
+            return;
+        }
+
         if (!this.props.fakelink && shouldOpenNewTab(event)) {
             /* let browser deal with opening the window so we don't get popup warnings */
             return;


### PR DESCRIPTION
Fixes #1003

## Proposed Changes

  - check if right mouse button is part of click event, and do nothing if it is.

## Additional Infos

Checking buttons bitmap: https://www.w3schools.com/jsref/event_buttons.asp
as fallback check button value: https://www.w3schools.com/jsref/event_button.asp

Left- and middle-button are still working.

##  Tested

- Desktop:
    - [x]  Firefox 71.0
    - [x]  Chromium 78.0
- Android:
    - [x]  Firefox 68.3.0

