### PR TITLE
Use an icon in the game history table to show clearly who won in each game

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -145,6 +145,8 @@ light.strong-l-text                     = light.bg
 light.weak-w-text                       = light.fg
 light.weak-l-text                       = light.fg
 
+light.winner-trophy                     = #e6c525
+
 light.shade0                            = lighten(light.fg, 20%)
 light.shade1                            = lighten(light.fg, 40%)
 light.shade2                            = lighten(light.fg, 60%)
@@ -170,7 +172,6 @@ light.react-select-selected-bg          = #2684FF
 light.react-select-selected-fg          = #FFFFFF
 light.react-select-focused-bg           = #DEEBFF
 light.react-select-focused-fg           = light.fg
-
 
 /** Navbar **/
 
@@ -287,6 +288,7 @@ dark.strong-l-text                      = dark.bg
 dark.weak-w-text                        = dark.fg
 dark.weak-l-text                        = dark.fg
 
+dark.winner-trophy                     = #e6b500
 
 /** React Select colors **/
 

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -459,8 +459,13 @@
             max-width: 9rem;
             overflow: hidden;
         }
-    }
 
+        .game-history-winner {
+            themed color winner-trophy;
+            padding-left: 4px;
+            vertical-align: middle;
+        }
+    }
 
     .moderator-log {
         td {

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -904,8 +904,8 @@ export class User extends React.PureComponent<UserProperties, any> {
                                         {header: _("Date"),   className: () => "date",                            render: (X) => moment(X.date).format("YYYY-MM-DD")},
                                         {header: _("Size"),   className: () => "board_size",                      render: (X) => `${X.width}x${X.height}`},
                                         {header: _("Name"),   className: () => "name",                            render: (X) => <Link to={X.href}>{X.name || interpolate('{{black_username}} vs. {{white_username}}', {'black_username': X.black.username, 'white_username': X.white.username}) }</Link>},
-                                        {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <Player user={X.historical.black} disableCacheUpdate />},
-                                        {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <Player user={X.historical.white} disableCacheUpdate />},
+                                        {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <React.Fragment><Player user={X.historical.black} disableCacheUpdate />{X.black_won ?  <i className="fa fa-trophy game-history-winner"/> : ""}</React.Fragment> },
+                                        {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <React.Fragment><Player user={X.historical.white} disableCacheUpdate />{X.white_won ?  <i className="fa fa-trophy game-history-winner"/> : ""}</React.Fragment> },
                                         {header: _("Result"), className: (X) => (X ? X.result_class : ""),            render: (X) => X.result},
                                     ]}
                                 />


### PR DESCRIPTION
## Proposed Changes

Put an icon next to the winner's name in the game history table, so you can see at a glance who won.

Dark:
![Screen Shot 2020-10-12 at 6 47 21 pm (3)](https://user-images.githubusercontent.com/61894/95722455-7f5ab200-0cbb-11eb-8ab8-3558d2ff4f41.png)

Light:
![Screen Shot 2020-10-12 at 6 47 05 pm (3)](https://user-images.githubusercontent.com/61894/95722510-90a3be80-0cbb-11eb-9833-16a31745b0c5.png)
