### PR TITLE
fix settings thumbnail list threshold

### DIFF
--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -741,8 +741,8 @@ function GeneralPreferences(props:SettingGroupProps):JSX.Element {
         _setProfanityFilter(Object.keys(new_profanity_settings));
     }
 
-    function updateGameListThreshold(ev) {
-        preferences.set("game-list-threshold", parseInt(ev.target.value));
+    function updateGameListThreshold(ev: number) {
+        preferences.set("game-list-threshold", ev);
         _setGameListThreshold(preferences.get("game-list-threshold"));
     }
 


### PR DESCRIPTION
The selection of a new value wasn't accepted by the selector.

It turned out that the `ev` value is a number, not an Object.