### PR TITLE
Default custom komi value

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -902,7 +902,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                         <label className="control-label"></label>
                         <div className="controls">
                             <div className="checkbox">
-                                <input type="number" value={this.state.challenge.game.komi} onChange={this.update_komi} className="form-control" style={{width: "4em"}} step="0.5"/>
+                                <input type="number" value={this.state.challenge.game.komi || 0} onChange={this.update_komi} className="form-control" style={{width: "4em"}} step="0.5"/>
                             </div>
                         </div>
                     </div>

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -380,6 +380,11 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
         */
         let conf = next.conf;
 
+        if (next.challenge.game.komi_auto === 'custom' && next.challenge.game.komi === null) {
+            swal(_("Invalid custom komi, please correct and try again"));
+            return;
+        }
+
         if (next.challenge.game.ranked) {
             next.challenge.game.komi_auto = "automatic";
         }


### PR DESCRIPTION

Based on: https://forums.online-go.com/t/cant-start-live-bot-games/27265/4, creates simple validation when trying to create challenges using an invalid custom komi.



## Proposed Changes

  - defaults the custom_komi to 0
  - Prompt user to correct custom komi settings in case they sent a null value (probably from bad session having being saved in the state)