### PR TITLE
Fixed wrong display of final board after using score estimation or AI review

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1438,6 +1438,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                 move_tree.clearMarks();
             }
             this.goban.redraw();
+            this.sync_state();
         }
         this.setState({ ai_review_enabled: !this.state.ai_review_enabled });
     }
@@ -1886,7 +1887,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
             estimating_score: false
         });
         this.goban.setScoringMode(false);
-        this.goban.engine.clearRemoved();
         this.goban.hideScores();
         this.goban.score_estimate = null;
         this.sync_state();
@@ -1945,7 +1945,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
         }
         this.setState({estimating_score: false});
         let ret = this.goban.setScoringMode(false);
-        this.goban.engine.clearRemoved();
         this.goban.hideScores();
         this.goban.score_estimate = null;
         //goban.engine.cur_move.clearMarks();
@@ -2682,7 +2681,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                 {(state.mode === "score estimation" || null) &&
                 <div className="analyze-mode-buttons">
                     <span>
-                        <button className="sm primary bold" onClick={this.stopEstimatingScore}>{_("Back to Game")}</button>
+                        <button className="sm primary bold" onClick={this.stopEstimatingScore}>{_("Back to Board")}</button>
                     </span>
                 </div>
                 }


### PR DESCRIPTION
Fixes #881 

Made the following changes to fix wrong display of final board after using some features:
- Sync state after disabling AI review.
- Remove `this.goban.engine.clearRemoved();` when exiting scoring estimate mode, which seemed to corrupt the final board state requiring a refresh to fix.

Also changed the "Back to Game" button for score estimation to "Back to Board" to reflect that it has different behavior than the "analysis toolbar" "Back to Game" button after https://github.com/online-go/goban/pull/14 merges (new behavior is to return to previous board position rather than the last official move). To get back to final board state after score estimation will require two presses: (1) "Back to Board", (2) "Back to Game", or alternatively just hit `esc` twice. I'm happy to name it something different if "Back to Board" doesn't feel appropriate, or drop this altogether (although I think having two buttons named the same that do different things is rather confusing). NOTE: If you're already in "play" mode (e.g. viewing the final board) pressing "Back to Board" or hitting `esc` once will take you back to the current game state.