### PR TITLE
Disable joseki comment entry when user doesn't have edit permission

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1496,7 +1496,9 @@ class ExplorePane extends React.Component<ExploreProps, any> {
                                         </div>
                                     )}
                                 </div>
-                                <textarea className="comment-input" rows={1} value={this.state.next_comment} onChange={this.onCommentChange} />
+                                <textarea className="comment-input"
+                                    hidden={!this.props.can_comment}
+                                    rows={1} value={this.state.next_comment} onChange={this.onCommentChange} />
                             </div>
                         }
 


### PR DESCRIPTION
Disable joseki comment entry when user doesn't have edit permission

... more relevant when recent Joseki Server commit is merged, disabling noobs from commenting