### PR TITLE
Preserve type for dup() and add some logging for Notifications error

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1224,7 +1224,42 @@ export function challenge_text_description(challenge) {
     return details_html;
 }
 
-export let blitz_config = {
+interface ChallengeConfig {
+    challenger_color: string;
+    game: {
+        name: string;
+        rules: string;
+        ranked: boolean;
+        handicap: number;
+        komi_auto: string;
+        disable_analysis: boolean;
+        initial_state: any;
+        private: boolean;
+        width?: number;
+        height?: number;
+    };
+    min_ranking?: number;
+    max_ranking?: number;
+}
+
+interface TimeControlConfig {
+    system: "fischer" | "byoyomi";
+    speed: "blitz" | "live" | "correspondence";
+    initial_time?: number;
+    main_time?: number;
+    time_increment?: number;
+    max_time?: number;
+    period_time?: number;
+    periods?: number;
+    pause_on_weekends: boolean;
+}
+interface GameConfig {
+    conf: { restrict_rank: boolean };
+    challenge: ChallengeConfig;
+    time_control: TimeControlConfig;
+}
+
+export let blitz_config: GameConfig = {
     conf: {
         restrict_rank: true,
     },
@@ -1250,7 +1285,7 @@ export let blitz_config = {
         pause_on_weekends: false,
     }
 };
-export let live_config = {
+export let live_config: GameConfig = {
     conf: {
         restrict_rank: true,
     },
@@ -1276,7 +1311,7 @@ export let live_config = {
         pause_on_weekends: false,
     }
 };
-export let correspondence_config = {
+export let correspondence_config: GameConfig = {
     conf: {
         restrict_rank: true,
     },

--- a/src/components/GameAcceptModal/GameAcceptModal.tsx
+++ b/src/components/GameAcceptModal/GameAcceptModal.tsx
@@ -16,8 +16,8 @@
  */
 
 import * as React from "react";
-import {_, pgettext, interpolate} from "translate";
-import {post, get} from "requests";
+import {_} from "translate";
+import {post} from "requests";
 import {openModal, Modal} from "Modal";
 import {timeControlDescription, usedForCheating} from "TimeControl";
 import {Player} from "Player";

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -662,6 +662,9 @@ class NotificationEntry extends React.Component<{notification}, any> {
             case "timecop":
             case "gameEnteredStoneRemoval":
             case "gameResumedFromStoneRemoval":
+                if (notification.game_id === undefined) {
+                    console.error("Notification Error: game_id not found", notification);
+                }
                 return `/game/${notification.game_id}`;
 
             case "friendAccepted":

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -66,7 +66,9 @@ export function rulesText(rules) {
     }
     return "[unknown]";
 }
-export function dup(obj: any): any {
+
+// Create a deep copy of obj
+export function dup<T>(obj: T): T {
 
     let ret;
     if (typeof(obj) === "object") {
@@ -90,6 +92,7 @@ export function dup(obj: any): any {
     }
     return ret;
 }
+
 export function deepEqual(a: any, b: any) {
     if (typeof(a) !== typeof(b)) { return false; }
 

--- a/src/views/Puzzle/PuzzleEditing.ts
+++ b/src/views/Puzzle/PuzzleEditing.ts
@@ -253,7 +253,7 @@ export class PuzzleEditor {
     }
 
 
-    getBounds(puzzle, width, height) {
+    getBounds(puzzle: PuzzleConfig, width: number, height: number) {
         let ret = {
             top: 9999,
             bottom: 0,

--- a/src/views/Puzzle/PuzzleEditing.ts
+++ b/src/views/Puzzle/PuzzleEditing.ts
@@ -16,17 +16,16 @@
  */
 
 import {
-    Goban,
     GobanCanvasConfig,
     GoMath,
     PuzzleConfig,
     PuzzlePlacementSetting,
 } from "goban";
-import {errorAlerter, dup, ignore} from "misc";
-import {TransformSettings, PuzzleTransform} from './PuzzleTransform';
+import {errorAlerter, dup} from "misc";
+import {PuzzleTransform} from './PuzzleTransform';
 import {Puzzle} from './Puzzle';
 import * as data from "data";
-import {abort_requests_in_flight, post, get, put, del} from "requests";
+import {abort_requests_in_flight, post, get} from "requests";
 import * as preferences from "preferences";
 
 
@@ -225,27 +224,28 @@ export class PuzzleEditor {
         let opts:GobanCanvasConfig = Object.assign({
             "board_div": goban_div,
             "interactive": true,
-            "mode": "puzzle",
+            "mode": "puzzle" as "puzzle",
             "draw_top_labels": (label_position === "all" || label_position.indexOf("top") >= 0),
             "draw_left_labels": (label_position === "all" || label_position.indexOf("left") >= 0),
             "draw_right_labels": (label_position === "all" || label_position.indexOf("right") >= 0),
             "draw_bottom_labels": (label_position === "all" || label_position.indexOf("bottom") >= 0),
-            "getPuzzlePlacementSetting": () => ({ "mode": "play" }),
+            "getPuzzlePlacementSetting": () => ({ "mode": "play" as "play"}),
             "bounds": bounds,
             "player_id": 0,
             "server_socket": null,
             "square_size": 4
         }, puzzle);
 
-        let newState = null;
-
         if (editing) {
             opts.getPuzzlePlacementSetting = replacementSettingsFunction;
             opts.puzzle_opponent_move_mode = "automatic";
             opts.puzzle_player_move_mode = "free";
-            opts.puzzle_rank = puzzle && puzzle.puzzle_rank ? puzzle.puzzle_rank : 0;
-            opts.puzzle_collection = (puzzle && puzzle.collection ? puzzle.collection.id : 0);
-            opts.puzzle_type = (puzzle && puzzle.type ? puzzle.type : "");
+            if (puzzle) {
+                opts.puzzle_rank = puzzle.puzzle_rank || 0;
+                opts.puzzle_collection = puzzle.puzzle_collection || 0;
+                opts.puzzle_type = puzzle.puzzle_type || "";
+            }
+
             opts.move_tree_container = document.getElementById("move-tree-container");
         }
 


### PR DESCRIPTION
## Proposed Changes

  - Signature of dup() changed from `dup(obj: any): any` to `dup<T>(obj: T): T`
  - Fix type errors that arose from above change
  - Log an error when `game_id` is missing from a notification

The third item may seem separate from the first two, but I came across `dup()` while debugging the stone removal notification error (hence the branch name).  Happy to break this PR up if necessary.