### PR TITLE
Fixed Puzzle goban container overlay blocking buttons in wide view

### DIFF
--- a/src/views/Puzzle/Puzzle.styl
+++ b/src/views/Puzzle/Puzzle.styl
@@ -47,12 +47,14 @@ puzzle-controls-width=400px
         display: flex;
         flex-direction: column;
         align-items: stretch;
+        overflow: hidden;
     }
     &.portrait .center-col {
         height: 100vw;
         max-height: 100vw;  // firefox needs this
         flex-basis: 99%;
         overflow-y: visible;
+        overflow-x: visible;
     }
 
     .left-col, .right-col {


### PR DESCRIPTION
As part of PR #1298 `overflow: hidden` was removed from `.center-col` in `Puzzle.styl`. This caused the goban container to extend over the buttons making it so you can no longer press them. This fixes `wide` view mode (the most commonly used mode). Sometimes the goban container can still extend down over the buttons on mobile, but that doesn't always happen and it's a harder fix, so I just wanted to get this one pushed out since it affects more people.

I'll fix all of these mobile issues (including #1300) in a future PR.

@anoek Puzzles are currently pretty broken without this fix, so probably worth getting this one deployed when you've got a minute.