### PR TITLE
Adding sorting case for board size

### DIFF
--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -144,6 +144,21 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                         }
                     });
                     break;
+
+                case '-size' :
+                case 'size' :
+                    lst.sort((a, b) => {
+                        try {
+                            let a_size = a.goban ? a.goban.width * a.goban.height : 0;
+                            let b_size = b.goban ? b.goban.width * b.goban.height : 0;
+
+                            return a_size - b_size || a.id - b.id;
+                        } catch (e) {
+                            console.error(a, b, e);
+                            return 0;
+                        }
+                    });
+                    break;
             }
 
             if (this.state.sort_order[0] === '-') {

--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -149,8 +149,10 @@ export class GameList extends React.PureComponent<GameListProps, any> {
                 case 'size' :
                     lst.sort((a, b) => {
                         try {
-                            let a_size = a.goban ? a.goban.width * a.goban.height : 0;
-                            let b_size = b.goban ? b.goban.width * b.goban.height : 0;
+                            // sort by number of intersection
+                            // for non-square boards with the same number of intersections, the wider board is concidered larger
+                            let a_size = a.width * a.height * 100 + a.width;
+                            let b_size = b.width * b.height * 100 + b.width;
 
                             return a_size - b_size || a.id - b.id;
                         } catch (e) {


### PR DESCRIPTION
Fixes #1388 

## Proposed Changes

  - Adding a sorting case for board size to fix bug #1388

It seems to be working as expected, when I check with some dummy games on http://dev.beta.online-go.com:8080/.

I would be happy to receive comments, since I'm not familiar with the code base.