### PR TITLE
Control the spacing between the color marker and the rank explicitly,…

### DIFF
--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -460,6 +460,10 @@
             overflow: hidden;
         }
 
+        .span {
+            padding-left: 0.5em;
+        }
+
         .user_info  {
             white-space: nowrap;
         }

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -903,7 +903,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                                     orderBy={["-ended"]}
                                     groom={game_history_groomer}
                                     columns={[                                /* I wish we could set properties at the row level! */
-                                        {header: _("User"), className: (X) => ("user_info" +         ((X && X.annulled) ? " annulled" : "")),     render: (X) => ((X.played_black ? "⚫ " : "⚪ ")) + "[" + rankString(X.player) + "]"},
+                                        {header: _("User"),   className: (X) => ("user_info" +         ((X && X.annulled) ? " annulled" : "")), render: (X) => (<React.Fragment>{(X.played_black ? <span>⚫</span> : <span>⚪</span>)}[{rankString(X.player)}]</React.Fragment>)},
                                         {header: _(""),       className: (X) => ("winner_marker" + ((X && X.annulled) ? " annulled" : "")),     render: (X) => (X.player_won ?  <i className="fa fa-trophy game-history-winner"/> : "")},
                                         {header: _("Date"),   className: (X) => ("date" +          ((X && X.annulled) ? " annulled" : "")),     render: (X) => moment(X.date).format("YYYY-MM-DD")},
                                         {header: _("Opponent"),  className: (X) => ("player" +     ((X && X.annulled) ? " annulled" : "")),     render: (X) => <Player user={X.opponent} disableCacheUpdate />} ,


### PR DESCRIPTION
… and tweak it better

Fixes 

The gap ended up too small between the colour marker and the rank.   Not sure why I didn't pick that up in Beta ... we sure could do with some more realistically populated accounts in there to test this stuff better.

Anyhow, sorry to have to tweak it again

## Proposed Changes

Put the colour marker into a span, so we can control the spacing, and set the spacing better.
