### PR TITLE
Plot rating by game

### DIFF
--- a/src/components/MiniGoban/MiniGoban.styl
+++ b/src/components/MiniGoban/MiniGoban.styl
@@ -17,6 +17,7 @@
 
 .MiniGoban {
     display: inline-flex;
+    flex-direction: column;
     width: 22rem;
     height: 25rem;
     max-width: 100vw;
@@ -31,6 +32,17 @@
 
     &.link {
         cursor: pointer;
+    }
+
+    .minigoban-title {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-bottom: 0.5rem;
+
+        .game-date {
+            font-size: smaller;
+        }
     }
 
     .inner-container {

--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -108,7 +108,6 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
     }
 
     sync_state() {
-        console.log(this.goban.engine);
         const score = this.goban.engine.computeScore(true);
         const black = this.props.black || "";
         const white = this.props.white || "";
@@ -126,7 +125,6 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
         }
 
         const player_to_move = (this.goban && this.goban.engine.playerToMove()) || 0;
-
 
         const black_points = score.black.prisoners + score.black.komi;
         const white_points = score.white.prisoners + score.white.komi;

--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import {Link} from "react-router-dom";
 import {browserHistory} from "ogsHistory";
 import {_, npgettext, interpolate} from "translate";
+import * as moment from "moment";
 import * as preferences from "preferences";
 import {Goban} from "goban";
 import {termination_socket} from "sockets";
@@ -42,6 +43,7 @@ interface MiniGobanProps {
     json?: any;
     noLink?: boolean;
     noText?: boolean;
+    title?: boolean;
 }
 
 export class MiniGoban extends React.Component<MiniGobanProps, any> {
@@ -124,6 +126,13 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
                 .catch( () => {console.log("Couldn't work out who played white"); });
         }
 
+        if (this.props.title) {
+            this.setState({
+                game_name: this.goban.engine.game_name || "",
+                game_date: this.goban.config.end_time ? moment(new Date(this.goban.config.end_time * 1000)).format("LLL") : ""
+            });
+        }
+
         const player_to_move = (this.goban && this.goban.engine.playerToMove()) || 0;
 
         const black_points = score.black.prisoners + score.black.komi;
@@ -159,6 +168,13 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
 
     inner() {
         return (
+            <React.Fragment>
+            {this.props.title &&
+                <div className={"minigoban-title"}>
+                    <div>{this.state.game_name}</div>
+                    <div className="game-date">{this.state.game_date}</div>
+                </div>
+            }
             <div className="inner-container">
                 <PersistentElement className={
                     "small board"
@@ -184,6 +200,7 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
                     </div>
                 }
             </div>
+            </React.Fragment>
         );
     }
 }

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -1062,7 +1062,7 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
     }
 
     renderWinLossNumbersAsText() {
-        if (this.state.loading || this.state.nodata || !this.game_entries) {
+        if (this.state.loading || this.state.nodata || !this.game_entries || !this.win_loss_aggregate) {
             return <div className='win-loss-stats'/>;
         }
 

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -242,7 +242,10 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
             this.graph_width = this.width;
         }
 
+        console.log("sizes:", sizes);
         this.pie_width = sizes.width / 3.0;
+
+        console.log(this.width, this.pie_width);
 
         this.height = height;
 
@@ -629,6 +632,8 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         ];
 
         let pie_radius = Math.min(this.pie_width, this.height) / 2.0 - 15; // just looks about right.
+
+        console.log("radius", pie_radius);
 
         /* Pie plotting as per example at http://zeroviscosity.com/d3-js-step-by-step/step-1-a-basic-pie-chart */
 

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -971,11 +971,6 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         this.rating_graph.select('.x.axis').call(this.selected_axis);
         this.y_axis_rating_labels.call(this.rating_axis);
         this.y_axis_rank_labels.call(this.rank_axis);
-
-        this.computeWinLossNumbers();
-        if (!this.state.loading && this.show_pie) {
-            this.plotWinLossPie();
-        }
     }
 
     setContainer = (e) => {
@@ -987,6 +982,10 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
     }
 
     render() {
+        this.computeWinLossNumbers();
+        if (!this.state.loading && this.show_pie) {
+            this.plotWinLossPie();
+        }
         return (
             <div ref={this.setContainer} className="RatingsChart">
                 {this.state.loading

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -27,12 +27,10 @@ import {_, pgettext, interpolate} from "translate";
 import {PersistentElement} from 'PersistentElement';
 import {RatingEntry, makeRatingEntry} from './RatingEntry';
 import {errorLogger} from 'misc';
+
 import {
-    rank_to_rating,
     rating_to_rank,
-    get_handicap_adjustment,
     rankString,
-    is_novice,
     is_rank_bounded,
     humble_rating,
     bounded_rank
@@ -44,6 +42,7 @@ interface RatingsChartProperties {
     playerId: number;
     speed: speed_t;
     size: 0 | 9 | 13 | 19;
+    updateChartSize: (height: number, width: number) => void; // callback with actual chart size on resize
 }
 
 
@@ -561,6 +560,8 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         this.setRanges();
         let width = this.graph_width;
 
+        this.props.updateChartSize(chart_height, width);
+
         this.svg.attr('width', this.width + margin.left + margin.right);
         this.svg.attr('height', height + margin.top + margin.bottom + win_loss_bars_height);
         this.clip.attr('width', width);
@@ -1069,22 +1070,24 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         let agg = this.win_loss_aggregate;
 
         return (
-            <div className='win-loss-stats'>
-                <div>
-                    <span className='win-loss-legend-block weak-wins' />
-                    {interpolate(pgettext("Number of wins against weaker opponents", "{{weak_wins}} wins vs. weaker opponents"), {weak_wins: agg.weak_wins})}
-                </div>
-                <div>
-                    <span className='win-loss-legend-block strong-wins' />
-                    {interpolate(pgettext("Number of wins against stronger opponents", "{{strong_wins}} wins vs. stronger opponents"), {strong_wins: agg.strong_wins})}
-                </div>
-                <div>
-                    <span className='win-loss-legend-block weak-losses' />
-                    {interpolate(pgettext("Number of losses against weaker opponents", "{{weak_losses}} losses vs. weaker opponents"), {weak_losses: agg.weak_losses})}
-                </div>
-                <div>
-                    <span className='win-loss-legend-block strong-losses' />
-                    {interpolate(pgettext("Number of losses against stronger opponents", "{{strong_losses}} losses vs. stronger opponents"), {strong_losses: agg.strong_losses})}
+            <div className="rating-chart">
+                <div className='win-loss-stats'>
+                    <div>
+                        <span className='win-loss-legend-block weak-wins' />
+                        {interpolate(pgettext("Number of wins against weaker opponents", "{{weak_wins}} wins vs. weaker opponents"), {weak_wins: agg.weak_wins})}
+                    </div>
+                    <div>
+                        <span className='win-loss-legend-block strong-wins' />
+                        {interpolate(pgettext("Number of wins against stronger opponents", "{{strong_wins}} wins vs. stronger opponents"), {strong_wins: agg.strong_wins})}
+                    </div>
+                    <div>
+                        <span className='win-loss-legend-block weak-losses' />
+                        {interpolate(pgettext("Number of losses against weaker opponents", "{{weak_losses}} losses vs. weaker opponents"), {weak_losses: agg.weak_losses})}
+                    </div>
+                    <div>
+                        <span className='win-loss-legend-block strong-losses' />
+                        {interpolate(pgettext("Number of losses against stronger opponents", "{{strong_losses}} losses vs. stronger opponents"), {strong_losses: agg.strong_losses})}
+                    </div>
                 </div>
             </div>
         );

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -50,8 +50,8 @@ interface RatingsChartProperties {
 const date_bisector = d3.bisector((d:RatingEntry) => { return d.ended; }).left;
 let format_date = (d:Date) => moment(d).format('ll');
 let format_month = (d:Date) => moment(d).format('MMM YYYY');
-const margin   = {top: 30, right: 20, bottom: 100, left: 20};
-const margin2  = {top: 210, right: 20, bottom: 20, left: 20};
+const margin   = {top: 30, right: 20, bottom: 100, left: 20}; // Margins around the rating chart - but win/loss bars are inside this at the bottom!
+const margin2  = {top: 210, right: 20, bottom: 20, left: 20}; // Margins around the 'timeline' chart with respect to the whole space
 const chart_min_width = 64;
 const chart_height = 283;
 const date_legend_width = 70;
@@ -794,6 +794,7 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         this.timeline_axis_labels
             .call(this.timeline_axis);
 
+        this.computeWinLossNumbers();
 
         if (this.show_pie) {
             this.plotWinLossPie();
@@ -969,6 +970,11 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         this.rating_graph.select('.x.axis').call(this.selected_axis);
         this.y_axis_rating_labels.call(this.rating_axis);
         this.y_axis_rank_labels.call(this.rank_axis);
+
+        this.computeWinLossNumbers();
+        if (!this.state.loading && this.show_pie) {
+            this.plotWinLossPie();
+        }
     }
 
     setContainer = (e) => {
@@ -980,10 +986,6 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
     }
 
     render() {
-        this.computeWinLossNumbers();
-        if (!this.state.loading && this.show_pie) {
-            this.plotWinLossPie();
-        }
         return (
             <div ref={this.setContainer} className="RatingsChart">
                 {this.state.loading

--- a/src/components/RatingsChartByGame/RatingEntry.ts
+++ b/src/components/RatingsChartByGame/RatingEntry.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {get_handicap_adjustment, effective_outcome, EffectiveOutcome} from 'rank_utils';
+
+export class RatingEntry {
+    ended: Date;
+    game_id:number;
+    played_black:boolean;
+    handicap:number;
+    rating:number;
+    deviation:number;
+    volatility:number;
+    opponent_id:number;
+    opponent_rating:number;
+    opponent_deviation:number;
+    outcome:number;
+    extra:any;
+    count:number;
+    starting_rating:number;
+    starting_deviation:number;
+    increase:boolean;
+    wins:number;
+    losses:number;
+    strong_wins:number;
+    strong_losses:number;
+    weak_wins:number;
+    weak_losses:number;
+    index: number;  // to be set by client as needed.
+
+    constructor(obj) {
+        this.ended = obj.ended;
+        this.game_id = obj.game_id;
+        this.played_black = obj.played_black;
+        this.handicap = obj.handicap;
+        this.rating = obj.rating;
+        this.deviation = obj.deviation;
+        this.volatility = obj.volatility;
+        this.opponent_id = obj.opponent_id;
+        this.opponent_rating = obj.opponent_rating;
+        this.opponent_deviation = obj.opponent_deviation;
+        this.outcome = obj.outcome;
+        this.extra = obj.extra;
+        this.count = obj.count;
+        this.starting_rating = obj.starting_rating;
+        this.starting_deviation = obj.starting_deviation;
+        this.increase = obj.increase;
+        this.wins = obj.wins;
+        this.losses = obj.losses;
+        this.strong_wins = obj.strong_wins;
+        this.strong_losses = obj.strong_losses;
+        this.weak_wins = obj.weak_wins;
+        this.weak_losses = obj.weak_losses;
+        this.index = obj.index;
+    }
+
+    copy() {
+        return new RatingEntry(this);
+    }
+
+    merge(other:RatingEntry):RatingEntry {
+        this.rating = other.rating;
+        this.deviation = other.deviation;
+        this.volatility = other.volatility;
+        this.wins += other.wins;
+        this.losses += other.losses;
+        this.count += other.count;
+        this.increase = other.increase;
+        this.strong_wins += other.strong_wins;
+        this.strong_losses += other.strong_losses;
+        this.weak_wins += other.weak_wins;
+        this.weak_losses += other.weak_losses;
+        // note: if you are using this.index, it doesn't make sense to be calling merge() !
+        return this;
+    }
+}
+
+export function makeRatingEntry(d:any):RatingEntry {
+    let played_black = parseInt(d.played_black) === 1;
+    let rating = parseFloat(d.rating);
+    let opponent_rating = parseFloat(d.opponent_rating);
+    let handicap = parseInt(d.handicap);
+    let won = parseInt(d.outcome);
+    let lost = 1 - won;
+    let extra = JSON.parse(d.extra);
+
+    if (d.opponent_id <= 0) {
+        // the initial rating entry has an invalid id like this
+        won = 0;
+        lost = 0;
+    }
+
+    let outcome: EffectiveOutcome;
+    if (played_black) {
+        outcome = effective_outcome(rating, opponent_rating, handicap);
+    }
+    else {
+        outcome = effective_outcome(opponent_rating, rating, handicap);
+    }
+
+    let new_rating_entry = new RatingEntry({
+        ended              : new Date(parseInt(d.ended) * 1000),
+        game_id            : parseInt(d.game_id),
+        played_black       : played_black,
+        handicap           : handicap,
+        rating             : parseFloat(d.rating),
+        deviation          : parseFloat(d.deviation),
+        starting_rating    : parseFloat(d.rating),
+        starting_deviation : parseFloat(d.deviation),
+        volatility         : parseFloat(d.volatility),
+        opponent_id        : parseInt(d.opponent_id),
+        opponent_rating    : parseFloat(d.oppponent_rating),
+        opponent_deviation : parseFloat(d.opponent_deviation),
+        outcome            : parseInt(d.outcome),
+        extra              : extra,
+        count              : d.opponent_id > 0 ? 1 : 0,
+        wins               : won,
+        losses             : lost,
+        strong_wins        : (played_black ? outcome.white_effective_stronger : outcome.black_effective_stronger) ? won : 0,
+        strong_losses      : (played_black ? outcome.white_effective_stronger : outcome.black_effective_stronger) ? lost : 0,
+        weak_wins          : (played_black ? outcome.black_effective_stronger : outcome.white_effective_stronger) ? won : 0,
+        weak_losses        : (played_black ? outcome.black_effective_stronger : outcome.white_effective_stronger) ? lost : 0,
+        // index deliberately not intialised.
+    });
+
+    //console.log(new_rating_entry);
+    return new_rating_entry;
+}

--- a/src/components/RatingsChartByGame/RatingsChartByGame.styl
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.styl
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+rating-chart-height=380px;
+
+.RatingsChartByGame {
+    height: rating-chart-height;
+    max-width: calc(100vw - 2em);
+
+    // Uncomment this to make charts resize.  But only when they support that.
+    // max-width: calc(100vw - 2em);
+
+    svg {
+        font-size: font-size-smaller;
+    }
+
+    .area {
+        fill: rgba(255,100,100,0.5)
+        clip-path: url("#clip")
+        themed fill chart-area
+        stroke: #3587BC
+    }
+
+    .axis path, .axis line {
+        fill: none
+        themed stroke shade3
+        shape-rendering: crispEdges
+    }
+
+    .brush {
+        .selection {
+            themed stroke shade1
+            themed fill shade1
+            fill-opacity 0.200
+            shape-rendering crispEdges
+        }
+    }
+
+    .loading, .nodata {
+        height: rating-chart-height;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        themed color shade2
+    }
+
+
+
+    .chart {
+        text {
+            fill: #7F8FAF
+        }
+        .line {
+            fill: none
+            stroke-width: 1.2px
+            clip-path: url("#clip")
+        }
+        .rating.line {
+            stroke-width: 2px
+            themed stroke chart-line
+        }
+        .overlay {
+            opacity: 0
+            pointer-events: all
+        }
+        .data-point-circle {
+            fill: red
+            stroke: red
+        }
+        .crosshairs {
+            themed stroke shade3;
+            stroke-width: 1px;
+            shape-rendering: crispEdges;
+        }
+        .win-loss-bar {
+            shape-rendering: crispEdges;
+        }
+    }
+
+    .deviation-area {
+        themed fill chart-area
+    }
+
+    .timeline .axis {
+        path, line {
+            display: none;
+        }
+    }
+
+    .y.axis {
+        .tick {
+            text {
+                text-anchor: start !important
+                fill: #7F8FAF
+            }
+            line {
+                display: none
+            }
+        }
+        path {
+            display: none
+        }
+    }
+
+    /* Bright for strong, darker for weak
+       green for win, red for loss ... */
+    .weak-wins {
+        themed fill weak-win
+        themed background-color weak-win
+    }
+    .strong-wins {
+        themed fill strong-win
+        themed background-color strong-win
+    }
+    .strong-losses {
+        themed fill strong-loss
+        themed background-color strong-loss
+    }
+    .weak-losses {
+        themed fill weak-loss
+        themed background-color weak-loss
+    }
+    .transparent {
+        fill: transparent;
+    }
+    .win-loss-stats {
+        font-size: font-size-small;
+        margin-bottom: 1rem;
+        display: flex;
+        align-items: stretch;
+        align-content: center;
+        justify-content: center;
+        flex-wrap: wrap;
+        div {
+            flex: 1;
+            display: flex;
+            justify-content: center;
+        }
+    }
+    .win-loss-legend-block {
+        border: 1px solid transparent;
+        themed border-color bg
+        width: 15px;
+        height: 15px;
+        display: inline-block;
+        margin-right: 0.2rem;
+    }
+
+    .pie-title {
+        font-size: larger;
+    }
+    .pie {
+        themed stroke chart-area;
+        stroke-width: 1;
+    }
+
+    .date-legend-background {
+        themed fill shade2
+    }
+    .date-legend-text {
+        themed fill colored-background-fg
+    }
+
+}

--- a/src/components/RatingsChartByGame/RatingsChartByGame.styl
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.styl
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-rating-chart-height=380px;
+rating-chart-height=380px;  // needs to match constant in .tsx file
 
 .RatingsChartByGame {
     height: rating-chart-height;
@@ -95,7 +95,7 @@ rating-chart-height=380px;
         themed fill chart-area
     }
 
-    .timeline .axis {
+    .subselect .axis {
         path, line {
             display: none;
         }

--- a/src/components/RatingsChartByGame/RatingsChartByGame.styl
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.styl
@@ -28,6 +28,7 @@ rating-chart-height=380px;  // needs to match constant in .tsx file
         top: 0;
         right: 0;
     }
+
     // Uncomment this to make charts resize.  But only when they support that.
     // max-width: calc(100vw - 2em);
 

--- a/src/components/RatingsChartByGame/RatingsChartByGame.styl
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.styl
@@ -58,8 +58,6 @@ rating-chart-height=380px;  // needs to match constant in .tsx file
         themed color shade2
     }
 
-
-
     .chart {
         text {
             fill: #7F8FAF

--- a/src/components/RatingsChartByGame/RatingsChartByGame.styl
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.styl
@@ -21,6 +21,13 @@ rating-chart-height=380px;  // needs to match constant in .tsx file
     height: rating-chart-height;
     max-width: calc(100vw - 2em);
 
+    position: relative; // so we can position the minigoban on over
+
+    .MiniGoban {
+        position: absolute;
+        top: 0;
+        right: 0;
+    }
     // Uncomment this to make charts resize.  But only when they support that.
     // max-width: calc(100vw - 2em);
 

--- a/src/components/RatingsChartByGame/RatingsChartByGame.tsx
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.tsx
@@ -29,6 +29,8 @@ import {_, pgettext, interpolate} from "translate";
 import {PersistentElement} from 'PersistentElement';
 import {RatingEntry, makeRatingEntry} from './RatingEntry';
 import {errorLogger} from 'misc';
+import { MiniGoban } from "MiniGoban";
+
 import {
     rating_to_rank,
     rankString,
@@ -43,7 +45,8 @@ interface RatingsChartProperties {
     playerId: number;
     speed: speed_t;
     size: 0 | 9 | 13 | 19;
-    updateHoveredGame: any; // callback taking the game number that the person hovered over
+    updateHoveredGame: (game_id: number) => void;       // callback with the game number that the person hovered over
+    updateChartSize: (height: number, width: number) => void;   // callback with the size of the actual chart within this component (for client to position stuff relative to that)
 }
 
 const margin   = {top: 30, right: 20, bottom: 110, left: 20}; // Margins around the rating chart with respect to the whole space
@@ -475,6 +478,8 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
         this.setRanges();
         let width = this.graph_width;
 
+        this.props.updateChartSize(chart_height, width);
+
         this.svg.attr('width', this.width + margin.left + margin.right);
         this.svg.attr('height', height + margin.top + margin.bottom);
         this.clip.attr('width', width);
@@ -729,6 +734,15 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
     render() {
         return (
             <div ref={this.setContainer} className="RatingsChartByGame">
+
+                {this.state.hovered_game_id &&
+                    <MiniGoban
+                        id={this.state.hovered_game_id}
+                        displayWidth={200}
+                        width={19}
+                        height={19}
+                    />
+                }
                 {this.state.loading
                     ? <div className='loading'>{_("Loading")}</div>
                     : this.state.nodata

--- a/src/components/RatingsChartByGame/RatingsChartByGame.tsx
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.tsx
@@ -497,7 +497,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
             .attr('transform', 'translate(' + (graph_right_side + this.pie_width / 2.0) + ',' + ((margin.top + this.height / 3.0)) + ')');
 
 
-        if (!this.state.nodata) {
+        if (!this.state.nodata && this.game_entries) {
             this.subselect_chart
                 .datum(this.game_entries)
                 .attr('d', this.subselect_area as any);
@@ -776,7 +776,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
     }
 
     renderWinLossNumbersAsText() {
-        if (this.state.loading || this.state.nodata || !this.game_entries) {
+        if (this.state.loading || this.state.nodata || !this.game_entries || !this.win_loss_aggregate) {
             return <div className='win-loss-stats'/>;
         }
 

--- a/src/components/RatingsChartByGame/RatingsChartByGame.tsx
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.tsx
@@ -46,12 +46,11 @@ interface RatingsChartProperties {
     size: 0 | 9 | 13 | 19;
 }
 
-const margin   = {top: 30, right: 20, bottom: 100, left: 20};
+const margin   = {top: 30, right: 20, bottom: 50, left: 20};
 const margin2  = {top: 210, right: 20, bottom: 20, left: 20};
 const chart_min_width = 64;
-const chart_height = 283;
+const chart_height = 380;  // matches definition in .styl
 const date_legend_width = 70;
-const win_loss_bars_start_y = 155;
 
 const height   = chart_height - margin.top - margin.bottom;
 
@@ -194,7 +193,10 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
             this.graph_width = this.width;
         }
 
+        console.log("sizes:", sizes);
         this.pie_width = sizes.width / 3.0;
+
+        console.log(this.width, this.pie_width);
 
         this.height = height;
 
@@ -244,7 +246,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
         /* The pie chart element is positioned at the centre of the circle of the pie.
            We need to create this even if show_pie is false, because it might become true from resizing */
         this.win_loss_pie = this.svg.append('g')
-            .attr('transform', 'translate(' + (graph_right_side + this.pie_width / 2.0) + ',' + ((margin.top + this.height / 2.0) + 20) + ')');
+            .attr('transform', 'translate(' + (graph_right_side + this.pie_width / 2.0) + ',' + ((margin.top + this.height / 3.0)) + ')');
 
         this.legend = this.svg.append('g')
             .attr('transform', 'translate(' + margin2.left + ', 10)')
@@ -470,7 +472,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
 
         let graph_right_side = this.graph_width + margin.left + margin.right;
         this.win_loss_pie
-            .attr('transform', 'translate(' + (graph_right_side + this.pie_width / 2.0) + ',' + ((margin.top + this.height / 2.0) + 20) + ')');
+            .attr('transform', 'translate(' + (graph_right_side + this.pie_width / 2.0) + ',' + ((margin.top + this.height / 3.0)) + ')');
     }
 
     plotWinLossPie = () => {
@@ -500,8 +502,9 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
             'weak-wins'
         ];
 
-        let pie_radius = Math.min(this.pie_width, this.height) / 2.0 - 15; // just looks about right.
+        let pie_radius = Math.min(this.pie_width, this.height) / 4.0 - 15; // just looks about right.
 
+        console.log("radius", pie_radius);
         /* Pie plotting as per example at http://zeroviscosity.com/d3-js-step-by-step/step-1-a-basic-pie-chart */
 
         let arc = d3.arc()
@@ -590,7 +593,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
         let upper = Math.max.apply(null, this.game_entries.map((d:RatingEntry) => Math.max(d.starting_rating, d.rating) + d.deviation));
         this.ratings_y.domain([lower * 0.95, upper * 1.05]);
 
-        this.range_label.text("range_label");
+        // this.range_label.text("range_label");  // when we implement selecting a range, say here what it is
 
         this.deviation_chart
             .datum(this.game_entries)
@@ -622,7 +625,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
 
     render() {
         return (
-            <div ref={this.setContainer} className="RatingsChart">
+            <div ref={this.setContainer} className="RatingsChartByGame">
                 {this.state.loading
                     ? <div className='loading'>{_("Loading")}</div>
                     : this.state.nodata

--- a/src/components/RatingsChartByGame/index.ts
+++ b/src/components/RatingsChartByGame/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2012-2020  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+export * from "./RatingsChartByGame";

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -61,6 +61,8 @@ let defaults = {
     "puzzle.randomize.color": true,
     "puzzle.randomize.transform": true,
     "puzzle.zoom": true,
+    "rating-graph-always-use": false,
+    "rating-graph-plot-by-games": false,
     "show-all-challenges": false,
     "show-unranked-challenges": true,
     "show-ranked-challenges": true,
@@ -71,7 +73,7 @@ let defaults = {
     "show-move-numbers": true,
     "show-offline-friends": true,
     "show-ratings-in-rating-grid": false,
-    "show-ratings-graph-by-game": false,
+
     "show-tournament-indicator": true,
     "show-variation-move-numbers": false,
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -43,6 +43,7 @@ let defaults = {
     "goban-theme-black": null,
     "goban-theme-board": null,
     "goban-theme-white": null,
+    "hide-ranks": false,
     "label-positioning": "all",
     "label-positioning-puzzles": "all",
     "language": "auto",
@@ -69,8 +70,8 @@ let defaults = {
     "show-other-boardsize-challenges": true,
     "show-move-numbers": true,
     "show-offline-friends": true,
-    "hide-ranks": false,
     "show-ratings-in-rating-grid": false,
+    "show-ratings-graph-by-game": false,
     "show-tournament-indicator": true,
     "show-variation-move-numbers": false,
 

--- a/src/views/Settings/Settings.styl
+++ b/src/views/Settings/Settings.styl
@@ -48,9 +48,14 @@
             margin-left: 1rem;
             min-width: 10rem;
         }
+
+        span {
+            margin-right: 0.2rem;
+            margin-left: 0.2rem;
+        }
     }
 
-    .PreferenceDropdown 
+    .PreferenceDropdown
     {
         min-width: 10rem;
         .PreferenceDropdown-value-container {
@@ -271,7 +276,7 @@
     .LogoutButtons {
         flex: 1;
 
-        > div { 
+        > div {
             text-align: center;
             margin-top: 3rem;
         }

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -1010,6 +1010,10 @@ function GeneralPreferences(props:SettingGroupProps):JSX.Element {
         = React.useState(preferences.get("show-tournament-indicator"));
     const [hide_ranks, _setHideRanks]:[boolean, (x: boolean) => void]
         = React.useState(preferences.get("hide-ranks"));
+    const [rating_graph_always_use, _setAlwaysUse]:[boolean, (x: boolean) => void]
+        = React.useState(preferences.get("rating-graph-always-use"));
+    const [rating_graph_plot_by_games, _setUseGames]:[boolean, (x: boolean) => void]
+        = React.useState(preferences.get("rating-graph-plot-by-games"));
     const [incident_report_notifications, setIncidentReportNotifications]:[boolean, (x: boolean) => void]
         = React.useState(preferences.get("notify-on-incident-report"));
 
@@ -1126,6 +1130,16 @@ function GeneralPreferences(props:SettingGroupProps):JSX.Element {
         _setShowTournamentIndicator(preferences.get("show-tournament-indicator"));
     }
 
+    function setAlwaysUse(checked) {
+        preferences.set("rating-graph-always-use", checked),
+        _setAlwaysUse(preferences.get("rating-graph-always-use"));
+    }
+
+    function setPlotByGames(checked) {
+        preferences.set("rating-graph-plot-by-games", checked),
+        _setUseGames(preferences.get("rating-graph-plot-by-games"));
+    }
+
     function setHideRanks(checked) {
         preferences.set("hide-ranks", checked),
         _setHideRanks(preferences.get("hide-ranks"));
@@ -1218,6 +1232,11 @@ function GeneralPreferences(props:SettingGroupProps):JSX.Element {
 
             <PreferenceLine title={_("Hide ranks and ratings")}>
                 <Toggle checked={hide_ranks} onChange={setHideRanks} />
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Plot rating graph by")}>
+                <span>{_("Ask me")}</span><Toggle checked={rating_graph_always_use} onChange={setAlwaysUse} />
+                <span>{_("Always use:")}</span><span>{_("time")}</span><Toggle checked={rating_graph_plot_by_games} onChange={setPlotByGames} disabled={!preferences.get("rating-graph-always-use")}/><span>{_("games")}</span>
             </PreferenceLine>
 
             {(user.is_moderator || null) &&

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -404,7 +404,24 @@
         flex-wrap: nowrap;
 
         .ratings-chart {
-            flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+
+            .graph-type-toggle-control {
+                display: flex;
+                flex-direction: column;
+                font-size: smaller;
+                width: min-content;
+                align-items: center;
+                .graph-type-toggle {
+                    display: flex;
+                    flex-direction: row;
+                    .label {
+                        margin-right: 0.5em;
+                        margin-left: 0.5em;
+                    }
+                }
+            }
         }
     }
 

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -402,26 +402,16 @@
         display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
+        position: relative; // so we can position the graph-type-toggle relative this
 
         .ratings-chart {
             display: flex;
             flex-direction: column;
+        }
 
-            .graph-type-toggle-control {
-                display: flex;
-                flex-direction: column;
-                font-size: smaller;
-                width: min-content;
-                align-items: center;
-                .graph-type-toggle {
-                    display: flex;
-                    flex-direction: row;
-                    .label {
-                        margin-right: 0.5em;
-                        margin-left: 0.5em;
-                    }
-                }
-            }
+        .graph-type-toggle {
+            position: absolute
+            top: -5px;  // manually align with first label row in chart
         }
     }
 

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -400,7 +400,7 @@
         margin-top: 1.5rem;
         margin-bottom: 1rem;
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
         flex-wrap: nowrap;
 
         .ratings-chart {

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -138,7 +138,7 @@ export class User extends React.PureComponent<UserProperties, any> {
             resolved: false,
             temporary_show_ratings: false,
             show_ratings_in_rating_grid: preferences.get('show-ratings-in-rating-grid'),
-            show_ratings_graph_by_game: preferences.get('rating-graph-plot-by-games'),
+            ratings_graph_plot_by_game: preferences.get('rating-graph-plot-by-games'),
             hovered_game_id: null,
         };
 
@@ -557,11 +557,6 @@ export class User extends React.PureComponent<UserProperties, any> {
         preferences.get('hide-ranks') ? "" : rank
     )
 
-    updateHoveredGame = ( game_id: number) => {
-        console.log("Saw hover:", game_id);
-        this.setState({hovered_game_id: game_id});
-    }
-
     updateTogglePosition = ( _height: number, width: number) => {
         this.setState({rating_chart_type_toggle_left: width + 30});  // eyeball enough extra left pad
     }
@@ -853,7 +848,7 @@ export class User extends React.PureComponent<UserProperties, any> {
                     <div className='ratings-chart'>
                         {this.state.ratings_graph_plot_by_game ?
                             <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size}
-                                updateHoveredGame={this.updateHoveredGame} updateChartSize={this.updateTogglePosition}
+                                updateChartSize={this.updateTogglePosition}
                             /> :
                             <RatingsChart playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size}
                                 updateChartSize={this.updateTogglePosition}

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -138,7 +138,8 @@ export class User extends React.PureComponent<UserProperties, any> {
             resolved: false,
             temporary_show_ratings: false,
             show_ratings_in_rating_grid: preferences.get('show-ratings-in-rating-grid'),
-            ratings_graph_plot_by_game: preferences.get('rating-graph-plot-by-games'),
+            rating_graph_plot_by_games: preferences.get('rating-graph-plot-by-games'),
+            show_graph_type_toggle: !preferences.get('rating-graph-always-use'),
             hovered_game_id: null,
         };
 
@@ -846,7 +847,7 @@ export class User extends React.PureComponent<UserProperties, any> {
             {(!preferences.get("hide-ranks") || this.state.temporary_show_ratings) && (!user.professional || global_user.id === user.id) &&
                 <div className='ratings-row'>
                     <div className='ratings-chart'>
-                        {this.state.ratings_graph_plot_by_game ?
+                        {this.state.rating_graph_plot_by_games ?
                             <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size}
                                 updateChartSize={this.updateTogglePosition}
                             /> :
@@ -855,20 +856,22 @@ export class User extends React.PureComponent<UserProperties, any> {
                             />
                         }
                     </div>
-                    <div className='graph-type-toggle' style={{
-                            left: this.state.rating_chart_type_toggle_left}
-                        }>
-                        <Toggle
-                            height={10}
-                            width={20}
-                            checked={this.state.ratings_graph_plot_by_game}
-                            id='show-ratings-in-days'
-                            onChange={(checked, ev, id) => {
-                                this.setState({'ratings_graph_plot_by_game': checked});
-                                preferences.set('ratings-graph-plot-by-game', checked);
-                            }}
-                            />
-                    </div>
+                    {this.state.show_graph_type_toggle &&
+                        <div className='graph-type-toggle' style={{
+                                left: this.state.rating_chart_type_toggle_left}
+                            }>
+                            <Toggle
+                                height={10}
+                                width={20}
+                                checked={this.state.rating_graph_plot_by_games}
+                                id='show-ratings-in-days'
+                                onChange={(checked, ev, id) => {
+                                    this.setState({'rating_graph_plot_by_games': checked});
+                                    preferences.set('rating-graph-plot-by-games', checked);
+                                }}
+                                />
+                        </div>
+                    }
                 </div>
             }
 

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -43,6 +43,7 @@ import {image_resizer} from "image_resizer";
 import {Flag} from "Flag";
 import {Markdown} from "Markdown";
 import {RatingsChart} from 'RatingsChart';
+import {RatingsChartByGame} from 'RatingsChartByGame';
 import {UIPush} from "UIPush";
 import {associations} from 'associations';
 import {browserHistory} from "ogsHistory";
@@ -137,6 +138,7 @@ export class User extends React.PureComponent<UserProperties, any> {
             resolved: false,
             temporary_show_ratings: false,
             show_ratings_in_rating_grid: preferences.get('show-ratings-in-rating-grid'),
+            show_ratings_graph_by_game: preferences.get('show-ratings-graph-by-game'),
         };
 
         try {
@@ -843,7 +845,20 @@ export class User extends React.PureComponent<UserProperties, any> {
             {(!preferences.get("hide-ranks") || this.state.temporary_show_ratings) && (!user.professional || global_user.id === user.id) &&
                 <div className='ratings-row'>
                     <div className='ratings-chart'>
-                        <RatingsChart playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} />
+                        {this.state.show_ratings_graph_by_game ?
+                            <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} /> :
+                            <RatingsChart playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} />
+                        }
+                        <Toggle
+                            height={14}
+                            width={30}
+                            checked={this.state.show_ratings_graph_by_game}
+                            id='show-ratings-in-days'
+                            onChange={(checked, ev, id) => {
+                                this.setState({'show_ratings_graph_by_game': checked});
+                                preferences.set('show-ratings-graph-by-game', checked);
+                            }}
+                            />
                     </div>
                 </div>
             }

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -849,16 +849,25 @@ export class User extends React.PureComponent<UserProperties, any> {
                             <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} /> :
                             <RatingsChart playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} />
                         }
-                        <Toggle
-                            height={14}
-                            width={30}
-                            checked={this.state.show_ratings_graph_by_game}
-                            id='show-ratings-in-days'
-                            onChange={(checked, ev, id) => {
-                                this.setState({'show_ratings_graph_by_game': checked});
-                                preferences.set('show-ratings-graph-by-game', checked);
-                            }}
-                            />
+                        <div className='graph-type-toggle-control'>
+                            <div className='graph-type-toggle-label'>
+                                {_('Plot by:')}
+                            </div>
+                            <div className='graph-type-toggle'>
+                                <span className='label'>{_('date')}</span>
+                                <Toggle
+                                    height={10}
+                                    width={20}
+                                    checked={this.state.show_ratings_graph_by_game}
+                                    id='show-ratings-in-days'
+                                    onChange={(checked, ev, id) => {
+                                        this.setState({'show_ratings_graph_by_game': checked});
+                                        preferences.set('show-ratings-graph-by-game', checked);
+                                    }}
+                                    />
+                                <span className='label'>{_('game')}</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             }

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -28,6 +28,8 @@ import {Card} from 'material';
 import {PlayerIcon} from 'PlayerIcon';
 import {GameList} from "GameList";
 import {Player} from "Player";
+import { MiniGoban } from "MiniGoban";
+import { GobanLineSummary } from "GobanLineSummary";
 import * as preferences from "preferences";
 import {updateDup, getGameResultText, ignore} from "misc";
 import {longRankString, rankString, getUserRating, humble_rating, effective_outcome, rating_to_rank, boundedRankString, rank_deviation} from "rank_utils";
@@ -139,6 +141,7 @@ export class User extends React.PureComponent<UserProperties, any> {
             temporary_show_ratings: false,
             show_ratings_in_rating_grid: preferences.get('show-ratings-in-rating-grid'),
             show_ratings_graph_by_game: preferences.get('show-ratings-graph-by-game'),
+            hovered_game_id: null,
         };
 
         try {
@@ -556,6 +559,11 @@ export class User extends React.PureComponent<UserProperties, any> {
         preferences.get('hide-ranks') ? "" : rank
     )
 
+    updateHoveredGame = ( game_id: number) => {
+        console.log("Saw hover:", game_id);
+        this.setState({hovered_game_id: game_id});
+    }
+
     render() {
         let user = this.state.user;
         if (!user) { return this.renderInvalidUser(); }
@@ -572,7 +580,6 @@ export class User extends React.PureComponent<UserProperties, any> {
             }
         };
         setTimeout(doDomWork, 0);
-
 
         let game_history_groomer = (results) => {
             let ret = [];
@@ -835,18 +842,15 @@ export class User extends React.PureComponent<UserProperties, any> {
                                 {this.renderRatingGrid(this.state.show_ratings_in_rating_grid)}
                             </div>
                         }
-
-
                     </div>
                 </div>
             </div>
-
 
             {(!preferences.get("hide-ranks") || this.state.temporary_show_ratings) && (!user.professional || global_user.id === user.id) &&
                 <div className='ratings-row'>
                     <div className='ratings-chart'>
                         {this.state.show_ratings_graph_by_game ?
-                            <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} /> :
+                            <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} updateHoveredGame={this.updateHoveredGame}/> :
                             <RatingsChart playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} />
                         }
                         <div className='graph-type-toggle-control'>
@@ -867,6 +871,12 @@ export class User extends React.PureComponent<UserProperties, any> {
                                     />
                                 <span className='label'>{_('game')}</span>
                             </div>
+                            {this.state.hovered_game_id &&
+                                <MiniGoban
+                                    id={this.state.hovered_game_id}
+                                    displayWidth={500}
+                                />
+                            }
                         </div>
                     </div>
                 </div>

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -28,8 +28,6 @@ import {Card} from 'material';
 import {PlayerIcon} from 'PlayerIcon';
 import {GameList} from "GameList";
 import {Player} from "Player";
-import { MiniGoban } from "MiniGoban";
-import { GobanLineSummary } from "GobanLineSummary";
 import * as preferences from "preferences";
 import {updateDup, getGameResultText, ignore} from "misc";
 import {longRankString, rankString, getUserRating, humble_rating, effective_outcome, rating_to_rank, boundedRankString, rank_deviation} from "rank_utils";
@@ -140,7 +138,7 @@ export class User extends React.PureComponent<UserProperties, any> {
             resolved: false,
             temporary_show_ratings: false,
             show_ratings_in_rating_grid: preferences.get('show-ratings-in-rating-grid'),
-            show_ratings_graph_by_game: preferences.get('show-ratings-graph-by-game'),
+            show_ratings_graph_by_game: preferences.get('rating-graph-plot-by-games'),
             hovered_game_id: null,
         };
 
@@ -564,6 +562,10 @@ export class User extends React.PureComponent<UserProperties, any> {
         this.setState({hovered_game_id: game_id});
     }
 
+    updateTogglePosition = ( _height: number, width: number) => {
+        this.setState({rating_chart_type_toggle_left: width + 30});  // eyeball enough extra left pad
+    }
+
     render() {
         let user = this.state.user;
         if (!user) { return this.renderInvalidUser(); }
@@ -849,35 +851,28 @@ export class User extends React.PureComponent<UserProperties, any> {
             {(!preferences.get("hide-ranks") || this.state.temporary_show_ratings) && (!user.professional || global_user.id === user.id) &&
                 <div className='ratings-row'>
                     <div className='ratings-chart'>
-                        {this.state.show_ratings_graph_by_game ?
-                            <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} updateHoveredGame={this.updateHoveredGame}/> :
-                            <RatingsChart playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size} />
+                        {this.state.ratings_graph_plot_by_game ?
+                            <RatingsChartByGame playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size}
+                                updateHoveredGame={this.updateHoveredGame} updateChartSize={this.updateTogglePosition}
+                            /> :
+                            <RatingsChart playerId={this.user_id} speed={this.state.selected_speed} size={this.state.selected_size}
+                                updateChartSize={this.updateTogglePosition}
+                            />
                         }
-                        <div className='graph-type-toggle-control'>
-                            <div className='graph-type-toggle-label'>
-                                {_('Plot by:')}
-                            </div>
-                            <div className='graph-type-toggle'>
-                                <span className='label'>{_('date')}</span>
-                                <Toggle
-                                    height={10}
-                                    width={20}
-                                    checked={this.state.show_ratings_graph_by_game}
-                                    id='show-ratings-in-days'
-                                    onChange={(checked, ev, id) => {
-                                        this.setState({'show_ratings_graph_by_game': checked});
-                                        preferences.set('show-ratings-graph-by-game', checked);
-                                    }}
-                                    />
-                                <span className='label'>{_('game')}</span>
-                            </div>
-                            {this.state.hovered_game_id &&
-                                <MiniGoban
-                                    id={this.state.hovered_game_id}
-                                    displayWidth={500}
-                                />
-                            }
-                        </div>
+                    </div>
+                    <div className='graph-type-toggle' style={{
+                            left: this.state.rating_chart_type_toggle_left}
+                        }>
+                        <Toggle
+                            height={10}
+                            width={20}
+                            checked={this.state.ratings_graph_plot_by_game}
+                            id='show-ratings-in-days'
+                            onChange={(checked, ev, id) => {
+                                this.setState({'ratings_graph_plot_by_game': checked});
+                                preferences.set('ratings-graph-plot-by-game', checked);
+                            }}
+                            />
                     </div>
                 </div>
             }


### PR DESCRIPTION
## Proposed Changes

Add a toggle that allows the rating graph to be plotted by game.

When selected, 
 - the win-loss bars are removed (because they don't make sense without timeline granularity)
 - the x axis becomes "games played"
 - the pie chart shows the date for the games selected by the lower sub-selection area 
 
![Screen Shot 2021-08-06 at 10 49 44 pm (3)](https://user-images.githubusercontent.com/61894/128516540-f555cab7-7c95-4024-bcde-d80dda60712f.png)
