### PR TITLE
Revamp Game History Table

### DIFF
--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -126,7 +126,7 @@
     td.date {
         width: 7em;
         text-align: left;
-        margin-right: 1em;
+        padding-right: 0.5em;
     }
 
     td.banned, th.banned {
@@ -414,7 +414,7 @@
     }
 
     .game-history-table, .review-history-table {
-        .name, .date, .player, .library-lost-result, .library-won-result, .library-tie-result, .library-lost-result-vs-weaker, .library-lost-result-vs-stronger, .library-won-result-vs-stronger, .library-won-result-vs-weaker, .library-won-result-unranked, .library-lost-result-unranked, .library-hidden-result {
+        .game_name, .date, .player, .library-lost-result, .library-won-result, .library-tie-result, .library-lost-result-vs-weaker, .library-lost-result-vs-stronger, .library-won-result-vs-stronger, .library-won-result-vs-weaker, .library-won-result-unranked, .library-lost-result-unranked, .library-hidden-result {
             white-space: nowrap;
         }
 
@@ -450,20 +450,25 @@
           themed color strong-loss
         }
 
-        .name {
+        .game_name {
             max-width: 12rem;
             overflow: hidden;
         }
 
         .player {
-            max-width: 9rem;
+            max-width: 12rem;
             overflow: hidden;
         }
 
-        .game-history-winner {
+        .winner_marker {
             themed color winner-trophy;
             padding-left: 4px;
             vertical-align: middle;
+            padding-right: 4px;
+        }
+
+        .annulled {
+            opacity: 30%;
         }
     }
 
@@ -512,7 +517,7 @@
             display: flex;
             align-items: middle;
             justify-content: center;
-            
+
             .name {
                 display: inline-block;
                 margin-left: 0.5rem;

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -554,6 +554,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                 item.date = r.ended ? new Date(r.ended) : null;
                 item.ranked = r.ranked;
                 item.handicap = r.handicap;
+                item.annulled = r.annulled || false;
                 item.black = r.players.black;
                 item.black_won = !r.black_lost && r.white_lost && !r.annulled;
                 item.black_class = item.black_won ? (item.black.id === this.user_id ? "library-won" : "library-lost") : "";
@@ -563,9 +564,10 @@ export class User extends React.PureComponent<UserProperties, any> {
                 item.historical = r.historical_ratings;
 
                 let outcome = effective_outcome(item.historical.black.ratings.overall.rating, item.historical.white.ratings.overall.rating, item.handicap);
-                if ((r.white_lost && r.black_lost) || (!r.white_lost && !r.black_lost) || r.annulled) {
-                    item.result_class = "library-tie-result";
-                } else if (item.white.id === this.user_id) /* played white */ {
+                if (item.white.id === this.user_id) /* played white */ {
+                    item.played_black = false;
+                    item.opponent = r.historical_ratings.black;
+                    item.player_won = item.white_won;
                     if (item.ranked && !preferences.get("hide-ranks")) {
                         if (item.white_won) /* player won */ {
                             item.result_class = outcome.white_effective_stronger ? "library-won-result-vs-weaker" : "library-won-result-vs-stronger";
@@ -576,6 +578,9 @@ export class User extends React.PureComponent<UserProperties, any> {
                         item.result_class = item.white_won ? "library-won-result-unranked" : "library-lost-result-unranked"; /* tie catched above */
                     }
                 } else if (item.black.id === this.user_id) /* played black */ {
+                    item.played_black = true;
+                    item.opponent = r.historical_ratings.white;
+                    item.player_won = item.black_won;
                     if (item.ranked && !preferences.get("hide-ranks")) {
                         if (item.black_won) /* player won */ {
                             item.result_class = outcome.black_effective_stronger ? "library-won-result-vs-weaker" : "library-won-result-vs-stronger";
@@ -585,6 +590,10 @@ export class User extends React.PureComponent<UserProperties, any> {
                     } else {
                         item.result_class = item.black_won ? "library-won-result-unranked" : "library-lost-result-unranked"; /* tie catched above */
                     }
+                }
+
+                if ((r.white_lost && r.black_lost) || (!r.white_lost && !r.black_lost) || r.annulled) {
+                    item.result_class = "library-tie-result";
                 }
 
                 if ("time_control_parameters" in r) {
@@ -891,14 +900,15 @@ export class User extends React.PureComponent<UserProperties, any> {
                                     }}
                                     orderBy={["-ended"]}
                                     groom={game_history_groomer}
-                                    columns={[
-                                        {header: _(""),       className: () => "speed",                           render: (X) => <i className={X.speed_icon_class} title={X.speed} />},
-                                        {header: _("Date"),   className: () => "date",                            render: (X) => moment(X.date).format("YYYY-MM-DD")},
-                                        {header: _("Size"),   className: () => "board_size",                      render: (X) => `${X.width}x${X.height}`},
-                                        {header: _("Name"),   className: () => "name",                            render: (X) => <Link to={X.href}>{X.name || interpolate('{{black_username}} vs. {{white_username}}', {'black_username': X.black.username, 'white_username': X.white.username}) }</Link>},
-                                        {header: _("Black"),  className: (X) => ("player " + (X ? X.black_class : "")), render: (X) => <React.Fragment><Player user={X.historical.black} disableCacheUpdate />{X.black_won ?  <i className="fa fa-trophy game-history-winner"/> : ""}</React.Fragment> },
-                                        {header: _("White"),  className: (X) => ("player " + (X ? X.white_class : "")), render: (X) => <React.Fragment><Player user={X.historical.white} disableCacheUpdate />{X.white_won ?  <i className="fa fa-trophy game-history-winner"/> : ""}</React.Fragment> },
-                                        {header: _("Result"), className: (X) => (X ? X.result_class : ""),        render: (X) => X.result},
+                                    columns={[                                /* I wish we could set properties at the row level! */
+                                        {header: _(""),       className: (X) => ("color" +         ((X && X.annulled) ? " annulled" : "")),     render: (X) => (X.played_black ? "⚫" : "⚪")},
+                                        {header: _(""),       className: (X) => ("winner_marker" + ((X && X.annulled) ? " annulled" : "")),     render: (X) => (X.player_won ?  <i className="fa fa-trophy game-history-winner"/> : "")},
+                                        {header: _("Date"),   className: (X) => ("date" +          ((X && X.annulled) ? " annulled" : "")),     render: (X) => moment(X.date).format("YYYY-MM-DD")},
+                                        {header: _("Opponent"),  className: (X) => ("player" +     ((X && X.annulled) ? " annulled" : "")),     render: (X) => <Player user={X.opponent} disableCacheUpdate />} ,
+                                        {header: _(""),       className: (X) => ("speed" +         ((X && X.annulled) ? " annulled" : "")),     render: (X) => <i className={X.speed_icon_class} title={X.speed} />},
+                                        {header: _("Size"),   className: (X) => ("board_size" +    ((X && X.annulled) ? " annulled" : "")),     render: (X) => `${X.width}x${X.height}`},
+                                        {header: _("Name"),   className: (X) => ("game_name" +     ((X && X.annulled) ? " annulled" : "")),     render: (X) => <Link to={X.href}>{X.name || interpolate('{{black_username}} vs. {{white_username}}', {'black_username': X.black.username, 'white_username': X.white.username}) }</Link>},
+                                        {header: _("Result"), className: (X) => (X ? X.result_class + (X.annulled ? " annulled" : "") : ""),    render: (X) => X.result},
                                     ]}
                                 />
                             </div>


### PR DESCRIPTION
# Proposed Changes

As discussed in this thread: https://forums.online-go.com/t/update-of-game-history-table/31742

 * Get rid of the "Black" and "White" player columns, and have just "Opponent", for major redundant information removal
 * Have a column for the colour of the current player
 * Reorder the columns to make this look good
 * Grey-out annulled games

![Screen Shot 2020-11-09 at 2 24 59 pm](https://user-images.githubusercontent.com/61894/98503661-ff693d00-22a4-11eb-9e83-4f527b0e4b8f.png)
