### PR TITLE
Maximise Goban in Zen Mode

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -511,7 +511,7 @@ goban-view-bar-width=400px
 				flex-grow: 0;
 			}
             flex-basis: 100vh
-			justify-content: center;
+			justify-content: flex-start;
 			flex-grow: 0;
 		}
         &.portrait {

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -503,19 +503,21 @@ goban-view-bar-width=400px
 				flex-grow: 0;
 			}
 			justify-content: center;
-			min-width: auto;
-			flex-basis: auto;
 			width: auto;
-			margin-left: 5%;
 			flex-grow: 0;
 		}
 		.center-col {
 			.goban-container {
 				flex-grow: 0;
 			}
+            flex-basis: 100vh
 			justify-content: center;
 			flex-grow: 0;
 		}
+        &.portrait {
+            .center-col {
+                flex-basis: 100%
+            }}
 		.align-row-start, .align-col-start {
 			align-self: flex-start;
 		}
@@ -523,7 +525,6 @@ goban-view-bar-width=400px
 			align-self: flex-end;
 		}
 		.align-row-start, .align-row-end {
-			flex-basis: 5%;
 			flex-grow: 1;
 		}
     }


### PR DESCRIPTION
There is a strange margin in portrait zen mode:

![Screenshot_2020-07-26 Tournament Game Kuksu Main Title Tournament 13th Cycle - League D3 (62330) R 1 (flovo vs IcedEarth)](https://user-images.githubusercontent.com/4864182/88475440-0f485580-cf30-11ea-8f87-17fe702c2a7d.png)

This PR changes the css to maximize the goban in zen mode when possible.
