### PR TITLE
keep users list sorted instead of re-sorting from scratch each time

### DIFF
--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -764,3 +764,16 @@ export function unitify(num: number): string {
     }
     return num.toString();
 }
+
+export function insert_into_sorted_list<T>(sorted_list: Array<T>, comparator: (a: T, b: T) => number, new_item: T) {
+    let insertion_index = sorted_list.findIndex((existing_item) => comparator(existing_item, new_item) > 0);
+
+    // If findIndex couldn't find any such index, it'll return -1.
+    // In that case we want to insert at the beginning of the array,
+    // so set insertionIndex to zero
+    if (insertion_index === -1) {
+        insertion_index = 0;
+    }
+
+    sorted_list.splice(insertion_index, 0, new_item);
+}


### PR DESCRIPTION
Fixes (improves, anyway) #1476 

## Proposed Changes

The chat_manager was re-sorting channel user lists twice every time someone joined or parted the channel. This led to the CPU graph below even when sitting idle on the home screen, where you can see a single call to `_update_sorted_lists` was taking about 20ms

![image](https://user-images.githubusercontent.com/1630424/117863803-c745b580-b259-11eb-8e07-0fa5c8848c99.png)

I changed the code to either insert joining users or remove parting users, with the assumption the sorted lists were already sorted. This made the CPU graph look more like this:

![image](https://user-images.githubusercontent.com/1630424/117863964-ee9c8280-b259-11eb-8372-5c28b8f1a84c.png)

I'm not totally sure what the gray hashes mean, but I think it's like "idle" or some such. The overall tab CPU usage dropped for me on my 2013 MBP from 25% CPU to 2% CPU.

## Caveats
I only tested on chromium on Mac - maybe Firefox or Safari have different optimizations that would see different CPU impact. It's hard to imagine this making things WORSE for any browser, but I've said things like that and been wrong before ;) I'd understand if you'd want to test this more widely before merging. I personally do not want to do that testing ;)


## Potential next steps
There's still quite a bit of optimization _possible_ - inserting items into the list still takes my CPU 2ms for each user, and there's no need I could see to maintain sorted lists of every channel. I thought a 20% drop in absolute CPU usage for this would be worth merging by itself.

Also, the chat window itself still completely pegs my CPU. This doesn't really improve that situation much. It should mainly help folks who are looking at games on their phones and not chatting.


----
I believe this could be ready to merge, let me know what you think and if you'd like any adjustments!