### PR TITLE
Improve report-raising modal

### DIFF
--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -448,7 +448,7 @@ export function alertModerator(obj) {
             _("Please provide a clear description of the problem"),
         input: "textarea",
         showCancelButton: true,
-        closeOnClickOutside: false // folk are accidentally losing their typing.  Shame this doesn't actually work.
+        allowOutsideClick: false // folk are accidentally losing their typing.
     }).then((description) => {
         if (description.length < 5) {
             alertModerator(obj);

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -445,9 +445,10 @@ export function n2s(n?: number) {
 export function alertModerator(obj) {
     swal({
         text: (obj.user ? _("Report user:") + " " : "") +
-            _("Please provide a brief description of the problem"),
-        input: "text",
+            _("Please provide a clear description of the problem"),
+        input: "textarea",
         showCancelButton: true,
+        closeOnClickOutside: false // folk are accidentally losing their typing.  Shame this doesn't actually work.
     }).then((description) => {
         if (description.length < 5) {
             alertModerator(obj);


### PR DESCRIPTION
Fixes the incorrect instruction, and the amount of space for typing.

Tries, but fails, to fix the problem of closing prematurely when accidentally clicking outside.

## Proposed Changes

 - Use a textarea instead of an input
 - Say "clear" instead of "brief"
 - Specify closeOnClickOutside to be false ~~(done, but doesn't work)~~

![Screen Shot 2021-05-15 at 12 32 27 pm](https://user-images.githubusercontent.com/61894/118346352-f326ab00-b579-11eb-86ae-4d816aae9425.png)
