### PR TITLE
Prevent the user's rank from wrapping in game history table.

### DIFF
--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -460,6 +460,10 @@
             overflow: hidden;
         }
 
+        .user_info  {
+            white-space: nowrap;
+        }
+
         .winner_marker {
             themed color winner-trophy;
             padding-left: 4px;

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -903,7 +903,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                                     orderBy={["-ended"]}
                                     groom={game_history_groomer}
                                     columns={[                                /* I wish we could set properties at the row level! */
-                                        {header: _("User"), className: (X) => ("color" +         ((X && X.annulled) ? " annulled" : "")),     render: (X) => ((X.played_black ? "⚫ " : "⚪ ")) + "[" + rankString(X.player) + "]"},
+                                        {header: _("User"), className: (X) => ("user_info" +         ((X && X.annulled) ? " annulled" : "")),     render: (X) => ((X.played_black ? "⚫ " : "⚪ ")) + "[" + rankString(X.player) + "]"},
                                         {header: _(""),       className: (X) => ("winner_marker" + ((X && X.annulled) ? " annulled" : "")),     render: (X) => (X.player_won ?  <i className="fa fa-trophy game-history-winner"/> : "")},
                                         {header: _("Date"),   className: (X) => ("date" +          ((X && X.annulled) ? " annulled" : "")),     render: (X) => moment(X.date).format("YYYY-MM-DD")},
                                         {header: _("Opponent"),  className: (X) => ("player" +     ((X && X.annulled) ? " annulled" : "")),     render: (X) => <Player user={X.opponent} disableCacheUpdate />} ,


### PR DESCRIPTION
## Fixes

https://forums.online-go.com/t/update-of-game-history-table/31742/113?u=eugene

## Proposed Changes

Don't let the first column wrap (note it has to be one column so that the header "User" spans it).