### PR TITLE
Hide user's own rank when "hide ranks" is active (and alignment tweak)

### DIFF
--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -462,6 +462,7 @@
 
         span {
             padding-right: 0.3em;
+            vertical-align: middle;
         }
 
         .user_info  {

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -523,6 +523,12 @@ export class User extends React.PureComponent<UserProperties, any> {
         this.moderator_note.value = "";
     }
 
+    // I think ideally this would be handled in rank_utils, except I'm not sure about polluting that with preferences
+    // It'd also likely be a big refactor to get right across the board...
+    maskedRank = (rank: string): string => (
+        preferences.get('hide-ranks') ? "" : rank
+    )
+
     render() {
         let user = this.state.user;
         if (!user) { return this.renderInvalidUser(); }
@@ -903,7 +909,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                                     orderBy={["-ended"]}
                                     groom={game_history_groomer}
                                     columns={[                                /* I wish we could set properties at the row level! */
-                                        {header: _("User"),   className: (X) => ("user_info" +         ((X && X.annulled) ? " annulled" : "")), render: (X) => (<React.Fragment>{(X.played_black ? <span>⚫</span> : <span>⚪</span>)}[{rankString(X.player)}]</React.Fragment>)},
+                                        {header: _("User"),   className: (X) => ("user_info" +         ((X && X.annulled) ? " annulled" : "")), render: (X) => (<React.Fragment>{(X.played_black ? <span>⚫</span> : <span>⚪</span>)}{this.maskedRank(`[${rankString(X.player)}]`)}</React.Fragment>)},
                                         {header: _(""),       className: (X) => ("winner_marker" + ((X && X.annulled) ? " annulled" : "")),     render: (X) => (X.player_won ?  <i className="fa fa-trophy game-history-winner"/> : "")},
                                         {header: _("Date"),   className: (X) => ("date" +          ((X && X.annulled) ? " annulled" : "")),     render: (X) => moment(X.date).format("YYYY-MM-DD")},
                                         {header: _("Opponent"),  className: (X) => ("player" +     ((X && X.annulled) ? " annulled" : "")),     render: (X) => <Player user={X.opponent} disableCacheUpdate />} ,


### PR DESCRIPTION
The user's rank should not be shown if they have selected "Hide ranks" option.

## Proposed Changes

Don't show it if they have selected hide ranks option 👍 

I also took the opportunity to vertically align the user's rank with the rest of the row.