### PR TITLE
Set OGS theme to match user's OS theme on first visit only

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -105,7 +105,18 @@
   <body>
       <script>
         try {
-            document.body.className = JSON.parse(localStorage.getItem('ogs.theme') || '"light"');
+            let theme = localStorage.getItem('ogs.theme');
+            if (theme) { // user has been on the site before
+                document.body.className = JSON.parse(theme);
+            } else { // first time user is on the site, so set initial theme according to his operating system theme.
+                if (window.matchMedia("(prefers-color-scheme: dark)").matches) { // if OS theme set to dark
+                    document.body.className = "dark";
+                    localStorage.setItem('ogs.theme', '"dark"');
+                } else { 
+                    document.body.className = "light";
+                    localStorage.setItem('ogs.theme', '"light"');
+                }
+            }
         } catch (e) {
             console.error(e);
             document.body.className = "light";


### PR DESCRIPTION
Fixes #1047 

This simply sets the OGS light/dark theme preference to match the user's own operating system's theme preference, only for the first visit. 

Note that afterwards if the user changes the light/dark theme from within OGS, that preference will remain on subsequent visits.

EDIT: To be honest I don't know if we want to sync up the OGS theme with the user's OS theme on _every_ visit, or just the first visit, or even perhaps implementing a new option entirely called "Set OGS theme to sync with OS". In any case for this PR I just went with first visit only sync.