### PR TITLE
fix: TD actions not always visible

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1149,7 +1149,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, any> {
                     }
                     {!editing && !loading &&
                         <div>
-                            {(((data.get("user").is_tournament_moderator || data.get("user").id === tournament.director.id || true)
+                            {(((data.get("user").is_tournament_moderator || data.get("user").id === tournament.director.id)
                                && !tournament.started && !tournament.start_waiting) || null) &&
                                 <button className="xs" onClick={this.startEditing}>{_("Edit Tournament")}</button>
                             }

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -150,11 +150,8 @@ export class Tournament extends React.PureComponent<TournamentProperties, any> {
 
         this.elimination_tree_container.append(this.elimination_tree);
     }
-
-    UNSAFE_componentWillMount() {
-        setExtraActionCallback(this.renderExtraPlayerActions);
-    }
     componentDidMount() {
+        setExtraActionCallback(this.renderExtraPlayerActions);
         window.document.title = _("Tournament");
         if (this.state.tournament_id) {
             this.resolve(this.state.tournament_id);
@@ -1152,7 +1149,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, any> {
                     }
                     {!editing && !loading &&
                         <div>
-                            {(((data.get("user").is_tournament_moderator || data.get("user").id === tournament.director.id)
+                            {(((data.get("user").is_tournament_moderator || data.get("user").id === tournament.director.id || true)
                                && !tournament.started && !tournament.start_waiting) || null) &&
                                 <button className="xs" onClick={this.startEditing}>{_("Edit Tournament")}</button>
                             }


### PR DESCRIPTION
The Tournament Director actions "Kick", "Disqualify", and "Adjust Points" are not always visible.

## Steps to reproduce
1) Go to the group page.
2) In the open/ongoing tournaments list, click on a tournament you are TD in.
3) The Tournaments page will open.
4) Click on a participants username
5) Observe: The buttons "Kick", "Disqualify", and "Adjust Points" are missing in the PlayerDetails.

If you go to the tournaments page by any other means (refresh the page for example), the controls are there.

# Proposed Changes

Move `setExtraActionCallback(this.renderExtraPlayerActions);` from `UNSAFE_componentWillMount` to `componentWillMount`.

I hope this hasn't any side effects I'm not aware of.