### PR TITLE
Align clocks above each other in horizontal zen mode

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -514,6 +514,13 @@ goban-view-bar-width=400px
 			justify-content: center;
 			width: auto;
 			flex-grow: 0;
+            .players {
+                flex-direction: column;
+                .player-container {
+                    width: 100%;
+                }
+            }
+            min-width 170px;
 		}
 		.center-col {
 			.goban-container {


### PR DESCRIPTION
Rebase of #1213.

In horizontal zen mode we have enough vertical space to place the clocks above each other.

This allows the user to reduce the windows width even further while keeping the goban at maximum size.