### PR TITLE
Limit the length of game names in game list

### DIFF
--- a/src/components/GobanLineSummary/GobanLineSummary.styl
+++ b/src/components/GobanLineSummary/GobanLineSummary.styl
@@ -55,6 +55,10 @@
 
     .game-name, .player {
         text-align: left;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 13em;
     }
 
     &.in-stone-removal-phase {


### PR DESCRIPTION
Limit the length of game and user names on the game-view page. 

A user complained at the [forum](https://forums.online-go.com/t/limit-length-of-game-names/26174?u=flovo)
![image](https://user-images.githubusercontent.com/4864182/77907569-203ad000-728a-11ea-9fa9-53938209e7b4.png)

This PR limits the width of the game and user name column to 13em.
![image](https://user-images.githubusercontent.com/4864182/77907926-d7cfe200-728a-11ea-8a50-579bc2fd55ef.png)

