### PR TITLE
Systematic fix to presence/flare alignment in Player

### DIFF
--- a/src/components/FriendList/FriendList.styl
+++ b/src/components/FriendList/FriendList.styl
@@ -17,7 +17,6 @@
 
 .FriendList {
 
-
     .show-offline {
         input, label {
             cursor: pointer;
@@ -26,10 +25,4 @@
         display: flex;
         align-items: center;
     }
-
-    .friend-entry {
-        padding-top: 0.25rem;
-    }
-
-
 }

--- a/src/components/Player/Player.styl
+++ b/src/components/Player/Player.styl
@@ -22,7 +22,7 @@
     white-space: nowrap;
     display: inline-flex !important;
     max-width: 100%;
-    align-items: baseline; /* needed for Game info modal */
+    align-items: center; // This centers not only the name, icon and rank, but also the presence indicator
 
     &:hover {
         text-decoration: underline;
@@ -40,8 +40,11 @@
         margin-left: 0.1rem;
     }
 
+    &.with-flare {
+        align-items: baseline;  // if we have flare, then we don't have presence indicator, and it's better to line up the baselines (looks better in chat)
+    }
+
     &.with-flare:before {
-        display: inline-block;
         width: 0.8rem;
         font-family: 'FontAwesome';
         font-size: 0.7rem;
@@ -131,7 +134,7 @@
         padding-left: 0.6rem;
         &:before {
             display: inline-flex;
-            align-items: flex-start;
+            align-items: center;
             font-size: 0.5rem;
             height: 1rem;
 
@@ -141,9 +144,6 @@
             themed color chat-offline;
             text-shadow: 0 0 1px rgba(0,0,0,0.5);
             padding-right: 0.25rem;
-            position: absolute;
-            top: -0.35em;
-            left: 0.25em;
         }
     }
 

--- a/src/components/PrivateChat/PrivateChat.styl
+++ b/src/components/PrivateChat/PrivateChat.styl
@@ -50,9 +50,8 @@
             overflow: hidden;
         }
         .Player::before {
-            margin-top: 5px;
-            padding-right: 10px;
-            font-size: 0.8em;
+            font-size: 0.8em; // a nice big presence indicator looks good here.
+            padding-right: 0.6rem;
         }
 
         .fa, .ogs-goban {


### PR DESCRIPTION
Fixes ongoing hassles of alignment of elements of `Player`

## Proposed Changes

- Don't use absolute positioning for presence indicator, use flex to line it up on the centreline no matter what size it is
- Use flex to put all the elements on the baseline in the case of "chat", where we have flare instead of presence indicator
- Put the primary parameters in `Player` and specialise only where it needs to be specialised (eg PrivateChat)
- This also fixes the squished private chat header.

![Screen Shot 2021-05-08 at 12 36 44 pm](https://user-images.githubusercontent.com/61894/117523979-653b4500-affa-11eb-9f3b-aaf4a476b251.png)

