### PR TITLE
game/id/move_number skips to move

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -117,7 +117,7 @@ export const routes = (
                     }
                 }
 
-                // Make sure it shows up in the left pannel
+                // Make sure it shows up in the left panel
                 joined[channel] = 1;
                 data.set("chat.joined", joined);
 
@@ -125,6 +125,7 @@ export const routes = (
             }}/>
             <Route path="/observe-games" component={ObserveGames}/>
             <Route path="/game/view/:game_id" component={Game}/>
+            <Route path="/game/:game_id/:move_number" component={Game}/>
             <Route path="/game/:game_id" component={Game}/>
             <Route path="/review/view/:review_id" exact component={Game}/>
             <Route path="/review/:review_id" component={Game}/>

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -713,7 +713,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
             .catch(ignore);
         }
 
-        const move_number_match = document.URL.match(/game\/\d+\/(\d+)$/);
+        const move_number_match = document.URL.match(/game\/\d+\/(\d+)\/?$/);
         if (move_number_match) {
             setTimeout(() => {
                 this.nav_goto_move(Number(move_number_match[1]));

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -712,6 +712,13 @@ export class Game extends React.PureComponent<GameProperties, any> {
             })
             .catch(ignore);
         }
+
+        const move_number_match = document.URL.match(/game\/\d+\/(\d+)$/);
+        if (move_number_match) {
+            setTimeout(() => {
+                this.nav_goto_move(Number(move_number_match[1]));
+            }, 1000);
+        }
     }
     private bindAudioEvents():void { // called by init
         let user = data.get('user');


### PR DESCRIPTION
Add ability to add move number on end of game url to automatically skip to that move upon loading game, e.g. online-go.com/game/24010741/123 will skip to move 123. setTimeout was initially me being lazy to find where to put code to run after the normal logic to skip to last move of game, but actually gives nice visual clue that you are not viewing last move but skipped earlier IMO.