### PR TITLE
Give bouncer a soft start

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -71,13 +71,20 @@
               display: none;
           }
           @keyframes bounce {
-              0%, 20%, 50%, 80%, 100% {transform: translateY(0);} 
-              40% {transform: translateY(-30px);} 
-              60% {transform: translateY(-15px);} 
+              0%, 20%, 50%, 80%, 100% {transform: translateY(0);}
+              40% {transform: translateY(-30px);}
+              60% {transform: translateY(-15px);}
+          }
+
+          @keyframes fade-in {
+             0% {opacity: 0}
+             20% {opacity: 0}
+             100% {opacity: 1}
           }
           #svg-bouncer {
-              animation: bounce 1s infinite;
+             animation: bounce 1s infinite, fade-in 2s;
           }
+
           #loading-svg-container {
               width: 100vw;
               height: 100vh;


### PR DESCRIPTION
… so it doesn't catch our eyes if page loads fast

## Proposed Changes

Fade the bouncer in, so we don't see it at all if the page loads fast (therefore don't have our eyes caught by it) and so it's appearance is gentler when it arrives.
