### PR TITLE
Fixed oversized element causing mobile horizontal scroll

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -121,7 +121,8 @@ goban-view-bar-width=400px
             justify-content: space-around;
             align-items: center;
 
-            margin: 5px;
+            margin-top: 5px;
+            margin-bottom: 5px;
             button {
                 themed background-color success
                 themed-darken border-color success border-darken-amount


### PR DESCRIPTION
When viewing my own games I noticed that there was horizontal scroll on mobile. See this screen capture: https://streamable.com/pbzr4e

It looks like the implicit left/right margin in `analyze-mode-buttons` was causing the issue:
![image](https://user-images.githubusercontent.com/4645409/99909240-1ee86880-2c9c-11eb-82b2-d79b9a0fa729.png)

This fixes the problem by explicitly only setting top/bottom margin.