### PR TITLE
Added variation stone transparency to game settings

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -35,6 +35,7 @@ let defaults = {
     "dock-delay": 0, // seconds.
     "double-click-submit-correspondence": false,
     "double-click-submit-live": false,
+    "variation-stone-transparency": 0.6,
     "dynamic-title": true,
     "function-keys-enabled": false,
     "game-list-threshold": 10,

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -580,6 +580,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     this.goban.one_click_submit = preferences.get("one-click-submit-correspondence");
                     this.goban.double_click_submit = preferences.get("double-click-submit-correspondence");
                 }
+                this.goban.variation_stone_transparency = preferences.get("variation-stone-transparency");
             } catch (e) {
                 console.error(e.stack);
             }

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -613,6 +613,7 @@ function GamePreferences(props:SettingGroupProps):JSX.Element {
     const [dynamic_title, _setDynamicTitle]:[boolean, (x: boolean) => void] = React.useState(preferences.get('dynamic-title'));
     const [function_keys_enabled, _setFunctionKeysEnabled]:[boolean, (x: boolean) => void] = React.useState(preferences.get('function-keys-enabled'));
     const [autoplay_delay, _setAutoplayDelay]:[number, (x: number) => void] = React.useState(preferences.get('autoplay-delay') / 1000);
+    const [variation_stone_transparency, _setVariationStoneTransparency]:[number, (x: number) => void] = React.useState(preferences.get("variation-stone-transparency"));
 
     function setDockDelay(ev) {
         let new_delay = parseFloat(ev.target.value);
@@ -677,6 +678,14 @@ function GamePreferences(props:SettingGroupProps):JSX.Element {
     }
     function setCorrSubmitMode(value) {
         setSubmitMode("correspondence", value);
+    }
+    function setVariationStoneTransparency(ev) {
+        let value = parseFloat(ev.target.value);
+
+        if (value >= 0.0 && value <= 1.0) {
+            _setVariationStoneTransparency(value);
+            preferences.set("variation-stone-transparency", value);
+        }
     }
     function setBoardLabeling(value) {
         preferences.set('board-labeling', value);
@@ -777,6 +786,12 @@ function GamePreferences(props:SettingGroupProps):JSX.Element {
                 description={_("This will enable or disable the hoverable and clickable variations displayed in a game or review chat.")}
                 >
                 <Toggle checked={!variations_in_chat} onChange={toggleVariationsInChat}/>
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Variation stone transparency")}
+                description={_("Choose the level of transparency for stones shown in variations. 0.0 is transparent and 1.0 is opaque.")}
+                >
+                <input type="number" step="0.1" min="0.0" max="1.0" onChange={setVariationStoneTransparency} value={variation_stone_transparency} />
             </PreferenceLine>
         </div>
     );


### PR DESCRIPTION
I've found it difficult when looking at an AI review to tell the current board state apart from the projected moves in a variation.

This change adds a setting to control the transparency level of stones in a variation (default is 0.6, my personal preference is 0.2). For the sake of not changing existing behavior I've kept the default the same, but if others agree that a lower value is better I am happy to change the default.

This diff requires this goban PR to merge first (shippable test will fail until goban PR is merged and version bumped): https://github.com/online-go/goban/pull/19

Below are some screenshots with different variation stone transparency settings values:

0.0:
![image](https://user-images.githubusercontent.com/4645409/101943488-059e5200-3ba0-11eb-9321-c39a01166aef.png)

0.2 (my personal preference):
![image](https://user-images.githubusercontent.com/4645409/101943515-1353d780-3ba0-11eb-9842-ee56bb8234aa.png)

0.3 (maybe would be a good happy medium for a new default?):
![image](https://user-images.githubusercontent.com/4645409/101943668-5dd55400-3ba0-11eb-8deb-25e8d138404b.png)

0.6 (default):
![image](https://user-images.githubusercontent.com/4645409/101943557-28c90180-3ba0-11eb-9b98-04f5582d1dcf.png)

1.0:
![image](https://user-images.githubusercontent.com/4645409/101943645-5150fb80-3ba0-11eb-8b27-ba4f281cc3d8.png)
