### PR TITLE
Show number of active games in User and Overview views

### DIFF
--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -137,7 +137,7 @@ export class Overview extends React.Component<{}, any> {
 
                     {((this.state.resolved && this.state.overview.active_games.length) || null) &&
                         <div className="active-games">
-                            <h2>{_("Active Games")}</h2>
+                            <h2>{_("Active Games")} ({this.state.overview.active_games.length})</h2>
                             <GameList list={this.state.overview.active_games} player={user}
                                 emptyMessage={_("You're not currently playing any games. Start a new game with the \"Create a new game\" or \"Look for open games\" buttons above.")}
                             />

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -871,7 +871,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                     </Card>
                 }
 
-                {(this.state.active_games.length > 0 || null) && <h2>{_("Active Games")}</h2>}
+                {(this.state.active_games.length > 0 || null) && <h2>{_("Active Games")} ({this.state.active_games.length})</h2>}
                 <GameList list={this.state.active_games} player={user}/>
 
 


### PR DESCRIPTION
Fixes #1180 

## Proposed Changes

  - Adds the number of active games in parentheses to `User` and `Overview` views

