### PR TITLE
Fix data id causing announcements not to go away.

### DIFF
--- a/src/components/Announcements/ActiveAnnouncements.tsx
+++ b/src/components/Announcements/ActiveAnnouncements.tsx
@@ -39,7 +39,7 @@ for (let k in hard_cleared_announcements) {
         delete hard_cleared_announcements[k];
     }
 }
-data.set("announcements.cleared", hard_cleared_announcements);
+data.set("announcements.hard_cleared", hard_cleared_announcements);
 
 export class ActiveAnnouncements extends React.PureComponent<ActiveAnnouncementsProperties, any> {
     constructor(props) {


### PR DESCRIPTION
I had copied `"announcements.cleared"` and did not change it to `"announcements.hard_cleared"`.  This meant that we were saving hidden announcements from the card, but actually overwriting the hidden pop-ups.

Apologies for the issues.  Thanks @anoek for looking into it and thanks @pdg137 for reporting!