### PR TITLE
Feature: Add "toggle coordinates" button in Puzzles

### DIFF
--- a/src/global_styl/global.styl
+++ b/src/global_styl/global.styl
@@ -434,7 +434,6 @@ button, a.btn, .btn {
     line-height: font-size-normal;
 
     themed background-color default-button
-    themed-darken border-color default-button border-darken-amount
     themed color default-button-color
 
     transition: background-color 0.3s ease;
@@ -539,7 +538,6 @@ for cls in primary danger info reject
 display: inline-block;
     margin: 0.15em;
     button, a.btn, .btn {
-        margin: 0;
         border-radius: 0;
 
         &:first-child {
@@ -553,6 +551,7 @@ display: inline-block;
 
         &.active {
             themed background-color shade2
+            themed border-color shade2
         }
     }
 }

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -779,6 +779,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
             <div className="btn-container">
                 <div className="btn-group">
                     <button type="button"
+                        title="Flip Diagonal"
                         className={this.state.transform_x ? "active" : ""}
                         disabled={!this.state.collection.position_transform_enabled}
                         onClick={this.toggle_transform_x}
@@ -787,6 +788,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-expand"></i>
                     </button>
                     <button type="button"
+                        title="Flip Horizontal"
                         className={this.state.transform_h ? "active" : ""}
                         disabled={!this.state.collection.position_transform_enabled}
                         onClick={this.toggle_transform_h}
@@ -795,6 +797,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-arrows-h"></i>
                     </button>
                     <button type="button"
+                        title="Flip Vertical"
                         className={this.state.transform_v ? "active" : ""}
                         disabled={!this.state.collection.position_transform_enabled}
                         onClick={this.toggle_transform_v}
@@ -803,6 +806,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-arrows-v"></i>
                     </button>
                     <button type="button"
+                        title="Reverse Colors"
                         className={this.state.transform_color ? "active" : ""}
                         disabled={!this.state.collection.color_transform_enabled}
                         onClick={this.toggle_transform_color}
@@ -811,25 +815,30 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-adjust"/>
                     </button>
                     {(this.state.zoomable || null) &&
-                        <button type="button" className={this.state.zoom ? "active" : ""} onClick={this.toggle_transform_zoom} ref={this.ref_transform_zoom_button}>
+                        <button type="button" 
+                            title="Toggle Zoom" 
+                            className={this.state.zoom ? "active" : ""} 
+                            onClick={this.toggle_transform_zoom} 
+                            ref={this.ref_transform_zoom_button}
+                        >
                         <i className="fa fa-arrows-alt"></i>
                         </button>
                     }
 
-                    <button type="button" onClick={this.openPuzzleSettings} ref={this.ref_settings_button}>
+                    <button type="button" title="Open Puzzle Settings" onClick={this.openPuzzleSettings} ref={this.ref_settings_button}>
                     <i className="fa fa-gear"/>
                     </button>
 
                     {(puzzle.owner.id === data.get("user").id || null) &&
-                        <button onClick={this.edit} ref={this.ref_edit_button}>
+                        <button title="Edit" onClick={this.edit} ref={this.ref_edit_button}>
                         <i className="fa fa-pencil"></i>
                         </button>
                     }
                     <button type="button" className={this.state.hintsOn ? "active" : ""} onClick={this.showHint} ref={this.ref_hint_button}>
                     {_("Hint")}
                     </button>
-                    <button type="button" onClick={this.toggleCoordinates} ref={this.ref_toggle_coordinates_button}>
-                    {_("Toggle Coordinates")}
+                    <button type="button" title="Toggle Coordinates" onClick={this.toggleCoordinates} ref={this.ref_toggle_coordinates_button}>
+                    <i className="ogs-coordinates"></i> 
                     </button>
                 </div>
             </div>

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -779,7 +779,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
             <div className="btn-container">
                 <div className="btn-group">
                     <button type="button"
-                        title="Flip Diagonal"
+                        title={_("Flip Diagonal")}
                         className={this.state.transform_x ? "active" : ""}
                         disabled={!this.state.collection.position_transform_enabled}
                         onClick={this.toggle_transform_x}
@@ -788,7 +788,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-expand"></i>
                     </button>
                     <button type="button"
-                        title="Flip Horizontal"
+                        title={_("Flip Horizontal")}
                         className={this.state.transform_h ? "active" : ""}
                         disabled={!this.state.collection.position_transform_enabled}
                         onClick={this.toggle_transform_h}
@@ -797,7 +797,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-arrows-h"></i>
                     </button>
                     <button type="button"
-                        title="Flip Vertical"
+                        title={_("Flip Vertical")}
                         className={this.state.transform_v ? "active" : ""}
                         disabled={!this.state.collection.position_transform_enabled}
                         onClick={this.toggle_transform_v}
@@ -806,7 +806,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-arrows-v"></i>
                     </button>
                     <button type="button"
-                        title="Reverse Colors"
+                        title={_("Reverse Colors")}
                         className={this.state.transform_color ? "active" : ""}
                         disabled={!this.state.collection.color_transform_enabled}
                         onClick={this.toggle_transform_color}
@@ -816,7 +816,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     </button>
                     {(this.state.zoomable || null) &&
                         <button type="button"
-                            title="Toggle Zoom"
+                            title={_("Toggle Zoom")}
                             className={this.state.zoom ? "active" : ""}
                             onClick={this.toggle_transform_zoom}
                             ref={this.ref_transform_zoom_button}
@@ -825,19 +825,19 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                         </button>
                     }
 
-                    <button type="button" title="Open Puzzle Settings" onClick={this.openPuzzleSettings} ref={this.ref_settings_button}>
+                    <button type="button" title={_("Open Puzzle Settings")} onClick={this.openPuzzleSettings} ref={this.ref_settings_button}>
                     <i className="fa fa-gear"/>
                     </button>
 
                     {(puzzle.owner.id === data.get("user").id || null) &&
-                        <button title="Edit" onClick={this.edit} ref={this.ref_edit_button}>
+                        <button title={_("Edit")} onClick={this.edit} ref={this.ref_edit_button}>
                         <i className="fa fa-pencil"></i>
                         </button>
                     }
                     <button type="button" className={this.state.hintsOn ? "active" : ""} onClick={this.showHint} ref={this.ref_hint_button}>
                     {_("Hint")}
                     </button>
-                    <button type="button" title="Toggle Coordinates" onClick={this.toggleCoordinates} ref={this.ref_toggle_coordinates_button}>
+                    <button type="button" title={_("Toggle Coordinates")} onClick={this.toggleCoordinates} ref={this.ref_toggle_coordinates_button}>
                     <i className="ogs-coordinates"></i>
                     </button>
                 </div>

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -815,10 +815,10 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     <i className="fa fa-adjust"/>
                     </button>
                     {(this.state.zoomable || null) &&
-                        <button type="button" 
-                            title="Toggle Zoom" 
-                            className={this.state.zoom ? "active" : ""} 
-                            onClick={this.toggle_transform_zoom} 
+                        <button type="button"
+                            title="Toggle Zoom"
+                            className={this.state.zoom ? "active" : ""}
+                            onClick={this.toggle_transform_zoom}
                             ref={this.ref_transform_zoom_button}
                         >
                         <i className="fa fa-arrows-alt"></i>
@@ -838,7 +838,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                     {_("Hint")}
                     </button>
                     <button type="button" title="Toggle Coordinates" onClick={this.toggleCoordinates} ref={this.ref_toggle_coordinates_button}>
-                    <i className="ogs-coordinates"></i> 
+                    <i className="ogs-coordinates"></i>
                     </button>
                 </div>
             </div>

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -114,6 +114,7 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
     ref_settings_button: React.RefObject<HTMLButtonElement>;
     ref_edit_button: React.RefObject<HTMLButtonElement>;
     ref_hint_button: React.RefObject<HTMLButtonElement>;
+    ref_toggle_coordinates_button: React.RefObject<HTMLButtonElement>;
 
     goban: Goban;
     goban_div: HTMLDivElement;
@@ -649,7 +650,27 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
             (this.goban as GobanCanvas).setMoveTreeContainer(this.ref_move_tree_container);
         }
     }
+    toggleCoordinates = () => {
+        let goban = this.goban;
 
+        let label_position = preferences.get("label-positioning");
+        switch (label_position) {
+            case "all": label_position = "none"; break;
+            case "none": label_position = "top-left"; break;
+            case "top-left": label_position = "top-right"; break;
+            case "top-right": label_position = "bottom-right"; break;
+            case "bottom-right": label_position = "bottom-left"; break;
+            case "bottom-left": label_position = "all"; break;
+        }
+        preferences.set("label-positioning", label_position);
+
+        goban.draw_top_labels = label_position === "all" || label_position.indexOf("top") >= 0;
+        goban.draw_left_labels = label_position === "all" || label_position.indexOf("left") >= 0;
+        goban.draw_right_labels = label_position === "all" || label_position.indexOf("right") >= 0;
+        goban.draw_bottom_labels = label_position === "all" || label_position.indexOf("bottom") >= 0;
+        this.onResize(true);
+        goban.redraw(true);
+    }
 
     render() {
         if (this.state.editing) {
@@ -804,8 +825,11 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                         <i className="fa fa-pencil"></i>
                         </button>
                     }
-                    <button className={this.state.hintsOn ? "active" : ""} onClick={this.showHint} ref={this.ref_hint_button}>
+                    <button type="button" className={this.state.hintsOn ? "active" : ""} onClick={this.showHint} ref={this.ref_hint_button}>
                     {_("Hint")}
+                    </button>
+                    <button type="button" onClick={this.toggleCoordinates} ref={this.ref_toggle_coordinates_button}>
+                    {_("Toggle Coordinates")}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #1454
## Proposed Changes

Hi, first time contributing. Love OGS! 

  - Add a "toggle coordinates" button in Puzzles
  - Add `title` attribute to buttons
  - Minor changes to clean up button styling 
     - Remove border outline and add margin instead (feels more modern and the spacing improves accessibility)
     - Fix active state border color

![Screen Recording 2021-04-18 at 2 19 52 PM](https://user-images.githubusercontent.com/34780520/115161273-a7074a00-a051-11eb-849e-c7fdf4b0d903.gif)

<img width="366" alt="Screen Shot 2021-04-18 at 2 20 43 PM" src="https://user-images.githubusercontent.com/34780520/115161266-98b92e00-a051-11eb-8234-571a5b52a885.png">



