### PR TITLE
replace tsumegodojo with tsumegododo in all chats

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -1001,6 +1001,10 @@ function ChatLine(props) {
 }
 export function chat_markup(body, extra_pattern_replacements?: Array<{split: RegExp; pattern: RegExp; replacement: ((m: any, idx: number) => any)}>): Array<JSX.Element> {
     let replacements = [
+        // spam mitigation
+        // replace tsumegodojo.worldpress.com urls with tsumegododo.worldpress.com as spam mitigation
+        {split: /(https?:\/\/\S*tsumegodojo\S*)/gi, pattern: /(https?:\/\/[^\s\/]*)(tsumegodojo)(\S*)/gi, replacement: (m, idx) => (<a key={idx} target="_blank" href={m[1] + "tsumegododo" + m[3]}>{m[1] + "tsumegododo" + m[3]}</a>)},
+        {split: /(\S*tsumegodojo\S*)/gi, pattern: /(\S*)(tsumegodojo)(\S*)/gi, replacement: (m, idx) => (m[1] + "tsumegododo" + m[3])},
         // Match github
         {split: /\b(https?:\/\/github\.com\/online-go\/online-go\.com\/pull\/[0-9]+(?:\/|\b))/gi,
             pattern: /\b(https?:\/\/github\.com\/online-go\/online-go\.com\/pull\/([0-9]+)(?:\/|\b))/gi,

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -615,6 +615,9 @@ function chat_markup(body) {
         ret = ret.replace(player_matcher, "<a target='_blank' href='/user/view/$2'>$1</a>");
         let group_matcher = /(#group-([0-9]+))/gi;
         ret = ret.replace(group_matcher, "<a target='_blank' href='/group/$2'>$1</a>");
+        // try to migigate tsumegodojo spam
+        let tsumegodojo_matcher = /(tsumegodojo)/gi;
+        ret = ret.replace(tsumegodojo_matcher, "tsumegododo");
         return ret;
     } else {
         console.log("Attempted to markup non-text object: ", body);


### PR DESCRIPTION
Replace tsumegodojo with tsumegododo as proposed in chat.

This is a rather aggressive implementation, not only replacing URLs but all occurrences of tsumegodojo.

It works in chat and PMs