### PR TITLE
Fixed supporters card text overlapping on support page in safari

### DIFF
--- a/src/views/Supporter/Supporter.styl
+++ b/src/views/Supporter/Supporter.styl
@@ -293,7 +293,7 @@ supporter-page-width=60rem;
             }
 
             .title {
-                flex: 0;
+                flex: 0 0 auto;
                 font-weight: bold;
                 font-size: font-size-mid;
                 display: flex;
@@ -306,6 +306,8 @@ supporter-page-width=60rem;
                 display: flex;
                 justify-content: space-between;
                 flex-direction: column;
+
+
 
                 .learn-more {
                     margin-top: 1rem;

--- a/src/views/Supporter/Supporter.styl
+++ b/src/views/Supporter/Supporter.styl
@@ -307,8 +307,6 @@ supporter-page-width=60rem;
                 justify-content: space-between;
                 flex-direction: column;
 
-
-
                 .learn-more {
                     margin-top: 1rem;
                     text-align: right;


### PR DESCRIPTION
Fixed on the Support page, the supporter card text overlapping in safari browser. Change flex: 0 to flex: 0 0 auto to make it the same as Chrome

Screenshot for overlapping text (Safari)
![Screenshot 2020-12-08 at 16 48 42](https://user-images.githubusercontent.com/46029164/101515104-e6bc7780-3975-11eb-9bdb-f0aacc81d16c.png)

