### PR TITLE
Increase length limit for notes in mod center

### DIFF
--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -146,7 +146,7 @@ export class Moderator extends React.PureComponent<ModeratorProperties, any> {
                          render: (X) => (
                             <div>
                                 <div>
-                                    <i>{_("Note")}: </i>{chat_markup(X.note)}
+                                    <i>{_("Note")}: </i>{chat_markup(X.note, undefined, 1024 * 128)}
                                 </div>
                                 <div>
                                     <i>{_("Action")}: </i>{X.action}


### PR DESCRIPTION
Some notes in the mod center are showing as `<Message too long>`.  I increased the limit of those to match what we're using for notes on user profiles. 