### PR TITLE
Joseki: Make sure that the URL update is using the most recent position id

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -536,7 +536,7 @@ export class Joseki extends React.Component<JosekiProps, any> {
         }
 
         // Give them the URL for this position in the URL bar
-        window.history.replaceState({}, document.title, '/joseki/' + this.state.current_node_id);
+        window.history.replaceState({}, document.title, '/joseki/' + position.node_id);
     }
 
     // Draw all the variations that we know about from the server (array of moves from the server)


### PR DESCRIPTION

Fixes: sometimes the URL doesn't update when the user uses arrow keys to move around the joseki

## Proposed Changes

Use the most recent value we have for the current position.
