### PR TITLE
Fix mod/supporter color issue in player boxes

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -404,7 +404,7 @@ accessible.chat-offline                       = accessible.bg;
 accessible.chat-offline-shadow                = -1px -1px 0 #ccc,  1px -1px 0 #ccc, -1px 1px 0 #ddd, 1px 1px 0 #ccc;
 
 accessible.user                               = #9dc6ff
-accessible.supporter                          = light.supporter; // because it ends up against a light background in player-container
+accessible.supporter                          = dark.supporter;
 accessible.aga-official                       = light.aga-official;
 accessible.professional                       = green;
 accessible.bot                                = light.bot

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -69,7 +69,7 @@ z = {
 
 supporter-gold = #dfba00
 
-special-type-priority = {
+special-player-type-priority = {
     supporter: 'supporter'
     professional: 'professional'
     ambassador: 'ambassador'

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -69,6 +69,17 @@ z = {
 
 supporter-gold = #dfba00
 
+special-type-priority = {
+    supporter: 'supporter'
+    professional: 'professional'
+    ambassador: 'ambassador'
+    teacher: 'teacher'
+    bot: 'bot'
+    moderator: 'moderator'
+    aga-official: 'aga'
+    admin: 'admin'
+}
+
 light = {}
 dark = {}
 accessible = {}
@@ -219,8 +230,6 @@ light.inactive-support-gradient         = linear-gradient(to bottom, #ffffff 0%,
 light.active-support-gradient           = linear-gradient(to bottom, #ffffff 0%, lighten(supporter-gold, 70%) 100%);
 light.player-black-fg                   = #eeeeee
 light.player-white-fg                   = light.fg
-light.player-black-name                 = lighten(light.user, 60%)
-light.player-white-name                 = light.user
 light.player-black-clock                = lighten(light.player-black-fg, 50%)
 light.player-white-clock                = light.player-white-fg
 light.player-black-paused-clock          = #ABA8AD;
@@ -350,8 +359,6 @@ dark.inactive-support-gradient          = linear-gradient(to bottom, #7d7d7d 0%,
 dark.active-support-gradient            = linear-gradient(to bottom, darken(supporter-gold, 30%) 0%, darken(supporter-gold, 60%) 100%);
 dark.player-black-fg                    = dark.fg
 dark.player-white-fg                    = darken(dark.fg, 90%)
-dark.player-black-name                  = dark.user
-dark.player-white-name                  = darken(dark.user, 60%)
 dark.player-black-clock                 = lighten(dark.player-black-fg, 50%)
 dark.player-white-clock                 = #000
 dark.player-white-paused-clock          = #5F4A71;
@@ -486,8 +493,6 @@ accessible.inactive-support-gradient          = linear-gradient(to bottom, #7d7d
 accessible.active-support-gradient            = linear-gradient(to bottom, darken(accessible.supporter, 30%) 0%, darken(accessible.supporter, 60%) 100%);
 accessible.player-black-fg                    = accessible.fg
 accessible.player-white-fg                    = darken(accessible.fg, 90%)
-accessible.player-black-name                  = accessible.user
-accessible.player-white-name                  = darken(accessible.user, 60%)
 accessible.player-black-clock                 = lighten(accessible.player-black-fg, 50%)
 accessible.player-white-clock                 = #000
 accessible.player-white-paused-clock          = #5F4A71;

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -124,7 +124,7 @@
         // Use the light mode color for names in the white player box
         .white.player-name-container .Player
             color light.user
-        for color-attr, class-attr in special-type-priority
+        for color-attr, class-attr in special-player-type-priority
             .white.player-name-container .Player.{class-attr}
                 color: light[color-attr]!important
 
@@ -141,7 +141,7 @@
         // Use the dark mode color for names in the black player box
         .black.player-name-container .Player
             color dark.user
-        for color-attr, class-attr in special-type-priority
+        for color-attr, class-attr in special-player-type-priority
             .black.player-name-container .Player.{class-attr}
                 color: dark[color-attr]!important
 

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -20,7 +20,7 @@
 }
 
 
-.MainGobanView .players {
+.MainGobanView .players
     flex-shrink: 0;
     flex-grow: 0;
     display: flex;
@@ -112,7 +112,7 @@
     }
 
 
-    .white.player-container {
+    .white.player-container
         box-shadow: 0 2px 5px rgba(50,50,50,.51);
         themed background player-white-background
         themed color player-white-fg
@@ -121,12 +121,14 @@
             themed color player-white-paused-clock
         }
 
-        .white.player-name-container .supporter {
-            color: light.supporter!important;
-        }
-    }
+        // Use the light mode color for names in the white player box
+        .white.player-name-container .Player
+            color light.user
+        for color-attr, class-attr in special-type-priority
+            .white.player-name-container .Player.{class-attr}
+                color: light[color-attr]!important
 
-    .black.player-container {
+    .black.player-container
         themed background player-black-background
         themed color player-black-fg
         border-top: 1px solid #202020;
@@ -136,14 +138,12 @@
             themed color player-black-paused-clock
         }
 
-        .player-name {
-            color: #00B8FF;
-        }
-
-        .black.player-name-container .supporter {
-            color: dark.supporter!important;
-        }
-    }
+        // Use the dark mode color for names in the black player box
+        .black.player-name-container .Player
+            color dark.user
+        for color-attr, class-attr in special-type-priority
+            .black.player-name-container .Player.{class-attr}
+                color: dark[color-attr]!important
 
     .player-container.shortgame.offline {
         border: 1px solid #f66 !important;
@@ -177,17 +177,6 @@
         overflow: hidden;
         text-align: left;
     }
-    .black.player-name-container{
-        .Player {
-            themed color player-black-name;
-        }
-    }
-    .white.player-name-container{
-        .Player {
-            themed color player-white-name;
-        }
-    }
-
 
     .player-name {
         display: inline-block;
@@ -304,7 +293,6 @@
 
         }
     }
-}
 
 
 .MainGobanView.portrait .players {


### PR DESCRIPTION
Fixes issue that Vsotep brought up [in the forums](https://forums.online-go.com/t/yellow-on-white-is-an-awful-color-choice-for-text/34275/43?u=benjito).  Mods who support were no longer getting purple'd.

## Proposed Changes

  - Ensure the proper "color priority" is followed (e.g. admin status is more important than supporter status)
  - Use dark mode in the black player box, and light mode in the white player box *for all player colors*
  - Also make sure the correct gold is in accessibility mode (my stuff and @GreenAsJade's stuff overlapped)

## Screenshots

Please let me know if y'all can think of any other good players/games to look at.

<img width="357" alt="Screen Shot 2021-02-23 at 2 55 36 AM" src="https://user-images.githubusercontent.com/25233703/108815621-c36f9480-7582-11eb-8893-e7321c66a4c1.png">
<img width="357" alt="Screen Shot 2021-02-23 at 2 46 49 AM" src="https://user-images.githubusercontent.com/25233703/108815662-d08c8380-7582-11eb-80b4-e510af040566.png">
<img width="342" alt="Screen Shot 2021-02-23 at 2 37 43 AM" src="https://user-images.githubusercontent.com/25233703/108815681-d84c2800-7582-11eb-9484-02f3deb5ce0f.png">
<img width="352" alt="Screen Shot 2021-02-23 at 2 37 17 AM" src="https://user-images.githubusercontent.com/25233703/108815713-e69a4400-7582-11eb-95a3-ce2b5d844721.png">
<img width="350" alt="Screen Shot 2021-02-23 at 2 58 27 AM" src="https://user-images.githubusercontent.com/25233703/108815801-0b8eb700-7583-11eb-9b11-0d4a14560c67.png">


