### PR TITLE
Unify "master" and "override" volume settings

### DIFF
--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -85,8 +85,8 @@ export function configure_goban() {
         getShowVariationMoveNumbers: ():boolean => preferences.get("show-variation-move-numbers"),
         getMoveTreeNumbering: ():"none" | "move-number" | "move-coordinates" => preferences.get("move-tree-numbering"),
         getCDNReleaseBase: ():string => data.get('config.cdn_release'),
-        getSoundEnabled: ():boolean => !!preferences.get('sound-enabled'),
-        getSoundVolume: ():number => preferences.get('sound-volume') as number,
+        getSoundEnabled: (): boolean => data.get('sound.volume.master') > 0,
+        getSoundVolume: (): number => data.get('sound.volume.master'),
 
         watchSelectedThemes: (cb) => preferences.watchSelectedThemes(cb),
         getSelectedThemes: () => preferences.getSelectedThemes(),

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -74,10 +74,8 @@ let defaults = {
     "show-tournament-indicator": true,
     "show-variation-move-numbers": false,
 
-    "sound-enabled": true,
     "sound-voice-countdown-main" : false,
     "sound-voice-countdown": true,
-    "sound-volume": 0.5,
 
     "sound.volume.master": 1.0,
 

--- a/src/lib/sfx.ts
+++ b/src/lib/sfx.ts
@@ -517,12 +517,6 @@ export class SFXManager {
         return data.get(`sound.voice-enabled.${sprite_name}`, true);
     }
 
-    public setVolumeOverride(volume:number) {
-        this.setVolume('master', volume);
-    }
-    public getVolumeOverride():number {
-        return this.getVolume('master');
-    }
     public playStonePlacementSound(x: number, y: number, width: number, height: number, color: 'black' | 'white'):void {
         try {
             let pan = ((x / Math.max(1, (width - 1))) - 0.5) * 0.3;

--- a/src/lib/sfx.ts
+++ b/src/lib/sfx.ts
@@ -220,10 +220,6 @@ export class SFXSprite {
     get volume():number {
         let master_volume = sfx.getVolume('master');
 
-        if (sfx.volume_override >= 0) {
-            master_volume = sfx.volume_override;
-        }
-
         return this._volume * master_volume;
     }
 
@@ -274,8 +270,7 @@ export class SFXSprite {
 
 export class SFXManager {
     private enabled:boolean = false;
-    private synced:boolean = false;
-    public volume_override?:number;
+    private synced: boolean = false;
     public howls:{
         [group_name:string]: Howl;
     } = {};
@@ -301,9 +296,6 @@ export class SFXManager {
         }
 
         let vol = this.getVolume('master');
-        if (this.volume_override >= 0) {
-            vol = this.volume_override;
-        }
 
         if (vol) {
             this.synced = true;
@@ -526,13 +518,10 @@ export class SFXManager {
     }
 
     public setVolumeOverride(volume:number) {
-        this.volume_override = volume;
-    }
-    public clearVolumeOverride() {
-        delete this.volume_override;
+        this.setVolume('master', volume);
     }
     public getVolumeOverride():number {
-        return this.volume_override;
+        return this.getVolume('master');
     }
     public playStonePlacementSound(x: number, y: number, width: number, height: number, color: 'black' | 'white'):void {
         try {

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -159,7 +159,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
             variation_name: "",
             strict_seki_mode: false,
             player_icons: {},
-            volume: preferences.get("sound-volume"),
+            volume: sfx.getVolumeOverride(),
             historical_black: null,
             historical_white: null,
             annulled: false,
@@ -171,7 +171,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
             show_game_timing: false,
         };
 
-        sfx.setVolumeOverride(this.state.volume);
         this.conditional_move_tree = $("<div class='conditional-move-tree-container'/>")[0];
         this.goban_div = document.createElement('div');
         this.goban_div.className = 'Goban';
@@ -297,7 +296,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
         this.onResize();
     }
     componentWillUnmount() {
-        sfx.clearVolumeOverride();
         this.deinitialize();
         setActiveGameView(null);
         setExtraActionCallback(null);
@@ -2230,7 +2228,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
 
         this.setState({
             volume: volume,
-            sound_enabled: enabled,
         });
         let idx = Math.round(Math.random() * 10000) % 5; /* 5 === number of stone sounds */
 
@@ -2239,9 +2236,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
         }
 
         this.volume_sound_debounce = setTimeout(() => sfx.playStonePlacementSound(5, 5, 9, 9, 'white'), 250);
-
-        preferences.set("sound-volume", volume);
-        preferences.set("sound-enabled", enabled);
     }
 
     /* Review stuff */

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -2222,8 +2222,6 @@ export class Game extends React.PureComponent<GameProperties, any> {
         this._setVolume(new_volume);
     }
     _setVolume(volume) {
-        let enabled = volume > 0;
-
         sfx.setVolume('master', volume);
 
         this.setState({

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -159,7 +159,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
             variation_name: "",
             strict_seki_mode: false,
             player_icons: {},
-            volume: sfx.getVolumeOverride(),
+            volume: sfx.getVolume('master'),
             historical_black: null,
             historical_white: null,
             annulled: false,
@@ -2224,7 +2224,7 @@ export class Game extends React.PureComponent<GameProperties, any> {
     _setVolume(volume) {
         let enabled = volume > 0;
 
-        sfx.setVolumeOverride(volume);
+        sfx.setVolume('master', volume);
 
         this.setState({
             volume: volume,


### PR DESCRIPTION
Hi there,

I'm Riley, and I've been a customer of online-go.com for about a year. I really enjoy the site, but I frequently find myself thinking the master volume is set to zero, but then surprised that the sounds are playing after all.

One potential area of confusion is the separation of the concepts of the "override" volume and "master" volume, I think. I was interested in checking it out and so I humbly submit this sacrificial PR.

## Proposed changes
* Merge the volume override setting visible on game boards with the master volume setting visible on the settings page
* Drop the `sound-volume` and `sound-enabled` preference keys. If deployed, this will cause existing user preferences to revert to their "master volume" setting.
* Overall, this means when a user adjusts the volume on a game screen, it ALSO adjusts the master volume. Conversely, adjusting the master volume means adjusting the volume for individual games. Before, those were two separate controls, which I personally have found confusing over the past year.

