### PR TITLE
Fixed player details popup not loading on first press

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -165,7 +165,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
             else if (player_id && player_id <= 0) {
                 // do nothing
             }
-            else if (username && username !== '...') {
+            else if (username && username !== "...") {
                 player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     if (this.unmounted) {
                         return;

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -92,7 +92,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
             else if (player_id && player_id <= 0) {
                 // do nothing
             }
-            else if (username) {
+            else if (username && username !== "...") {
                 player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     if (this.unmounted) {
                         return;
@@ -142,7 +142,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
 
         if (!new_props.disableCacheUpdate) {
             let player_id = typeof(new_props.user) !== "object" ? new_props.user : (new_props.user.id || new_props.user.player_id) ;
-            let username = typeof(this.props.user) !== "object" ? null : this.props.user.username ;
+            let username = typeof(new_props.user) !== "object" ? null : new_props.user.username ;
 
             if (typeof(new_props.user) === "object" && new_props.user.id > 0) {
                 player_cache.update(new_props.user);

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -165,7 +165,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
             else if (player_id && player_id <= 0) {
                 // do nothing
             }
-            else if (username) {
+            else if (username && username !== '...') {
                 player_cache.fetch_by_username(username, ["username", "ui_class", "ranking", "pro"]).then((user) => {
                     if (this.unmounted) {
                         return;

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -76,7 +76,6 @@ export class PlayerDetails extends React.PureComponent<PlayerDetailsProperties, 
     blankState() {
         return {
             resolved: false,
-            resolving: 0,
             username: "...",
             //icon: data.get('config.cdn_release') + '/img/default-user.svg',
             icon: "",
@@ -101,11 +100,11 @@ export class PlayerDetails extends React.PureComponent<PlayerDetailsProperties, 
             ]
         )
         .then((player) => {
-            this.setState(Object.assign({resolved: true}, player as any));
+            this.setState(Object.assign({}, player as any, {resolved: true}));
         })
         .catch((err) => {
             if (player_id === this.props.playerId) {
-                this.setState({resolved: true, error: _("Error loading player information")});
+                this.setState({resolved: false, error: _("Error loading player information")});
                 console.error(err);
             }
         });
@@ -266,18 +265,18 @@ export class PlayerDetails extends React.PureComponent<PlayerDetailsProperties, 
                 {!user.anonymous && (user.id !== this.props.playerId || null) &&
                     <div className="actions">
                         {!this.props.nochallenge &&
-                            <button className="xs noshadow primary" disabled={this.state.resolved} onClick={this.challenge}><i className="ogs-goban"/>{_("Challenge")}</button>
+                            <button className="xs noshadow primary" disabled={!this.state.resolved} onClick={this.challenge}><i className="ogs-goban"/>{_("Challenge")}</button>
                         }
                         {!this.props.nochallenge &&
                             <div style={{width: '48%'}}></div>
                         }
-                        <button className="xs noshadow success" disabled={this.state.resolved} onClick={this.message}><i className="fa fa-comment-o"/>{_("Message")}</button>
+                        <button className="xs noshadow success" disabled={!this.state.resolved} onClick={this.message}><i className="fa fa-comment-o"/>{_("Message")}</button>
                         {friends[this.props.playerId]
-                            ? <button className="xs noshadow reject" disabled={this.state.resolved} onClick={this.removeFriend}><i className="fa fa-frown-o"/>{_("Remove friend")}</button>
-                            : <button className="xs noshadow success" disabled={this.state.resolved} onClick={this.addFriend}><i className="fa fa-smile-o"/>{_("Add friend")}</button>
+                            ? <button className="xs noshadow reject" disabled={!this.state.resolved} onClick={this.removeFriend}><i className="fa fa-frown-o"/>{_("Remove friend")}</button>
+                            : <button className="xs noshadow success" disabled={!this.state.resolved} onClick={this.addFriend}><i className="fa fa-smile-o"/>{_("Add friend")}</button>
                         }
-                        <button className="xs noshadow reject" disabled={this.state.resolved} onClick={this.report}><i className="fa fa-exclamation-triangle"/>{_("Report")}</button>
-                        <button className="xs noshadow reject" disabled={this.state.resolved} onClick={this.block}><i className="fa fa-ban"/>{_("Block")}</button>
+                        <button className="xs noshadow reject" disabled={!this.state.resolved} onClick={this.report}><i className="fa fa-exclamation-triangle"/>{_("Report")}</button>
+                        <button className="xs noshadow reject" disabled={!this.state.resolved} onClick={this.block}><i className="fa fa-ban"/>{_("Block")}</button>
                     </div>
                 }
                 {!user.anonymous && !this.props.noextracontrols && extraActionCallback && extraActionCallback(this.props.playerId, this.state)}


### PR DESCRIPTION
Fixes #1286 

Two main changes were required to get this fixed:

### `PlayerDetails` fix to get grayed out buttons enabled

I fixed the `resolved` state property logic in `PlayerDetails` to get the buttons to not be disabled. The previous semantics of `resolved` were inverted, where the buttons were disabled if the state was resolved as opposed to the other way around. 

There was a crazy bug here that was causing it to "work" before despite the semantics being wrong: for some reason the `player` object (of type `PlayerCacheEntry`) was getting the `PlayerDetails` state properties added to the object! So on first `resolve()` for a player we set `resolved: true` which disabled the buttons, then on second `resolve()` the player had `resolved: false` property set (false due to initial blank state), so `Object.assign({resolved: true}, player as any)` had `resolved: false` set! 

I still haven't figured out how this is possible, but it seems related to react's `setState()` internals (likely a bug). To fix this I changed it to `Object.assign({}, player as any, {resolved: true})` to make sure the final state update had `resolved: true`.

### `Player` race condition causing player name to be `...`

This was the sequence of the race:
1. `PlayerDetails` component is created and set to initial blank state.
1. In `PlayerDetails` constructor, player is looked up in the cache but isn't present.
1. `Player` component inherits the default props from its parent `PlayerDetails`, including `{username: '...'}`.
1. `Player.componentDidMount()` attempts to fetch the player, and since `player_id` is undefined (due to inheriting props) it attempts to fetch by username `...`.
1. `PlayerDetails.resolve()` is called from `PlayerDetails.UNSAFE_componentWillMount()` which fetches the player (using `playerId`) which leads to updating the user props of `Player`.
1. `Player.UNSAFE_componentWillReceiveProps()` is called which updates its user state from the new props (all good at this point!).
1. The username player fetch from `Player.componentDidMount()` returns, and overwrites the state to the username captured by the promise callback closure which was the original `...`.

This race leads to the username in state being set to `...` despite the props having the proper username.

To fix this I just prevented fetching by username if username is `...`. @BHydden mentioned that at one point there was a user with the username `...` but that was taken care of so I think this should be safe (would be good to get confirmation on that).


### Other misc fixes

It looks like there was a bug in `UNSAFE_componentWillReceiveProps` where it was using the username from the old props rather than the new ones, so I fixed that even though it likely won't affect anything (didn't notice any changes with or without the change).