### PR TITLE
Enabled escape and 'Back to Game' for uploaded sgf games

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1664,7 +1664,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
             this.toggleZenMode();
         }
 
-        if (this.goban && !this.goban.engine.config.original_sgf) {
+        if (this.goban) {
             if (this.goban.mode === "score estimation") {
                 this.leaveScoreEstimation();
             } else if (this.goban.mode === "analyze" && this.game_id) {
@@ -2875,7 +2875,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                 </button>
             </div>
              <div className="analyze-mode-buttons">
-                 {(state.mode === "analyze" && !this.goban.engine.config.original_sgf || null) &&
+                 {(state.mode === "analyze" || null) &&
                  <span>
                      {(!this.review_id || null) &&
                         <button className="sm primary bold" onClick={this.goban_setModeDeferredPlay}>{_("Back to Game")}</button>


### PR DESCRIPTION
I noticed that in uploaded sgf games if you entered analyze mode (e.g. pressed left arrow a few times) you couldn't go back to the end board state by pressing "Back to Game" like you normally can in games. For example: https://online-go.com/game/28512079

I found two ways to go back to the end game state:
1. Refresh the page.
2. Enter score estimation and then press "Back to Game".

When looking at the code I noticed we also disabled the escape key from returning to end game state for these games. I have enabled both of these features for uploaded sgf games in this diff.

I wasn't able to test this as it seems the dev server doesn't support uploading sgf's, but it should follow similar logic to the "Back to Game" button press when leaving score estimation mode (i.e. return to "play" mode and set to last official move, at least that's the current behavior of leaving score estimation until https://github.com/online-go/goban/pull/14 merges).

If there's a staging environment to test this change out on before being deployed to prod that's probably advisable. Also, if there's a reason why this was disabled for these types of games in the first place let me know.