### PR TITLE
Remove "user has recently timed out of a game"

### DIFF
--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -746,7 +746,7 @@ export class User extends React.PureComponent<UserProperties, any> {
 
                                 {(user.ui_class_extra && user.ui_class_extra.indexOf("aga") >= 0) && <div ><h4 style={inlineBlock}><img src="https://cdn.online-go.com/assets/agaico1.png" /> {_("AGA Staff")} </h4></div>}
 
-                                {(user.timeout_provisional) && <div ><h4 style={inlineBlock}><i className="fa fa-exclamation-triangle"></i> {_("Has recently timed out of a game")} <i className="fa fa-exclamation-triangle"></i></h4></div>}
+                                {(false /* suppress this message until backend fix is implemented */ && user.timeout_provisional) && <div ><h4 style={inlineBlock}><i className="fa fa-exclamation-triangle"></i> {_("Has recently timed out of a game")} <i className="fa fa-exclamation-triangle"></i></h4></div>}
 
                                 {(!user.is_superuser && user.is_moderator) && <div ><h3 style={inlineBlock}><i className="fa fa-gavel"></i> {_("Moderator")}</h3></div>}
 


### PR DESCRIPTION
Credit to benjito in link beneath

https://forums.online-go.com/t/has-recently-timed-out-of-a-game-uh-does-years-ago-count/31064/12

This display is erroneous, and the backend fix, it seems, is non-trivial. While we wait for a backend fix, this removes the message entirely and frees the users from any potential negative impact on their reputation.

Fixes #

## Proposed Changes

  -
  -
  -
