### PR TITLE
Don't leave joseki throbber running after a server response we couldn't parse

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -420,6 +420,7 @@ export class Joseki extends React.Component<JosekiProps, any> {
                 });
             }).catch((r) => {
                 console.log("Node GET failed:", r);
+                this.setState({throb: false});
             });
 
             this.processNewMoves(node_id, this.cached_positions[node_id]);
@@ -449,6 +450,7 @@ export class Joseki extends React.Component<JosekiProps, any> {
                 });
             }).catch((r) => {
                 console.log("Node GET failed:", r);
+                this.setState({throb: false});
             });
         }
     }


### PR DESCRIPTION
Fixes #

If you enter a bad URL looking like a joseki position, the server will respond with an error.

This is caught by the joseki client code, but it leaves the throbber running, so the user has no idea that actually there's nothing else going to happen.

## Proposed Changes

Turn off the throbber when a server error is received.
