### PR TITLE
Don't create a new tab on notification click if the game is finished

### DIFF
--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -276,9 +276,11 @@ class NotificationManager {
         }
 
         idx = (idx + 1 + this.turn_offset) % board_ids.length;
+
+        const goban = window["global_goban"];
         if (ev && shouldOpenNewTab(ev) ||
             // If we're on a live game, and there are other games, then open the next one in a new tab, so we don't disconnect from this one...
-            (window["global_goban"] && isLiveGame(window["global_goban"].engine.time_control) && board_ids.length > 1)) {
+            (goban && goban.phase !== "finished" && isLiveGame(goban.engine.time_control) && board_ids.length > 1)) {
             ++this.turn_offset;
             window.open("/game/" + board_ids[idx], "_blank");
         } else {


### PR DESCRIPTION
Fixes [the problem of creating a new tab on notification click if the live game has finished](https://forums.online-go.com/t/clicking-on-black-dot-with-of-moves-waiting-opens-in-new-tab/32626/4?u=eugene) .

## Proposed Changes

Don't create a new tab on notification click if the live game on the current tab is finished.