### PR TITLE
Fix bug where stone placed right after sequence reset in play mode

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -324,7 +324,8 @@ export class Joseki extends React.Component<JosekiProps, any> {
     }
 
     resetJosekiSequence = (pos: string) => {
-        // ask the server for the moves from postion pos
+        // ask the server for the moves from position pos
+        this.goban.disableStonePlacement(); // prevents a bug where move is played before moves are fetched
         this.fetchNextMovesFor(pos);
     }
 


### PR DESCRIPTION
Fixes #1151

It just forces user to wait until fetch before placing first stone. Fixes bug

See below video: [https://www.loom.com/share/ff2b8c42db1f4dee988c7d42c2383449](https://www.loom.com/share/ff2b8c42db1f4dee988c7d42c2383449)

I'm clicking actively, but it doesn't place the stone until sequence loaded

It may be possible to have this work where it doesn't say "That move isn't listed!" if it sees the fetch didn't happen yet, and perhaps just wait until the fetch occurs. I could try implementing that if desired, but this quick solution works