### PR TITLE
Show moderator the accept clock 

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2467,8 +2467,8 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     <div className="stone-removal-controls">
 
                        <div>
-                           {(this.state.user_is_player || null) &&
-                               <button id="game-stone-removal-accept" className="primary" onClick={this.onStoneRemovalAccept}>
+                           {(this.state.user_is_player || user.is_moderator || null) &&
+                               <button id="game-stone-removal-accept" className="primary" onClick={this.state.user_is_player ? this.onStoneRemovalAccept :  null}>
                                    {_("Accept removed stones")}
                                    <Clock goban={this.goban} color='stone-removal' />
                                </button>


### PR DESCRIPTION
Fixes #1053

## Proposed Changes

Make the accept-clock visible to the moderator (noting that they can't press the button on behalf of the players, largely because goodness knows if that would work).
