### PR TITLE
Fix puzzle scroll jump and puzzle collection mobile

### DIFF
--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -320,7 +320,9 @@ export class Puzzle extends React.Component<PuzzleProperties, any> {
             show_wrong: false,
         });
         setTimeout(() => {
+            let position = $(window).scrollTop();
             $(this.refs.next_link).focus();
+            $(window).scrollTop(position);
         }, 1);
     }
     jumpToPuzzle = (ev) => {

--- a/src/views/PuzzleCollection/PuzzleCollection.styl
+++ b/src/views/PuzzleCollection/PuzzleCollection.styl
@@ -21,4 +21,15 @@
         flex-direction: column;
         align-items: center;
     }
+
+    .horizontal {
+        overflow-x: hidden;
+        dt, dd {
+            width: 45%;
+        }
+    }
+
+    .update {
+        text-align: center;
+    }
 }

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -53,7 +53,7 @@ export function PuzzleCollection({match:{params:{collection_id}}}:{match:{params
     return (
         <div className="page-width">
             <div id='PuzzleCollection'>
-                <dl>
+                <dl className="horizontal">
                     <dt>{_("Puzzle collection")}</dt>
                     <dd><input value={name} onChange={ev => setName(ev.target.value)} placeholder={_('Name')} /></dd>
 
@@ -70,8 +70,10 @@ export function PuzzleCollection({match:{params:{collection_id}}}:{match:{params
                     }
                 </dl>
 
-                <button className='btn reject' onClick={remove}>{_("Delete")}</button>
-                <button className='btn primary' onClick={save}>{_("Save")}</button>
+                <div className="update">
+                    <button className='btn reject' onClick={remove}>{_("Delete")}</button>
+                    <button className='btn primary' onClick={save}>{_("Save")}</button>
+                </div>
 
                 <div className='center'>
                     <div style={{'textAlign': 'center', 'margin': '1rem'}}>

--- a/src/views/PuzzleCollection/SortablePuzzleList.styl
+++ b/src/views/PuzzleCollection/SortablePuzzleList.styl
@@ -18,6 +18,7 @@
 .SortablePuzzleList {
     width: 35rem;
     padding: 0;
+    max-width: 100vw;
 }
 
 // this has to be outside, the drag/drop stuff creates a wandering <li> node


### PR DESCRIPTION
### Fix scroll jump on Puzzle after solving

After solving a puzzle, if the text field is too large the `Next` button is off screen. When we focus on `Next` it would cause the screen to jump. Fixed by ensuring we don't scroll after focusing on `Next` by restoring previous scroll position.

### Made Puzzle Collection page layout better on mobile

Fixes #1306 

Before (desktop, mobile):

![image](https://user-images.githubusercontent.com/4645409/101382604-ff8d3600-386c-11eb-8c95-1e573a81cf26.png)
![image](https://user-images.githubusercontent.com/4645409/101382809-3c592d00-386d-11eb-91b1-00154ba6ed2c.png)

After (desktop, mobile):

![image](https://user-images.githubusercontent.com/4645409/101382911-57c43800-386d-11eb-921e-94f47f4347e9.png)
![image](https://user-images.githubusercontent.com/4645409/101382883-50049380-386d-11eb-906f-29a0b33da5cb.png)

The mobile screen is still horizontally scrollable so we can rearrange puzzle list entries and edit them:

![image](https://user-images.githubusercontent.com/4645409/101383073-89d59a00-386d-11eb-9baa-7895224f65f4.png)

