### PR TITLE
Per-user keyed player notes

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -64,14 +64,16 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
 
     constructor(props) {
         super(props);
+        let user = data.get('config.user');
         this.state = {
             is_online: false,
             user: typeof(props.user) === "object" ? props.user : null,
-            has_notes: !!data.get(`player-notes.${props.user.id}`),
+            has_notes: !!data.get(`player-notes.${user.id}.${props.user.id}`),
         };
     }
 
     componentDidMount() {
+        let user = data.get('config.user');
         if (!this.props.disableCacheUpdate) {
             if (this.state.user && this.state.user.id > 0) {
                 player_cache.update(this.state.user);
@@ -113,12 +115,13 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
 
         this.syncUpdateOnline(this.props.user);
         if (this.props.shownotesindicator) {
-            data.watch(`player-notes.${this.props.user.id}`, this.updateHasNotes);
+            data.watch(`player-notes.${user.id}.${this.props.user.id}`, this.updateHasNotes);
         }
     }
 
     updateHasNotes = () => {
-        let tf = !!data.get(`player-notes.${this.props.user.id}`);
+        let user = data.get('config.user');
+        let tf = !!data.get(`player-notes.${user.id}.${this.props.user.id}`);
         if (tf !== this.state.has_notes) {
             this.setState({has_notes: tf});
         }
@@ -148,8 +151,9 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
     }
 
     UNSAFE_componentWillReceiveProps(new_props) {
+        let user = data.get('config.user');
         if (this.props.shownotesindicator) {
-            data.unwatch(`player-notes.${this.state.user.id}`, this.updateHasNotes);
+            data.unwatch(`player-notes.${user.id}.${this.state.user.id}`, this.updateHasNotes);
         }
 
         if (typeof(new_props.user) === "object") {
@@ -159,7 +163,7 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
         }
 
         if (new_props.shownotesindicator) {
-            data.watch(`player-notes.${new_props.user.id}`, this.updateHasNotes);
+            data.watch(`player-notes.${user.id}.${new_props.user.id}`, this.updateHasNotes);
         }
 
         if (!new_props.disableCacheUpdate) {
@@ -208,10 +212,11 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
         this.syncUpdateOnline(this.props.user);
     }
     componentWillUnmount() {
+        let user = data.get('config.user');
         this.unmounted = true;
         this.syncUpdateOnline(null);
         if (this.props.shownotesindicator) {
-            data.unwatch(`player-notes.${this.state.user.id}`, this.updateHasNotes);
+            data.unwatch(`player-notes.${user.id}.${this.state.user.id}`, this.updateHasNotes);
         }
     }
 

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -65,10 +65,11 @@ export class Player extends React.PureComponent<PlayerProperties, any> {
     constructor(props) {
         super(props);
         let user = data.get('config.user');
+        let viewed_user = typeof(props.user) === "object" ? props.user : null;
         this.state = {
             is_online: false,
-            user: typeof(props.user) === "object" ? props.user : null,
-            has_notes: !!data.get(`player-notes.${user.id}.${props.user.id}`),
+            user: viewed_user,
+            has_notes: viewed_user && !!data.get(`player-notes.${user.id}.${viewed_user.id}`),
         };
     }
 

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -238,7 +238,7 @@ export class PlayerDetails extends React.PureComponent<PlayerDetailsProperties, 
 
         let rating = !preferences.get("hide-ranks") && (this.state.ratings ? getUserRating(this.state, 'overall', 0) : null);
 
-        const add_note_label = data.get(`player-notes.${this.props.playerId}`) ? _('Player notes') : _('Add notes');
+        const add_note_label = data.get(`player-notes.${user.id}.${this.props.playerId}`) ? _('Player notes') : _('Add notes');
 
         return (
             <div className="PlayerDetails">

--- a/src/components/PlayerNotesModal/PlayerNotesModal.tsx
+++ b/src/components/PlayerNotesModal/PlayerNotesModal.tsx
@@ -28,7 +28,6 @@ interface PlayerNotesModalProperties {
 }
 
 export class PlayerNotesModal extends Modal<Events, PlayerNotesModalProperties, any> {
-
     constructor(props) {
         super(props);
         this.state = {
@@ -49,7 +48,12 @@ export class PlayerNotesModal extends Modal<Events, PlayerNotesModalProperties, 
     }
 
     saveNotes = () => {
-        data.set(`player-notes.${this.props.playerId}`, this.state.notes, data.Replication.REMOTE_OVERWRITES_LOCAL);
+        let notes = this.state.notes.trim();
+        if (notes) {
+            data.set(`player-notes.${this.props.playerId}`, notes, data.Replication.REMOTE_OVERWRITES_LOCAL);
+        } else {
+            data.remove(`player-notes.${this.props.playerId}`, data.Replication.REMOTE_OVERWRITES_LOCAL);
+        }
         this.close();
     }
 

--- a/src/components/PlayerNotesModal/PlayerNotesModal.tsx
+++ b/src/components/PlayerNotesModal/PlayerNotesModal.tsx
@@ -37,7 +37,8 @@ export class PlayerNotesModal extends Modal<Events, PlayerNotesModalProperties, 
 
     componentDidMount = () => {
         super.componentDidMount(); /* this.close() doesn't work if you don't do this */
-        this.setState({ notes: data.get(`player-notes.${this.props.playerId}`) });
+        let user = data.get('config.user');
+        this.setState({ notes: data.get(`player-notes.${user.id}.${this.props.playerId}`) });
     }
 
     updateNotes = (ev) => {
@@ -48,11 +49,12 @@ export class PlayerNotesModal extends Modal<Events, PlayerNotesModalProperties, 
     }
 
     saveNotes = () => {
+        let user = data.get('config.user');
         let notes = this.state.notes.trim();
         if (notes) {
-            data.set(`player-notes.${this.props.playerId}`, notes, data.Replication.REMOTE_OVERWRITES_LOCAL);
+            data.set(`player-notes.${user.id}.${this.props.playerId}`, notes, data.Replication.REMOTE_OVERWRITES_LOCAL);
         } else {
-            data.remove(`player-notes.${this.props.playerId}`, data.Replication.REMOTE_OVERWRITES_LOCAL);
+            data.remove(`player-notes.${user.id}.${this.props.playerId}`, data.Replication.REMOTE_OVERWRITES_LOCAL);
         }
         this.close();
     }


### PR DESCRIPTION
Per-user keyed player notes

This ensures that when you log in as a different user, you don't see
notes from another account.

While there's a loose idea that should be firmed up regarding keying all
data and preferences with the user id, I have a nagging suscpicion that
we'll want still have these keyed to make our lives easier when it comes
to transitioning data and preferences to those keyed values, and dealing
with what do we do when we change accounts and transition from being
logged out to logged in and vise versa.


This PR stacks on top of #1462 @GreenAsJade 