### PR TITLE
Fixed z-index for the "Player name" search-box

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -52,11 +52,11 @@ z = {
         backdrop       : 300,
         menu           : 310
     },
+    player-autocomplete: 900,
     nav-menu: {
         backdrop       : 1000,
         menu           : 1010,
     },
-    player-autocomplete: 1900,
     modal: {
         backdrop       : 2000,
         container      : 2010,


### PR DESCRIPTION
Fixes #1384

## Proposed Changes

  - changed the z-index for the "Player name" search-box from 1900 to 900

[issue 1384](https://github.com/online-go/online-go.com/issues/1384) was very similar to [issue 736](https://github.com/online-go/online-go.com/pull/736)
