### PR TITLE
fixes #1118: prevent linebreak in headline on observe games

### DIFF
--- a/src/views/ObserveGames/ObserveGames.styl
+++ b/src/views/ObserveGames/ObserveGames.styl
@@ -100,6 +100,7 @@
             .labelshow {
                 margin-left: 1rem;
                 margin-right: 0.5rem;
+                white-space: nowrap;
             }
             .show {
                 width: 4rem;


### PR DESCRIPTION
Fixes #1118. This should prevent the reported line breaks in the head line of Observe games.
