### PR TITLE
Fix link to position from "Updates" table

### DIFF
--- a/src/components/JosekiAdmin/JosekiAdmin.tsx
+++ b/src/components/JosekiAdmin/JosekiAdmin.tsx
@@ -352,7 +352,7 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, any> {
                             getProps: ((state, rowInfo, column) => (
                                 {
                                     onClick: (e, handleOriginal) => {
-                                        this.props.loadPositionToBoard(rowInfo.original.node_id);
+                                        this.props.loadPositionToBoard(rowInfo.original.node_id.toString());
                                     },
                                     className: "position-link"
                                 }

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -344,7 +344,8 @@ export class Joseki extends React.Component<JosekiProps, any> {
         }
     }
 
-    loadPosition = (node_id) => {
+    loadPosition = (node_id: string) => {
+        //console.log("load position:", node_id);
         this.load_sequence_to_board = true;
         this.fetchNextMovesFor(node_id);
         this.move_trace = [];
@@ -438,6 +439,9 @@ export class Joseki extends React.Component<JosekiProps, any> {
                 if ((this.waiting_for === "root" && target_node.placement === "root") ||
                     (this.waiting_for === target_node.node_id.toString()) ) {
                     this.processNewMoves(node_id, target_node);
+                }
+                else {
+                    // console.log("Ignoring server response ", target_node, " looking for ", this.waiting_for);
                 }
                 // update the cache with anything we got (irrespective of what we were waiting for)
                 body.forEach((move_info) => {


### PR DESCRIPTION
The recent "dump outdated server requests" check exposed a bug from Joseki Admin that was calling loadPosition with an integer instead of a string, resulting in positions not loading from the "updates" table.

## Proposed Changes

Convert to string.