### PR TITLE
Make online status visible on groups member list

### DIFF
--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -691,7 +691,7 @@ export class Group extends React.PureComponent<GroupProperties, any> {
                             source={`groups/${group.id}/members`}
                             groom={(u_arr) => u_arr.map((u) => player_cache.update(u.user))}
                             columns={[
-                                {header: _("Members"), className: "", render: (X) => <Player icon user={X}/>},
+                                {header: _("Members"), className: "", render: (X) => <Player icon user={X} online/>},
                             ]}
                         />
                     </Card>


### PR DESCRIPTION
On the forum, we got multiple [requests](https://forums.online-go.com/t/kgs-style-rooms-in-groups/25191/5?u=flovo) to make the online status of group members visible. 

This adds the online indicator to the members list on the group page.

![image](https://user-images.githubusercontent.com/4864182/77538657-5948fe00-6ea0-11ea-89a8-1dad0070d36e.png)
