### PR TITLE
Restore the old indicator's color after changes in #1391

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -272,7 +272,7 @@ dark.error-boundary-bg                  = darken(light.reject, 50%)
 dark.error-boundary-fg                  = lighten(light.reject, 50%)
 
 dark.indicate-online                    = #6f6
-dark.indicate-online-shadow             = -1px -1px 0 #fff,  1px -1px 0 #8c8, -1px 1px 0 #8c8, 1px 1px 0 #6a6;
+dark.indicate-online-shadow             = -1px -1px 0 #afa,  1px -1px 0 #8c8, -1px 1px 0 #8c8, 1px 1px 0 #6a6;
 dark.chat-offline                       = #ccc
 dark.chat-offline-shadow                = -1px -1px 0 #ccc,  1px -1px 0 #ccc, -1px 1px 0 #ccc, 1px 1px 0 #ccc;
 


### PR DESCRIPTION
Restore the old color from https://github.com/online-go/online-go.com/pull/1391#issuecomment-870628520