### PR TITLE
Add support for the move number suffix of game urls in the chat windo…

### DIFF
--- a/src/components/Chat/chat_markup.tsx
+++ b/src/components/Chat/chat_markup.tsx
@@ -86,9 +86,9 @@ const global_replacements: TextReplacement[] = [
         replacement: (m, idx) => (<Link key={idx} to={`/game/${m[2]}`}>{m[1] + '-' + m[2]}</Link>)
     },
     {
-        split: /\b((?:game )?https?:\/\/online-go\.com\/game(?:\/view)?\/[0-9]+(?:\/|\b))/i,
-        pattern: /\b((game )?https?:\/\/online-go\.com\/game(?:\/view)?\/([0-9]+)(?:\/|\b))/i,
-        replacement: (m, idx) => (<Link key={idx} to={`/game/${m[3]}`}>{(m[2] ? m[2] : "game ") + m[3]}</Link>)
+        split: /\b((?:game )?https?:\/\/online-go\.com\/game(?:\/view)?\/[0-9]+(?:\/[0-9]+)?(?:\/|\b))/i,
+        pattern: /\b((game )?https?:\/\/online-go\.com\/game(?:\/view)?\/([0-9]+)\/?([0-9]+)?(?:\/|\b))/i,
+        replacement: (m, idx) => (<Link key={idx} to={`/game/${m[3]}${m[4] >= 0 ? "/" + m[4] : ""}`}>{(m[2] ? m[2] : "game ") + m[3] + (m[4] >= 0 ? " move " + m[4] : "")}</Link>)
     },
     // reviews
     {

--- a/src/components/Chat/chat_markup.tsx
+++ b/src/components/Chat/chat_markup.tsx
@@ -88,7 +88,7 @@ const global_replacements: TextReplacement[] = [
     {
         split: /\b((?:game )?https?:\/\/online-go\.com\/game(?:\/view)?\/[0-9]+(?:\/[0-9]+)?(?:\/|\b))/i,
         pattern: /\b((game )?https?:\/\/online-go\.com\/game(?:\/view)?\/([0-9]+)\/?([0-9]+)?(?:\/|\b))/i,
-        replacement: (m, idx) => (<Link key={idx} to={`/game/${m[3]}${m[4] >= 0 ? "/" + m[4] : ""}`}>{(m[2] ? m[2] : "game ") + m[3] + (m[4] >= 0 ? " move " + m[4] : "")}</Link>)
+        replacement: (m, idx) => (<Link key={idx} to={`/game/${m[3]}${Number(m[4]) >= 0 ? "/" + m[4] : ""}`}>{(m[2] ? m[2] : "game ") + m[3] + (Number(m[4]) >= 0 ? " move " + m[4] : "")}</Link>)
     },
     // reviews
     {


### PR DESCRIPTION
Add support for the move number suffix of game urls in the chat window linkification function, so that "https://online-go.com/game/10509/45" becomes that link with text "game 10509 move 45" rather than a link to just the game "game 1050945" with the move number not part of the link mashed on the end.

This is a postscript to https://github.com/online-go/online-go.com/pull/1215 which added support for these urls with move suffix, but had no update to the chat regex so the chat window mangles them.

### Fixes
Chat window mangling the game urls with move suffix

## Proposed Changes
Adds optional move number to the chat link replacing regex for game urls.