### PR TITLE
Fixed more Puzzle/PuzzleList/Joseki bugs

### DIFF
--- a/src/global_styl/global.styl
+++ b/src/global_styl/global.styl
@@ -119,7 +119,8 @@ a.primary:active, a.primary:hover, .primary.clickable:hover, .primary.fakelink:h
     align-content: left;
     width: 100%;
     max-width: 1110px;
-    padding: 0.7rem 1rem;
+    padding-top: 0.7rem;
+    padding-bottom: 0.7rem;
 }
 
 .page-nav{

--- a/src/views/Joseki/Joseki.styl
+++ b/src/views/Joseki/Joseki.styl
@@ -62,9 +62,9 @@
         }
         padding-top: 1em;
 
-        @media screen and (max-width: 801px) {
+        @media screen and (max-width: 800px) {
             height: 100vw;
-            max-height: 100vw;  // firefox needs this
+            min-height: 100vw;  // firefox needs this
             flex-basis: 99%;
         }
     }
@@ -339,6 +339,10 @@
             margin-top: 3em;
             margin-bottom: 1em;
             margin-left: 1em;
+
+            @media screen and (max-width: 800px) {
+                margin-left: 0rem;
+            }
 
             @media screen and (max-width: 1160px) {
                 margin-right 1em;

--- a/src/views/Joseki/Joseki.styl
+++ b/src/views/Joseki/Joseki.styl
@@ -65,6 +65,7 @@
         @media screen and (max-width: 800px) {
             height: 100vw;
             min-height: 100vw;  // firefox needs this
+            max-height: 100vw;  // firefox needs this
             flex-basis: 99%;
         }
     }

--- a/src/views/Puzzle/Puzzle.styl
+++ b/src/views/Puzzle/Puzzle.styl
@@ -28,12 +28,11 @@ puzzle-controls-width=400px
     bottom: 0;
     left: 0;
     right: 0;
-    overflow: hidden;
 
 
     &.portrait {
         flex-direction: column;
-        overflow-y: auto;
+        overflow-x: hidden;
     }
 
     .left-col {
@@ -52,7 +51,7 @@ puzzle-controls-width=400px
     }
     &.portrait .center-col {
         height: 100vw;
-        max-height: 100vw;  // firefox needs this
+        min-height: 100vw;  // firefox needs this
         flex-basis: 99%;
         overflow-y: visible;
         overflow-x: visible;
@@ -93,6 +92,7 @@ puzzle-controls-width=400px
 
 
     .horizontal {
+        overflow-x: hidden;
         dt, dd {
             width: 45%;
         }

--- a/src/views/Puzzle/Puzzle.styl
+++ b/src/views/Puzzle/Puzzle.styl
@@ -32,7 +32,6 @@ puzzle-controls-width=400px
 
     &.portrait {
         flex-direction: column;
-        overflow-x: hidden;
     }
 
     .left-col {
@@ -52,9 +51,8 @@ puzzle-controls-width=400px
     &.portrait .center-col {
         height: 100vw;
         min-height: 100vw;  // firefox needs this
+        max-height: 100vw;  // firefox needs this
         flex-basis: 99%;
-        overflow-y: visible;
-        overflow-x: visible;
     }
 
     .left-col, .right-col {

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -73,6 +73,9 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
     ref_transform_v_button: React.RefObject<HTMLButtonElement>;
     ref_transform_color_button: React.RefObject<HTMLButtonElement>;
     ref_transform_zoom_button: React.RefObject<HTMLButtonElement>;
+    ref_settings_button: React.RefObject<HTMLButtonElement>;
+    ref_edit_button: React.RefObject<HTMLButtonElement>;
+    ref_hint_button: React.RefObject<HTMLButtonElement>;
 
     goban: Goban;
     goban_div: HTMLDivElement;
@@ -106,6 +109,9 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
         this.ref_transform_v_button = React.createRef<HTMLButtonElement>();
         this.ref_transform_color_button = React.createRef<HTMLButtonElement>();
         this.ref_transform_zoom_button = React.createRef<HTMLButtonElement>();
+        this.ref_settings_button = React.createRef<HTMLButtonElement>();
+        this.ref_edit_button = React.createRef<HTMLButtonElement>();
+        this.ref_hint_button = React.createRef<HTMLButtonElement>();
 
         this.goban_div = document.createElement("div");
         this.goban_div.className = "Goban";
@@ -413,6 +419,8 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
         }
     }
     edit = () => {
+        this.ref_edit_button.current.blur();
+
         get("puzzles/collections/", {page_size: 100, owner: data.get("user").id})
         .then((collections) => {
             this.setState({
@@ -430,6 +438,8 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
 
         let randomize_transform = preferences.get("puzzle.randomize.transform");
         let randomize_color = preferences.get("puzzle.randomize.color");
+
+        this.ref_settings_button.current.blur();
 
         puzzle_settings.on("close", () => {
             if (randomize_transform !== preferences.get("puzzle.randomize.transform")  ||
@@ -569,6 +579,8 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
     }
 
     showHint = () => {
+        this.ref_hint_button.current.blur();
+
         if (this.state.hintsOn) {
             this.removeHints();
         } else if (!this.goban.engine.cur_move.correct_answer) {
@@ -711,14 +723,18 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
                         </button>
                     }
 
-                    <button type="button" onClick={this.openPuzzleSettings}>
+                    <button type="button" onClick={this.openPuzzleSettings} ref={this.ref_settings_button}>
                         <i className="fa fa-gear"/>
                     </button>
 
                     {(puzzle.owner.id === data.get("user").id || null) &&
-                        <button onClick={this.edit}><i className="fa fa-pencil"></i></button>
+                        <button onClick={this.edit} ref={this.ref_edit_button}>
+                            <i className="fa fa-pencil"></i>
+                        </button>
                     }
-                    <button className={this.state.hintsOn ? "active" : ""} onClick={this.showHint} >{_("Hint")}</button>
+                    <button className={this.state.hintsOn ? "active" : ""} onClick={this.showHint} ref={this.ref_hint_button}>
+                        {_("Hint")}
+                    </button>
                 </div>
             </div>
         );


### PR DESCRIPTION
Fixes #1300

Fixes the following bugs:
- Removed focus on settings, edit, and hint buttons to match behavior of transform buttons.
- Fixed nav bar not scrolling with rest of Puzzle page (Puzzle needed to be visible so the whole main div would scroll rather than just the puzzle).
- Fixed puzzle list scrolling to the side on mobile due to left/right padding in `page-width` css class. This padding change also fixed a bug where scrolling down in the puzzle list on mobile would sometimes jerk down after you stop scrolling (I was already planning on looking into that separately, but it turned out that the padding change had already taken care of it!).
- Centered Joseki extra info box in explore pane by removing left margin when in portrait.
- Fixed broken Joseki/Puzzle in Firefox portrait landscape. Added `min-height: 100vw` (in addition to existing `max-height: 100vw`)!
