### PR TITLE
Fixed puzzle jumping on resize issue.

### DIFF
--- a/src/views/Puzzle/Puzzle.styl
+++ b/src/views/Puzzle/Puzzle.styl
@@ -67,6 +67,7 @@ puzzle-controls-width=400px
         overflow-y: visible;
         overflow-x: visible;
         align-self: center;
+        min-height: 100vh;
     }
 
     .btn-container {


### PR DESCRIPTION
I noticed that when the `.right-col` page elements dynamically change as you click on moves in a puzzle, sometimes the screen would jump. See screen capture: https://streamable.com/ke1oaa

To fix this I set a minimum height on `.right-col`, which means that even if you're scrolled down to look at the puzzle text box and click a move, the page height shouldn't shrink enough to cause the screen to jump up. If the puzzle text box is larger than this minimum height, it is possible to scroll down far enough that after clicking a move the page height would shrink, _however_, this isn't really a concern as the goban would most likely be out of frame (since min height is based on page height with `vh`) so you shouldn't be able to click on anything that would cause the `.right-col` elements to rerender.

One side effect of this is that there's some empty space at the bottom of the screen if the puzzle info text box is empty, but I don't think this causes any usability issues:

![image](https://user-images.githubusercontent.com/4645409/101564256-a9f57e00-397f-11eb-8bdd-d15a4f7741fc.png)

