### PR TITLE
Improved SGF collection page (LibraryPlayer) on mobile

### DIFF
--- a/src/views/LibraryPlayer/LibraryPlayer.styl
+++ b/src/views/LibraryPlayer/LibraryPlayer.styl
@@ -41,6 +41,10 @@
     .games {
     }
 
+    .Card {
+        overflow-x: auto;
+    }
+
     .collections, .games {
         display: table;
     }


### PR DESCRIPTION
The SGF details were overflowing their container. Made the container horizontally scrollable instead.

### Before
![image](https://user-images.githubusercontent.com/4645409/101655513-8d485d00-39f6-11eb-80ff-bd2f80d55689.png)
![image](https://user-images.githubusercontent.com/4645409/101655552-9802f200-39f6-11eb-940f-cc650f3a4322.png)
![image](https://user-images.githubusercontent.com/4645409/101655574-9df8d300-39f6-11eb-8e52-ce5aabe52f8c.png)

### After
![image](https://user-images.githubusercontent.com/4645409/101655620-ab15c200-39f6-11eb-99b5-53196ccba4c1.png)
![image](https://user-images.githubusercontent.com/4645409/101655652-b23cd000-39f6-11eb-8467-89a763d33d85.png)
![image](https://user-images.githubusercontent.com/4645409/101655688-b8cb4780-39f6-11eb-8183-598fa7b890ee.png)
