### PR TITLE
Fix: Make threshold settings accept 0

### DIFF
--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -742,10 +742,14 @@ function GeneralPreferences(props:SettingGroupProps):JSX.Element {
     }
 
     function updateGameListThreshold(ev: React.ChangeEvent<HTMLInputElement>) {
-        if (ev.target.value && parseInt(ev.target.value)) {
-            preferences.set("game-list-threshold", Math.min(300, Math.max(0, parseInt(ev.target.value))));
+        let threshold = parseInt(ev.target.value);
+        if (!isNaN(threshold)) {
+            threshold = Math.min(300, Math.max(0, threshold));
+            preferences.set("game-list-threshold", threshold);
+            _setGameListThreshold(threshold);
+        } else {
+            _setGameListThreshold(ev.target.value as any);
         }
-        _setGameListThreshold(ev.target.value as any);
     }
 
     function setShowOfflineFriends(checked) {


### PR DESCRIPTION
Fixes: Thumbnail threshold setting didn't save 0. When `parseInt` evaluated to 0 (false), we skipped the save settings part.

## Proposed Changes

- Check if `parseInt` evaluates to NaN. `parseInt(undefined)` and `parseInt("")` both evalutate to NaN, therefor we can skip the check for undefined.
- Also, when the preference is changed, set the text field to the stored value. This makes it more transparent, which value is used.