### PR TITLE
Darker gold in light mode

### DIFF
--- a/src/components/NavBar/NavBar.styl
+++ b/src/components/NavBar/NavBar.styl
@@ -257,10 +257,9 @@ navbar-width= 17rem;
             themed color reject;
         }
 
-        .fa-star {
-            themed color supporter
+        :not(:hover) .fa-star {
+            color: supporter-gold;
         }
-
 
         ul.nav-items {
             box-shadow: 2px 0px 2px 0px rgba(0, 0, 0, 0.16);

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -67,7 +67,7 @@ z = {
     superchat          : 50010,
 }
 
-
+supporter-gold = #dfba00
 
 light = {}
 dark = {}
@@ -116,9 +116,8 @@ light.chart-line                        = #184A6B
 light.error-boundary-bg                 = lighten(light.reject, 50%)
 light.error-boundary-fg                 = darken(light.reject, 50%)
 
-//light.supporter                         = #fdd017;
 light.user                              = #3070A7
-light.supporter                         = #DBAF00;
+light.supporter                         = supporter-gold;
 light.aga-official                      = #B95200;
 light.professional                      = green;
 light.bot                               = #888;
@@ -203,7 +202,7 @@ light.miniboard-stone-removal-hover-border= darken(light.miniboard-stone-removal
 light.player-black-background           = linear-gradient(to bottom, #7d7e7d 0%, #0e0e0e 100%);
 light.player-white-background           = linear-gradient(to bottom, #cccccc 0%, #eeeeee 30%, #ffffff 100%);
 light.inactive-support-gradient         = linear-gradient(to bottom, #ffffff 0%, #e5e5e5 100%);
-light.active-support-gradient           = linear-gradient(to bottom, #ffffff 0%, lighten(light.supporter, 70%) 100%);
+light.active-support-gradient           = linear-gradient(to bottom, #ffffff 0%, lighten(supporter-gold, 70%) 100%);
 light.player-black-fg                   = #eeeeee
 light.player-white-fg                   = light.fg
 light.player-black-name                 = lighten(light.user, 60%)
@@ -251,7 +250,7 @@ dark.error-boundary-bg                  = darken(light.reject, 50%)
 dark.error-boundary-fg                  = lighten(light.reject, 50%)
 
 dark.user                               = #9dc6ff
-dark.supporter                          = light.supporter; // because it ends up against a light background in player-container
+dark.supporter                          = supporter-gold;
 dark.aga-official                       = light.aga-official;
 dark.professional                       = green;
 dark.bot                                = light.bot
@@ -330,7 +329,7 @@ dark.miniboard-stone-removal-hover-border= darken(dark.miniboard-stone-removal-h
 dark.player-black-background            = linear-gradient(to bottom, #7d7d7d 0%, #333333 50%, #0c0c0c 100%);
 dark.player-white-background            = linear-gradient(to bottom, #888888 0%, #efefef 50%, #efefef 100%);
 dark.inactive-support-gradient          = linear-gradient(to bottom, #7d7d7d 0%, #333333 100%);
-dark.active-support-gradient            = linear-gradient(to bottom, darken(dark.supporter, 30%) 0%, darken(dark.supporter, 60%) 100%);
+dark.active-support-gradient            = linear-gradient(to bottom, darken(supporter-gold, 30%) 0%, darken(supporter-gold, 60%) 100%);
 dark.player-black-fg                    = dark.fg
 dark.player-white-fg                    = darken(dark.fg, 90%)
 dark.player-black-name                  = dark.user

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -117,7 +117,7 @@ light.error-boundary-bg                 = lighten(light.reject, 50%)
 light.error-boundary-fg                 = darken(light.reject, 50%)
 
 light.user                              = #3070A7
-light.supporter                         = supporter-gold;
+light.supporter                         = #A48200;  // Approximately darker(supporter-gold, 30%)
 light.aga-official                      = #B95200;
 light.professional                      = green;
 light.bot                               = #888;

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -120,6 +120,10 @@
         .paused-correspondence {
             themed color player-white-paused-clock
         }
+
+        .white.player-name-container .supporter {
+            color: light.supporter!important;
+        }
     }
 
     .black.player-container {
@@ -134,6 +138,10 @@
 
         .player-name {
             color: #00B8FF;
+        }
+
+        .black.player-name-container .supporter {
+            color: dark.supporter!important;
         }
     }
 

--- a/src/views/Supporter/Supporter.styl
+++ b/src/views/Supporter/Supporter.styl
@@ -33,7 +33,7 @@ supporter-page-width=60rem;
     }
 
     .fa-star {
-        themed color supporter
+        color: supporter-gold;
     }
 
     #supporter-payment-block-container {
@@ -289,7 +289,7 @@ supporter-page-width=60rem;
 
             &.active {
                 themed background active-support-gradient
-                themed border-color supporter
+                border-color: supporter-gold;
             }
 
             .title {

--- a/src/views/TournamentList/TournamentList.styl
+++ b/src/views/TournamentList/TournamentList.styl
@@ -68,7 +68,7 @@
         justify-content: center;
 
         .fa, .ogs-turtle {
-            themed color supporter
+            color: supporter-gold;
         }
 
     }
@@ -80,7 +80,7 @@
         text-align: center;
     }
     .site-tourny {
-        themed color supporter
+        color: supporter-gold;
     }
     .group-tourny {
         themed color shade3


### PR DESCRIPTION
Fixes #1404

## Proposed Changes

  - Use #A48200 for site-supporter player names on light backgrounds. (For a contrast ratio of about 3:1)
  - Use light theme color for the white Player info in a game

<img width="366" alt="Screen Shot 2021-02-21 at 5 40 45 PM" src="https://user-images.githubusercontent.com/25233703/108641201-fecb6f80-746b-11eb-860a-828adec86bc4.png">
<img width="475" alt="Screen Shot 2021-02-21 at 5 41 01 PM" src="https://user-images.githubusercontent.com/25233703/108641204-01c66000-746c-11eb-86ad-df5ae3715d55.png">
