### PR TITLE
Reduce min rank from 25k to 35k

### DIFF
--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -42,7 +42,7 @@ class Rating {
     partial_bounded_rank_label:string;
 }
 
-export const MinRank: number = 5;
+export const MinRank: number = -5;
 export const MaxRank: number = 38;
 export const PROVISIONAL_RATING_CUTOFF = 160;
 


### PR DESCRIPTION
Fixes #1127


## Proposed Changes

  - Lower minimum rank from 25k to 35k as per discussion in [the forums](https://forums.online-go.com/t/recognising-and-fully-implementing-ranks-beyond-25-kyu/27079)


Change tested by @GreenAsJade 
