### PR TITLE
Remove animation which causes constant 60fps repaints

### DIFF
--- a/src/components/Notifications/Notifications.styl
+++ b/src/components/Notifications/Notifications.styl
@@ -18,13 +18,6 @@
 
 indiciator-size=1.5rem
 
-@keyframes pulsate-notification {
-    0% { opacity: 0.5;  }
-    15% { opacity: 1.0; box-shadow 0 1px 1px rgba(0,0,255,0.3);}
-    30% { opacity: 0.5;}
-    100% { opacity: 0.5;}
-}
-
 .notification-indicator {
     position: absolute;
     bottom: 0;
@@ -41,10 +34,6 @@ indiciator-size=1.5rem
 
     &.active {
         display: inline-block;
-        animation-name: pulsate-notification;
-        animation-duration: 10s;
-        animation-timing-function: ease-in-out;
-        animation-iteration-count: infinite
     }
 
 }


### PR DESCRIPTION
Fixes issue I reported in the forums (sorry - will use Github Issues in the future)

https://forums.online-go.com/t/web-client-performance-issues/35191/8

## Proposed Changes

There is apparently an infinite webkit animation in the unread notifications UI which causes the browser to continuously repaint at 60 frames per second, causing high CPU/GPU usage.

This PR simply removes the animation, because as far as I can tell it's not even really noticeable to begin with. This fixes the CPU load issue.

See below the difference (pay attention to the "Frames" row)

## Before

![image](https://user-images.githubusercontent.com/897596/112244701-36693b00-8c15-11eb-8d1a-bc7b0679cb1a.png)

## After

![image](https://user-images.githubusercontent.com/897596/112244713-3bc68580-8c15-11eb-9e32-267ffd4ae30d.png)
