### PR TITLE
Fix #1132, Display correct pricing information

### DIFF
--- a/src/views/Supporter/Supporter.tsx
+++ b/src/views/Supporter/Supporter.tsx
@@ -154,7 +154,7 @@ function formatMoney(currency: string, n:number, no_fraction_digits:boolean = fa
     let ret = Intl.NumberFormat(navigator.language, { style: 'currency', currency: currency}).format(n);
 
     if (no_fraction_digits) {
-        return ret.replace(/[.,].*/, "");
+        return ret.replace(/[.,].{2}$/, "");
     }
     return ret;
 }


### PR DESCRIPTION
Fixes #1132 

Currently any price >= 1,000 will drop all digits below the thousands place. 

![Screen Shot 2020-06-05 at 11 50 42 PM](https://user-images.githubusercontent.com/42720842/83936309-2cf70b00-a788-11ea-8967-d0776554d767.png)

![Screen Shot 2020-06-05 at 11 50 55 PM](https://user-images.githubusercontent.com/42720842/83936311-31bbbf00-a788-11ea-9583-74c697fd5737.png)

![Screen Shot 2020-06-05 at 11 51 33 PM](https://user-images.githubusercontent.com/42720842/83936315-33858280-a788-11ea-8ae8-e67849c71a32.png)

This PR fixes the regex responsible.


