### PR TITLE
Fixed various Puzzle bugs

### DIFF
--- a/src/views/Puzzle/Puzzle.styl
+++ b/src/views/Puzzle/Puzzle.styl
@@ -48,6 +48,7 @@ puzzle-controls-width=400px
         flex-direction: column;
         align-items: stretch;
         overflow: hidden;
+        z-index: 1;
     }
     &.portrait .center-col {
         height: 100vw;
@@ -63,6 +64,7 @@ puzzle-controls-width=400px
         overflow-x: hidden;
         min-height: auto;
         padding: 0.5rem;
+        z-index: 2;
     }
     &.portrait .right-col {
         overflow-y: visible;

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -66,7 +66,13 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
         name;
         puzzle_type;
     };
-    ref_move_tree_container:HTMLElement;
+    ref_move_tree_container: HTMLElement;
+
+    ref_transform_x_button: React.RefObject<HTMLButtonElement>;
+    ref_transform_h_button: React.RefObject<HTMLButtonElement>;
+    ref_transform_v_button: React.RefObject<HTMLButtonElement>;
+    ref_transform_color_button: React.RefObject<HTMLButtonElement>;
+    ref_transform_zoom_button: React.RefObject<HTMLButtonElement>;
 
     goban: Goban;
     goban_div: HTMLDivElement;
@@ -94,6 +100,12 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
             puzzle_collection_summary: [],
             hintsOn: false,
         };
+
+        this.ref_transform_x_button = React.createRef<HTMLButtonElement>();
+        this.ref_transform_h_button = React.createRef<HTMLButtonElement>();
+        this.ref_transform_v_button = React.createRef<HTMLButtonElement>();
+        this.ref_transform_color_button = React.createRef<HTMLButtonElement>();
+        this.ref_transform_zoom_button = React.createRef<HTMLButtonElement>();
 
         this.goban_div = document.createElement("div");
         this.goban_div.className = "Goban";
@@ -346,25 +358,28 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
             }
         }
 
-       this.transform.settings.log();
+        this.transform.settings.log();
 
-        $("#selected_puzzle").focus().blur(); /* otherwise last button unselected will look kinda like it's selected still */
-        this.reset();
-        this.onResize();
+        this.doReset();
     }
     toggle_transform_x = () => {
+        this.ref_transform_x_button.current.blur();
         this.setTransformation("x");
     }
     toggle_transform_h = () => {
+        this.ref_transform_h_button.current.blur();
         this.setTransformation("h");
     }
     toggle_transform_v = () => {
+        this.ref_transform_v_button.current.blur();
         this.setTransformation("v");
     }
     toggle_transform_color = () => {
+        this.ref_transform_color_button.current.blur();
         this.setTransformation("color");
     }
     toggle_transform_zoom = () => {
+        this.ref_transform_zoom_button.current.blur();
         this.setTransformation("zoom");
     }
 
@@ -678,20 +693,20 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
         return (
             <div className="btn-container">
                 <div className="btn-group">
-                    <button type="button" className={this.state.transform_x ? "active" : ""} onClick={this.toggle_transform_x}>
+                    <button type="button" className={this.state.transform_x ? "active" : ""} onClick={this.toggle_transform_x} ref={this.ref_transform_x_button}>
                         <i className="fa fa-expand"></i>
                     </button>
-                    <button type="button" className={this.state.transform_h ? "active" : ""} onClick={this.toggle_transform_h}>
+                    <button type="button" className={this.state.transform_h ? "active" : ""} onClick={this.toggle_transform_h} ref={this.ref_transform_h_button}>
                         <i className="fa fa-arrows-h"></i>
                     </button>
-                    <button type="button" className={this.state.transform_v ? "active" : ""} onClick={this.toggle_transform_v}>
+                    <button type="button" className={this.state.transform_v ? "active" : ""} onClick={this.toggle_transform_v} ref={this.ref_transform_v_button}>
                         <i className="fa fa-arrows-v"></i>
                     </button>
-                    <button type="button" className={this.state.transform_color ? "active" : ""} onClick={this.toggle_transform_color}>
+                    <button type="button" className={this.state.transform_color ? "active" : ""} onClick={this.toggle_transform_color} ref={this.ref_transform_color_button}>
                         <i className="fa fa-adjust"/>
                     </button>
                     {(this.state.zoomable || null) &&
-                        <button type="button" className={this.state.zoom ? "active" : ""} onClick={this.toggle_transform_zoom}>
+                        <button type="button" className={this.state.zoom ? "active" : ""} onClick={this.toggle_transform_zoom} ref={this.ref_transform_zoom_button}>
                             <i className="fa fa-arrows-alt"></i>
                         </button>
                     }

--- a/src/views/Puzzle/PuzzleTransform.ts
+++ b/src/views/Puzzle/PuzzleTransform.ts
@@ -69,16 +69,24 @@ export class PuzzleTransform {
             };
 
 
-            let t = "tttttttttttt";
-            let T = "TTTTTTTTTTTT";
-            let tr = /tttttttttttt/g;
-            let Tr = /TTTTTTTTTTTT/g;
+            let tt = "tttttttttttt";
+            let Tt = "Tttttttttttt";
+            let TT = "TTTTTTTTTTTT";
+            let ttr = /tttttttttttt/g;
+            let Ttr = /Tttttttttttt/g;
+            let TTr = /TTTTTTTTTTTT/g;
             for (let c1 in colors) {
                 let c2 = colors[c1];
 
+                // Replace first-letter-capitalized color.
                 let c1r = new RegExp("\\b" + c1 + "\\b", "gm");
                 let c2r = new RegExp("\\b" + c2 + "\\b", "gm");
 
+                // Replace all caps color.
+                let c1ru = new RegExp("\\b" + c1.toUpperCase() + "\\b", "gm");
+                let c2ru = new RegExp("\\b" + c2.toUpperCase() + "\\b", "gm");
+
+                // Replace any other type of capitalization with all lowercase color.
                 let c1caser = new RegExp("\\b" + c1 + "\\b", "gmi");
                 let c2caser = new RegExp("\\b" + c2 + "\\b", "gmi");
 
@@ -86,22 +94,27 @@ export class PuzzleTransform {
                 let c2case = c2.toLowerCase();
 
                 txt = txt
-                        .replace(c1r, T)
-                        .replace(c1, T)
-                        .replace(c1caser, t)
+                        .replace(c1r, Tt)
+                        .replace(c1, Tt)
+                        .replace(c1.toUpperCase(), TT)
+                        .replace(c1ru, TT)
+                        .replace(c1caser, tt)
                         .replace(c2r, c1)
                         .replace(c2, c1)
+                        .replace(c2.toUpperCase(), c1.toUpperCase())
+                        .replace(c2ru, c1.toUpperCase())
                         .replace(c2caser, c1case)
-                        .replace(tr, c2case)
-                        .replace(Tr, c2);
+                        .replace(ttr, c2case)
+                        .replace(TTr, c2.toUpperCase())
+                        .replace(Ttr, c2);
             }
             for (let c1 in utf8_colors) {
                 let c2 = utf8_colors[c1];
 
                 txt = txt
-                        .replace(c1, T)
+                        .replace(c1, TT)
                         .replace(c2, c1)
-                        .replace(Tr, c2);
+                        .replace(TTr, c2);
             }
         }
 

--- a/src/views/Puzzle/PuzzleTransform.ts
+++ b/src/views/Puzzle/PuzzleTransform.ts
@@ -96,12 +96,10 @@ export class PuzzleTransform {
                 txt = txt
                         .replace(c1r, Tt)
                         .replace(c1, Tt)
-                        .replace(c1.toUpperCase(), TT)
                         .replace(c1ru, TT)
                         .replace(c1caser, tt)
                         .replace(c2r, c1)
                         .replace(c2, c1)
-                        .replace(c2.toUpperCase(), c1.toUpperCase())
                         .replace(c2ru, c1.toUpperCase())
                         .replace(c2caser, c1case)
                         .replace(ttr, c2case)


### PR DESCRIPTION
**_Note_**: this doesn't fix the Firefox issues, I'll work on that soon and post a new PR for it. Was planning on doing that tonight but started shaving the yak instead...

### Fixed goban container blocking buttons on mobile

Moved center col (i.e. goban) behind right-col elements so the overly long goban container didn't block transformation and undo/reset buttons (using `z-index`). This only was an issue on mobile for certain goban dimensions, so wasn't really a problem until the portrait mode was added in #1298.

### Fixed page jumping down when transform button pressed on mobile

Prevented jumping when transformation button pressed (issue was when we tried to focus on a different element (`$("#selected_puzzle").focus().blur()`) so that button didn't look improperly selected, we ended up causing page to jump). Changed to blur the just-pressed button instead, using react refs to get the button element. In desktop mode the puzzle element was usually always in frame so it wouldn't cause the jump, but in the mobile layout this was more prominent.

### Fixed puzzle solution text boxes not being cleared on transformation

Cleared `Correct`/`Incorrect` box when transformation button pressed (`this.reset()` -> `this.doReset()` which properly resets the state rather than just the Goban).

### Handled all caps color text on color invert transformation

I noticed in a puzzle dialog box that on color invert "BLACK" was being changed to "white" (case did not match). This was caused by code in `transformMoveText()` replacing any color that didn't match camel-case with all lowercase. I enhanced this to handle all caps, so now it properly handles: (1) camel-case (e.g. first letter capitalized) (2) all lower case, and (3) all upper case. Anything that doesn't match those will default to lower case.

Original text:
![image](https://user-images.githubusercontent.com/4645409/100834020-fee54180-341f-11eb-8940-a6a533e8f338.png)

After color transformation WITHOUT this fix:
![image](https://user-images.githubusercontent.com/4645409/100834063-18868900-3420-11eb-9f1e-18af5598c1fb.png)

After color transformation WITH this fix:
![image](https://user-images.githubusercontent.com/4645409/100833926-c5acd180-341f-11eb-932d-507fbff3b563.png)

 