### PR TITLE
Increased spacing between Joseki move control buttons.

### DIFF
--- a/src/views/Joseki/Joseki.styl
+++ b/src/views/Joseki/Joseki.styl
@@ -143,7 +143,7 @@
 
                 i {
                     cursor: pointer;
-                    margin-right: 1em;
+                    margin-right: 2em;
                 }
 
                 .pass-button {


### PR DESCRIPTION
Fixes #1324 

Increased spacing from `1em` to `2em`. Original suggestion was to increase to `3em`, but I think `2em` looks good on both desktop and mobile and gives enough separation to avoid misclicks.

Before (desktop, mobile):
![image](https://user-images.githubusercontent.com/4645409/102522098-a7afb580-404a-11eb-9cd7-8edd4b4bd8a6.png)
![image](https://user-images.githubusercontent.com/4645409/102522081-9d8db700-404a-11eb-9143-8ab8a88931d1.png)

After (desktop, mobile):
![image](https://user-images.githubusercontent.com/4645409/102521951-6e774580-404a-11eb-991c-e13b97d969f3.png)
![image](https://user-images.githubusercontent.com/4645409/102521989-7a630780-404a-11eb-8332-ebdf82e112dc.png)