### PR TITLE
 add LGBT+ Pride flag

### DIFF
--- a/src/global_styl/flags16.styl
+++ b/src/global_styl/flags16.styl
@@ -321,3 +321,4 @@
 .f16 ._Pirate{background-position:0 -4784px;}
 .f16 ._Lord_Howe_Island{background-position:0 -4800px;}
 .f16 ._cat{background-position:0 -4816px;}
+.f16 ._LGBT{background-position:0 -4832px;}

--- a/src/global_styl/flags32.styl
+++ b/src/global_styl/flags32.styl
@@ -322,3 +322,4 @@
 .f32 ._Pirate{background-position:0 -9568px;}
 .f32 ._Lord_Howe_Island{background-position:0 -9600px;}
 .f32 ._cat{background-position:0 -9632px;}
+.f32 ._LGBT{background-position:0 -9664px;}

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -298,6 +298,7 @@ fantasy_countries.push(["_GoT_Stark", gettext("House Stark")]);
 fantasy_countries.push(["_GoT_Targaryen", gettext("House Targaryen")]);
 fantasy_countries.push(["_GoT_Tully", gettext("House Tully")]);
 fantasy_countries.push(["_GoT_Tyrell", gettext("House Tyrell")]);
+fantasy_countries.push(["_LGBT", gettext("LGBT+ Pride")]);
 
 try {
     for (let e of fantasy_countries) {


### PR DESCRIPTION
I am not sure if this is implemented correctly, I tried to follow previous PRs. apologies if there is some mistake

## Proposed Changes
  - add the “Progress Pride Flag” by Daniel Quasar as an option. image taken from [here](https://quasar.digital/terms/) note the CC license. not sure if there is more OGS needs to do to use it
  - originally suggested by Gooplet on the forums: https://forums.online-go.com/t/adding-an-lgbt-pride-flag/38303
  - I assume this depends on the new sprites file, see [this PR](https://github.com/online-go/world-flags-sprite/pull/2/files)

tested it locally:

![Screenshot 2021-07-31 104229](https://user-images.githubusercontent.com/74801510/127743486-8ecb3184-ea7c-4443-bb11-19890c57e818.png)
