### PR TITLE
Navigate to last visited puzzle of collection

### DIFF
--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -206,6 +206,7 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
                 this.setState(state);
                 this.onResize(true);
                 window.document.title = state.collection.name + ": " + state.name;
+                data.set(`puzzle.collection.${state.collection.id}.last-visited`, state.id);
                 this.solve_time_start = Date.now();
                 this.attempts = 1;
             }

--- a/src/views/PuzzleList/PuzzleList.tsx
+++ b/src/views/PuzzleList/PuzzleList.tsx
@@ -97,7 +97,10 @@ export class PuzzleList extends React.PureComponent<PuzzleListProperties, any> {
                                     return arr;
                                 }
                             }
-                            onRowClick={(row, ev) => navigateTo(`/puzzle/${row.starting_puzzle.id}`, ev)}
+                            onRowClick={(row, ev) => {
+                                const id = data.get(`puzzle.collection.${row.id}.last-visited`, row.starting_puzzle.id);
+                                navigateTo(`/puzzle/${id}`, ev);
+                            }}
                             columns={[
                                 {header: "",  className: () => "icon",
                                  render: (X) => (


### PR DESCRIPTION
Fixes #1112

## Proposed Changes

  - Save a visited puzzle of collection in local storage
  - If a collection is found in local storage, navigate to it instead of the starting puzzle.