### PR TITLE
Fixed SGF rank issue

### DIFF
--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -164,7 +164,11 @@ export function rankString(r, with_tenths?:boolean) {
 
         let ranking = "ranking" in r ? r.ranking : r.rank;
         if (r.pro || r.professional) {
-            return interpolate(pgettext("Pro", "%sp"), [((ranking - 36))]);
+            if (ranking > 900) {
+                return interpolate(pgettext("Pro", "%sp"), [(((ranking - 1000) - 36))]);
+            } else {
+                return interpolate(pgettext("Pro", "%sp"), [((ranking - 36))]);
+            }
         }
         if ('ratings' in r) {
             r = overall_rank(r);


### PR DESCRIPTION
Fixes #1307

Before:
![image](https://user-images.githubusercontent.com/4645409/101444222-eb305400-38d3-11eb-927f-64e91d41677e.png)

After:
![image](https://user-images.githubusercontent.com/4645409/101444316-161aa800-38d4-11eb-8b13-024e0bcb026b.png)

The server is returning player ranks >900 in the game data which wasn't properly handled in the `rankString()` util:
```
{
   "related":{
      "reviews":"/api/v1/games/9677/reviews"
   },
   "players":{
      "black":{
         "username":"Sun Zhe",
         "ranking":43,
         "professional":true
      },
      "white":{
         "username":"Fujisawa Rina",
         "ranking":40,
         "professional":true
      }
   },
   ...,
   "gamedata":{
      "players":{
         "black":{
            "username":"Sun Zhe",
            "rank":1043,
            "pro":true
         },
         "white":{
            "username":"Fujisawa Rina",
            "rank":1040,
            "pro":true
         }
      },
      ...,
   }
}
```


