### PR TITLE
Put annul-opacity (in game history table) into the theme

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -146,6 +146,7 @@ light.weak-w-text                       = light.fg
 light.weak-l-text                       = light.fg
 
 light.winner-trophy                     = #e6c525
+light.annul-opacity                    = 0.5
 
 light.shade0                            = lighten(light.fg, 20%)
 light.shade1                            = lighten(light.fg, 40%)
@@ -289,6 +290,7 @@ dark.weak-w-text                        = dark.fg
 dark.weak-l-text                        = dark.fg
 
 dark.winner-trophy                     = #e6b500
+dark.annul-opacity                    = 0.3
 
 /** React Select colors **/
 

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -468,7 +468,7 @@
         }
 
         .annulled {
-            opacity: 0.3;
+            themed opacity annul-opacity;
         }
     }
 


### PR DESCRIPTION
In the thread on this topic, it was complained that the opacity of annulled games in the game history table was not enough - I believe this is referring to light mode, and I agree with that.

## Proposed Changes

Theme the opacity, so it can be greater in light mode.
