### PR TITLE
Added a space between play icon and play in the Navbar

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -376,7 +376,7 @@ export class NavBar extends React.PureComponent<{}, any> {
                     <ul id="items">
                         {user && <li><Link to="/overview"><i className="fa fa-home"></i>{_("Home")}</Link></li>}
                         {anon && <li><Link to="/sign-in"><i className="fa fa-sign-in"></i>{_("Sign In")}</Link></li>}
-                        {user && <li><Link to="/play"><i className="ogs-goban"></i>{_("Play")}</Link></li>}
+                        {user && <li><Link to="/play"><i className="fa ogs-goban"></i>{_("Play")}</Link></li>}
                         {/* user && <li><span className="fakelink" onClick={this.newGame}><i className="fa fa-plus"></i>{_("New Game")}</span></li> */}
                         {user && <li><span className="fakelink" onClick={this.newDemo}><i className="fa fa-plus"></i>{_("Demo Board")}</span></li>}
                         <li><Link to="/observe-games"><i className="fa fa-eye"></i>{_("Games")}</Link></li>


### PR DESCRIPTION
In the navbar, there's no space between the play icon and the play word, which looks odd compared to the rest of the items in the menu. I think this might be a typo?

Just added a fa in the className in Navbar.tsx so it added the extra space and look consistent. 