### PR TITLE
External goban image

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.styl
+++ b/src/components/GobanThemePicker/GobanThemePicker.styl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017  Online-Go.com
+ * Copyright (C) 2012-2020  Online-Go.com
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/components/GobanThemePicker/GobanThemePicker.styl
+++ b/src/components/GobanThemePicker/GobanThemePicker.styl
@@ -28,15 +28,19 @@
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: center;
-		text-align: center;
-		font-size: 10px;
+        text-align: center;
+        font-size: 10px;
+        }
 
         .selector {
             margin: 1px;
             cursor: pointer;
             border: 1px solid transparent;
             opacity: 0.5;
-			color: white;
+            color: white;
+            word-wrap: break-word;
+            overflow: hidden;
+            text-transform: uppercase;
         }
 
         .selector:hover, .selector.active {
@@ -52,13 +56,12 @@
             vertical-align: top;
             margin-top: 0.4rem;
         }
-	
-		.customUrlSelector {
-			width: 212px;
-			height: 24px;
-			border: 1px solid lightgrey;
-			margin-top: 0px;
-			margin-bottom: 10px;
-		}
-    }
+
+        .customUrlSelector {
+            width: 212px;
+            height: 24px;
+            border: 1px solid lightgrey;
+            margin-top: 0px;
+            margin-bottom: 10px;
+        }
 }

--- a/src/components/GobanThemePicker/GobanThemePicker.styl
+++ b/src/components/GobanThemePicker/GobanThemePicker.styl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2020  Online-Go.com
+ * Copyright (C) 2012-2017  Online-Go.com
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -28,12 +28,15 @@
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: center;
+		text-align: center;
+		font-size: 10px;
 
         .selector {
             margin: 1px;
             cursor: pointer;
             border: 1px solid transparent;
             opacity: 0.5;
+			color: white;
         }
 
         .selector:hover, .selector.active {
@@ -49,5 +52,13 @@
             vertical-align: top;
             margin-top: 0.4rem;
         }
+	
+		.customUrlSelector {
+			width: 212px;
+			height: 24px;
+			border: 1px solid lightgrey;
+			margin-top: 0px;
+			margin-bottom: 10px;
+		}
     }
 }

--- a/src/components/GobanThemePicker/GobanThemePicker.styl
+++ b/src/components/GobanThemePicker/GobanThemePicker.styl
@@ -30,7 +30,6 @@
         justify-content: center;
         text-align: center;
         font-size: 10px;
-        }
 
         .selector {
             margin: 1px;
@@ -64,4 +63,5 @@
             margin-top: 0px;
             margin-bottom: 10px;
         }
+    }
 }

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -127,8 +127,8 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
                             }}
                             onClick={this.selectTheme["board"][theme.theme_name]}
                             >
-                            
-                            {theme.theme_name === "Plain" 
+
+                            {theme.theme_name === "Plain"
                                 ? <span>CUSTOM</span>
                                 : <PersistentElement elt={this.canvases.board[idx]} />
                             }
@@ -140,8 +140,8 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
                             <button className="color-reset" onClick={this.setCustom.bind(this, "board")}><i className="fa fa-undo"/></button>
                             <input type="color" style={inputStyle} value={lineCustom} onChange={this.setCustom.bind(this, "line")} />
                             <button className="color-reset" onClick={this.setCustom.bind(this, "line")}><i className="fa fa-undo"/></button>
-							<input className="customUrlSelector" type="text" value={urlCustom} onFocus={e => e.target.select()} onChange={this.setCustom.bind(this, "url")} />	
-						</div>
+                            <input className="customUrlSelector" type="text" value={urlCustom} onFocus={e => e.target.select()} onChange={this.setCustom.bind(this, "url")} />
+                        </div>
                     }
                 </div>
 

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -129,7 +129,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
                             >
 
                             {theme.theme_name === "Plain"
-                                ? <span>CUSTOM</span>
+                                ? <span>{pgettext("Custom board theme", "Custom")}</span>
                                 : <PersistentElement elt={this.canvases.board[idx]} />
                             }
                         </div>

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -51,7 +51,8 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
             boardCustom: this.getCustom("board"),
             lineCustom: this.getCustom("line"),
             whiteCustom: this.getCustom("white"),
-            blackCustom: this.getCustom("black")
+            blackCustom: this.getCustom("black"),
+			urlCustom: this.getCustom("url")
         };
 
         for (let k in GoThemesSorted) {
@@ -100,6 +101,10 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
         this.setState(up);
         this.renderPickers();
 
+        if (key === "url") { // Changing the custom image should update the board theme
+            key = "board";
+        }
+		
         if (key === "line") { // Changing the line color should update the board theme
             key = "board";
         }
@@ -108,7 +113,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
 
     render() {
         let inputStyle = {height: `${this.state.size}px`, width: `${this.state.size * 1.5}px`};
-        let {boardCustom, lineCustom, whiteCustom, blackCustom} = this.state;
+        let {boardCustom, lineCustom, whiteCustom, blackCustom, urlCustom} = this.state;
 
         return (
             <div className="GobanThemePicker">
@@ -118,11 +123,17 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
                             className={"selector" + (this.state.board === theme.theme_name ? " active" : "")}
                             style={{
                                 ...theme.styles,
-                                ...(theme.theme_name === "Plain" ? {backgroundColor: boardCustom} : {})
+                                ...(theme.theme_name === "Plain" ? {backgroundImage: "linear-gradient(-45deg, orange,yellow,green,blue,indigo,violet)"} : {})
                             }}
                             onClick={this.selectTheme["board"][theme.theme_name]}
                             >
-                            <PersistentElement elt={this.canvases.board[idx]} />
+							
+								{theme.theme_name === "Plain" 
+									? <span>CUSTOM</span>
+									: <PersistentElement elt={this.canvases.board[idx]} />
+								}
+							
+                            
                         </div>
                     ))}
                     {this.state.board === "Plain" &&
@@ -131,7 +142,8 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
                             <button className="color-reset" onClick={this.setCustom.bind(this, "board")}><i className="fa fa-undo"/></button>
                             <input type="color" style={inputStyle} value={lineCustom} onChange={this.setCustom.bind(this, "line")} />
                             <button className="color-reset" onClick={this.setCustom.bind(this, "line")}><i className="fa fa-undo"/></button>
-                        </div>
+							<input className="customUrlSelector" type="text" value={urlCustom} onFocus={e => e.target.select()} onChange={this.setCustom.bind(this, "url")} />	
+						</div>
                     }
                 </div>
 

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -52,7 +52,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
             lineCustom: this.getCustom("line"),
             whiteCustom: this.getCustom("white"),
             blackCustom: this.getCustom("black"),
-			urlCustom: this.getCustom("url")
+            urlCustom: this.getCustom("url")
         };
 
         for (let k in GoThemesSorted) {
@@ -104,7 +104,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
         if (key === "url") { // Changing the custom image should update the board theme
             key = "board";
         }
-		
+
         if (key === "line") { // Changing the line color should update the board theme
             key = "board";
         }
@@ -127,13 +127,11 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
                             }}
                             onClick={this.selectTheme["board"][theme.theme_name]}
                             >
-							
-								{theme.theme_name === "Plain" 
-									? <span>CUSTOM</span>
-									: <PersistentElement elt={this.canvases.board[idx]} />
-								}
-							
                             
+                            {theme.theme_name === "Plain" 
+                                ? <span>CUSTOM</span>
+                                : <PersistentElement elt={this.canvases.board[idx]} />
+                            }
                         </div>
                     ))}
                     {this.state.board === "Plain" &&

--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -97,8 +97,8 @@ export function configure_goban() {
         discWhiteTextColor: ():string => data.get("custom.black"),
         plainBoardColor: ():string => data.get("custom.board"),
         plainBoardLineColor: ():string => data.get("custom.line"),
-		plainBoardUrl: ():string => data.get("custom.url"),
-		
+        plainBoardUrl: ():string => data.get("custom.url"),
+
         addCoordinatesToChatInput: (coordinates:string):void => {
             let chat_input = $(".chat-input");
 

--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -29,7 +29,7 @@ data.setDefault("custom.black", "#000000");
 data.setDefault("custom.white", "#FFFFFF");
 data.setDefault("custom.board", "#DCB35C");
 data.setDefault("custom.line", "#000000");
-data.setDefault("custom.url", "Url for custom image");
+data.setDefault("custom.url", pgettext("Custom board url text", "Url for custom image"));
 
 export function configure_goban() {
     Goban.setHooks({

--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -29,6 +29,7 @@ data.setDefault("custom.black", "#000000");
 data.setDefault("custom.white", "#FFFFFF");
 data.setDefault("custom.board", "#DCB35C");
 data.setDefault("custom.line", "#000000");
+data.setDefault("custom.url", "Url for custom image");
 
 export function configure_goban() {
     Goban.setHooks({
@@ -96,7 +97,8 @@ export function configure_goban() {
         discWhiteTextColor: ():string => data.get("custom.black"),
         plainBoardColor: ():string => data.get("custom.board"),
         plainBoardLineColor: ():string => data.get("custom.line"),
-
+		plainBoardUrl: ():string => data.get("custom.url"),
+		
         addCoordinatesToChatInput: (coordinates:string):void => {
             let chat_input = $(".chat-input");
 


### PR DESCRIPTION
**WARNING: This PR is co-dependant with [this one](https://github.com/online-go/goban/pull/6) on goban**

---

The basic idea is to allow users to style their goban with a custom image in the form of supplying a link to an external picture. 

- I have changed the look of the plain board preview in the selector, to more intuitively represent the cutomizable nature
![Screenshot_2020-06-21 OGS](https://user-images.githubusercontent.com/27279102/85224143-68204d80-b3c8-11ea-836a-0e14b57aa6ea.png)

- Upon selecting the custom option an input form appears together with the color selectors, once the text is replaced with an image link, it will automatically update the board background. 
![Screenshot_2020-06-21 OGS(1)](https://user-images.githubusercontent.com/27279102/85224183-cc431180-b3c8-11ea-86cb-4a2ab8d242b6.png)

- in the future I was thinking of creating a similar option for the stones, together with two buttons allowing for playing one-color-go and blind-go easily. Let me know what you think about that.

---

Please note, this is my first barbecue with React. I mostly wanted to have a look around with a simple/fun project. If the code is not up to par, or if you think it was a stupid idea to begin with, don't be afraid to tell me to shove it :) 