### PR TITLE
Fix ogs-font loading issue due to stylus bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "1.19.1",
     "pump": "^3.0.0",
     "source-map-loader": "^0.2.4",
-    "stylus": "^0.54.7",
+    "stylus": "0.54.7",
     "supervisor": "^0.12.0",
     "ts-jest": "^26.4.3",
     "ts-loader": "^8.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6039,7 +6039,7 @@ mkdirp@1.x, mkdirp@^1.0.4, mkdirp@~1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^0.5.3, mkdirp@~0.5.1:
+mkdirp@^0.5.3, mkdirp@~0.5.1, mkdirp@~0.5.x:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -8227,7 +8227,21 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-stylus@^0.54.0, stylus@^0.54.7:
+stylus@0.54.7:
+  version "0.54.7"
+  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.7.tgz#c6ce4793965ee538bcebe50f31537bfc04d88cd2"
+  integrity sha512-Yw3WMTzVwevT6ZTrLCYNHAFmanMxdylelL3hkWNgPMeTCpMwpV3nXjpOHuBXtFv7aiO2xRuQS6OoAdgkNcSNug==
+  dependencies:
+    css-parse "~2.0.0"
+    debug "~3.1.0"
+    glob "^7.1.3"
+    mkdirp "~0.5.x"
+    safer-buffer "^2.1.2"
+    sax "~1.2.4"
+    semver "^6.0.0"
+    source-map "^0.7.3"
+
+stylus@^0.54.0:
   version "0.54.8"
   resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.8.tgz#3da3e65966bc567a7b044bfe0eece653e099d147"
   integrity sha512-vr54Or4BZ7pJafo2mpf0ZcwA74rpuYCZbxrHBsH8kbcXOwSfvBFwsRfpGO5OD5fhG5HDCFW737PKaawI7OqEAg==


### PR DESCRIPTION
Fixes #1280 

When upgrading webpack (00b295ef6aa676ad5264c8f49e9c57e9d365b5b2) `stylus` was upgraded from `0.54.7` to `0.54.8` which broke `embedurl()`: https://github.com/stylus/stylus/issues/2546

This caused the embedded `ogs-font.woff` data in `ogs.css` to be corrupt, leading to:
`Failed to decode downloaded font: data:application/font-woff;base64,...` and 
`OTS parsing error: incorrect file size in WOFF header` in the console.

This change downgrades `stylus` to `0.54.7` which fixes the problem.