### PR TITLE
Prevent rtl chats from losing rtl class when scrolled

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -540,7 +540,7 @@ export class Chat extends React.Component<ChatProperties, ChatState> {
         let tf = this.refs.chat_log.scrollHeight - this.refs.chat_log.scrollTop - 10 < this.refs.chat_log.offsetHeight;
         if (tf !== this.scrolled_to_bottom) {
             this.scrolled_to_bottom  = tf;
-            this.refs.chat_log.className = "chat-log " + (tf ? "autoscrolling" : "");
+            this.refs.chat_log.className = (this.state.rtl_mode ? "rtl chat-log " : "chat-log ") + (tf ? "autoscrolling" : "");
         }
         this.scrolled_to_bottom = this.refs.chat_log.scrollHeight - this.refs.chat_log.scrollTop - 10 < this.refs.chat_log.offsetHeight;
     }


### PR DESCRIPTION
I was looking at #946 and while I couldn't reproduce the error he was having, I did nevertheless find the rtl (right to left reading languages) chat channels a bit buggy. 

Initially when we click on an rtl chat channel (like, say Arabic), the text is displayed correctly, sticking to the right hand side. As soon as we scroll, the div with the `chat-log` class loses the `rtl` class, which ends up displaying the text messages sticking to the left hand side (incorrect for rtl languages).

This fixes it.