### PR TITLE
Fixed repeated "Game started" sfx

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -512,7 +512,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                     off();
                     swal.close();
                     //sfx.play("game_accepted");
-                    sfx.play("game_started");
+                    sfx.play("game_started", 3000);
                     //sfx.play("setup-bowl");
                     browserHistory.push(`/game/${game_id}`);
                 }


### PR DESCRIPTION
Fixes #1293 

There's a race condition that causes the `Game started` sfx to play twice:

1. User A requests live game from User B.
1. User B accepts the game.
1. User A receives the `gameStarted` notification and plays `game_started` sfx.
1. User A receives game data and `ChallengeModal` plays `game_started` sfx.

If 3/4 are swapped then the notification is suppressed since the game is already open and notifications for the actively viewed game are suppressed, hence why this only happens some of the time and is a race.

This "fixes" the bug by suppressing the repeated `Game started` sfx if the race condition occurs and steps 3/4 are less than 3 seconds apart. Fixing the race condition itself seemed much more complicated. If we find this still triggers frequently we can increase the window (5s, 10s?), but it's a balancing act to make sure we still properly sound the notification when a future game is accepted while in the challenge modal. From my testing steps 3/4 have always been less than a second apart.
