### PR TITLE
Use a new tab for advance to next board if this game is live.

### DIFF
--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -239,6 +239,7 @@ class NotificationManager {
         this.auth = data.get("config.notification_auth");
         this.connect();
     }
+
     advanceToNextBoard(ev?) {
         let game_id = getCurrentGameId() || 0;
         let board_ids = [];
@@ -275,7 +276,9 @@ class NotificationManager {
         }
 
         idx = (idx + 1 + this.turn_offset) % board_ids.length;
-        if (ev && shouldOpenNewTab(ev)) {
+        if (ev && shouldOpenNewTab(ev) ||
+            // If we're on a live game, and there are other games, then open the next one in a new tab, so we don't disconnect from this one...
+            (window["global_goban"] && isLiveGame(window["global_goban"].engine.time_control) && board_ids.length > 1)) {
             ++this.turn_offset;
             window.open("/game/" + board_ids[idx], "_blank");
         } else {
@@ -285,6 +288,7 @@ class NotificationManager {
             }
         }
     }
+
     deleteNotification(notification, dont_rebuild?: boolean) {
         comm_socket.send("notification/delete", {"player_id": this.user.id, "auth": this.auth, "notification_id": notification.id});
         delete this.notifications[notification.id];


### PR DESCRIPTION
Fixes the problem that people click on the TurnIndicator in live games and thereby disconnect from their current game, which we don't want them to do.

## Proposed Changes

Create a new tab for the next game if it is different to the current one.

(Note that once people have a tab for each live game they are playing at the same time, they should not click on the turn indicator, they should just switch tabs.   If they click on the turn indicator they'll get another tab, but there is not much we can do about that other than let them learn not to do that)
