### PR TITLE
Add option to show '?' on latest move if there is an undo request for it

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -36,6 +36,7 @@ let defaults = {
     "double-click-submit-correspondence": false,
     "double-click-submit-live": false,
     "variation-stone-transparency": 0.6,
+    "visual-undo-request-indicator": false,
     "dynamic-title": true,
     "function-keys-enabled": false,
     "game-list-threshold": 10,

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -581,6 +581,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
                     this.goban.double_click_submit = preferences.get("double-click-submit-correspondence");
                 }
                 this.goban.variation_stone_transparency = preferences.get("variation-stone-transparency");
+                this.goban.visual_undo_request_indicator = preferences.get("visual-undo-request-indicator");
             } catch (e) {
                 console.error(e.stack);
             }

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -614,6 +614,7 @@ function GamePreferences(props:SettingGroupProps):JSX.Element {
     const [function_keys_enabled, _setFunctionKeysEnabled]:[boolean, (x: boolean) => void] = React.useState(preferences.get('function-keys-enabled'));
     const [autoplay_delay, _setAutoplayDelay]:[number, (x: number) => void] = React.useState(preferences.get('autoplay-delay') / 1000);
     const [variation_stone_transparency, _setVariationStoneTransparency]:[number, (x: number) => void] = React.useState(preferences.get("variation-stone-transparency"));
+    const [visual_undo_request_indicator, _setVisualUndoRequestIndicator]:[boolean, (x: boolean) => void] = React.useState(preferences.get("visual-undo-request-indicator"));
 
     function setDockDelay(ev) {
         let new_delay = parseFloat(ev.target.value);
@@ -686,6 +687,10 @@ function GamePreferences(props:SettingGroupProps):JSX.Element {
             _setVariationStoneTransparency(value);
             preferences.set("variation-stone-transparency", value);
         }
+    }
+    function setVisualUndoRequestIndicator(checked) {
+        preferences.set("visual-undo-request-indicator", checked);
+        _setVisualUndoRequestIndicator(checked);
     }
     function setBoardLabeling(value) {
         preferences.set('board-labeling', value);
@@ -770,6 +775,12 @@ function GamePreferences(props:SettingGroupProps):JSX.Element {
                 description={_("This will disable the analysis mode and conditional moves for you in all games, even if it is not disabled in the game's settings. (If allowed in game settings, your opponent will still have access to analysis.)")}
                 >
                 <Toggle checked={always_disable_analysis} onChange={setAlwaysDisableAnalysis} />
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Visual undo request indicator")}
+                description={_("This will cause an undo request to be indicated by a mark on your opponent's last move.")}
+                >
+                <Toggle checked={visual_undo_request_indicator} onChange={setVisualUndoRequestIndicator} />
             </PreferenceLine>
 
             <PreferenceLine title={_("Dynamic title")}


### PR DESCRIPTION
Fixes [the problem some people have knowing that they got an undo request](https://forums.online-go.com/t/wish-better-noticeable-undo-requests/964/70?u=eugene)

## Proposed Changes

Add a player preference for showing a visual indicator of undo pending.

Show a '?' instead of the circle for the most recent move if there is an undo request for it and the preference is turned on.

This implementation requires the Goban support provided in https://github.com/online-go/goban/pull/23 .

This implementation does _not_ attempt to colour the '?' red, as requested by some, because that is a can of worms to get right visually (think themes, custom boards, highlights on stones etc).
