### PR TITLE
Bugfix in choosing whether to open new game tab or not

### DIFF
--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -294,6 +294,9 @@ class NotificationManager {
     lookingAtOurLiveGame = (): boolean => {
         // Is the current page looking at a game we are live playing in...
         const goban = window["global_goban"] as Goban;
+        if (!goban) {
+            return false;
+        }
         const player_id = goban.config.player_id;
         return (goban && goban.engine.phase !== "finished" && isLiveGame(goban.engine.time_control) && (player_id === goban.config.black_player_id || player_id === goban.config.white_player_id));
     }

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -280,7 +280,7 @@ class NotificationManager {
         const goban = window["global_goban"];
         if (ev && shouldOpenNewTab(ev) ||
             // If we're on a live game, and there are other games, then open the next one in a new tab, so we don't disconnect from this one...
-            (goban && goban.phase !== "finished" && isLiveGame(goban.engine.time_control) && board_ids.length > 1)) {
+            (goban && goban.engine.phase !== "finished" && isLiveGame(goban.engine.time_control) && board_ids.length > 1)) {
             ++this.turn_offset;
             window.open("/game/" + board_ids[idx], "_blank");
         } else {

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -278,8 +278,8 @@ class NotificationManager {
 
         idx = (idx + 1 + this.turn_offset) % board_ids.length;
 
-        // open a new tab if the user asked for it, or if we must protect against disconnection
-        // (there's no point in opoening a new tab if they only have one game, because it will be this same game)
+        // open a new tab if the user asked for it, or if we must protect against disconnection from a live game
+        // (there's no point in opening a new tab if they only have one game, because it will be this same game)
         if (ev && shouldOpenNewTab(ev) || (this.lookingAtOurLiveGame() && board_ids.length > 1)) {
             ++this.turn_offset;
             window.open("/game/" + board_ids[idx], "_blank");
@@ -292,7 +292,7 @@ class NotificationManager {
     }
 
     lookingAtOurLiveGame = (): boolean => {
-        // If we're playing a live game, then open the next one in a new tab, so we don't disconnect from this one...
+        // Is the current page looking at a game we are live playing in...
         const goban = window["global_goban"] as Goban;
         const player_id = goban.config.player_id;
         return (goban && goban.engine.phase !== "finished" && isLiveGame(goban.engine.time_control) && (player_id === goban.config.black_player_id || player_id === goban.config.white_player_id));


### PR DESCRIPTION
Fixes [the problem of opening a new tab if on a game that is finished](https://forums.online-go.com/t/clicking-on-black-dot-with-of-moves-waiting-opens-in-new-tab/32626/15?u=eugene) which should not happen

## Proposed Changes
 
Look in the right place for window's game status.