### PR TITLE
Make game links and user profiles clickable in mod notes

### DIFF
--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -25,6 +25,7 @@ import {UIPush} from "UIPush";
 import {SearchInput} from "misc-ui";
 import {Player} from "Player";
 import * as moment from "moment";
+import { chat_markup } from "Chat";
 
 declare var swal;
 
@@ -145,8 +146,8 @@ export class Moderator extends React.PureComponent<ModeratorProperties, any> {
                          render: (X) => (
                             <div>
                                 <div>
-                                    <i>{_("Note")}: </i>{X.note}
-                                </div>
+                                    <i>{_("Note")}: </i>{chat_markup(X.note)}
+                                    </div>
                                 <div>
                                     <i>{_("Action")}: </i>{X.action}
                                 </div>

--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -147,7 +147,7 @@ export class Moderator extends React.PureComponent<ModeratorProperties, any> {
                             <div>
                                 <div>
                                     <i>{_("Note")}: </i>{chat_markup(X.note)}
-                                    </div>
+                                </div>
                                 <div>
                                     <i>{_("Action")}: </i>{X.action}
                                 </div>

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -46,6 +46,7 @@ import {RatingsChart} from 'RatingsChart';
 import {UIPush} from "UIPush";
 import {associations} from 'associations';
 import {browserHistory} from "ogsHistory";
+import {chat_markup} from "Chat";
 
 declare let swal;
 
@@ -865,7 +866,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                                                 <i> {X.incident_report.moderator_note}</i>
                                             </div>
                                         }
-                                        <pre>{X.note}</pre>
+                                        <pre>{chat_markup(X.note)}</pre>
                                     </div>
                                 },
                             ]}


### PR DESCRIPTION


## Proposed Changes

  - Leverage existing chat markup to automatically convert mod note links in mod center and on user profiles


