### PR TITLE
Various fixes for game popup in rating chart

### DIFF
--- a/src/components/MiniGoban/MiniGoban.styl
+++ b/src/components/MiniGoban/MiniGoban.styl
@@ -40,7 +40,7 @@
         align-items: center;
         margin-bottom: 0.5rem;
 
-        .game-date {
+        .game-date, .game-result {
             font-size: smaller;
         }
     }

--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -28,6 +28,7 @@ import {PersistentElement} from "PersistentElement";
 import {rankString, getUserRating} from "rank_utils";
 import { Clock } from 'Clock';
 import { fetch } from "player_cache";
+import { getGameResultText } from "misc";
 
 interface MiniGobanProps {
     id: number;
@@ -127,9 +128,37 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
         }
 
         if (this.props.title) {
+
+            // we have to cook up a `result` object to pass to getGameResultText
+            let result:any;
+
+            if (this.goban.engine.winner === this.goban.engine.black_player_id) {
+                result = {
+                    black_lost: false,
+                    white_lost: true
+                };
+            }
+            else if (this.goban.engine.winner === this.goban.engine.white_player_id) {
+                result = {
+                    black_lost: true,
+                    white_lost: false
+                };
+            }
+            else {
+                result = {
+                    black_lost: true,
+                    white_lost: true
+                };
+            }
+
+            result.outcome = this.goban.engine.outcome;
+
+            const result_string = getGameResultText(result);
+
             this.setState({
                 game_name: this.goban.engine.game_name || "",
-                game_date: this.goban.config.end_time ? moment(new Date(this.goban.config.end_time * 1000)).format("LLL") : ""
+                game_date: this.goban.config.end_time ? moment(new Date(this.goban.config.end_time * 1000)).format("LLL") : "",
+                game_result: result_string
             });
         }
 
@@ -173,6 +202,7 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
                 <div className={"minigoban-title"}>
                     <div>{this.state.game_name}</div>
                     <div className="game-date">{this.state.game_date}</div>
+                    <div className="game-result">{this.state.game_result}</div>
                 </div>
             }
             <div className="inner-container">
@@ -188,7 +218,7 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
                         <span className={`player-name`}>{this.state.black_name}</span>
                         <span className={`player-rank`}>{this.state.black_rank}</span>
                         {this.state.finished || <Clock compact goban={this.goban} color='black' className='mini-goban' />}
-                        <span className="score">{this.state.black_points}</span>
+                        {this.state.finished || <span className="score">{this.state.black_points}</span>}
                     </div>
                 }
                 {!this.props.noText &&
@@ -196,7 +226,7 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
                         <span className={`player-name`}>{this.state.white_name}</span>
                         <span className={`player-rank`}>{this.state.white_rank}</span>
                         {this.state.finished || <Clock compact goban={this.goban} color='white' className='mini-goban' />}
-                        <span className="score">{this.state.white_points}</span>
+                        {this.state.finished || <span className="score">{this.state.white_points}</span>}
                     </div>
                 }
             </div>

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -232,11 +232,15 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         this.graph_width = 2.0 * sizes.width / 3.0;
 
         if (this.width > 768) {  /* it gets too bunched up to show the pie */
-            this.show_pie = true;
+            if (!this.show_pie) {
+                this.show_pie = true;
+                this.plotWinLossPie();
+            }
         }
         else {
             this.show_pie = false;
             this.graph_width = this.width;
+            this.hideWinLossPie();
         }
 
         this.pie_width = sizes.width / 3.0;
@@ -600,7 +604,17 @@ export class RatingsChart extends React.Component<RatingsChartProperties, any> {
         }
     }
 
+    hideWinLossPie = () => {
+        if (this.win_loss_pie) {
+            this.win_loss_pie.selectAll('path').remove();
+            this.win_loss_pie.selectAll('rect').remove();
+            this.win_loss_pie.selectAll('text').remove();
+        }
+    }
+
     plotWinLossPie = () => {
+        if (!this.win_loss_pie) { return; }
+
         let agg = this.win_loss_aggregate;
 
         /* with well spread data, the order here places wins on top, and stronger opponent on right of pie */


### PR DESCRIPTION
Fixes:
 - Lingering PieChart artifacts on resize (corner cases)
 - Display of game hover popup when pie chart won't fit (don't do that)
 - Overlapping textual win-loss information in by-game chart in phone form factor (don't display this info, for now)
 - Display of meaningless points when game is finished (don't do that)
 - Display result of game that is finished in the title (do do that)
 
## Proposed Changes

Got rid of renderWinLostResultsAsText in the by-game component, for now.   This is actually buggy in the original chart component: the render of this extends below the extent of the element (it looks like vertical clip was turned off to allow this). but due to fortunate spacing in the rating-by-time case, it looks almost OK.

I couldn't quickly work out how to solve this properly - the whole "calculation of the height of various elements" needs a big tidyup to be comprehendable, then this fix would probably be easy.  In the mean time, simply not showing it works.

The turning off and on of pie chart had some buggy cases during resize even in the original - that should be fixed now (I had thought that pushing it off to the right offscreen was enough, but it turns out sometimes it can sneak onscreen in thin form factors, so now it is completely un-rendered)

