### PR TITLE
Align clocks above each other in horizontal zen mode

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -507,7 +507,14 @@ goban-view-bar-width=400px
 			flex-basis: auto;
 			width: auto;
 			margin-left: 5%;
-			flex-grow: 0;
+			flex-grow: 0;            
+            .players {
+                flex-direction: column;
+                .player-container {
+                    width: 100%;
+                }
+            }
+            min-width 170px;
 		}
 		.center-col {
 			.goban-container {


### PR DESCRIPTION
In horizontal zen mode we have enough vertical space to place the clocks above each other. 

This allows the user to reduce the windows width even further while keeping the goban at maximum size.