### PR TITLE
Fixing games list wider than view

### DIFF
--- a/src/views/Overview/Overview.styl
+++ b/src/views/Overview/Overview.styl
@@ -43,7 +43,7 @@
     .active-games {
         flex-grow: 1;
         flex-basis: 20rem;
-        max-width: max-content;
+        max-width: 100%;
         align-self: center;
     }
     .no-active-games {


### PR DESCRIPTION
Games list on home and profile page was cropped on the left and right.

With this change, horizontal scroll is available when the list is wider than the available space.