### PR TITLE
Alernative: Use numeric input for thumbnail list threshold

### DIFF
--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -850,16 +850,13 @@ function GeneralPreferences(props:SettingGroupProps):JSX.Element {
                 </Card>
             </PreferenceLine>
 
-            <PreferenceLine title={_("Game thumbnail list threshold")}>
-                <PreferenceDropdown
+            <PreferenceLine title={_("Game thumbnail list threshold")} description={_("Set to 0 to always show list.")}>
+                <input
                     value={game_list_threshold}
                     onChange={updateGameListThreshold}
-                    options={
-                        [0, 3, 5, 10, 25, 50, 100, 200].map((value, idx) => ({
-                            value: value,
-                            label: value ? value.toString() : _("Always show list")
-                        }))
-                    }
+                    type="number"
+                    min="0"
+                    step="1"
                 />
             </PreferenceLine>
 


### PR DESCRIPTION
The ideal number of MiniGobans depends on the usecase, display size, …. In my case 8 would be a good number (2 rows of 4 games on the home page), but it isn't in the list. A numeric input is more flexible.

![image](https://user-images.githubusercontent.com/4864182/78120363-1cce5280-740a-11ea-915e-ee65e65edb18.png)

Conflicts with https://github.com/online-go/online-go.com/pull/1083. `updateGameListThreshold` works in this case as expected.
