### PR TITLE
Added display of the time of last thing that happens 

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2900,8 +2900,13 @@ export class Game extends React.PureComponent<GameProperties, any> {
     frag_timings = () => {
         if (this.goban &&
             this.goban.engine) {
+
+            let config:any = this.goban.engine.config; // detyping because GoEngineConfig doesn't have start_time decleared, but it definitely has that attribute here!
+
             return <GameTimings
                 moves={this.goban.engine.config.moves}
+                start_time={config.start_time}
+                end_time={config.end_time}
                 free_handicap_placement={this.goban.engine.config.free_handicap_placement}
                 handicap={this.goban.engine.config.handicap}/>;
         }

--- a/src/views/Game/GameTimings.tsx
+++ b/src/views/Game/GameTimings.tsx
@@ -26,6 +26,8 @@ declare var swal;
 
 interface GameTimingProperties {
     moves: any;
+    start_time: number;
+    end_time: number;
     free_handicap_placement: boolean;
     handicap: number;
 }
@@ -156,9 +158,12 @@ export class GameTimings extends React.Component<GameTimingProperties> {
                     ))
                 }
                 <div>Totals:</div>
-                <div>{black_elapsed.asMinutes() < 1 ? `${black_elapsed.asSeconds().toFixed(1)}s` : black_elapsed.format()}</div>
-                <div>{white_elapsed.asMinutes() < 1 ? `${white_elapsed.asSeconds().toFixed(1)}s` : white_elapsed.format()}</div>
-                <div></div>
+                <div>{this.show_seconds_nicely(black_elapsed)}</div>
+                <div>{this.show_seconds_nicely(white_elapsed)}</div>
+                <div>{/* empty cell at end of row */}</div>
+                <div>Final action:</div>
+                <div>{this.show_seconds_nicely(moment.duration(this.props.end_time - this.props.start_time, "seconds").subtract(game_elapsed))}</div>
+                <div>{/* empty cell at end of row */}</div>
             </div>
         );
     }


### PR DESCRIPTION
As per Vsotvep request here: https://forums.online-go.com/t/move-timing-go-public/31770/9?u=eugene

Calculate and show how much time was spent in the game after the last move was played (this is either score phase or timeout time)


![Screen Shot 2020-11-11 at 10 26 19 pm](https://user-images.githubusercontent.com/61894/98809145-0642ac00-246d-11eb-9c85-e897e81fb990.png)
