### PR TITLE
tutorial: put board presentation first, add simpler examples of captu…

### DIFF
--- a/src/views/LearningHub/Capture.tsx
+++ b/src/views/LearningHub/Capture.tsx
@@ -30,6 +30,9 @@ export class Capture extends LearningHubSection {
             Page3,
             Page4,
             Page5,
+            Page6,
+            Page7,
+            Page8,
         ];
     }
 
@@ -60,6 +63,7 @@ class Page1 extends LearningPage {
         };
     }
 }
+
 class Page2 extends LearningPage {
     constructor(props) {
         super(props);
@@ -86,6 +90,7 @@ class Page2 extends LearningPage {
     }
 
 }
+
 class Page3 extends LearningPage {
     constructor(props) {
         super(props);
@@ -112,6 +117,7 @@ class Page3 extends LearningPage {
     }
 
 }
+
 class Page4 extends LearningPage {
     constructor(props) {
         super(props);
@@ -145,6 +151,65 @@ class Page5 extends LearningPage {
     }
 
     text() {
+        return _("Surrounding isn't enough, you have to fill all the space around the stones. Capture the white stones.");
+    }
+    config():PuzzleConfig {
+        return {
+            mode: "puzzle",
+            initial_state: {
+                'black': 'b6b5b4c6c4g6g5g4d7e7f7d3e3f3',
+                'white': 'd6d5d4f6f5f4e6e4'
+            },
+            move_tree: this.makePuzzleMoveTree(
+                [
+                    "c5c7e5"
+                ],
+                [
+                ]
+            )
+        };
+    }
+
+}
+
+class Page6 extends LearningPage {
+    constructor(props) {
+        super(props);
+    }
+
+    text() {
+        return _("Capture the white stones before white can form two \"eyes\"");
+    }
+    config():PuzzleConfig {
+        return {
+            mode: "puzzle",
+            initial_state: {
+                'black': 'b6b5b4c7c3d7e7f7d3e3f3g7g3h6h5h4',
+                'white': 'c6c5c4d6d4e6e4f6f4g6g5g4'
+            },
+            move_tree: this.makePuzzleMoveTree(
+                [
+                    "e5h7d5f5e5d5e5",
+                    "e5h7f5d5e5f5e5",
+                    "e5h7d5f5d5e5d5",
+                    "e5h7f5d5f5e5f5",
+                ],
+                [
+                    "d5e5",
+                    "f5e5",
+                ]
+            )
+        };
+    }
+
+}
+
+class Page7 extends LearningPage {
+    constructor(props) {
+        super(props);
+    }
+
+    text() {
         return _("Capture the white stones before white can form two \"eyes\"");
     }
     config():PuzzleConfig {
@@ -162,6 +227,39 @@ class Page5 extends LearningPage {
                     "c3c2",
                     "b2c2",
                     "d4c2",
+                ]
+            )
+        };
+    }
+}
+
+class Page8 extends LearningPage {
+    constructor(props) {
+        super(props);
+    }
+
+    text() {
+        return _("Capture the white stones before white can form two \"eyes\"");
+    }
+    config():PuzzleConfig {
+        return {
+            mode: "puzzle",
+            initial_state: {
+                'black': 'b6b5b4b3c7c2d7e7f7d2e2f2g7g2h6h5h4h3',
+                'white': 'c6c5c4d6d4e6e4f6f4g6g5g4'
+            },
+            move_tree: this.makePuzzleMoveTree(
+                [
+                    "e5"
+                ],
+                [
+                    "d5e5",
+                    "f5e5",
+                    "c3e5",
+                    "d3e5",
+                    "e3e5",
+                    "f3e5",
+                    "g3e5",
                 ]
             )
         };

--- a/src/views/LearningHub/Intro.tsx
+++ b/src/views/LearningHub/Intro.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { PuzzleConfig } from 'goban';
+import {LearningPage, DummyPage} from './LearningPage';
+import {_, pgettext, interpolate} from "translate";
+import {LearningHubSection} from './LearningHubSection';
+
+export class Intro extends LearningHubSection {
+    static pages():Array<typeof LearningPage> {
+        return [
+            Page1
+        ];
+    }
+
+    static section():string { return "rules-intro"; }
+    static title():string { return pgettext("Tutorial section name on rules introduction", "The Game!"); }
+    static subtext():string { return pgettext("Tutorial section subtext on rules introduction", "Build territory one stone at a time"); }
+}
+
+class Page1 extends LearningPage {
+    constructor(props) {
+        super(props);
+    }
+
+    text() {
+        return _("You can play a stone on any crossline, even the outer ones. The goal of the game is to surround the largest areas. Stones don't move but can be captured. Make a move to continue");
+    }
+    config():PuzzleConfig {
+        return {
+            mode: "puzzle",
+            initial_state: {black: "", white: ""},
+
+            move_tree: this.makePuzzleMoveTree(
+                [
+                    "a1",
+                    "a2",
+                    "a3",
+                    "a4",
+                    "a5",
+                    "a6",
+                    "a7",
+                    "a8",
+                    "a9",
+                    "b1",
+                    "b2",
+                    "b3",
+                    "b4",
+                    "b5",
+                    "b6",
+                    "b7",
+                    "b8",
+                    "b9",
+                    "c1",
+                    "c2",
+                    "c3",
+                    "c4",
+                    "c5",
+                    "c6",
+                    "c7",
+                    "c8",
+                    "c9",
+                    "d1",
+                    "d2",
+                    "d3",
+                    "d4",
+                    "d5",
+                    "d6",
+                    "d7",
+                    "d8",
+                    "d9",
+                    "e1",
+                    "e2",
+                    "e3",
+                    "e4",
+                    "e5",
+                    "e6",
+                    "e7",
+                    "e8",
+                    "e9",
+                    "f1",
+                    "f2",
+                    "f3",
+                    "f4",
+                    "f5",
+                    "f6",
+                    "f7",
+                    "f8",
+                    "f9",
+                    "g1",
+                    "g2",
+                    "g3",
+                    "g4",
+                    "g5",
+                    "g6",
+                    "g7",
+                    "g8",
+                    "g9",
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6",
+                    "h7",
+                    "h8",
+                    "h9",
+                    "j1",
+                    "j2",
+                    "j3",
+                    "j4",
+                    "j5",
+                    "j6",
+                    "j7",
+                    "j8",
+                    "j9"
+                ], [ ]
+            )
+        };
+    }
+}
+

--- a/src/views/LearningHub/Ladders.tsx
+++ b/src/views/LearningHub/Ladders.tsx
@@ -108,9 +108,29 @@ class Page3 extends LearningPage {
             initial_state: {black: "fcef", white: "eedfegfg"},
             move_tree: this.makePuzzleMoveTree(
                 [
-                    "f4g4f5f6g5h5g6e6"
+                    "f4g4f5f6g5h5g6e6g7",
+                    "f4g4f5f6g5h5g6e6g8",
+                    "f4g4f5f6g5h5g6e6h7h6g7",
+                    "f4g4f5f6g5h5g6e6h6g7h4",
+                    "f4g4f5f6g5h5g6e6h6g7h7",
+                    "f4g4f5f6g5h5g6e6h4g3h6j5j4j6j7",
+                    "f4g4f5f6g5h5g6e6h4g3h6j5j6j4j3",
+                    "f4g4f5f6g5h5g6e6h4g3g7",
+                    "f4g4f5f6g5h5g6e6h4g3h7h6g7",
+                    "f4g4f5f6g5h5g6e6g3h4g7",
+                    "f4g4f5f6g5h5g6e6g3h4h6g7h7g8h8f8h3",
+                    "f4g4f5f6g5h5g6e6g3h4h7h6g7"
                 ],
                 [
+                    "f4g4f5f6g5h5g6e6d3g7",
+                    "f4g4f5f6g5h5g6e6d5g7",
+                    "f4g4f5f6g5h5g6e6e7g7",
+                    "f4g4f5f6g5h5g6e6d6g7",
+                    "f4g4f5f6g5h5g6e6f8g7",
+                    "f4g4f5f6g5h5g6e6e8g7",
+                    "f4g4f5f6g5h5g6e6h8g7",
+                    "f4g4f5f6g5h5g6e6h3g7",
+                    "f4g4f5f6g5h5g6e6g3h4h6g7h7g8f8h8",
                     "f4g4f5f6g6g5",
                     "g4f4",
                     "f5f4",
@@ -120,4 +140,3 @@ class Page3 extends LearningPage {
         };
     }
 }
-

--- a/src/views/LearningHub/Seki.tsx
+++ b/src/views/LearningHub/Seki.tsx
@@ -28,7 +28,7 @@ export class Seki extends LearningHubSection {
             Page2,
             Page3,
             Page4,
-            //Page5,
+            Page5,
             //Page6,
             //Page7,
         ];
@@ -38,7 +38,6 @@ export class Seki extends LearningHubSection {
     static title():string { return pgettext("Tutorial section on seki", "Seki!"); }
     static subtext():string { return pgettext("Tutorial section on seki", "Mutual life"); }
 }
-
 
 class Page1 extends LearningPage {
     constructor(props) {
@@ -63,7 +62,7 @@ class Page1 extends LearningPage {
                     "e2e1",
                     "e1e2",
                     "e5e1",
-                    "h1e1",
+                    "h1e1"
                 ]
             )
         };
@@ -71,6 +70,34 @@ class Page1 extends LearningPage {
 }
 
 class Page2 extends LearningPage {
+    constructor(props) {
+        super(props);
+    }
+
+    text() {
+        return _("Sometimes you cannot capture, but you can prevent from being captured. Save your black stones!");
+    }
+    config():PuzzleConfig {
+        return {
+            mode: "puzzle",
+            initial_state: {
+                'black': 'a1a2a3b3c3d3e3f3g3h3j3j2j1d1f1',
+                'white': 'b1b2c2d2e2f2g2h2h1'
+            },
+            move_tree: this.makePuzzleMoveTree(
+                [
+                    "e1"
+                ],
+                [
+                    "c1e1",
+                    "g1e1"
+                ]
+            )
+        };
+    }
+}
+
+class Page3 extends LearningPage {
     constructor(props) {
         super(props);
     }
@@ -92,14 +119,14 @@ class Page2 extends LearningPage {
                 [
                     "j4j5",
                     "g2j5",
-                    "g5j5",
+                    "g5j5"
                 ]
             )
         };
     }
 }
 
-class Page3 extends LearningPage {
+class Page4 extends LearningPage {
     constructor(props) {
         super(props);
     }
@@ -124,14 +151,14 @@ class Page3 extends LearningPage {
                     "j1j2g1j3",
                     "j1j2j3g1",
                     "g5g1",
-                    "e3g1",
+                    "e3g1"
                 ]
             )
         };
     }
 }
 
-class Page4 extends LearningPage {
+class Page5 extends LearningPage {
     constructor(props) {
         super(props);
     }
@@ -154,7 +181,7 @@ class Page4 extends LearningPage {
                     "g5j4",
                     "j4h5",
                     "g2f2g1f1h1j1",
-                    "g2f2g1f1j1h1",
+                    "g2f2g1f1j1h1"
                 ]
             )
         };

--- a/src/views/LearningHub/sections.ts
+++ b/src/views/LearningHub/sections.ts
@@ -28,6 +28,7 @@ import {Ko} from './Ko';
 import {Ladders} from './Ladders';
 import {EndingTheGame} from './EndingTheGame';
 import {TheBoard} from './TheBoard';
+import {Intro} from './Intro';
 
 
 export class FalseEyes extends LearningHubSection {
@@ -85,7 +86,7 @@ export class Terminology extends LearningHubSection {
 
 export let sections = [
     [pgettext("Learning hub section title", "Fundamentals"),
-        [Capture, Defend, /*Territory, */ EndingTheGame]],
+        [Intro, Capture, Defend, /*Territory, */ EndingTheGame]],
     [pgettext("Learning hub section title", "Basics"),
         [TheBoard, Ladders, SnapBack, Seki, Ko ]],
     /*


### PR DESCRIPTION
…re and seki. Add variations for the last ladder page

no extra translations needed

Fixes #975

## Proposed Changes

  - put the existing board presentation as first into the first section
  - add more straightforward examples of capture and seki
  - add variations and refutations of moves in the last ladder page. to make it more understandable why a move is wrong
