### PR TITLE
Make page size of ObserveGames numeric input

### DIFF
--- a/src/views/ObserveGames/ObserveGames.styl
+++ b/src/views/ObserveGames/ObserveGames.styl
@@ -92,9 +92,18 @@
             }
         }
         .right {
-            display: inline-block;
+            display: inline-flex;
             flex:1;
             text-align: right;
+            align-items: baseline;
+
+            .labelshow {
+                margin-left: 1rem;
+                margin-right: 0.5rem;
+            }
+            .show {
+                width: 4rem;
+            }
         }
     }
 

--- a/src/views/ObserveGames/ObserveGames.tsx
+++ b/src/views/ObserveGames/ObserveGames.tsx
@@ -173,17 +173,8 @@ export class ObserveGames extends React.PureComponent<ObserveGamesProperties, an
                                 {this.state.page < this.state.num_pages ? <i className="fa fa-step-forward" onClick={this.nextPage}/> : <i className="fa"/>}
                             </div>
                             <div className="right">
-                                <select onChange={this.setPageSize} value={this.state.page_size}>
-                                    <option value="3">{_("Show 3")}</option>
-                                    <option value="4">{_("Show 4")}</option>
-                                    <option value="6">{_("Show 6")}</option>
-                                    <option value="8">{_("Show 8")}</option>
-                                    <option value="9">{_("Show 9")}</option>
-                                    <option value="12">{_("Show 12")}</option>
-                                    <option value="16">{_("Show 16")}</option>
-                                    <option value="20">{_("Show 20")}</option>
-                                    <option value="28">{_("Show 28")}</option>
-                                </select>
+                                <label className="labelshow">{_("Show") + ":"}</label>
+                                <input className="show" onChange={this.setPageSize} value={this.state.page_size} type="number" min="1" max="100" step="1" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
There is nothing special about the numbers in the drop down list. Just make it numeric input.

![image](https://user-images.githubusercontent.com/4864182/78123501-88b2ba00-740e-11ea-9477-479ad45cdeb6.png)
