### PR TITLE
Show number of byo-yomi periods in zen mode

### DIFF
--- a/src/components/Clock/Clock.styl
+++ b/src/components/Clock/Clock.styl
@@ -126,17 +126,7 @@
 
 
 .MainGobanView {
-    .period-moves {
-        font-size: 10pt;
-    }
-    .period-time {
-        font-size: 10pt;
-    }
-    .byo-yomi-periods {
-        font-size: 10pt;
-    }
-
-    .periods, .period-time, .byo-yomi-periods {
+    .byo-yomi-container, .canadian-container {
         font-size: font-size-mid;
     }
 }

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -340,110 +340,110 @@
 }
 
 body.dark .MainGobanView.zen .players {
-	.white {
-		&.player-container {
-			background: linear-gradient(#2C2C2C 0%, #383838 100%);
-			border: 1px solid #181818;
-			color: #DDD;
-		}
-	}
-	#game-white-clock,
-	.white .score-container {
-		color: #DDD;
-	}
+    .white {
+        &.player-container {
+            background: linear-gradient(#2C2C2C 0%, #383838 100%);
+            border: 1px solid #181818;
+            color: #DDD;
+        }
+    }
+    #game-white-clock,
+    .white .score-container {
+        color: #DDD;
+    }
 
-	.black {
-		&.player-container {
-			background: linear-gradient(#111111 0%, #1A1A1A 100%);
-			// background: none;
-			background-color: #111111;
-			border: 1px solid #181818;
-			color: #BBB;
-		}
-	}
-	#game-black-clock,
-	.black .score-container {
-		color: #BBB;
-	}
+    .black {
+        &.player-container {
+            background: linear-gradient(#111111 0%, #1A1A1A 100%);
+            // background: none;
+            background-color: #111111;
+            border: 1px solid #181818;
+            color: #BBB;
+        }
+    }
+    #game-black-clock,
+    .black .score-container {
+        color: #BBB;
+    }
 }
 body.light .MainGobanView.zen .players {
-	.white.player-container {
-	}
-	.black.player-container {
-		background: linear-gradient(#666 0%, #181818 100%);
-	}
+    .white.player-container {
+    }
+    .black.player-container {
+        background: linear-gradient(#666 0%, #181818 100%);
+    }
 }
 .MainGobanView.zen .play-controls{
-	.game-state {
-		display: none;
-	}
+    .game-state {
+        display: none;
+    }
 }
 .MainGobanView.zen .players {
-	.black.player-container {
-		border-top: none;
-	}
-	.player-container {
-		justify-content: center;
-		min-width: 150px;
-	}
-	.player-icon-clock-row {
-		width: auto;
-		flex-grow: 1;
-	}
-	.Clock {
-		min-height: 80px;
-		.pause-text {
-			display: none;
+    .black.player-container {
+        border-top: none;
+    }
+    .player-container {
+        justify-content: center;
+        min-width: 150px;
+    }
+    .player-icon-clock-row {
+        width: auto;
+        flex-grow: 1;
+    }
+    .Clock {
+        min-height: 80px;
+        .pause-text {
+            display: none;
         }
-		.main-time {
-			line-height: 50px;
-			font-size: 26pt;
-			text-align: center;
-		}
-		.byo-yomi-container,
-		.canadian-clock-container {
-			display: block;
+        .main-time {
+            line-height: 50px;
+            font-size: 26pt;
+            text-align: center;
+        }
+        .byo-yomi-container,
+        .canadian-clock-container {
+            display: block;
             font-size: font-size-mid
-			flex-grow: 1;
-		}
-	}
+            flex-grow: 1;
+        }
+    }
     .Clock:not(.in-overtime) {
-		.byo-yomi-container,
-		.canadian-clock-container {
-			display: none;
-		}
-	}
-	.captures {
-		display: flex;
-		justify-content: center;
-		flex-basis: 70%;
-	}
-	.score-container {
-		margin: 0px;
-		justify-content: center;
-		flex-grow: 0;
-	}
-	.num-captures-container {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		flex-direction: row;
-		flex-grow: 1;
-		.stone-image {
-			width: 14px;
-			height: 14px;
-		}
-		.num-captures-stone {
-			margin-left: 3px;
-			margin-right: 3px;
-		}
-	}
-	.player-icon-container,
-	.player-name-container,
-	.player-name-plain,
-	.score-details,
-	.komi {
-		display: none;
-	}
+        .byo-yomi-container,
+        .canadian-clock-container {
+            display: none;
+        }
+    }
+    .captures {
+        display: flex;
+        justify-content: center;
+        flex-basis: 70%;
+    }
+    .score-container {
+        margin: 0px;
+        justify-content: center;
+        flex-grow: 0;
+    }
+    .num-captures-container {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: row;
+        flex-grow: 1;
+        .stone-image {
+            width: 14px;
+            height: 14px;
+        }
+        .num-captures-stone {
+            margin-left: 3px;
+            margin-right: 3px;
+        }
+    }
+    .player-icon-container,
+    .player-name-container,
+    .player-name-plain,
+    .score-details,
+    .komi {
+        display: none;
+    }
 }
 

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -393,7 +393,8 @@ body.light .MainGobanView.zen .players {
         .pause-text {
             display: none;
         }
-        .main-time {
+        .main-time,
+        .period-time {
             line-height: 50px;
             font-size: 26pt;
             text-align: center;

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -367,8 +367,6 @@ body.dark .MainGobanView.zen .players {
     }
 }
 body.light .MainGobanView.zen .players {
-    .white.player-container {
-    }
     .black.player-container {
         background: linear-gradient(#666 0%, #181818 100%);
     }

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -331,7 +331,9 @@
         .main-time {
             font-size: font-size-small;
         }
-        .period-moves, .period-time {
+        .byo-yomi-container,
+        .canadian-container
+        {
             font-size: font-size-extra-small;
         }
     }
@@ -390,15 +392,10 @@ body.light .MainGobanView.zen .players {
 	}
 	.Clock {
 		min-height: 80px;
-		.byo-yomi-periods,
-		.canadian-periods,
-		.periods-delimiter,
-		.period-moves,
 		.pause-text {
 			display: none;
-		}
-		.main-time,
-		.period-time {
+        }
+		.main-time {
 			line-height: 50px;
 			font-size: 26pt;
 			text-align: center;
@@ -406,10 +403,11 @@ body.light .MainGobanView.zen .players {
 		.byo-yomi-container,
 		.canadian-clock-container {
 			display: block;
+            font-size: font-size-mid
 			flex-grow: 1;
 		}
 	}
-	.Clock:not(.in-overtime) {
+    .Clock:not(.in-overtime) {
 		.byo-yomi-container,
 		.canadian-clock-container {
 			display: none;


### PR DESCRIPTION
Fixes #1373

## Proposed Changes

  - Show number of byo-yomi periods left once byo-yomi has started
  - Some code style fixes: mixed tabs/spaces
  - Some css simplification: elements inside byo-yomi-container were handled separately, even though they share the same style in all cases.

Note: Byo yomi periods do not show up until main time is used up.  If desired, it would be easy to add byo-yomi during main time, but I tried to maintain the minimalist philosophy of zen-mode.

<img width="305" alt="image" src="https://user-images.githubusercontent.com/25233703/107112396-525f7b80-6825-11eb-9ec1-b3b8824da121.png">

<img width="331" alt="image" src="https://user-images.githubusercontent.com/25233703/107112509-1c6ec700-6826-11eb-8bb6-3ba30ba41846.png">
