### PR TITLE
Fixed stale rank on homescreen

### DIFF
--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -70,6 +70,7 @@ export class Overview extends React.Component<{}, any> {
         }
 
         this.state = {
+            user: data.get("config.user"),
             overview: {
                 active_games: [],
             },
@@ -91,6 +92,7 @@ export class Overview extends React.Component<{}, any> {
     componentDidMount() {
         this.setTitle();
         notification_manager.event_emitter.on("turn-count", this.setBoardsToMoveOn);
+        data.watch("config.user", (user) => this.setState({"user": user}));
         this.refresh().then(ignore).catch(ignore);
     }
 
@@ -115,7 +117,7 @@ export class Overview extends React.Component<{}, any> {
     }
 
     render() {
-        let user = data.get("config.user");
+        let user = this.state.user;
 
         return (
         <div id="Overview-Container">

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -92,12 +92,16 @@ export class Overview extends React.Component<{}, any> {
     componentDidMount() {
         this.setTitle();
         notification_manager.event_emitter.on("turn-count", this.setBoardsToMoveOn);
-        data.watch("config.user", (user) => this.setState({"user": user}));
+        data.watch("config.user", this.updateUser);
         this.refresh().then(ignore).catch(ignore);
     }
 
     componentDidUpdate() {
         this.setTitle();
+    }
+
+    updateUser = (user) => {
+        this.setState({"user": user});
     }
 
     refresh() {
@@ -114,6 +118,7 @@ export class Overview extends React.Component<{}, any> {
         abort_requests_in_flight("ui/overview");
         notification_manager.event_emitter.off("turn-count", this.setBoardsToMoveOn);
         window.document.title = Overview.defaultTitle;
+        data.unwatch("config.user", this.updateUser);
     }
 
     render() {


### PR DESCRIPTION
Fixes #1277 

I noticed that the `ProfileCard` user prop had stale data in it and didn't match the child `Player` component's user ratings. Looks like this is just because we assign the user once during initial render and `data.get("config.user")` when the page first loads could be out of date. This fix watches for `config.user` changes and forces re-render if it occurs, preventing stale homescreen data.
