### PR TITLE
Fixed mobile rotation view_mode bug

### DIFF
--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -183,7 +183,7 @@ export class LadderComponent extends React.PureComponent<LadderComponentProperti
 
         return (
             <div className="LadderComponent">
-                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
 
                 <UIPush event="players-updated" channel={`ladder-${this.props.ladderId}`} action={this.updatePlayers} />
 

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -988,7 +988,7 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
                     : this.state.nodata
                         ? <div className='nodata'>{_("No rated games played yet")}</div>
                         : <div className='ratings-graph'>
-                            <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                            <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
                             <PersistentElement elt={this.chart_div}/>
                         </div>
                 }

--- a/src/views/Game/AIReviewChart.tsx
+++ b/src/views/Game/AIReviewChart.tsx
@@ -499,7 +499,7 @@ export class AIReviewChart extends React.Component<AIReviewChartProperties, any>
     render() {
         return (
             <div ref={this.setContainer} className="AIReviewChart">
-                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
                 <PersistentElement elt={this.chart_div}/>
             </div>
         );

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2286,7 +2286,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
 
                     {((this.state.view_mode !== "portrait" || this.state.portrait_tab === "game") || null) &&
                         <div ref={el => this.ref_goban_container = el} className="goban-container">
-                            <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                            <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
                             <PersistentElement className="Goban" elt={this.goban_div}/>
                         </div>
                     }

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1043,7 +1043,7 @@ export class Joseki extends React.Component<JosekiProps, any> {
 
                 <div className={"left-col" + (this.state.mode === PageMode.Admin ? " admin-mode" : "")}>
                     <div ref={(e) => this.goban_container = e} className="goban-container">
-                        <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                        <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
                         <PersistentElement ref={(e) => this.goban_persistent_element = e} className="Goban" elt={this.goban_div} />
                     </div>
                 </div>

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -377,7 +377,7 @@ export class Play extends React.Component<PlayProperties, any> {
                     <div className='col-sm-6'>
                         <Card>
                             <div ref={el => this.ref_container = el} className="seek-graph-container">
-                                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                                <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
                                 <PersistentElement elt={this.canvas}/>
                             </div>
                         </Card>

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -612,7 +612,7 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
 
             <div className={"center-col"}>
                 <div ref="goban_container" className="goban-container">
-                    <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                    <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
                     <PersistentElement className="Goban" elt={this.goban_div}/>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #1292

It looks like the `onResize=...` callback passes in some arguments, so `skip_state_update` arg in `this.onResize()` had integer values (maybe the window height or width?) which are "true" values (as opposed to the default false for the argument), causing the view mode to not be re-evaluated when rotating screen. Wrapping in a lambda to discard the args and use default ones fixed the issue. Made the change in all `onResize=...` places to avoid the bug in other places.
