### PR TITLE
fix tabcompletion match every username thats's 1 letter longer than input

### DIFF
--- a/src/lib/tabcomplete.ts
+++ b/src/lib/tabcomplete.ts
@@ -135,7 +135,8 @@ function matchFullName(input, nicknames) {
     let letter;
     let letters = "";
     $.each(nicknames, (index, value) => {
-        if (input.lastIndexOf(value) === input.length - value.length) {
+        let idx = input.lastIndexOf(value);
+        if (idx >= 0 && idx === input.length - value.length) {
             matches.push(value);
         }
     });
@@ -227,7 +228,7 @@ function onKeyPress(e, options) {
                 completed_event.caret = sel.start;
                 $this.trigger(completed_event);
 
-                if ((match.value && !completed_event.isDefaultPrevented()) || true) {
+                if ((match.value && !completed_event.isDefaultPrevented())) {
                     first = val.substr(0, sel.start - match.value.length - space.length);
                     last    = val.substr(sel.start);
                     /* Space should not be added when there is only 1 match


### PR DESCRIPTION
Fixes: In some cases `matchFullName` matched multiple different usernames. This resulted in various occurrences of `@" /0"`. The result was either additional `@"/0"` cluttering the chat line, or worse, the chat substitution to interpret is as user 0. The later results in hiding the username.

This fix prevents the mismatch from happening. 

----

The error happens if the input is 1 char shorter than any username. In this case `lastIndexOf` retruns -1, since the username isn't a substring of input. Since input.length was 1 letter shorter than the username, the result of `input.length - value.length` was -1 (equal to `lastIndexOf`). 

An additional check if the username is a substring of input solves this issue.