### PR TITLE
Change the social login buttons' text from "Login..." to "Sign in..." to comply with Apple's Guideline

### DIFF
--- a/src/views/Register/Register.tsx
+++ b/src/views/Register/Register.tsx
@@ -144,11 +144,11 @@ export class Register extends React.PureComponent<{}, any> {
                     </form>
 
                     <div className="social-buttons">
-                        <Link to="/sign-in" className="s btn md-icon"><i className='email-icon fa fa-envelope-o' /> {_("Login with Email")}</Link>
-                        <a href="/login/google-oauth2/" className="s btn md-icon" target="_self"><span  className="google google-oauth2-icon" /> {_("Login with Google")}</a>
-                        <a href="/login/facebook/" className="s btn md-icon" target="_self"><span className="facebook facebook-icon" /> {_("Login with Facebook")}</a>
-                        <a href="/login/twitter/" className="s btn md-icon" target="_self"><i className="twitter twitter-icon fa fa-twitter" />{_("Login with Twitter")}</a>
-                        <a href="/login/apple-id/" className="s btn md-icon" target="_self"><i className="twitter apple-id-icon fa fa-apple" />{_("Login with Apple")}</a>
+                        <Link to="/sign-in" className="s btn md-icon"><i className='email-icon fa fa-envelope-o' /> {_("Sign in with Email")}</Link>
+                        <a href="/login/google-oauth2/" className="s btn md-icon" target="_self"><span  className="google google-oauth2-icon" /> {_("Sign in with Google")}</a>
+                        <a href="/login/facebook/" className="s btn md-icon" target="_self"><span className="facebook facebook-icon" /> {_("Sign in with Facebook")}</a>
+                        <a href="/login/twitter/" className="s btn md-icon" target="_self"><i className="twitter twitter-icon fa fa-twitter" />{_("Sign in with Twitter")}</a>
+                        <a href="/login/apple-id/" className="s btn md-icon" target="_self"><i className="twitter apple-id-icon fa fa-apple" />{_("Sign in with Apple")}</a>
                     </div>
                 </Card>
             </div>

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -178,7 +178,7 @@ export class SignIn extends React.PureComponent<{}, any> {
                         </form>
 
                         <LineText>{
-                            _("or log in using another account:") /* translators: username or password, or sign in with social authentication */
+                            _("or sign in using another account:") /* translators: username or password, or sign in with social authentication */
                         }</LineText>
                         <SocialLoginButtons />
                     </Card>
@@ -200,10 +200,10 @@ export class SignIn extends React.PureComponent<{}, any> {
 export function SocialLoginButtons():JSX.Element {
     return (
         <div className="social-buttons">
-            <a href="/login/google-oauth2/" className="s btn md-icon" target="_self"><span className="google google-oauth2-icon" /> {_("Login with Google")}</a>
-            <a href="/login/facebook/" className="s btn md-icon" target="_self"><span className="facebook facebook-icon" /> {_("Login with Facebook")}</a>
-            <a href="/login/twitter/" className="s btn md-icon" target="_self"><i className="twitter twitter-icon fa fa-twitter" />{_("Login with Twitter")}</a>
-            <a href="/login/apple-id/" className="s btn md-icon" target="_self"><i className="apple apple-id-icon fa fa-apple" />{_("Login with AppleID")}</a>
+            <a href="/login/google-oauth2/" className="s btn md-icon" target="_self"><span className="google google-oauth2-icon" /> {_("Sign in with Google")}</a>
+            <a href="/login/facebook/" className="s btn md-icon" target="_self"><span className="facebook facebook-icon" /> {_("Sign in with Facebook")}</a>
+            <a href="/login/twitter/" className="s btn md-icon" target="_self"><i className="twitter twitter-icon fa fa-twitter" />{_("Sign in with Twitter")}</a>
+            <a href="/login/apple-id/" className="s btn md-icon" target="_self"><i className="apple apple-id-icon fa fa-apple" />{_("Sign in with Apple")}</a>
         </div>
     );
 }


### PR DESCRIPTION
This is to change the texts on the social login buttons from "Login with ..." to "Sign in with ...", since Apple just rejected my iOS app again due to the text on the AppleID login button. 😔

<img width="835" alt="Screen Shot 2021-05-16 at 11 01 41" src="https://user-images.githubusercontent.com/1177495/118385099-50803200-b636-11eb-9e2b-f3081e881019.png">

According to [Apple's guideline](https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple/overview/buttons/), there are only three options: "Sign in with Apple", "Sign up with Apple", or "Continue with Apple".

## Proposed Changes

  - Change the texts on the social login buttons on Sign in and Register page from "Login with ..." to "Sign in with ...".
