### PR TITLE
Chat indicator

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -393,44 +393,9 @@ export class Chat extends React.Component<ChatProperties, ChatState> {
             }
         }
 
-        if (!channel) {
-            throw new Error(`Invalid channel ID: ${channel}`);
-        }
-
-        let state_update: any = {};
-        if (channel !== this.state.active_channel) {
-            state_update.active_channel = channel;
-        }
-
-        let chan = getChannel(channel);
-        chan.markAsRead();
-        if (!(channel in data.get("chat.joined"))) {
-            this.join(channel);
-        }
-        state_update.user_list = chan.user_list;
-        state_update.chat_log = chan.chat_log;
-        state_update.rtl_mode = chan.rtl_mode;
-        this.scrolled_to_bottom = true;
-        this.setState(state_update);
         if (!this.props.channel) {
             data.set("chat.active_channel", channel);
         }
-
-        if (!(channel in data.get("chat.joined"))) {
-            this.join(channel);
-        }
-        /*
-        this.last_date = "";
-        for (let i=0; i < chan.log.length; ++i) {
-            this._appendChat(chan.log[i]);
-        }
-
-        if (!jQuery.browser.mobile && !jQuery.browser.ios) {
-            $(this.id_chat_input).focus();
-        }
-        this.should_scroll_chatlog = true;
-        this.scrollChats();
-        */
     }
     onActiveChannelChanged = (active_channel: string) => {
         if (this.state.active_channel === active_channel) {
@@ -441,8 +406,32 @@ export class Chat extends React.Component<ChatProperties, ChatState> {
             // don't change active channel
             return;
         }
-        this.setActiveChannel(active_channel);
+
+        if (!active_channel) {
+            throw new Error(`Invalid channel ID: ${active_channel}`);
+        }
+
+        let state_update: any = {};
+        if (active_channel !== this.state.active_channel) {
+            state_update.active_channel = active_channel;
+        }
+
+        let chan = getChannel(active_channel);
+        chan.markAsRead();
+        if (!(active_channel in data.get("chat.joined"))) {
+            this.join(active_channel);
+        }
+        state_update.user_list = chan.user_list;
+        state_update.chat_log = chan.chat_log;
+        state_update.rtl_mode = chan.rtl_mode;
+        this.scrolled_to_bottom = true;
+        this.setState(state_update);
+
+        if (!(active_channel in data.get("chat.joined"))) {
+            this.join(active_channel);
+        }
     }
+
     sortedUserList(): Array<any> {
         let lst = [];
         for (let id in this.state.user_list) {

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -755,7 +755,7 @@ export class Chat extends React.Component<ChatProperties, ChatState> {
         }
 
         popover({
-            elt: (<ChatDetails chatChannelId={channel} partFunc={this.part} />),
+            elt: (<ChatDetails chatChannelId={channel} subscribale={!(channel.startsWith("global") || channel === "shadowban")} partFunc={this.part} />),
             below: event.currentTarget,
             minWidth: 130,
         });

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -261,7 +261,6 @@ export class Chat extends React.Component<ChatProperties, ChatState> {
         this.syncStateSoon();
 
         if (document.hasFocus()) {
-            c.markAsRead();
             if (this.props.updateTitle) {
                 window.document.title = _("Chat");
             }

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -22,6 +22,7 @@ import {shouldOpenNewTab} from "misc";
 import {close_all_popovers} from "popover";
 import {close_friend_list} from "FriendList/FriendIndicator";
 import * as data from "data";
+import { getUnreadChatPreference, getMentionedChatPreference, watchChatSubscriptionChanged, unwatchChatSubscriptionChanged } from "Chat";
 
 interface ChatDetailsProperties {
     chatChannelId: string;
@@ -43,20 +44,17 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
     }
 
     componentDidMount() {
-        data.watch("chat-indicator.chat-subscriptions", this.onChatSubscriptionChanged);
+        watchChatSubscriptionChanged(this.onChatSubscriptionChanged);
     }
 
     componentWillUnmount() {
-        data.unwatch("chat-indicator.chat-subscriptions", this.onChatSubscriptionChanged);
+        unwatchChatSubscriptionChanged(this.onChatSubscriptionChanged);
     }
 
     onChatSubscriptionChanged = (obj) => {
-        if (obj === undefined) {
-            obj = {};
-        }
         this.setState({
-            notify_unread: this.state.channelId in obj && "unread" in obj[this.state.channelId] && obj[this.state.channelId].unread,
-            notify_mentioned: this.state.channelId in obj && "mentioned" in obj[this.state.channelId] && obj[this.state.channelId].mentioned
+            notify_unread: getUnreadChatPreference(this.state.channelId),
+            notify_mentioned: getMentionedChatPreference(this.state.channelId)
         });
     }
 

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -27,6 +27,7 @@ import { getUnreadChatPreference, getMentionedChatPreference, watchChatSubscript
 interface ChatDetailsProperties {
     chatChannelId: string;
     partFunc?: any;
+    subscribale?: boolean;
 }
 
 
@@ -37,6 +38,7 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
         if (channel) {
             this.state = {
                 channelId: channel,
+                subscribale: props.subscribale,
                 notify_unread: false,
                 notify_mentioned: false
             };
@@ -139,16 +141,20 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
                                 <i className="fa fa-trophy"/>{" "}{tournament_text}
                         </button>
                     }
-                    <button
-                        className={"xs noshadow "}// + this.state.notify_mentioned ? "active" : "inactive"}
-                        onClick={this.toggleMentionNotification}>
-                            <i className="fa fa-comment" />{" " + (this.state.notify_mentioned ? _("unfollow mentioned") : _("follow mentioned"))}
-                    </button>
-                    <button
-                        className={"xs noshadow "}// + this.state.notify_unread ? "active" : "inactive"}
-                        onClick={this.toggleNewMessageNotification}>
-                            <i className="fa fa-comment" />{" " + (this.state.notify_unread ? _("unfollow unread") : _("follow unread"))}
-                    </button>
+                    {this.state.subscribale &&
+                        <button
+                            className={"xs noshadow "}// + this.state.notify_mentioned ? "active" : "inactive"}
+                            onClick={this.toggleMentionNotification}>
+                                <i className="fa fa-comment" />{" " + (this.state.notify_mentioned ? _("unfollow mentioned") : _("follow mentioned"))}
+                        </button>
+                    }
+                    {this.state.subscribale &&
+                        <button
+                            className={"xs noshadow "}// + this.state.notify_unread ? "active" : "inactive"}
+                            onClick={this.toggleNewMessageNotification}>
+                                <i className="fa fa-comment" />{" " + (this.state.notify_unread ? _("unfollow unread") : _("follow unread"))}
+                        </button>
+                    }
                     {(this.props.partFunc ? <button
                         className="xs noshadow reject"
                         onClick={this.leave}>

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -142,12 +142,12 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
                     <button
                         className={"xs noshadow "}// + this.state.notify_mentioned ? "active" : "inactive"}
                         onClick={this.toggleMentionNotification}>
-                            <i className="fa fa-comment">{" " + (this.state.notify_mentioned ? _("unfollow mentioned") : _("follow mentioned"))}</i>
+                            <i className="fa fa-comment" />{" " + (this.state.notify_mentioned ? _("unfollow mentioned") : _("follow mentioned"))}
                     </button>
                     <button
                         className={"xs noshadow "}// + this.state.notify_unread ? "active" : "inactive"}
                         onClick={this.toggleNewMessageNotification}>
-                            <i className="fa fa-comment">{" " + (this.state.notify_unread ? _("unfollow unread") : _("follow unread"))}</i>
+                            <i className="fa fa-comment" />{" " + (this.state.notify_unread ? _("unfollow unread") : _("follow unread"))}
                     </button>
                     {(this.props.partFunc ? <button
                         className="xs noshadow reject"

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -142,14 +142,14 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
                         </button>
                     }
                     <button
-                        className={"xs noshadow " + this.state.notify_mentioned ? "active" : "inactive"}
+                        className={"xs noshadow "}// + this.state.notify_mentioned ? "active" : "inactive"}
                         onClick={this.toggleMentionNotification}>
-                            <i className="fa fa-comment">{this.state.notify_mentioned ? _("don't notify if mentioned") : _("notify if mentioned")}</i>
+                            <i className="fa fa-comment">{" " + (this.state.notify_mentioned ? _("unfollow mentioned") : _("follow mentioned"))}</i>
                     </button>
                     <button
-                        className={"xs noshadow " + this.state.notify_unread ? "active" : "inactive"}
+                        className={"xs noshadow "}// + this.state.notify_unread ? "active" : "inactive"}
                         onClick={this.toggleNewMessageNotification}>
-                            <i className="fa fa-comment">{this.state.notify_unread ? _("don't notify if there are unread messages") : _("notify if there are unread")}</i>
+                            <i className="fa fa-comment">{" " + (this.state.notify_unread ? _("unfollow unread") : _("follow unread"))}</i>
                     </button>
                     {(this.props.partFunc ? <button
                         className="xs noshadow reject"

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -21,6 +21,7 @@ import {_, pgettext} from "translate";
 import {shouldOpenNewTab} from "misc";
 import {close_all_popovers} from "popover";
 import {close_friend_list} from "FriendList/FriendIndicator";
+import * as data from "data";
 
 interface ChatDetailsProperties {
     chatChannelId: string;
@@ -32,9 +33,13 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
     constructor(props) {
         super(props);
         let channel = this.props.chatChannelId;
+        let notify_messages:Array<string> = data.get("chat-indicator.notify_messages", []);
+        let notify_mentions:Array<string> = data.get("chat-indicator.notify_mentions", []);
         if (channel) {
             this.state = {
                 channelId: channel,
+                notify_messages: notify_messages.indexOf(channel) >= 0,
+                notify_mentions: notify_mentions.indexOf(channel) >= 0
             };
         }
     }
@@ -70,6 +75,28 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
         }
     }
 
+    toggleNewMessageNotification = (ev) => {
+        let n_list: Array<string> = data.get("chat-indicator.notify_messages", []);
+        if (this.state.notify_messages) {
+            n_list.splice(n_list.indexOf(this.state.channelId), 1);
+        } else {
+            n_list.push(this.state.channelId);
+        }
+        data.set("chat-indicator.notify_messages", n_list);
+        this.close_all_modals_and_popovers();
+    }
+
+    toggleMentionNotification = (ev) => {
+        let n_list: Array<string> = data.get("chat-indicator.notify_mentions", []);
+        if (this.state.notify_mentions) {
+            n_list.splice(n_list.indexOf(this.state.channelId), 1);
+        } else {
+            n_list.push(this.state.channelId);
+        }
+        data.set("chat-indicator.notify_mentions", n_list);
+        this.close_all_modals_and_popovers();
+    }
+
     render() {
         let group_text = pgettext("Go to the main page for this group.", "Group Page");
         let tournament_text = pgettext("Go to the main page for this tournament.", "Tournament Page");
@@ -94,6 +121,16 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
                                 <i className="fa fa-trophy"/>{" "}{tournament_text}
                         </button>
                     }
+                    <button
+                        className={"xs noshadow " + this.state.notify_mentions ? "active" : "inactive"}
+                        onClick={this.toggleMentionNotification}>
+                            <i className="fa fa-comment">{this.state.notify_mentions ? _("don't notify if mentioned") : _("notify if mentioned")}</i>
+                    </button>
+                    <button
+                        className={"xs noshadow " + this.state.notify_messages ? "active" : "inactive"}
+                        onClick={this.toggleNewMessageNotification}>
+                            <i className="fa fa-comment">{this.state.notify_messages ? _("don't notify if there are unread messages") : _("notify if there are unread")}</i>
+                    </button>
                     <button
                         className="xs noshadow reject"
                         onClick={this.leave}>

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -51,7 +51,7 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
         unwatchChatSubscriptionChanged(this.onChatSubscriptionChanged);
     }
 
-    onChatSubscriptionChanged = (obj) => {
+    onChatSubscriptionChanged = () => {
         this.setState({
             notify_unread: getUnreadChatPreference(this.state.channelId),
             notify_mentioned: getMentionedChatPreference(this.state.channelId)

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -25,7 +25,7 @@ import * as data from "data";
 
 interface ChatDetailsProperties {
     chatChannelId: string;
-    partFunc: any;
+    partFunc?: any;
 }
 
 
@@ -151,11 +151,11 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, any>
                         onClick={this.toggleNewMessageNotification}>
                             <i className="fa fa-comment">{this.state.notify_unread ? _("don't notify if there are unread messages") : _("notify if there are unread")}</i>
                     </button>
-                    <button
+                    {(this.props.partFunc ? <button
                         className="xs noshadow reject"
                         onClick={this.leave}>
                             <i className="fa fa-times"/>{" "}{leave_text}
-                    </button>
+                    </button> : null)}
                 </div>
             </div>
         );

--- a/src/components/Chat/ChatIndicator.styl
+++ b/src/components/Chat/ChatIndicator.styl
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+.ChatIndicator {
+    display: inline-flex;
+    flex-direction: column;
+    padding-right: 0.5rem;
+    padding-left: 0.5rem;
+    align-items: center;
+    margin-bottom: -3px;
+    margin-top: 1px;
+    cursor: pointer;
+
+    .fa-comment {
+        themed color shade3;
+        font-size: 0.9rem;
+    }
+    .count {
+        font-size: font-size-smaller;
+        padding-bottom: -5px;
+    }
+
+    &.mentioned .fa-comment {
+        themed color chat-mentions;
+    }
+    &.mentioned .count {
+        themed color chat-mentions;
+    }
+
+    &.unread .fa-comment {
+        themed color primary;
+    }
+    &.unread .count {
+        themed color primary;
+    }
+
+}

--- a/src/components/Chat/ChatIndicator.styl
+++ b/src/components/Chat/ChatIndicator.styl
@@ -49,4 +49,23 @@
         themed color primary;
     }
 
+    .ChatList {
+        display: flex;
+        position: absolute;
+        themed background-color bg
+        top: navbar-height;
+        right: 0;
+        width: 12rem;
+        height: max-content;
+        max-width: 100vw;
+        max-height: 40%;
+        overflow-x: hidden;
+        box-shadow: -2px 2px 1px 0px rgba(0, 0, 0, 0.16);
+        padding-left: 1rem;
+        padding-right: 1rem;
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+        z-index: z.friend-list.menu;
+    }
+
 }

--- a/src/components/Chat/ChatIndicator.styl
+++ b/src/components/Chat/ChatIndicator.styl
@@ -17,18 +17,25 @@
 
 
 .ChatIndicator {
-    display: inline-flex;
-    flex-direction: column;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    display: flex;
     align-items: center;
-    margin-bottom: -3px;
-    margin-top: 1px;
     cursor: pointer;
+    align-self: baseline;
+    font-size: 12pf;
 
+    .navbar-icon {
+        display: inline-flex;
+        flex-direction: column;
+        padding-right: 0.5rem;
+        padding-left: 0.5rem;
+        align-items: center;
+        margin-bottom: -3px;
+        margin-top: 1px;
+        cursor: pointer;
+        width: max-content;
+    }
     .fa-comment {
         themed color shade3;
-        font-size: 0.9rem;
     }
     .count {
         font-size: font-size-smaller;

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -200,6 +200,14 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
         });
     }
 
+    partFunc = (channel:string, dont_autoset_active:boolean, dont_clear_joined:boolean) => {
+        chat_subscriptions[channel] = {
+            mentioned: false,
+            unread: false
+        };
+        data.set("chat-indicator.chat-subscriptions", chat_subscriptions);
+    }
+
     render() {
         return (
             <span className={"ChatIndicator" + (this.state.mentioned ? " mentioned" : (this.state.unread_ct > 0 ? " unread" : ""))}>
@@ -211,7 +219,7 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
                 {(this.state.show_friend_list || null) &&
                     <div>
                         <KBShortcut shortcut="escape" action={this.toggleChatList}/>
-                        <ChatList join_subscriptions show_unjoined hide_global show_unsubscribed_chat show_read collapse_read collapse_unjoined collapse_unsubscribed_chat collapse_state_store_name="chat-indicator.collapse-chat-group" closing_toggle={this.toggleChatList}/>
+                        <ChatList join_subscriptions show_unjoined hide_global show_read collapse_read collapse_unjoined collapse_state_store_name="chat-indicator.collapse-chat-group" closing_toggle={this.toggleChatList} partFunc={this.partFunc} />
                     </div>
                 }
             </span>

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -185,8 +185,8 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
 
     render() {
         return (
-            <span className={"ChatIndicator" + (this.state.mentioned ? " mentioned" : (this.state.unread_ct > 0 ? " unread" : "empty"))}>
-                {
+            <span className={"ChatIndicator" + (this.state.mentioned ? " mentioned" : (this.state.unread_ct > 0 ? " unread" : ""))}>
+                {(this.state.show_empty_notification || this.state.mentioned || this.state.unread_ct > 0) &&
                 <span className={"navbar-icon"} onClick={this.toggleChatList} >
                     <i className="fa fa-comment" />
                     <span className="count" >{this.state.unread_ct} </span>

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -211,7 +211,7 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
                 {(this.state.show_friend_list || null) &&
                     <div>
                         <KBShortcut shortcut="escape" action={this.toggleChatList}/>
-                        <ChatList join_subscriptions show_read collapse_read collapse_unsubscribed_chat collapse_state_store_name="chat-indicator.collapse-chat-group" closing_toggle={this.toggleChatList}/>
+                        <ChatList join_subscriptions show_unjoined hide_global show_unsubscribed_chat show_read collapse_read collapse_unjoined collapse_unsubscribed_chat collapse_state_store_name="chat-indicator.collapse-chat-group" closing_toggle={this.toggleChatList}/>
                     </div>
                 }
             </span>

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -117,7 +117,7 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
                 {(this.state.show_friend_list || null) &&
                     <div>
                         <KBShortcut shortcut="escape" action={this.toggleChatList}/>
-                        <ChatList show_subscribed_notifications closing_toggle={this.toggleChatList}/>
+                        <ChatList join_subscriptions show_read collapse_read collapse_unjoined collapse_unsubscribed_chat collapse_state_store_name="chat-indicator.collapse-chat-group" closing_toggle={this.toggleChatList}/>
                     </div>
                 }
             </span>

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -180,16 +180,16 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
                     mentioned = mentioned || this.channels[channel].channel.mentioned;
                 }
             }
-        }
+        };
         global_channels.forEach(element => {
             add_count(element.id);
         });
         group_channels.forEach(element => {
             add_count("group-" + element.id);
-        })
+        });
         tournament_channels.forEach(element => {
             add_count("tournament-" + element.id);
-        })
+        });
         this.setState({unread_ct: unread_ct,
                        mentioned: mentioned});
     }

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -18,19 +18,83 @@
 import * as React from "react";
 import {Link} from "react-router-dom";
 import * as moment from "moment";
-import {chat_manager, ChatChannelProxy, UnreadChanged} from "chat_manager";
+import {chat_manager, ChatChannelProxy, UnreadChanged, global_channels, group_channels, tournament_channels} from "chat_manager";
 import * as data from "data";
 import { KBShortcut } from "../KBShortcut";
-import { FriendList } from "../FriendList";
-import { ChatList } from "./ChatList";
+import { ChatList } from "Chat";
+import * as preferences from "preferences";
+import * as EventEmitter from "eventemitter3";
 
+let chat_subscriptions = {};
+data.watch("chat-indicator.chat-subscriptions", onChatSubscriptionUpdate);
+function onChatSubscriptionUpdate(pref) {
+    chat_subscriptions = pref;
+}
+let chat_subscribe_new_group_chat_messages = false;
+preferences.watch("chat-subscribe-group-chat-unread", onChatSubscribeGroupMessageChange);
+function onChatSubscribeGroupMessageChange(pref) {
+    chat_subscribe_new_group_chat_messages = pref;
+}
+let chat_subscribe_new_group_chat_mentioned = false;
+preferences.watch("chat-subscribe-group-mentions", onChatSubscribeGroupMentionsChange);
+function onChatSubscribeGroupMentionsChange(pref) {
+    chat_subscribe_new_group_chat_mentioned = pref;
+}
+let chat_subscribe_new_tournament_chat_messages = false;
+preferences.watch("chat-subscribe-tournament-chat-unread", onChatSubscribeTournamentMessageChange);
+function onChatSubscribeTournamentMessageChange(pref) {
+    chat_subscribe_new_tournament_chat_messages = pref;
+}
+let chat_subscribe_new_tournament_chat_mentioned = false;
+preferences.watch("chat-subscribe-tournament-mentions", onChatSubscribeTournamentMentionsChange);
+function onChatSubscribeTournamentMentionsChange(pref) {
+    chat_subscribe_new_tournament_chat_mentioned = pref;
+}
+
+export function getUnreadChatPreference(channel:string): boolean {
+    if (channel in chat_subscriptions && "unread" in chat_subscriptions[channel]) {
+        return chat_subscriptions[channel].unread;
+    }
+    if (channel.startsWith("group-")) {
+        return chat_subscribe_new_group_chat_messages;
+    }
+    if (channel.startsWith("tournament-")) {
+        return chat_subscribe_new_group_chat_messages;
+    }
+    return false;
+}
+export function getMentionedChatPreference(channel:string): boolean {
+    if (channel in chat_subscriptions && "mentioned" in chat_subscriptions[channel]) {
+        return chat_subscriptions[channel].mentioned;
+    }
+    if (channel.startsWith("group-")) {
+        return chat_subscribe_new_group_chat_mentioned;
+    }
+    if (channel.startsWith("tournament-")) {
+        return chat_subscribe_new_group_chat_mentioned;
+    }
+    return false;
+}
+export function watchChatSubscriptionChanged(cb: (obj:any) => void):void { // Give a single place to subscribe to setting changes
+    preferences.watch("chat-subscribe-group-chat-unread", cb, true, false);
+    preferences.watch("chat-subscribe-group-mentions", cb), true, false;
+    preferences.watch("chat-subscribe-tournament-chat-unread", cb, true, false);
+    preferences.watch("chat-subscribe-tournament-mentions", cb, true, false);
+    data.watch("chat-indicator.chat-subscriptions", cb, true, true);
+}
+export function unwatchChatSubscriptionChanged(cb: (obj:any) => void):void {
+    preferences.unwatch("chat-subscribe-group-chat-unread", cb);
+    preferences.unwatch("chat-subscribe-group-mentions", cb);
+    preferences.unwatch("chat-subscribe-tournament-chat-unread", cb);
+    preferences.unwatch("chat-subscribe-tournament-mentions", cb);
+    data.unwatch("chat-indicator.chat-subscriptions", cb);
+}
 
 let chat_indicator_sinleton:ChatIndicator;
 
 export class ChatIndicator extends React.PureComponent<{}, any> {
 
     channels: {[channel:string]: ChatChannelProxy} = {};
-    chat_subscriptions: {[channel:string]: {[channel:string]: Boolean}} = {};
 
     constructor(props) {
         super(props);
@@ -38,46 +102,58 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
             unread_ct: 0,
             mentioned: false,
             show_friend_list: false,
+            show_empty_notification: true,
         };
     }
 
     componentDidMount() {
-        data.watch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
+        preferences.watch("show-empty-chat-notification", this.onShowEmptyNotification);
+        watchChatSubscriptionChanged(this.onChatSubscriptionUpdate);
     }
 
     componentWillUnmount() {
-        data.unwatch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
+        preferences.unwatch("show-empty-chat-notification", this.onShowEmptyNotification);
+        unwatchChatSubscriptionChanged(this.onChatSubscriptionUpdate);
         Object.keys(this.channels).forEach(channel => {
             this.channels[channel].part();
             delete this.channels[channel];
         });
     }
 
-    onChatSubscriptionUpdate = (subscriptions: {[channel:string]: {[channel:string]: Boolean}}) => {
-        if (subscriptions === undefined) {
-            subscriptions = {};
-        }
+    onShowEmptyNotification = (pref) => {
+        this.setState({show_empty_notification: pref});
+    }
+
+    onChatSubscriptionUpdate = (obj) => {
         // Join new chats
-        Object.keys(subscriptions).forEach(channel => {
+        let join = (channel:string) => {
             if (!(channel in this.channels) &&
-                    ("unread" in subscriptions[channel] && subscriptions[channel].unread) ||
-                    ("mentioned" in subscriptions[channel] && subscriptions[channel].mentioned)) {
+                    getUnreadChatPreference(channel) ||
+                    getMentionedChatPreference(channel)) {
                 let channelProxy = chat_manager.join(channel);
                 channelProxy.on("unread-count-changed", this.onUnreadCountChange);
                 this.channels[channel] = channelProxy;
             }
+        };
+        global_channels.forEach(element => {
+            join(element.id);
+        });
+        group_channels.forEach(element => {
+            join("group-" + element.id);
+        });
+        tournament_channels.forEach(element => {
+            join("tournament-" + element.id);
         });
         // remove unsubscribed chats
         Object.keys(this.channels).forEach(channel => {
-            if (!(channel in subscriptions) ||
-                    !(("unread" in subscriptions[channel] && subscriptions[channel].unread) ||
-                      ("mentioned" in subscriptions[channel] && subscriptions[channel].mentioned))) {
+            if (!(getUnreadChatPreference(channel) ||
+                  getMentionedChatPreference(channel))) {
                 this.channels[channel].part();
                 delete this.channels[channel];
             }
         });
-        this.chat_subscriptions = subscriptions;
         this.updateStats();
+        this.forceUpdate();
     }
 
     onUnreadCountChange = (obj) => {
@@ -87,12 +163,12 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
     updateStats() {
         let unread_ct = 0;
         let mentioned = false;
-        Object.keys(this.chat_subscriptions).forEach(channel => {
+        Object.keys(chat_subscriptions).forEach(channel => {
             if (channel in this.channels) {
-                if ("unread" in this.chat_subscriptions[channel] && this.chat_subscriptions[channel].unread) {
+                if (getUnreadChatPreference(channel)) {
                     unread_ct = unread_ct + this.channels[channel].channel.unread_ct;
                 }
-                if ("mentioned" in this.chat_subscriptions[channel] && this.chat_subscriptions[channel].mentioned) {
+                if (getMentionedChatPreference(channel)) {
                     mentioned = mentioned || this.channels[channel].channel.mentioned;
                 }
             }
@@ -109,15 +185,16 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
 
     render() {
         return (
-            <span className={"ChatIndicator " + (this.state.mentioned ? "mentioned " : (this.state.unread_ct > 0 ? "unread" : ""))}>
+            <span className={"ChatIndicator" + (this.state.mentioned ? " mentioned" : (this.state.unread_ct > 0 ? " unread" : "empty"))}>
+                {
                 <span className={"navbar-icon"} onClick={this.toggleChatList} >
                     <i className="fa fa-comment" />
                     <span className="count" >{this.state.unread_ct} </span>
-                </span>
+                </span>}
                 {(this.state.show_friend_list || null) &&
                     <div>
                         <KBShortcut shortcut="escape" action={this.toggleChatList}/>
-                        <ChatList join_subscriptions show_read collapse_read collapse_unjoined collapse_unsubscribed_chat collapse_state_store_name="chat-indicator.collapse-chat-group" closing_toggle={this.toggleChatList}/>
+                        <ChatList join_subscriptions show_read collapse_read collapse_unsubscribed_chat collapse_state_store_name="chat-indicator.collapse-chat-group" closing_toggle={this.toggleChatList}/>
                     </div>
                 }
             </span>

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -101,7 +101,7 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
                        mentioned: mentioned});
     }
 
-    toggleFriendList = () => {
+    toggleChatList = () => {
         this.setState({
             show_friend_list: !this.state.show_friend_list
         });
@@ -109,14 +109,15 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
 
     render() {
         return (
-            <span className={"ChatIndicator " + (this.state.mentioned ? "mentioned " : (this.state.unread_ct > 0 ? "unread" : ""))}  onClick={this.toggleFriendList} >
-                <i className="fa fa-comment"/>
-                <span className="count">{this.state.unread_ct}</span>
+            <span className={"ChatIndicator " + (this.state.mentioned ? "mentioned " : (this.state.unread_ct > 0 ? "unread" : ""))}>
+                <span className={"navbar-icon"} onClick={this.toggleChatList} >
+                    <i className="fa fa-comment" />
+                    <span className="count" >{this.state.unread_ct} </span>
+                </span>
                 {(this.state.show_friend_list || null) &&
                     <div>
-                        <KBShortcut shortcut="escape" action={this.toggleFriendList}/>
-                        <div className='FriendListBackdrop' onClick={this.toggleFriendList} />
-                        <ChatList show_subscribed_notifications/>
+                        <KBShortcut shortcut="escape" action={this.toggleChatList}/>
+                        <ChatList show_subscribed_notifications closing_toggle={this.toggleChatList}/>
                     </div>
                 }
             </span>

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import {Link} from "react-router-dom";
+import * as moment from "moment";
+import {chat_manager, ChatChannelProxy, UnreadChanged} from "chat_manager";
+import * as data from "data";
+
+
+let chat_indicator_sinleton:ChatIndicator;
+
+export class ChatIndicator extends React.PureComponent<{}, any> {
+
+    channels_watch_mentions: {[channel:string]: ChatChannelProxy} = {};
+    channels_watch_messages: {[channel:string]: ChatChannelProxy} = {};
+    mentions: Array<string> = [];
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            unread_ct: 0,
+            mentioned: false
+        };
+    }
+
+    componentDidMount() {
+        data.watch("chat-indicator.notify_messages", this.onMessagesWatchListUpdate);
+        //this.onMessagesWatchListUpdate(data.get("chat-indicator.notify_messages", []));
+        data.watch("chat-indicator.notify_mentions", this.onMentionsWatchListUpdate);
+        //this.onMentionsWatchListUpdate(data.get("chat-indicator.notify_mentions", []));
+    }
+
+    onMentionsWatchListUpdate = (channels: Array<string>) => {
+        // Join new chats
+        channels.forEach(channel => {
+            if (!(channel in this.channels_watch_mentions)) {
+                let channelProxy = chat_manager.join(channel);
+                channelProxy.on("unread-count-changed", this.onMentionedChanged);
+                if (channelProxy.channel.mentioned) {
+                    this.mentions.push(channel);
+                    this.setState({mentioned: true});
+                }
+                this.channels_watch_mentions[channel] = channelProxy;
+            }
+        });
+        // remove unsubscribed chats
+        Object.keys(this.channels_watch_mentions).forEach(channel => {
+            if (channels.indexOf(channel) < 0) {
+                if (this.channels_watch_mentions[channel].channel.mentioned) {
+                    this.mentions.splice(this.mentions.indexOf(channel), 1);
+                    this.setState({
+                        mentioned: this.mentions.length > 0
+                    });
+                }
+                this.channels_watch_mentions[channel].part();
+                delete this.channels_watch_mentions[channel];
+            }
+        });
+    }
+
+    onMessagesWatchListUpdate = (channels: Array<string>) => {
+        // Join new chats
+        channels.forEach(channel => {
+            if (!(channel in this.channels_watch_messages)) {
+                let channelProxy = chat_manager.join(channel);
+                channelProxy.on("unread-count-changed", this.onUnreadCountChanged);
+                this.setState({
+                    unread_ct: this.state.unread_ct + channelProxy.channel.unread_ct
+                });
+                this.channels_watch_messages[channel] = channelProxy;
+            }
+        });
+        // remove unsubscribed chats
+        Object.keys(this.channels_watch_messages).forEach(channel => {
+            if (channels.indexOf(channel) < 0) {
+                this.setState({
+                    unread_ct: this.state.unread_ct - this.channels_watch_messages[channel].channel.unread_ct
+                });
+                this.channels_watch_messages[channel].part();
+                delete this.channels_watch_messages[channel];
+            }
+        });
+    }
+
+    onMentionedChanged = (obj: UnreadChanged) => {
+        if (obj.mentioned) {
+            if (this.mentions.indexOf(obj.channel) < 0) {
+                this.mentions.push(obj.channel);
+                this.setState({mentioned: true});
+            }
+        } else {
+            if (this.mentions.indexOf(obj.channel) >= 0) {
+                this.mentions.splice(this.mentions.indexOf(obj.channel), 1);
+                this.setState({mentioned: this.mentions.length > 0})
+            }
+        }
+    }
+
+    onUnreadCountChanged = (obj: UnreadChanged) => {
+        this.setState({
+            unread_ct: this.state.unread_ct + obj.unread_delta
+        });
+
+    }
+
+    onMessage = (obj) => {
+        this.setState({notification_count: this.state.notification_count + 1});
+    }
+
+    render() {
+        return (
+            <span className={"ChatIndicator " + (this.state.mentioned ? "mentioned " : (this.state.unread_ct > 0 ? "unread" : ""))} >
+                <i className="fa fa-comment"/>
+                <span className="count">{this.state.unread_ct}</span>
+            </span>
+            );
+    }
+}
+

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -168,9 +168,10 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
     }
 
     updateStats() {
+        console.warn("updateStats");
         let unread_ct = 0;
         let mentioned = false;
-        Object.keys(chat_subscriptions).forEach(channel => {
+        let add_count = (channel: string) => {
             if (channel in this.channels) {
                 if (getUnreadChatPreference(channel)) {
                     unread_ct = unread_ct + this.channels[channel].channel.unread_ct;
@@ -179,7 +180,16 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
                     mentioned = mentioned || this.channels[channel].channel.mentioned;
                 }
             }
+        }
+        global_channels.forEach(element => {
+            add_count(element.id);
         });
+        group_channels.forEach(element => {
+            add_count("group-" + element.id);
+        })
+        tournament_channels.forEach(element => {
+            add_count("tournament-" + element.id);
+        })
         this.setState({unread_ct: unread_ct,
                        mentioned: mentioned});
     }

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -45,6 +45,14 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
         data.watch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
     }
 
+    componentWillUnmount() {
+        data.unwatch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
+        Object.keys(this.channels).forEach(channel => {
+            this.channels[channel].part();
+            delete this.channels[channel];
+        });
+    }
+
     onChatSubscriptionUpdate = (subscriptions: {[channel:string]: {[channel:string]: Boolean}}) => {
         if (subscriptions === undefined) {
             subscriptions = {};
@@ -93,12 +101,24 @@ export class ChatIndicator extends React.PureComponent<{}, any> {
                        mentioned: mentioned});
     }
 
+    toggleFriendList = () => {
+        this.setState({
+            show_friend_list: !this.state.show_friend_list
+        });
+    }
 
     render() {
         return (
-            <span className={"ChatIndicator " + (this.state.mentioned ? "mentioned " : (this.state.unread_ct > 0 ? "unread" : ""))}>
+            <span className={"ChatIndicator " + (this.state.mentioned ? "mentioned " : (this.state.unread_ct > 0 ? "unread" : ""))}  onClick={this.toggleFriendList} >
                 <i className="fa fa-comment"/>
                 <span className="count">{this.state.unread_ct}</span>
+                {(this.state.show_friend_list || null) &&
+                    <div>
+                        <KBShortcut shortcut="escape" action={this.toggleFriendList}/>
+                        <div className='FriendListBackdrop' onClick={this.toggleFriendList} />
+                        <ChatList show_subscribed_notifications/>
+                    </div>
+                }
             </span>
             );
     }

--- a/src/components/Chat/ChatList.styl
+++ b/src/components/Chat/ChatList.styl
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.ChatList {
+    display: flex;
+    flex-direction: column;
+    height: "calc(100vh - %s - %s)" % (navbar-height channel-utils-height);
+    overflow-y: auto;
+    width: channel-width;
+
+    .channel-container {
+        flex-basis: channel-width;
+        flex-shrink: 1;
+        flex-grow: 1;
+        width: channel-width;
+
+        border-right: 1px solid transparent;
+        themed border-right-color shade3
+        display: flex;
+        flex-direction: column;
+        user-select: none;
+    }
+    .channels {
+        flex-grow: 0;
+        flex-shrink: 0;
+        overflow-x: hidden;
+
+        .channel-header {
+            margin-top: 1.0rem;
+            text-transform: uppercase;
+            font-weight: bold;
+            font-size: font-size-smaller;
+            margin-bottom: 0.3rem;
+            display: flex;
+            justify-content: space-between;
+            align-content: center;
+
+            .channel-expand-toggle {
+                padding: 0.2rem;
+                padding-right: 0.5rem;
+                cursor: pointer;
+
+            }
+        }
+        .channel-header:first-child {
+            margin-top: 0;
+        }
+
+        .channel {
+            padding-left: 0.2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+
+            &.active {
+                themed background-color primary
+                themed color colored-background-fg
+            }
+            &.unjoined {
+                themed color shade2
+            }
+            &.unread {
+                themed color primary
+            }
+            &.mentioned {
+                themed color chat-mentions
+            }
+        }
+
+        .channel-name {
+            flex-shrink: 1;
+            flex-grow: 1;
+            cursor: pointer;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+
+        .unread-count {
+            flex-shrink: 0;
+            @extend .monospace
+            font-size: 0.8rem;
+            font-style: normal !important;
+            float: right;
+            padding-left: 0.5rem;
+            padding-top: 0.10rem;
+
+            &:before {
+                content: attr(data-count);
+            }
+        }
+        .channel:hover .unread-count:before {
+            cursor: pointer;
+            content: attr(data-menu);
+            border: 1px solid transparent
+            border-radius: 0.2rem;
+            themed background-color shade4
+            themed border-color shade3
+            padding-left: 0.3rem;
+            padding-right: 0.3rem;
+            themed color fg
+        }
+        .channel:hover .unread-count:hover:before {
+            themed background-color shade5
+            themed border-color shade4
+            themed color fg
+        }
+    }
+    .channels.hide-unjoined {
+        .unjoined {
+            display: none;
+        }
+    }
+    .seekgraph-container {
+        height: channel-utils-height;
+        .SeekGraph {
+            width: channel-width;
+            height: 8rem;
+        }
+    }
+    .channel-buttons {
+        display: flex;
+        //justify-content: space-between;
+    }
+
+    .users {
+        flex-basis: 12rem;
+        flex-shrink: 0;
+        flex-grow: 0;
+        overflow-y: auto;
+        user-select: none;
+
+        .user-header {
+            margin-top: 0.5rem;
+            text-transform: uppercase;
+            font-weight: bold;
+            font-size: font-size-smaller;
+            margin-bottom: 0.2rem;
+            cursor: pointer;
+            .fa-sort-numeric-asc, .fa-sort-alpha-asc  {
+                margin-left: 0.2rem;
+                width: 0.8rem;
+            }
+        }
+
+    }
+    .Player {
+        themed color fg
+    }
+    .center-container {
+        flex-basis: 100%;
+        flex-grow: 1;
+        flex-shrink: 1;
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid transparent;
+        themed border-right-color shade3
+
+        .chat-log {
+            flex-basis: 100%;
+            flex-grow: 1;
+            flex-shrink: 1;
+            max-width: "calc(100vw - %s * 2)" % channel-width;
+            border-bottom: 1px solid transparent;
+            themed border-bottom-color shade3
+            .Player {
+                themed color fg
+            }
+        }
+
+        input {
+            width: 100%;
+            border: none;
+            font-size: 1.0rem;
+            line-height: 1.5rem;
+            padding: 0.2rem;
+        }
+    }
+
+
+    .timestamp {
+        @extend .monospace
+        font-size: 0.8rem;
+        font-style: normal !important;
+    }
+
+    .third-person {
+        font-style: italic;
+    }
+
+    .mentions .body {
+        themed color chat-mentions
+        //font-weight: bold;
+    }
+    /body.light .mentions .body {
+        font-weight: bold;
+    }
+    .self .body {
+        themed color chat-self-message
+    }
+
+    .icon {
+        width: 15px;
+        height: 15px;
+    }
+
+    .system {
+        themed color chat-system
+        padding-left: 1rem;
+        border-top: 1px solid transparent;
+        themed border-top-color chat-system
+        padding-top: 0.5rem
+        padding-bottom: 0.5rem
+        margin-top: 0.5rem
+    }
+
+    .Player {
+        font-weight: bold;
+    }
+
+
+    .input-container {
+        display: flex;
+        align-items: center;
+        button {
+            margin: 0;
+            padding-bottom: 0;
+            padding-top: 0;
+            font-size: 0.85rem;
+        }
+        input {
+            flex: 1;
+            overflow: hidden;
+        }
+        .channel-toggle {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+        .users-toggle {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+    }
+}

--- a/src/components/Chat/ChatList.styl
+++ b/src/components/Chat/ChatList.styl
@@ -91,7 +91,7 @@
             }
         }
         &.hide-unscubscribed {
-            .chat-unscubscribed {
+            .chat-unsubscribed {
                 display: none;
             }
         }
@@ -145,7 +145,7 @@
         }
     }
     &.hide-unscubscribed {
-        .chat-unscubscribed {
+        .chat-unsubscribed {
             display: none;
         }
     }

--- a/src/components/Chat/ChatList.styl
+++ b/src/components/Chat/ChatList.styl
@@ -80,6 +80,21 @@
                 themed color chat-mentions
             }
         }
+        &.hide-unjoined {
+            .unjoined {
+                display: none;
+            }
+        }
+        &.hide-read {
+            .read {
+                display: none;
+            }
+        }
+        &.hide-unscubscribed {
+            .chat-unscubscribed {
+                display: none;
+            }
+        }
 
         .channel-name {
             flex-shrink: 1;
@@ -119,8 +134,18 @@
             themed color fg
         }
     }
-    .channels.hide-unjoined {
+    &.hide-unjoined {
         .unjoined {
+            display: none;
+        }
+    }
+    &.hide-read {
+        .read {
+            display: none;
+        }
+    }
+    &.hide-unscubscribed {
+        .chat-unscubscribed {
             display: none;
         }
     }

--- a/src/components/Chat/ChatList.styl
+++ b/src/components/Chat/ChatList.styl
@@ -90,11 +90,6 @@
                 display: none;
             }
         }
-        &.hide-unscubscribed {
-            .chat-unsubscribed {
-                display: none;
-            }
-        }
 
         .channel-name {
             flex-shrink: 1;

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import {_, pgettext, interpolate} from "translate";
+import { group_channels, tournament_channels, global_channels, ChatChannelProxy, chat_manager } from "chat_manager";
+import * as data from "data";
+import { PersistentElement } from "PersistentElement";
+import { Flag } from "Flag";
+
+
+interface ChatListProperties {
+    show_all?: boolean;
+    show_read?: boolean;
+    show_subscribed_notifications?: boolean;
+    join_subscriptions?: boolean;
+    join_joined?: boolean;
+}
+
+export class ChatList extends React.PureComponent<ChatListProperties, any> {
+    channels: {[channel:string]: ChatChannelProxy} = {};
+    chat_subscriptions: {[channel:string]: {[subscription:string]: Boolean}} = {};
+    constructor(props) {
+        super(props);
+        this.state = {
+            show_all: props.show_all,
+            show_read: props.show_read,
+            show_subscribed_notifications: props.show_subscribed_notifications,
+            join_subscriptions: props.join_subscriptions,
+            join_joined: props.join_joined,
+            global_channels: [],
+            group_channels: [],
+            tournament_channels: [],
+        };
+    }
+
+    componentDidMount() {
+        data.watch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
+    }
+
+    componentWillUnmount() {
+        data.unwatch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
+        Object.keys(this.channels).forEach(channel => {
+            this.channels[channel].part();
+            delete this.channels[channel];
+        });
+    }
+
+    onChatSubscriptionUpdate = (subscriptions: {[channel:string]: {[channel:string]: Boolean}}) => {
+        if (subscriptions === undefined) {
+            subscriptions = {};
+        }
+        // Join new chats
+        Object.keys(subscriptions).forEach(channel => {
+            if (!(channel in this.channels) &&
+                    ("unread" in subscriptions[channel] && subscriptions[channel].unread) ||
+                    ("mentioned" in subscriptions[channel] && subscriptions[channel].mentioned)) {
+                let channelProxy = chat_manager.join(channel);
+                channelProxy.on("unread-count-changed", this.onUnreadCountChange);
+                this.channels[channel] = channelProxy;
+            }
+        });
+        // remove unsubscribed chats
+        Object.keys(this.channels).forEach(channel => {
+            if (!(channel in subscriptions) ||
+                    !(("unread" in subscriptions[channel] && subscriptions[channel].unread) ||
+                      ("mentioned" in subscriptions[channel] && subscriptions[channel].mentioned))) {
+                this.channels[channel].part();
+                delete this.channels[channel];
+            }
+        });
+        this.chat_subscriptions = subscriptions;
+        this.updateChannelLists();
+    }
+
+    onUnreadCountChange = (obj) => {
+        this.updateChannelLists();
+    }
+
+    updateChannelLists() {
+        let showChannel = (channel: string) => {
+            if (this.state.show_all) {
+                return true;
+            }
+            if (channel in this.channels) {
+                if (this.state.show_read) {
+                    return true;
+                }
+                if (this.state.show_subscribed_notifications) {
+                    if ("unread" in this.chat_subscriptions[channel] && this.chat_subscriptions[channel].unread && this.channels[channel].channel.unread_ct > 0) {
+                        return true;
+                    }
+                    if ("mentioned" in this.chat_subscriptions[channel] && this.chat_subscriptions[channel].mentioned && this.channels[channel].channel.mentioned) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
+        // global-channels
+        let globals = [];
+        let tournaments = [];
+        let groups = [];
+        for (let idx = 0; idx < global_channels.length; idx = idx + 1) {
+            if (showChannel(global_channels[idx].id)) {
+                globals.push(global_channels[idx]);
+            }
+        }
+        for (let idx = 0; idx < tournament_channels.length; idx = idx + 1) {
+            if (showChannel("tournament-" + tournament_channels[idx].id)) {
+                tournaments.push(tournament_channels[idx]);
+            }
+        }
+        for (let idx = 0; idx < group_channels.length; idx = idx + 1) {
+            if (showChannel("group-" + group_channels[idx].id)) {
+                groups.push(group_channels[idx]);
+            }
+        }
+        this.setState({
+            global_channels: globals,
+            tournament_channels: tournaments,
+            group_channels: groups
+        });
+        console.warn(globals);
+    }
+
+    render() {
+        let user = data.get('user');
+        let user_country = user.country || 'un';
+
+        let chan_class = (chan: string): string => {
+            if (!(chan in this.channels)) {
+                return "";
+            }
+            return (this.channels[chan].channel.unread_ct > 0 ? " unread" : "") +
+                (this.channels[chan].channel.mentioned ? " mentioned" : "");
+//                (chan in this.state.joined_channels ? " joined" : " unjoined")+
+        };
+
+        let user_count = (channel: string) => {
+            if (!(channel in this.channels)) {
+                return null;
+            }
+            let c = this.channels[channel].channel;
+            if (c.unread_ct > 0) {
+                return <span className="unread-count" data-count={"(" + c.unread_ct + ")"} data-menu="▼" data-channel={channel} />;
+            }
+            /*
+            if (c.user_count) {
+                return <span className='user-count' data-count={c.user_count} data-leave={_("leave")} onClick={this.part.bind(this, channel, false, false)} />;
+            }
+            */
+            return null;
+        };
+
+//        let showChannels = !!this.props.showChannels;
+//        let showUserList = !!this.props.showUserList;
+        return (
+            <div className="ChatList">
+                <div className={"channels" + (!this.state.show_all_group_channels ? " hide-unjoined" : "")}>
+                    {(this.state.group_channels.length > 0 || null) && (
+                        <div className="channel-header">
+                            <span>{_("Group Channels")}</span>
+                            <i className={"channel-expand-toggle " + (this.state.show_all_group_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                        </div>
+                    ) }
+                    {this.state.group_channels.map((chan) => (
+                        <div key={chan.id}
+                            className={
+                                (this.state.active_channel === ("group-" + chan.id) ? "channel active" : "channel")
+                                + chan_class("group-" + chan.id)
+                            }
+                        >
+                            <span className="channel-name" data-channel={"group-" + chan.id}>
+                                <img className="icon" src={chan.icon}/> {chan.name}
+                            </span>
+                            {user_count("group-" + chan.id)}
+                        </div>
+                    ))}
+                </div>
+
+                <div className={"channels" + (!this.state.show_all_tournament_channels ? " hide-unjoined" : "")}>
+                    {(this.state.tournament_channels.length > 0 || null) && (
+                        <div className="channel-header">
+                            <span>{_("Tournament Channels")}</span>
+                            <i className={"channel-expand-toggle " + (this.state.show_all_tournament_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                        </div>
+                    )}
+                    {this.state.tournament_channels.map((chan) => (
+                        <div key={chan.id}
+                            className={
+                                (this.state.active_channel === ("tournament-" + chan.id) ? "channel active" : "channel")
+                                + chan_class("tournament-" + chan.id)
+                            }
+                        >
+                            <span className="channel-name" data-channel={"tournament-" + chan.id} >
+                                <i className="fa fa-trophy" /> {chan.name}
+                            </span>
+                            {user_count("tournament-" + chan.id)}
+                        </div>
+                    ))}
+                </div>
+
+                <div className={"channels" + (!this.state.show_all_global_channels ? " hide-unjoined" : "")}>
+                    <div className="channel-header">
+                        <span>{_("Global Channels")}</span>
+                        <i className={"channel-expand-toggle " + (this.state.show_all_global_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                    </div>
+                    {this.state.global_channels.map((chan) => (
+                        <div key={chan.id}
+                            className={
+                                (this.state.active_channel === chan.id ? "channel active" : "channel")
+                                + chan_class(chan.id)
+                            }
+                        >
+                            <span className="channel-name" data-channel={chan.id}>
+                                <Flag country={chan.country} language={chan.language} user_country={user_country} /> {chan.name}
+                            </span>
+                            {user_count(chan.id)}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -135,7 +135,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
         this.updateConnectedChannels();
     }
 
-    onChatSubscriptionUpdate = (obj) => {
+    onChatSubscriptionUpdate = () => {
         this.updateConnectedChannels();
     }
 

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -28,24 +28,30 @@ import * as preferences from "preferences";
 
 
 interface ChatListProperties {
-    show_all?: boolean;
+    show_unjoined?: boolean;
     show_read?: boolean;
-    show_subscribed_notifications?: boolean;
+    show_unsubscribed_chat?: boolean;
+    collapse_unjoined?: boolean;
+    collapse_read?: boolean;
+    collapse_unsubscribed_chat?: boolean;
     join_subscriptions?: boolean;
     join_joined?: boolean;
     highlight_active_channel?: boolean;
     closing_toggle?: () => void;
+    collapse_state_store_name?: string;
 }
 
 interface ChatListState {
-    show_all: boolean;
+    show_unjoined: boolean;
     show_read: boolean;
-    show_subscribed_notifications: boolean;
+    show_unsubscribed_chat: boolean;
+    collapse_unjoined: boolean;
+    collapse_read: boolean;
+    collapse_unsubscribed_chat: boolean;
     join_subscriptions: boolean;
     join_joined: boolean;
-    show_all_group_channels: boolean;
-    show_all_tournament_channels: boolean;
-    show_all_global_channels: boolean;
+    collapsed_channel_groups: {[channel_group:string]: boolean};
+    collapse_state_store_name: string;
     highlight_active_channel: boolean;
     active_channel: string;
 }
@@ -62,26 +68,32 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
             this.closing_toggle = props.closing_toggle;
         }
         this.state = {
-            show_all: props.show_all,
+            show_unjoined: props.show_unjoined,
             show_read: props.show_read,
-            show_subscribed_notifications: props.show_subscribed_notifications,
+            show_unsubscribed_chat: props.show_unsubscribed_chat,
+            collapse_unjoined: props.collapse_unjoined,
+            collapse_read: props.collapse_read,
+            collapse_unsubscribed_chat: props.collapse_unsubscribed_chat,
             join_subscriptions: props.join_subscriptions,
             join_joined: props.join_joined,
-            show_all_group_channels: props.show_all || preferences.get("chat.show-all-group-channels"),
-            show_all_tournament_channels: props.show_all || preferences.get("chat.show-all-tournament-channels"),
-            show_all_global_channels: props.show_all || preferences.get("chat.show-all-global-channels"),
+            collapsed_channel_groups: props.collapse_state_store_name ? {global: false, groups: false, tournaments: false} : undefined,
+            collapse_state_store_name: props.collapse_state_store_name,
             highlight_active_channel: props.highlight_active_channel,
             active_channel: data.get("chat.active_channel", ""),
         };
     }
 
     componentDidMount() {
+        if (this.state.collapse_state_store_name) {
+            data.watch(this.state.collapse_state_store_name, this.onCollapseStoreChanged);
+        }
         data.watch("chat.active_channel", this.onActiveChannelChanged);
         data.watch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
         data.watch("chat.joined", this.onJoinedChanged);
     }
 
     componentWillUnmount() {
+        data.unwatch(this.state.collapse_state_store_name, this.onCollapseStoreChanged);
         data.unwatch("chat.active_channel", this.onActiveChannelChanged);
         data.unwatch("chat-indicator.chat-subscriptions", this.onChatSubscriptionUpdate);
         data.unwatch("chat.joined", this.onJoinedChanged);
@@ -89,6 +101,19 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
             this.channels[channel].part();
             delete this.channels[channel];
         });
+    }
+
+    onCollapseStoreChanged = (obj: {[channel_group: string]: boolean}) => {
+        if (!("groups" in obj)) {
+            obj.groups = false;
+        }
+        if (!("global" in obj)) {
+            obj.global = false;
+        }
+        if (!("tournaments" in obj)) {
+            obj.tournaments = false;
+        }
+        this.setState({collapsed_channel_groups: obj});
     }
 
     onActiveChannelChanged = (channel) => {
@@ -172,22 +197,28 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
     }
 
     toggleShowAllGlobalChannels = () => {
-        if (this.state.show_all) {
-            preferences.set("chat.show-all-global-channels", !this.state.show_all_global_channels);
+        let collapsed_channel_groups = this.state.collapsed_channel_groups;
+        collapsed_channel_groups.global = !collapsed_channel_groups.global;
+        if (this.state.collapse_state_store_name) {
+            data.set(this.state.collapse_state_store_name, collapsed_channel_groups);
         }
-        this.setState({show_all_global_channels: !this.state.show_all_global_channels});
+        this.forceUpdate();
     }
     toggleShowAllGroupChannels = () => {
-        if (this.state.show_all) {
-            preferences.set("chat.show-all-group-channels", !this.state.show_all_group_channels);
+        let collapsed_channel_groups = this.state.collapsed_channel_groups;
+        collapsed_channel_groups.groups = !collapsed_channel_groups.groups;
+        if (this.state.collapse_state_store_name) {
+            data.set(this.state.collapse_state_store_name, collapsed_channel_groups);
         }
-        this.setState({show_all_group_channels: !this.state.show_all_group_channels});
+        this.forceUpdate();
     }
     toggleShowAllTournamentChannels = () => {
-        if (this.state.show_all) {
-            preferences.set("chat.show-all-tournament-channels", !this.state.show_all_tournament_channels);
+        let collapsed_channel_groups = this.state.collapsed_channel_groups;
+        collapsed_channel_groups.tournaments = !collapsed_channel_groups.tournaments;
+        if (this.state.collapse_state_store_name) {
+            data.set(this.state.collapse_state_store_name, collapsed_channel_groups);
         }
-        this.setState({show_all_tournament_channels: !this.state.show_all_tournament_channels});
+        this.forceUpdate();
     }
 
     render() {
@@ -196,16 +227,25 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
 
         let chan_class = (channel: string) => {
             let chan_class = "";
+            let unread = false;
             if (!(channel in this.joined_chats && this.joined_chats[channel])) {
                 chan_class = chan_class + " unjoined";
             }
             if (channel in this.channels) {
+                chan_class = chan_class + " chat-subscribed";
                 if (channel in this.chat_subscriptions && "unread" in this.chat_subscriptions[channel] && this.chat_subscriptions[channel].unread && this.channels[channel].channel.unread_ct > 0) {
                     chan_class = chan_class + " unread";
+                    unread = true;
                 }
                 if (channel in this.chat_subscriptions && "mentioned" in this.chat_subscriptions[channel] && this.chat_subscriptions[channel].mentioned && this.channels[channel].channel.mentioned) {
                     chan_class = chan_class + " mentioned";
+                    unread = true;
                 }
+            } else {
+                chan_class = chan_class + " chat-unsubscribed";
+            }
+            if (!unread) {
+                chan_class = chan_class + " read";
             }
             return chan_class;
         };
@@ -220,19 +260,32 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
             }
             return null;
         };
+        let channel_visibility = () => {
+            let visibility = "";
+            if (this.state.collapse_read) {
+                visibility = visibility + " hide-read";
+            }
+            if (this.state.collapse_unjoined) {
+                visibility = visibility + " hide-unjoined";
+            }
+            if (this.state.collapse_unsubscribed_chat) {
+                visibility = visibility + " hide-unsubscribed";
+            }
+            return visibility;
+        };
         return (
-            <div className="ChatList">
-                <div className={"channels" + (!this.state.show_all_group_channels ? " hide-unjoined" : "")}>
+            <div className={"ChatList" + (!this.state.show_read ? " hide-read" : "") + (!this.state.show_unjoined ? " hide-unjoined" : "") + (!this.state.show_unsubscribed_chat ? " hide-unscubscribed" : "")}>
+                <div className={"channels" + (!this.state.collapsed_channel_groups["groups"] ? channel_visibility() : "")}>
                     {(group_channels.length > 0 || null) && (
                         <div className="channel-header">
                             <span>{_("Group Channels")}</span>
-                            <i onClick={this.toggleShowAllGroupChannels} className={"channel-expand-toggle " + (this.state.show_all_group_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                            <i onClick={this.toggleShowAllGroupChannels} className={"channel-expand-toggle " + (this.state.collapsed_channel_groups["groups"] ?  "fa fa-minus" : "fa fa-plus")}/>
                         </div>
                     ) }
                     {group_channels.map((chan) => (
                         <div key={chan.id}
                             className={
-                                (this.state.active_channel === ("group-" + chan.id) ? "channel active" : "channel")
+                                ((this.state.highlight_active_channel && this.state.active_channel === ("group-" + chan.id)) ? "channel active" : "channel")
                                 + chan_class("group-" + chan.id)
                             }
                             data-channel={"group-" + chan.id}
@@ -246,17 +299,17 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
                     ))}
                 </div>
 
-                <div className={"channels" + (!this.state.show_all_tournament_channels ? " hide-unjoined" : "")}>
+                <div className={"channels" + (!this.state.collapsed_channel_groups["tournaments"] ? channel_visibility() : "")}>
                     {(tournament_channels.length > 0 || null) && (
                         <div className="channel-header">
                             <span>{_("Tournament Channels")}</span>
-                            <i onClick={this.toggleShowAllTournamentChannels} className={"channel-expand-toggle " + (this.state.show_all_tournament_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                            <i onClick={this.toggleShowAllTournamentChannels} className={"channel-expand-toggle " + (this.state.collapsed_channel_groups["tournaments"] ?  "fa fa-minus" : "fa fa-plus")}/>
                         </div>
                     )}
                     {tournament_channels.map((chan) => (
                         <div key={chan.id}
                             className={
-                                (this.state.active_channel === ("tournament-" + chan.id) ? "channel active" : "channel")
+                                ((this.state.highlight_active_channel && this.state.active_channel === ("tournament-" + chan.id)) ? "channel active" : "channel")
                                 + chan_class("tournament-" + chan.id)
                             }
                             data-channel={"tournaments-" + chan.id}
@@ -270,15 +323,15 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
                     ))}
                 </div>
 
-                <div className={"channels" + (!this.state.show_all_global_channels ? " hide-unjoined" : "")}>
+                <div className={"channels" + (!this.state.collapsed_channel_groups["global"] ? channel_visibility() : "")}>
                     <div className="channel-header">
                         <span>{_("Global Channels")}</span>
-                        <i onClick={this.toggleShowAllGlobalChannels} className={"channel-expand-toggle " + (this.state.show_all_global_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                        <i onClick={this.toggleShowAllGlobalChannels} className={"channel-expand-toggle " + (this.state.collapsed_channel_groups["global"] ?  "fa fa-minus" : "fa fa-plus")}/>
                     </div>
                     {global_channels.map((chan) => (
                         <div key={chan.id}
                             className={
-                                (this.state.active_channel === chan.id ? "channel active" : "channel")
+                                ((this.state.highlight_active_channel && this.state.active_channel === chan.id) ? "channel active" : "channel")
                                 + chan_class(chan.id)
                             }
                             data-channel={chan.id}

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -199,7 +199,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
             visible_global_channels: visible_global_channels,
             visible_group_channels: visible_group_channels,
             visible_tournament_channels: visible_tournament_channels
-        })
+        });
         this.forceUpdate();
     }
 
@@ -267,7 +267,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
         }
 
         popover({
-            elt: (<ChatDetails chatChannelId={channel} />),
+            elt: (<ChatDetails chatChannelId={channel} subscribale={!(channel.startsWith("global") || channel === "shadowban")}/>),
             below: event.currentTarget,
             minWidth: 130,
         });

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -33,6 +33,7 @@ interface ChatListProperties {
     show_unjoined?: boolean;
     show_read?: boolean;
     show_unsubscribed_chat?: boolean;
+    hide_global?: boolean;
     collapse_unjoined?: boolean;
     collapse_read?: boolean;
     collapse_unsubscribed_chat?: boolean;
@@ -48,6 +49,7 @@ interface ChatListState {
     show_unjoined: boolean;
     show_read: boolean;
     show_unsubscribed_chat: boolean;
+    hide_global?: boolean;
     visible_group_channels: boolean;
     visible_global_channels: boolean;
     visible_tournament_channels: boolean;
@@ -77,6 +79,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
             show_unjoined: props.show_unjoined,
             show_read: props.show_read,
             show_unsubscribed_chat: props.show_unsubscribed_chat,
+            hide_global: props.hide_global,
             visible_group_channels: false,
             visible_global_channels: false,
             visible_tournament_channels: false,
@@ -174,7 +177,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
     }
 
     updateConnectedChannels() {
-        let visible_global_channels = this.state.show_unjoined && global_channels.length > 0;
+        let visible_global_channels = !this.state.hide_global && this.state.show_unjoined && global_channels.length > 0;
         let visible_group_channels = this.state.show_unjoined && group_channels.length > 0;
         let visible_tournament_channels = this.state.show_unjoined && tournament_channels.length > 0;
         for (let idx = 0; idx < global_channels.length; idx = idx + 1) {

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -256,7 +256,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
         let chan_class = (channel: string) => {
             let chan_class = "";
             let unread = false;
-            if (!(channel in this.joined_chats && this.joined_chats[channel])) {
+            if (!(channel in this.joined_chats && this.joined_chats[channel]) && !(channel in this.channels)) {
                 chan_class = chan_class + " unjoined";
             }
             if (channel in this.channels) {

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -43,6 +43,7 @@ interface ChatListProperties {
     closing_toggle?: () => void;
     collapse_state_store_name?: string;
     fakelink?: boolean;
+    partFunc?: (channel:string, dont_autoset_active:boolean, dont_clear_joined:boolean) => void;
 }
 
 interface ChatListState {
@@ -63,6 +64,7 @@ interface ChatListState {
     highlight_active_channel: boolean;
     active_channel: string;
     fakelink: boolean;
+    partFunc?: (channel:string, dont_autoset_active:boolean, dont_clear_joined:boolean) => void;
 }
 
 export class ChatList extends React.PureComponent<ChatListProperties, ChatListState> {
@@ -93,6 +95,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
             highlight_active_channel: props.highlight_active_channel,
             active_channel: data.get("chat.active_channel", ""),
             fakelink: props.fakelink,
+            partFunc: props.partFunc,
         };
     }
 
@@ -270,7 +273,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
         }
 
         popover({
-            elt: (<ChatDetails chatChannelId={channel} subscribale={!(channel.startsWith("global") || channel === "shadowban")}/>),
+            elt: (<ChatDetails chatChannelId={channel} subscribale={!(channel.startsWith("global") || channel === "shadowban")} partFunc={(channel in this.channels ? this.state.partFunc : undefined)}/>),
             below: event.currentTarget,
             minWidth: 130,
         });

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -32,11 +32,9 @@ import { ChatDetails, getUnreadChatPreference, getMentionedChatPreference, watch
 interface ChatListProperties {
     show_unjoined?: boolean;
     show_read?: boolean;
-    show_unsubscribed_chat?: boolean;
     hide_global?: boolean;
     collapse_unjoined?: boolean;
     collapse_read?: boolean;
-    collapse_unsubscribed_chat?: boolean;
     join_subscriptions?: boolean;
     join_joined?: boolean;
     highlight_active_channel?: boolean;
@@ -49,14 +47,12 @@ interface ChatListProperties {
 interface ChatListState {
     show_unjoined: boolean;
     show_read: boolean;
-    show_unsubscribed_chat: boolean;
     hide_global?: boolean;
     visible_group_channels: boolean;
     visible_global_channels: boolean;
     visible_tournament_channels: boolean;
     collapse_unjoined: boolean;
     collapse_read: boolean;
-    collapse_unsubscribed_chat: boolean;
     join_subscriptions: boolean;
     join_joined: boolean;
     collapsed_channel_groups: {[channel_group:string]: boolean};
@@ -80,14 +76,12 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
         this.state = {
             show_unjoined: props.show_unjoined,
             show_read: props.show_read,
-            show_unsubscribed_chat: props.show_unsubscribed_chat,
             hide_global: props.hide_global,
             visible_group_channels: false,
             visible_global_channels: false,
             visible_tournament_channels: false,
             collapse_unjoined: props.collapse_unjoined,
             collapse_read: props.collapse_read,
-            collapse_unsubscribed_chat: props.collapse_unsubscribed_chat,
             join_subscriptions: props.join_subscriptions,
             join_joined: props.join_joined,
             collapsed_channel_groups: props.collapse_state_store_name ? {global: false, groups: false, tournaments: false} : undefined,
@@ -286,7 +280,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
         let chan_class = (channel: string) => {
             let chan_class = "";
             let unread = false;
-            if (!(channel in this.joined_chats && this.joined_chats[channel]) && !(channel in this.channels)) {
+            if (!(channel in this.channels)) {
                 chan_class = chan_class + " unjoined";
             }
             if (channel in this.channels) {
@@ -299,8 +293,6 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
                     chan_class = chan_class + " mentioned";
                     unread = true;
                 }
-            } else {
-                chan_class = chan_class + " chat-unsubscribed";
             }
             if (!unread) {
                 chan_class = chan_class + " read";
@@ -309,16 +301,13 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
         };
 
         let message_count = (channel: string) => {
-            if (!(channel in this.channels)) {
-                return null;
+            if (channel in this.channels) {
+                let c = this.channels[channel].channel;
+                if (c.unread_ct > 0) {
+                    return <span className="unread-count" data-count={"(" + c.unread_ct + ")"} data-menu="▼" data-channel={channel} onClick={this.display_details} />;
+                }
             }
-            let c = this.channels[channel].channel;
-            if (c.unread_ct > 0) {
-                return <span className="unread-count" data-count={"(" + c.unread_ct + ")"} data-menu="▼" data-channel={channel} onClick={this.display_details} />;
-            } else if (channel in this.joined_chats) {
-                return <span className="unread-count" data-count="" data-menu="▼" data-channel={channel} onClick={this.display_details} />;
-            }
-            return null;
+            return <span className="unread-count" data-count="" data-menu="▼" data-channel={channel} onClick={this.display_details} />;
         };
         let channel_visibility = () => {
             let visibility = "";
@@ -328,13 +317,10 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
             if (this.state.collapse_unjoined) {
                 visibility = visibility + " hide-unjoined";
             }
-            if (this.state.collapse_unsubscribed_chat) {
-                visibility = visibility + " hide-unsubscribed";
-            }
             return visibility;
         };
         return (
-            <div className={"ChatList" + (!this.state.show_read ? " hide-read" : "") + (!this.state.show_unjoined ? " hide-unjoined" : "") + (!this.state.show_unsubscribed_chat ? " hide-unscubscribed" : "")}>
+            <div className={"ChatList" + (!this.state.show_read ? " hide-read" : "") + (!this.state.show_unjoined ? " hide-unjoined" : "") }>
                 <div className={"channels" + (!this.state.collapsed_channel_groups["groups"] ? channel_visibility() : "")}>
                     {(this.state.visible_group_channels || null) && (
                         <div className="channel-header">

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -21,6 +21,9 @@ import { group_channels, tournament_channels, global_channels, ChatChannelProxy,
 import * as data from "data";
 import { PersistentElement } from "PersistentElement";
 import { Flag } from "Flag";
+import { setActiveChannel } from "Chat";
+import { shouldOpenNewTab } from "misc";
+import {browserHistory} from "ogsHistory";
 
 
 interface ChatListProperties {
@@ -135,7 +138,18 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
             tournament_channels: tournaments,
             group_channels: groups
         });
-        console.warn(globals);
+    }
+
+    goToChannel = (ev) => {
+        setActiveChannel($(ev.target).attr("data-channel"));
+        if (ev && shouldOpenNewTab(ev)) {
+            window.open("/chat");
+        } else {
+            //window.open("/game/" + board_ids[idx]);
+            if (window.location.pathname !== "/chat") {
+                browserHistory.push("/chat");
+            }
+        }
     }
 
     render() {
@@ -175,6 +189,8 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                                 (this.state.active_channel === ("group-" + chan.id) ? "channel active" : "channel")
                                 + chan_class("group-" + chan.id)
                             }
+                            data-channel={"group-" + chan.id}
+                            onClick={this.goToChannel}
                         >
                             <span className="channel-name" data-channel={"group-" + chan.id}>
                                 <img className="icon" src={chan.icon}/> {chan.name}
@@ -197,6 +213,8 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                                 (this.state.active_channel === ("tournament-" + chan.id) ? "channel active" : "channel")
                                 + chan_class("tournament-" + chan.id)
                             }
+                            data-channel={"tournaments-" + chan.id}
+                            onClick={this.goToChannel}
                         >
                             <span className="channel-name" data-channel={"tournament-" + chan.id} >
                                 <i className="fa fa-trophy" /> {chan.name}
@@ -217,6 +235,8 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                                 (this.state.active_channel === chan.id ? "channel active" : "channel")
                                 + chan_class(chan.id)
                             }
+                            data-channel={chan.id}
+                            onClick={this.goToChannel}
                         >
                             <span className="channel-name" data-channel={chan.id}>
                                 <Flag country={chan.country} language={chan.language} user_country={user_country} /> {chan.name}

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -147,8 +147,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                 return "";
             }
             return (this.channels[chan].channel.unread_ct > 0 ? " unread" : "") +
-                (this.channels[chan].channel.mentioned ? " mentioned" : "");
-//                (chan in this.state.joined_channels ? " joined" : " unjoined")+
+                   (this.channels[chan].channel.mentioned ? " mentioned" : "");
         };
 
         let user_count = (channel: string) => {
@@ -159,16 +158,8 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
             if (c.unread_ct > 0) {
                 return <span className="unread-count" data-count={"(" + c.unread_ct + ")"} data-menu="▼" data-channel={channel} />;
             }
-            /*
-            if (c.user_count) {
-                return <span className='user-count' data-count={c.user_count} data-leave={_("leave")} onClick={this.part.bind(this, channel, false, false)} />;
-            }
-            */
             return null;
         };
-
-//        let showChannels = !!this.props.showChannels;
-//        let showUserList = !!this.props.showUserList;
         return (
             <div className="ChatList">
                 <div className={"channels" + (!this.state.show_all_group_channels ? " hide-unjoined" : "")}>

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -24,6 +24,7 @@ import { Flag } from "Flag";
 import { setActiveChannel } from "Chat";
 import { shouldOpenNewTab } from "misc";
 import {browserHistory} from "ogsHistory";
+import * as preferences from "preferences";
 
 
 interface ChatListProperties {
@@ -32,13 +33,19 @@ interface ChatListProperties {
     show_subscribed_notifications?: boolean;
     join_subscriptions?: boolean;
     join_joined?: boolean;
+    closing_toggle?: () => void;
 }
 
 export class ChatList extends React.PureComponent<ChatListProperties, any> {
     channels: {[channel:string]: ChatChannelProxy} = {};
     chat_subscriptions: {[channel:string]: {[subscription:string]: Boolean}} = {};
+    closing_toggle: () => void = () => null;
+
     constructor(props) {
         super(props);
+        if (props.closing_toggle) {
+            this.closing_toggle = props.closing_toggle;
+        }
         this.state = {
             show_all: props.show_all,
             show_read: props.show_read,
@@ -48,6 +55,9 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
             global_channels: [],
             group_channels: [],
             tournament_channels: [],
+            show_all_group_channels: props.show_all || preferences.get("chat.show-all-group-channels"),
+            show_all_tournament_channels: props.show_all || preferences.get("chat.show-all-tournament-channels"),
+            show_all_global_channels: props.show_all || preferences.get("chat.show-all-global-channels"),
         };
     }
 
@@ -150,6 +160,20 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                 browserHistory.push("/chat");
             }
         }
+        this.closing_toggle();
+    }
+
+    toggleShowAllGlobalChannels = () => {
+        preferences.set("chat.show-all-global-channels", !this.state.show_all_global_channels),
+        this.setState({show_all_global_channels: !this.state.show_all_global_channels});
+    }
+    toggleShowAllGroupChannels = () => {
+        preferences.set("chat.show-all-group-channels", !this.state.show_all_group_channels),
+        this.setState({show_all_group_channels: !this.state.show_all_group_channels});
+    }
+    toggleShowAllTournamentChannels = () => {
+        preferences.set("chat.show-all-tournament-channels", !this.state.show_all_tournament_channels),
+        this.setState({show_all_tournament_channels: !this.state.show_all_tournament_channels});
     }
 
     render() {
@@ -180,7 +204,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                     {(this.state.group_channels.length > 0 || null) && (
                         <div className="channel-header">
                             <span>{_("Group Channels")}</span>
-                            <i className={"channel-expand-toggle " + (this.state.show_all_group_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                            <i onClick={this.toggleShowAllGroupChannels} className={"channel-expand-toggle " + (this.state.show_all_group_channels ?  "fa fa-minus" : "fa fa-plus")}/>
                         </div>
                     ) }
                     {this.state.group_channels.map((chan) => (
@@ -204,7 +228,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                     {(this.state.tournament_channels.length > 0 || null) && (
                         <div className="channel-header">
                             <span>{_("Tournament Channels")}</span>
-                            <i className={"channel-expand-toggle " + (this.state.show_all_tournament_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                            <i onClick={this.toggleShowAllTournamentChannels} className={"channel-expand-toggle " + (this.state.show_all_tournament_channels ?  "fa fa-minus" : "fa fa-plus")}/>
                         </div>
                     )}
                     {this.state.tournament_channels.map((chan) => (
@@ -227,7 +251,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, any> {
                 <div className={"channels" + (!this.state.show_all_global_channels ? " hide-unjoined" : "")}>
                     <div className="channel-header">
                         <span>{_("Global Channels")}</span>
-                        <i className={"channel-expand-toggle " + (this.state.show_all_global_channels ?  "fa fa-minus" : "fa fa-plus")}/>
+                        <i onClick={this.toggleShowAllGlobalChannels} className={"channel-expand-toggle " + (this.state.show_all_global_channels ?  "fa fa-minus" : "fa fa-plus")}/>
                     </div>
                     {this.state.global_channels.map((chan) => (
                         <div key={chan.id}

--- a/src/components/Chat/index.ts
+++ b/src/components/Chat/index.ts
@@ -19,3 +19,4 @@
 export * from "./Chat";
 export * from "./ChatDetails";
 export * from "./ChatIndicator";
+export * from "./ChatList";

--- a/src/components/Chat/index.ts
+++ b/src/components/Chat/index.ts
@@ -18,3 +18,4 @@
 
 export * from "./Chat";
 export * from "./ChatDetails";
+export * from "./ChatIndicator";

--- a/src/components/ChatPresenceIndicator/ChatPresenceIndicator.tsx
+++ b/src/components/ChatPresenceIndicator/ChatPresenceIndicator.tsx
@@ -52,7 +52,7 @@ export class ChatPresenceIndicator extends React.PureComponent<ChatPresenceIndic
     }
 
     init(channel, user_id) {
-        this.proxy = chat_manager.join(channel, user_id);
+        this.proxy = chat_manager.join(channel);
         this.proxy.on("join", () => this.update(user_id));
         this.proxy.on("part", () => this.update(user_id));
         this.update(user_id);

--- a/src/components/ChatUserList/ChatUserList.tsx
+++ b/src/components/ChatUserList/ChatUserList.tsx
@@ -26,7 +26,6 @@ import {GameChat} from "Game/Chat";
 
 interface ChatUserListProperties {
     channel: string;
-    display_name?: string;
 }
 
 interface ChatUserCountProperties extends ChatUserListProperties {
@@ -42,12 +41,12 @@ export class ChatUsers<T extends ChatUserListProperties> extends React.PureCompo
         this.state = {tick: 0};
     }
     UNSAFE_componentWillMount() {
-        this.init(this.props.channel, this.props.display_name);
+        this.init(this.props.channel);
     }
     UNSAFE_componentWillReceiveProps(next_props) {
         if (this.props.channel !== next_props.channel) {
             this.deinit();
-            this.init(next_props.channel, next_props.display_name);
+            this.init(next_props.channel);
         }
     }
     //componentDidUpdate(old_props, old_state) { }
@@ -55,8 +54,8 @@ export class ChatUsers<T extends ChatUserListProperties> extends React.PureCompo
         this.deinit();
     }
 
-    init(channel, display_name) {
-        this.proxy = chat_manager.join(channel, display_name);
+    init(channel) {
+        this.proxy = chat_manager.join(channel);
         this.proxy.on("join", () => this.setState({tick: this.state.tick + 1}));
         this.proxy.on("part", () => this.setState({tick: this.state.tick + 1}));
     }

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -37,6 +37,7 @@ import {Player} from "Player";
 import * as player_cache from "player_cache";
 import * as preferences from "preferences";
 import cached from 'cached';
+import {ChatIndicator} from "Chat";
 
 let body = $(document.body);
 
@@ -303,6 +304,7 @@ export class NavBar extends React.PureComponent<{}, any> {
                 <section className="right">
                     <IncidentReportTracker />
                     { preferences.get("show-tournament-indicator") && <TournamentIndicator /> }
+                    <ChatIndicator />
                     <FriendIndicator />
                     <TurnIndicator />
                     <span className="icon-container" onClick={this.toggleRightNav}>

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -173,7 +173,12 @@ class ChatChannel extends TypedEventEmitter<Events> {
         setTimeout(() => this.joining = false, 10000); /* don't notify for name matches within 10s of joining a channel */
         comm_socket.on("connect", this._rejoin);
         this._rejoin();
-        this.last_seen_timestamp = data.get("chat_manager_last_seen." + this.channel, 0);
+        let last_seen = data.get("chat-manager.last-seen", {});
+        if (channel in last_seen) {
+            this.last_seen_timestamp = last_seen[channel];
+        } else {
+            this.last_seen_timestamp = 0;
+        }
     }
 
     markAsRead() {
@@ -181,7 +186,9 @@ class ChatChannel extends TypedEventEmitter<Events> {
         let previous_mentioned = this.mentioned;
         this.unread_ct = 0;
         this.mentioned = false;
-        data.set("chat_manager_last_seen." + this.channel, this.last_seen_timestamp);
+        let last_seen = data.get("chat-manager.last-seen", {});
+        last_seen[this.channel] = this.last_seen_timestamp;
+        data.set("chat-manager.last-seen", last_seen);
         try {
             this.emit("unread-count-changed",
                         {channel: this.channel,

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -21,20 +21,113 @@ import * as data from "data";
 import {emitNotification} from "Notifications";
 import * as player_cache from "player_cache";
 import {bounded_rank} from 'rank_utils';
+import cached from 'cached';
+import { ActiveTournamentList, GroupList } from 'types';
+import {_, interpolate} from "translate";
 
 interface Events {
     "chat": any;
+    "chat-removed": any;
     "join": Array<any>;
     "part": any;
 }
 
+
+/* Any modifications to this must also be mirrored on the server */
+export let global_channels: Array<any> = [
+    {"id": "global-english" , "name": "English", "country": "us", "language": "english"},
+    {"id": "global-help" , "name": "Help", "country": "un"},
+    {"id": "global-offtopic" , "name": "Off Topic", "country": "un"},
+    {"id": "global-japanese", "name": "日本語 ", "country": "jp", "language": "japanese"},
+    {"id": "global-chinese" , "name": "中文"   , "country": "cn", "language": "chinese"},
+    {"id": "global-korean"  , "name": "한국어" , "country": "kr", "language": "korean"},
+    {"id": "global-russian"  , "name": "Русский" , "country": "ru"},
+    {"id": "global-polish"  , "name": "Polski" , "country": "pl"},
+    {"id": "global-arabic", "name": "العَرَبِيَّةُ", "country": "_Arab_League", "rtl": true},
+    {"id": "global-bulgarian"  , "name": "Български" , "country": "bg"},
+    {"id": "global-catalan"  , "name": "Català" , "country": "es"},
+    {"id": "global-czech"  , "name": "Čeština" , "country": "cz"},
+    {"id": "global-esperanto"  , "name": "Esperanto" , "country": "_Esperanto"},
+    {"id": "global-german"  , "name": "Deutsch" , "country": "de", "language": "german"},
+    {"id": "global-spanish"  , "name": "Español" , "country": "es", "language": "spanish"},
+    {"id": "global-french"  , "name": "Français" , "country": "fr", "language": "french"},
+    {"id": "global-filipino"  , "name": "Filipino" , "country": "ph"},
+    {"id": "global-indonesian", "name": "Indonesian", "country": "id"},
+    {"id": "global-hebrew", "name": "עִבְרִית", "country": "il", "rtl": true},
+    {"id": "global-hindi"  , "name": "हिन्दी" , "country": "in"},
+    {"id": "global-nepali" , "name": "नेपाली", "country": "np"},
+    {"id": "global-bangla"  , "name": "বাংলা" , "country": "bd"},
+    {"id": "global-lithuanian", "name": "Lietuvių", "country": "lt"},
+    {"id": "global-hungarian"  , "name": "Magyar" , "country": "hu"},
+    {"id": "global-dutch"  , "name": "Nederlands" , "country": "nl", "language": "dutch"},
+    {"id": "global-norwegian"  , "name": "Norsk" , "country": "no"},
+    {"id": "global-italian"  , "name": "Italiano" , "country": "it", "language": "italian"},
+    {"id": "global-portuguese"  , "name": "Português" , "country": "pt", "language": "portuguese"},
+    {"id": "global-romanian"  , "name": "Română" , "country": "ro"},
+    {"id": "global-swedish"  , "name": "Svenska" , "country": "se"},
+    {"id": "global-finnish"  , "name": "Suomi" , "country": "fi"},
+    {"id": "global-turkish"  , "name": "Türkçe" , "country": "tr"},
+    {"id": "global-ukrainian"  , "name": "Українська" , "country": "ua"},
+    {"id": "global-vietnamese"  , "name": "Tiếng Việt" , "country": "vn"},
+    {"id": "global-thai"  , "name": "ภาษาไทย" , "country": "th"},
+];
+data.watch("config.ogs", (settings) => {
+    if (settings && settings.channels) {
+        global_channels = settings.channels;
+    }
+});
+
+
+export function resolveChannelDisplayName(channel: string): string {
+    if (channel.startsWith("global-")) {
+        global_channels.forEach(element => {
+            if (channel === element.id) {
+                return element.name;
+            }
+        });
+    } else if (channel.startsWith("tournament-")) {
+        let id:number = parseInt(channel.substring(11));
+        tournament_channels.forEach(element => {
+            if (id === element.id) {
+                return element.name;
+            }
+        });
+    } else if (channel.startsWith("group-")) {
+        let id:number = parseInt(channel.substring(6));
+        group_channels.forEach(element => {
+            if (id === element.id) {
+                return element.name;
+            }
+        });
+    } else if (channel.startsWith("game-")) {
+        return interpolate(_("Game {{number}}"), {"number": channel.substring(5)});
+    } else if (channel.startsWith("review-")) {
+        return interpolate(_("Review {{number}}"), {"number": channel.substring(7)});
+    }
+    return "<error>";
+}
+
+export let group_channels: GroupList = [];
+export let tournament_channels: ActiveTournamentList = [];
+
+function updateGroups(groups:GroupList) {
+    group_channels = groups;
+}
+function updateTournaments(tournaments:ActiveTournamentList) {
+    tournament_channels = tournaments;
+}
+data.watch(cached.groups, updateGroups);
+data.watch(cached.active_tournaments, updateTournaments);
+
+
 let name_match_regex = /^loading...$/;
 data.watch("config.user", (user) => {
-    try {
-        name_match_regex = new RegExp("\b" + user.username.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + "\b", "i");
-    } catch (e) {
-        console.error("Failed to construct name matching regular expression", e);
-    }
+    let cleaned_username_regex = user.username.replace(/[\\^$*+.()|[\]{}]/g, "\\$&");
+    name_match_regex = new RegExp(
+          "\\b"  + cleaned_username_regex + "\\b"
+        + "|\\bplayer ?" + user.id + "\\b"
+        + "|\\bhttps?:\\/\\/online-go\\.com\\/user\\/view\\/" + user.id + "\\b"
+        , "i");
 });
 
 
@@ -47,27 +140,38 @@ let last_proxy_id = 0;
 
 class ChatChannel extends TypedEventEmitter<Events> {
     channel: string;
-    display_name: string;
+    name: string;
     proxies: {[id: number]: ChatChannelProxy} = {};
     joining: boolean = false;
     chat_log   = [];
     chat_ids   = {};
     has_unread = false;
+    unread_ct = 0;
+    mentioned = false;
     user_list  = {};
     users_by_rank = [];
     users_by_name = [];
     user_count = 0;
     rtl_mode   = false;
+    last_seen_timestamp: number;
 
 
     constructor(channel: string, display_name: string) {
         super();
         this.channel = channel;
+        this.name = display_name;
         this.rtl_mode = channel in rtl_channels;
         this.joining = true;
         setTimeout(() => this.joining = false, 10000); /* don't notify for name matches within 10s of joining a channel */
         comm_socket.on("connect", this._rejoin);
         this._rejoin();
+        this.last_seen_timestamp = data.get("chat_manager_last_seen." + this.channel, 0);
+    }
+
+    markAsRead() {
+        this.unread_ct = 0;
+        this.mentioned = false;
+        data.set("chat_manager_last_seen." + this.channel, this.last_seen_timestamp);
     }
 
     _rejoin = () => {
@@ -103,17 +207,12 @@ class ChatChannel extends TypedEventEmitter<Events> {
         this.chat_log.push(obj);
 
         try {
-            this.emit("chat", obj);
-        } catch (e) {
-            console.error(e);
-        }
-
-        try {
             if (typeof(obj.message.m) === "string") {
                 if (name_match_regex.test(obj.message.m)) {
-                    if (!this.joining) {
-                        emitNotification("[" + this.display_name + "]: " + obj.username,
-                                         "[" + this.display_name + "] " + obj.username + ": " + obj.message.m);
+                    if (obj.message.t > this.last_seen_timestamp) { // TODO remember chat read position
+                        this.mentioned = true;
+                        emitNotification("[" + this.name + "]: " + obj.username,
+                                         "[" + this.name + "] " + obj.username + ": " + obj.message.m);
                     } else {
                         console.log("Not sending name match notification since we just joined the channel ", obj.channel);
                     }
@@ -122,7 +221,35 @@ class ChatChannel extends TypedEventEmitter<Events> {
         } catch (e) {
             console.error(e);
         }
+
+        if (obj.message.t > this.last_seen_timestamp) {
+            this.unread_ct++;
+            this.last_seen_timestamp = obj.message.t;
+        }
+
+        try {
+            this.emit("chat", obj);
+        } catch (e) {
+            console.error(e);
+        }
     }
+
+    handleChatRemoved(obj) {
+        console.log("Chat message removed: ", obj);
+        this.chat_ids[obj.uuid] = true;
+        for (let idx = 0; idx < this.chat_log.length; ++idx) {
+            let entry = this.chat_log[idx];
+            if (entry.message.i === obj.uuid) {
+                this.chat_log.splice(idx, 1);
+            }
+        }
+        try {
+            this.emit("chat-removed", obj);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
     handleJoins(users: Array<any>): void {
         for (let user of users) {
             if (!(user.id in this.user_list)) {
@@ -195,6 +322,7 @@ export class ChatChannelProxy extends TypedEventEmitter<Events> {
         this.channel.on("chat", this._onChat);
         this.channel.on("join", this._onJoin);
         this.channel.on("part", this._onPart);
+        this.channel.on("chat-removed", this._onChatRemoved);
     }
 
     part() {
@@ -210,10 +338,14 @@ export class ChatChannelProxy extends TypedEventEmitter<Events> {
     _onPart = (...args) => {
         this.emit.apply(this, ["part"].concat(args));
     }
+    _onChatRemoved = (...args) => {
+        this.emit.apply(this, ["chat-removed"].concat(args));
+    }
     _destroy() {
         this.channel.off("chat", this._onChat);
         this.channel.off("join", this._onJoin);
         this.channel.off("part", this._onPart);
+        this.channel.off("chat-removed", this._onChatRemoved);
         this.removeAllListeners();
         this.channel.removeProxy(this);
     }
@@ -225,6 +357,7 @@ class ChatManager {
 
     constructor() {
         comm_socket.on("chat-message", this.onMessage);
+        comm_socket.on("chat-message-removed", this.onMessageRemoved);
         comm_socket.on("chat-join", this.onJoin);
         comm_socket.on("chat-part", this.onPart);
     }
@@ -245,6 +378,13 @@ class ChatManager {
 
         this.channels[obj.channel].handleChat(obj);
     }
+    onMessageRemoved = (obj) => {
+        if (!(obj.channel in this.channels)) {
+            return;
+        }
+
+        this.channels[obj.channel].handleChatRemoved(obj);
+    }
     onJoin = (joins) => {
         for (let i = 0; i < joins.users.length; ++i) {
             player_cache.update(joins.users[i]);
@@ -263,7 +403,8 @@ class ChatManager {
 
         this.channels[part.channel].handlePart(part.user);
     }
-    join(channel: string, display_name: string): ChatChannelProxy {
+    join(channel: string): ChatChannelProxy {
+        let display_name = resolveChannelDisplayName(channel);
         if (!(channel in this.channels)) {
             this.channels[channel] = new ChatChannel(channel, display_name);
         }

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -24,6 +24,7 @@ import {bounded_rank} from 'rank_utils';
 import cached from 'cached';
 import { ActiveTournamentList, GroupList } from 'types';
 import {_, interpolate} from "translate";
+import { shadowban } from "src/views/Moderator";
 
 interface Events {
     "chat": any;
@@ -87,6 +88,9 @@ data.watch("config.ogs", (settings) => {
 
 
 export function resolveChannelDisplayName(channel: string): string {
+    if (channel === "shadowban") {
+        return global_channels[channel];
+    }
     if (channel.startsWith("global-")) {
         global_channels.forEach(element => {
             if (channel === element.id) {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -89,6 +89,13 @@ let defaults = {
     "translation-dialog-never-show": false,
     "unicode-filter": false,
     "variations-in-chat-enabled": true,
+
+    "show-empty-chat-notification": true,
+    "chat-subscribe-group-chat-unread": true,
+    "chat-subscribe-group-mentions": true,
+    "chat-subscribe-tournament-chat-unread": true,
+    "chat-subscribe-tournament-mentions": true,
+
 };
 
 defaults['profanity-filter'][current_language] = true;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -343,8 +343,8 @@ export class Game extends React.PureComponent<GameProperties, any> {
     }
     initialize() {
         this.chat_proxy = this.game_id
-            ? chat_manager.join(`game-${this.game_id}`, interpolate(_("Game {{number}}"), {"number": this.game_id}))
-            : chat_manager.join(`review-${this.review_id}`, interpolate(_("Review {{number}}"), {"number": this.review_id}));
+            ? chat_manager.join(`game-${this.game_id}`)
+            : chat_manager.join(`review-${this.review_id}`);
         $(document).on("keypress", this.setLabelHandler);
 
         let label_position = preferences.get("label-positioning");

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -147,6 +147,7 @@ export function Settings():JSX.Element {
         { key: 'general'  , label: _("General Preferences") },
         { key: 'sound'    , label: _("Sound Preferences") },
         { key: 'game'     , label: _("Game Preferences") },
+        { key: 'chat'     , label: _("Chat Preferences")},
         { key: 'vacation' , label: _("Vacation") },
         { key: 'email'    , label: _("Email Notifications") },
         { key: 'account'  , label: _("Account Settings") },
@@ -163,6 +164,7 @@ export function Settings():JSX.Element {
         case 'email'    : SelectedPage = EmailPreferences   ; break;
         case 'game'     : SelectedPage = GamePreferences    ; break;
         case 'general'  : SelectedPage = GeneralPreferences ; break;
+        case 'chat'     : SelectedPage = ChatPreferences    ; break;
     }
 
     let props:SettingGroupProps = {
@@ -494,6 +496,71 @@ function AccountSettings(props:SettingGroupProps):JSX.Element {
             </dl>
 
             <i><Link to={`/user/view/${user.id}#edit`}>{_("To update your profile information, click here")}</Link></i>
+        </div>
+    );
+}
+
+function ChatPreferences(props:SettingGroupProps):JSX.Element {
+    const [show_empty_chat_notification, _setEmptyChatNotification]:[boolean, (x: boolean) => void] = React.useState(preferences.get("show-empty-chat-notification"));
+    const [group_chat_unread, _setGroupChatUnread]:[boolean, (x: boolean) => void] = React.useState(preferences.get("chat-subscribe-group-chat-unread"));
+    const [group_chat_mentions, _setGroupChatMentions]:[boolean, (x: boolean) => void] = React.useState(preferences.get("chat-subscribe-group-mentions"));
+    const [tournament_chat_unread, _setTournamentChatUnread]:[boolean, (x: boolean) => void] = React.useState(preferences.get("chat-subscribe-tournament-chat-unread"));
+    const [tournament_chat_mentions, _setTournamentChatMentions]:[boolean, (x: boolean) => void] = React.useState(preferences.get("chat-subscribe-tournament-mentions"));
+
+    function toggleEmptyChatNotification(checked) {
+        preferences.set("show-empty-chat-notification", checked);
+        _setEmptyChatNotification(checked);
+    }
+
+    function toggleGroupChatMentions(checked) {
+        preferences.set("chat-subscribe-group-mentions", checked);
+        _setGroupChatMentions(checked);
+    }
+
+    function toggleGroupChatUnread(checked) {
+        preferences.set("chat-subscribe-group-chat-unread", checked);
+        _setGroupChatUnread(checked);
+    }
+
+    function toggleTournamentChatMentions(checked) {
+        preferences.set("chat-subscribe-tournament-mentions", checked);
+        _setTournamentChatMentions(checked);
+    }
+
+    function toggleTournamentChatUnread(checked) {
+        preferences.set("chat-subscribe-tournament-chat-unread", checked);
+        _setTournamentChatUnread(checked);
+    }
+
+    return (
+        <div>
+            <PreferenceLine title={_("Show chat notification icon when there are no unread messages.")}>
+                <Toggle checked={show_empty_chat_notification} onChange={toggleEmptyChatNotification}/>
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Notify me when I'm mentioned in group chats I'm a member of.")}
+                description={_("This only applies to chats you haven't choosen a different setting.")}
+                >
+                <Toggle checked={group_chat_mentions} onChange={toggleGroupChatMentions}/>
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Notify me about unread messages in group chats I'm a member of.")}
+                description={_("This only applies to chats you haven't choosen a different setting.")}
+                >
+                <Toggle checked={group_chat_unread} onChange={toggleGroupChatUnread}/>
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Notify me when I'm mentioned in tournament chats I'm a member of.")}
+                description={_("This only applies to chats you haven't choosen a different setting.")}
+                >
+                <Toggle checked={tournament_chat_mentions} onChange={toggleTournamentChatMentions}/>
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Notify me about unread messages in tournament chats I'm a member of.")}
+                description={_("This only applies to chats you haven't choosen a different setting.")}
+                >
+                <Toggle checked={tournament_chat_unread} onChange={toggleTournamentChatUnread}/>
+            </PreferenceLine>
         </div>
     );
 }


### PR DESCRIPTION
Adds a chat notification Icon to the NavBar. The Notification Icon shows the total count of unread messages and if the user is mentioned in any chat room selected by the user.

![image](https://user-images.githubusercontent.com/4864182/78601456-19492a00-7855-11ea-8f01-6321ce0596ad.png)

![image](https://user-images.githubusercontent.com/4864182/78601414-09c9e100-7855-11ea-9115-a309a680dae4.png)

![image](https://user-images.githubusercontent.com/4864182/78601489-26661900-7855-11ea-858c-19e86bf16548.png)

---

To achieve this, the following changes are made:
-   The chat receiving logic moved to a central location (`chat_manager`), to keep the different components in sync. 
    The `chat_manager` seems to be a good place for this. It's called chat_manager after all.
-   The read timestamp for each chat room is stored in local storage, to be able to notify the user if there was chat activity while they were offline. Due to backend limitations the backlog is limited to 40 messages.
-    A copy of the Chat Room List (left hand site on Chats page) is used as dropdown for the Chat indicator. A click there on the chat room opens the selected room on the chat page.
    With some minor abstractions, the new ChatList can replace the list on the ChatList, without changing the feel of the ChatPage.
-    Adding a settings page for chat notification defaults (join all group/tournament chats). Those settings are overwritten by room specific settings.
    To keep the settings in sync, there are some hacky snippets in `ChatIndicator.tsx` (line 28-92). There is probably a better way to do it (probably an eventEmiter like in data).