### PR TITLE
Allow more time settings

### DIFF
--- a/src/components/TimeControl/TimeControl.ts
+++ b/src/components/TimeControl/TimeControl.ts
@@ -16,7 +16,7 @@
  */
 
 export namespace TimeControlTypes {
-    export type TimeControlSpeed = "blitz" | "live" | "correspondence";
+    export type TimeControlSpeed = "live" | "correspondence";
     export type TimeControlSystem = "fischer" | "byoyomi" | "canadian" | "simple" | "absolute" | "none";
 
     export interface Fischer {

--- a/src/components/TimeControl/TimeControlPicker.tsx
+++ b/src/components/TimeControl/TimeControlPicker.tsx
@@ -180,7 +180,6 @@ export class TimeControlPicker extends React.PureComponent<TimeControlPickerProp
                       <div className="checkbox">
                           <select id="challenge-speed" value={speed} onChange={this.update_speed_bracket}
                                 className="challenge-dropdown form-control" style={{overflow: "hidden"}}>
-                            <option value="blitz">{_("Blitz")}</option>
                             <option value="live">{_("Live")}</option>
                             <option value="correspondence">{_("Correspondence")}</option>
                           </select>

--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -121,23 +121,23 @@ export const time_options = {
     },
     "live": {
         "fischer": {
-            "initial_time": gen(30, 3600),
-            "time_increment": gen(10, 1800),
-            "max_time": gen(30, 3600),
+            "initial_time": gen(5, 21600),
+            "time_increment": gen(1, 1800),
+            "max_time": gen(5, 21600),
         },
         "simple": {
-            "per_move": gen(10, 3600),
+            "per_move": gen(3, 3600),
         },
         "canadian": {
-            "main_time": [zero].concat(gen(30, 3600 * 4)),
-            "period_time": gen(20, 3600),
+            "main_time": [zero].concat(gen(0, 21600)),
+            "period_time": gen(5, 3600),
         },
         "byoyomi": {
-            "main_time": [zero].concat(gen(30, 3600 * 4)),
-            "period_time": gen(10, 3600),
+            "main_time": [zero].concat(gen(0, 21600)),
+            "period_time": gen(1, 1800),
         },
         "absolute": {
-            "total_time": gen(600, 14400),
+            "total_time": gen(30, 21600),
         },
     },
     "correspondence": {
@@ -166,7 +166,7 @@ export const time_options = {
 
 export function makeTimeControlParameters(tc: any): TimeControl {
     let tpm = computeAverageMoveTime(tc);
-    let speed: TimeControlTypes.TimeControlSpeed = tpm === 0 || tpm > 3600 ? "correspondence" : (tpm < 10 ? "blitz" : "live");
+    let speed: TimeControlTypes.TimeControlSpeed = tpm === 0 || tpm > 3600 ? "correspondence" : "live";
 
     switch (tc.time_control || tc.system) {
         case "fischer":


### PR DESCRIPTION
On the forum, we got multiple requests to allow a wider range of time settings. One request is to increase the time cap for fisher time, the other to allow live games with high main time and blitz like time increment. 

https://forums.online-go.com/t/fixed-max-time-in-fischer-blitz-settings/29003?u=flovo
https://forums.online-go.com/t/suggestion-allow-disabling-time-cap-for-fischer-time/21665?u=flovo

Besides adding additional time options, I merged live and blitz. A distinction in the selection dialogue is difficult. Already right now time settings like 5m+9s are only available in the blitz category, but count as live game for `computeAverageMoveTime` it is a live game. So I would just drop the distinction between the two and just distinguish between live and correspondence games when creating a game. 