### PR TITLE
Show rank instead of rating in rating-grid

### DIFF
--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -60,6 +60,10 @@ export function rating_to_rank(rating:number) {
     return Math.log(Math.min(MAX_RATING, Math.max(MIN_RATING, rating)) / A) * C;
 }
 
+export function rank_deviation(rating:number, deviation:number) {
+    return rating_to_rank(rating + deviation) - rating_to_rank(rating);
+}
+
 export function get_handicap_adjustment(rating:number, handicap:number):number {
     return rank_to_rating(rating_to_rank(rating) + handicap) - rating;
 }

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -30,7 +30,7 @@ import {GameList} from "GameList";
 import {Player} from "Player";
 import * as preferences from "preferences";
 import {updateDup, getGameResultText, ignore} from "misc";
-import {longRankString, rankString, getUserRating, humble_rating, effective_outcome} from "rank_utils";
+import {longRankString, rankString, getUserRating, humble_rating, effective_outcome, rating_to_rank, boundedRankString, rank_deviation} from "rank_utils";
 import {durationString, daysOnlyDurationString} from "TimeControl";
 import {openModerateUserModal} from "ModerateUser";
 import {PaginatedTable} from "PaginatedTable";
@@ -1208,7 +1208,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                  onClick={() => this.setState({'selected_size': size, 'selected_speed': speed})}
                 >
                 <div className='rating'>
-                    <span className='left'>{humble_rating(r.rating, r.deviation).toFixed(0)}</span>&plusmn;<span className='right'>{r.deviation.toFixed(0)}</span>
+                    <span className='left'>{boundedRankString(rating_to_rank(humble_rating(r.rating, r.deviation)), true)}</span>&plusmn;<span className='right'>{rank_deviation(r.rating, r.deviation).toFixed(1)}</span>
                 </div>
             </div>
         );


### PR DESCRIPTION
With the breakdown ratings now being comparable with the overall rating — they are the would be rating if the player had only played the games with the speed+boardsize — we can show the ranks in the breakdown chart instead of the ratings. Most users do not know how to read the ratings, and we are using rank everywhere else on the site already.

## Proposed Changes

![image](https://user-images.githubusercontent.com/4864182/106187767-572d8b00-61a6-11eb-9658-9795963920db.png)
