### PR TITLE
Escaper warning initial implementation

### DIFF
--- a/src/components/EscaperWarningModal/EscaperWarningModal.styl
+++ b/src/components/EscaperWarningModal/EscaperWarningModal.styl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.EscaperWarningModal {
+    text-align: center;
+
+    padding: 1em 0 1em 0 !important;
+    border-color: red !important;
+
+    div {
+        padding: 0.1em 2em 0.1em 2em;
+    }
+
+    button {
+        width: fit-content;
+        align-self: center;
+        margin-top: 1em;
+        margin-bottom: 1em
+    }
+}

--- a/src/components/EscaperWarningModal/EscaperWarningModal.tsx
+++ b/src/components/EscaperWarningModal/EscaperWarningModal.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { _ } from 'translate';
+
+import { Modal, openModal } from "Modal";
+
+interface Events {
+}
+
+interface EscaperWarningModalProperties {
+}
+
+export class EscaperWarningModal extends Modal<Events, EscaperWarningModalProperties, any> {
+
+    render() {
+        return (
+            <div className="Modal EscaperWarningModal" ref="modal">
+                <div>{_("Sorry for interrupting...")}</div>
+                <div>{_("It seems you disconnected from a game recently without finishing it.")}</div>
+                <div>{_("Abandoning games is not OK.")}</div>
+                <div>{_("Please either resign if you have lost, or pass and promptly accept the correct score when the game is over.")}</div>
+                <button className="primary" onClick={this.close}>{_("OK, got it!")}</button>
+            </div>
+        );
+    }
+}

--- a/src/components/EscaperWarningModal/index.ts
+++ b/src/components/EscaperWarningModal/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+export * from "./EscaperWarningModal";


### PR DESCRIPTION


As discussed, we need automated help warning escapers.

This first client-side implementation warns people who disconnect from games.

## Proposed Changes

When someone goes to play a game, check if they have a recent disconnect, and warn them with a modal.

When they acknowledge, note the time that they acknowledged, and don't hassle them again unless they disconnect again after this.

I really would have liked to add a mod note that they received the warning, but unfortunately that can't be done client side from the user's account.

![Screen Shot 2020-12-01 at 4 44 01 pm](https://user-images.githubusercontent.com/61894/100704264-1fe46d00-33f5-11eb-8552-0ccf8b719b84.png)

