### PR TITLE
Long usernames

### DIFF
--- a/src/components/Clock/Clock.styl
+++ b/src/components/Clock/Clock.styl
@@ -113,6 +113,10 @@
 
     &.mini-goban {
         float: right;
+        flex: auto;
+        flex-shrink: 0;
+        flex-grow: 1;
+        flex-basis: auto;
 
         &.paused {
             color: #888;

--- a/src/components/MiniGoban/MiniGoban.styl
+++ b/src/components/MiniGoban/MiniGoban.styl
@@ -39,8 +39,23 @@
     }
 
 
+    .player-rank {
+        float: left;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex-shrink: 0;
+        flex-basis: auto;
+        margin-right: 0.5em;
+        margin-left: 0.5em
+    }
     .player-name {
         float: left;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex-shrink: 1;
+        flex-basis: auto;
     }
     .score {
         position: absolute;
@@ -48,7 +63,8 @@
 
     .title-white, .title-black {
         position: absolute;
-        display: inline-block;
+        display: flex;
+        flex-direction: row;
         font-size: 0.9em;
         left: 1rem;
         right: 1rem;

--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -113,9 +113,12 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
             black_score: interpolate("%s points", [(score.black.prisoners + score.black.komi)]),
             white_score: interpolate("%s points", [(score.white.prisoners + score.white.komi)]),
 
-            black_name: (typeof(black) === "object" ? (black.username + (preferences.get('hide-ranks') ? "" : (" [" + getUserRating(black).bounded_rank_label + "]"))) : black),
-            white_name: (typeof(white) === "object" ? (white.username + (preferences.get('hide-ranks') ? "" : (" [" + getUserRating(white).bounded_rank_label + "]"))) : white),
+            black_name: (typeof(black) === "object" ? (black.username) : black),
+            white_name: (typeof(white) === "object" ? (white.username) : white),
             paused: this.state.black_pause_text ? "paused" : "",
+
+            black_rank: (typeof(black) === "object" ? (preferences.get('hide-ranks') ? "" : (" [" + getUserRating(black).bounded_rank_label + "]")) : ""),
+            white_rank: (typeof(white) === "object" ? (preferences.get('hide-ranks') ? "" : (" [" + getUserRating(white).bounded_rank_label + "]")) : ""),
 
             current_users_move: player_to_move === data.get("config.user").id,
             black_to_move_cls: (this.goban && black.id === player_to_move) ? "to-move" : "",
@@ -146,11 +149,13 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
                 elt={this.goban_div} />
                 <div className={`title-black ${this.state.black_to_move_cls}`}>
                     <span className={`player-name`}>{this.state.black_name}</span>
+                    <span className={`player-rank`}>{this.state.black_rank}</span>
                     <Clock compact goban={this.goban} color='black' className='mini-goban' />
                     <span className="score">{this.state.black_score}</span>
                 </div>
                 <div className={`title-white ${this.state.white_to_move_cls}`}>
                     <span className={`player-name`}>{this.state.white_name}</span>
+                    <span className={`player-rank`}>{this.state.white_rank}</span>
                     <Clock compact goban={this.goban} color='white' className='mini-goban' />
                     <span className="score">{this.state.white_score}</span>
                 </div>

--- a/src/components/Player/Player.styl
+++ b/src/components/Player/Player.styl
@@ -132,6 +132,8 @@
     .Player-username {
         flex: 1;
         overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .Player-rank {

--- a/src/components/Player/PlayerDetails.styl
+++ b/src/components/Player/PlayerDetails.styl
@@ -30,6 +30,7 @@
         justify-content: space-between;
         .icon {
             display: inline-block;
+            flex-shrink: 0;
             position: relative;
             width: 64px;
             height: 64px;
@@ -45,6 +46,11 @@
                 width: 16px;
             }
 
+        }
+        .player-info {
+            flex-shrink: 1;
+            margin-left: 6px;
+            max-width: 170px;
         }
         .player-link {
             cursor: pointer !important;

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -237,7 +237,7 @@ export class PlayerDetails extends React.PureComponent<PlayerDetailsProperties, 
                     <div className="icon" style={{backgroundImage: 'url("' + icon_size_url(this.state.icon, 64) + '")'}}>
                         <Flag country={this.state.country}/>
                     </div>
-                    <div>
+                    <div className="player-info">
                         <div>
                             <Player user={this.state} nodetails rank={false} />
                         </div>

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -58,6 +58,9 @@
 
     .username {
         font-size: font-size-big;
+        max-width: -webkit-fill-available;
+        max-width: -mox-available;
+        max-width: fill-available;
     }
     .ratings-title {
         font-size: font-size-big;


### PR DESCRIPTION
Long usernames are disrupting the layout at several places.

![image](https://user-images.githubusercontent.com/4864182/76840610-c83aad00-6837-11ea-81e7-53547db104dd.png)

![image](https://user-images.githubusercontent.com/4864182/76840757-fd46ff80-6837-11ea-9134-8f4c561b8df6.png)

This PR tries to fix the layout. 

![image](https://user-images.githubusercontent.com/4864182/76841187-b7d70200-6838-11ea-8313-3b07c4b100bc.png)


![image](https://user-images.githubusercontent.com/4864182/76841115-9f66e780-6838-11ea-8091-9f4b5c4d4343.png)


Related to:
https://forums.online-go.com/t/clock-hard-to-read-with-long-usernames/25747?u=flovo