### PR TITLE
Mark annulled games more clearly.

### DIFF
--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -190,6 +190,7 @@ export function getOutcomeTranslation(outcome:string) {
 
     return outcome;
 }
+
 export function getGameResultText(game) {
     /* SGFs will encode the full result in the outcome */
     if (/[+]/.test(game.outcome)) {
@@ -211,16 +212,9 @@ export function getGameResultText(game) {
     game.outcome = game.outcome.replace(" points", "");
     result += winner + "+"  + getOutcomeTranslation(game.outcome);
 
-    if (game.ranked) {
-        result += ", ";
-        result += _("ranked");
-    }
-    if (game.annulled) {
-        result += ", ";
-        result += _("annulled");
-    }
     return result;
 }
+
 export function acceptGroupInvite(invite_id):Promise<any> {
     return post("me/groups/invitations", { request_id: invite_id }).catch(errorAlerter);
 }

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -105,6 +105,11 @@ goban-view-bar-width=400px
             text-align: center;
         }
 
+        .annulled-indicator {
+            color: red;
+            text-align: center;
+        }
+
         .game-action-buttons {
             position: relative;
             text-align: center;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2518,7 +2518,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                 </div>
                 <div className='annulled-indicator'>
                     { state.annulled &&
-                        'GAME ANNULLED'
+                        pgettext("Displayed to the user when the game is annulled", "Game Annulled")
                     }
                 </div>
                 {/* } */}

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2503,7 +2503,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     }
 
                     {(state.mode === "play" && state.phase === "finished" || null) &&
-                        <span>
+                        <span style={{textDecoration: state.annulled ? 'line-through' : 'none' }}>
                             {state.winner
                                 ?
                                 (interpolate(pgettext("Game winner", "{{color}} wins by {{outcome}}"), {
@@ -2514,6 +2514,11 @@ export class Game extends React.PureComponent<GameProperties, any> {
                                 (interpolate(pgettext("Game winner", "Tie by {{outcome}}"), {"outcome": pgettext("Game outcome", this.goban.engine.outcome)}))
                             }
                         </span>
+                    }
+                </div>
+                <div className='annulled-indicator'>
+                    { state.annulled &&
+                        'GAME ANNULLED'
                     }
                 </div>
                 {/* } */}

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -71,7 +71,7 @@ function getGameResultRichText(game) {
     if (game.annulled) {
         result = <span>
                      <span style={{textDecoration: 'line-through'}}>{result}</span>
-                     <span>, {pgettext("Game has been annulled", "annulled")}</span>
+                     <span>, {_("annulled")}</span>
                  </span>;
     }
 

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -29,13 +29,11 @@ import {PlayerIcon} from 'PlayerIcon';
 import {GameList} from "GameList";
 import {Player} from "Player";
 import * as preferences from "preferences";
-import {updateDup, alertModerator, getGameResultText, ignore} from "misc";
+import {updateDup, getGameResultText, ignore} from "misc";
 import {longRankString, rankString, getUserRating, humble_rating, effective_outcome} from "rank_utils";
 import {durationString, daysOnlyDurationString} from "TimeControl";
 import {openModerateUserModal} from "ModerateUser";
-import {openSupporterAdminModal} from "SupporterAdmin";
 import {PaginatedTable} from "PaginatedTable";
-import {challenge} from "ChallengeModal";
 import {errorAlerter} from "misc";
 import * as player_cache from "player_cache";
 import {getPrivateChat} from "PrivateChat";
@@ -60,23 +58,22 @@ interface UserProperties {
     // callback?: ()=>any,
 }
 
-let UserRating = (props: {rating: number}) => {
-    let wholeRating = Math.floor(props.rating);
-    return <span className="UserRating">{wholeRating}</span>;
-};
-
-let rating_percentage = (rating: number) => {
-    rating %= 100;
-    rating = rating >= 0 ? rating : rating + 100;
-    return rating;
-};
-
-let Rank = (props: {ranking: number, pro?: boolean}) => (<span>{rankString(props)}</span>);
-
 let inlineBlock = {display: "inline-flex", "alignItems": "center"};
-let marginRight0 = {marginRight: "0"};
 let marginBottom0 = {marginBottom: "0"};
-let nowrapAlignTop = {whiteSpace: "nowrap", verticalAlign: "top"};
+
+function getGameResultRichText(game) {
+    let result = getGameResultText(game);
+
+    if (game.ranked) {
+        result += ", ";
+        result += _("ranked");
+    }
+    if (game.annulled) {
+        result = <span><span style={{textDecoration: 'line-through'}}>{result}</span><span>, annulled</span></span>;
+    }
+
+    return result;
+}
 
 export class User extends React.PureComponent<UserProperties, any> {
     refs: {
@@ -531,7 +528,6 @@ export class User extends React.PureComponent<UserProperties, any> {
 
         /* any dom binding stuff needs to happen after the template has been
          * processed and added to the dom, this can be done with a 0ms timer */
-        let domWorkScaleback = 1;
         let doDomWork = () => {
             try {
                 $("#user-su-is-bot").prop("checked", this.state.user.is_bot);
@@ -541,12 +537,6 @@ export class User extends React.PureComponent<UserProperties, any> {
         };
         setTimeout(doDomWork, 0);
 
-        const rows = [
-            ["a1", "b1", "c1"],
-            ["a2", "b2", "c2"],
-            ["a3", "b3", "c3"],
-            // .... and more
-        ];
 
         let game_history_groomer = (results) => {
 
@@ -629,7 +619,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                 }
 
                 item.href = "/game/" + item.id;
-                item.result = getGameResultText(r);
+                item.result = getGameResultRichText(r);
 
                 ret.push(item);
             }
@@ -906,7 +896,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                                         {header: _("Name"),   className: () => "name",                            render: (X) => <Link to={X.href}>{X.name || interpolate('{{black_username}} vs. {{white_username}}', {'black_username': X.black.username, 'white_username': X.white.username}) }</Link>},
                                         {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <React.Fragment><Player user={X.historical.black} disableCacheUpdate />{X.black_won ?  <i className="fa fa-trophy game-history-winner"/> : ""}</React.Fragment> },
                                         {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <React.Fragment><Player user={X.historical.white} disableCacheUpdate />{X.white_won ?  <i className="fa fa-trophy game-history-winner"/> : ""}</React.Fragment> },
-                                        {header: _("Result"), className: (X) => (X ? X.result_class : ""),            render: (X) => X.result},
+                                        {header: _("Result"), className: (X) => (X ? X.result_class : ""),        render: (X) => X.result},
                                     ]}
                                 />
                             </div>

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -69,7 +69,10 @@ function getGameResultRichText(game) {
         result += _("ranked");
     }
     if (game.annulled) {
-        result = <span><span style={{textDecoration: 'line-through'}}>{result}</span><span>, annulled</span></span>;
+        result = <span>
+                     <span style={{textDecoration: 'line-through'}}>{result}</span>
+                     <span>, {pgettext("Game has been annulled", "annulled")}</span>
+                 </span>;
     }
 
     return result;


### PR DESCRIPTION
Fixes #1244 

## Proposed Changes

  - In the Game view, strikethrough the game result and add "GAME ANNULLED"
  - Strikethrough the game result in the Game History pane if the game has been annulled.

<img width="796" alt="Screen Shot 2020-10-24 at 11 42 43 PM" src="https://user-images.githubusercontent.com/25233703/97098383-b1bcc580-1652-11eb-8c15-3b8e793c3b5a.png">
<img width="1069" alt="Screen Shot 2020-10-24 at 11 42 23 PM" src="https://user-images.githubusercontent.com/25233703/97098387-b4b7b600-1652-11eb-8e90-709d58b7ff60.png">

