### PR TITLE
OJE Throbber Spinner Light theme and Go Resources IGA

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/jest": "^26.0.15",
     "autoprefixer": "^10.2.5",
     "body-parser": "^1.16.1",
+    "cache-loader": "^4.1.0",
     "cssnano": "^5.0.2",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0",
@@ -53,9 +54,8 @@
     "webpack": "^5.37.0",
     "webpack-bundle-analyzer": "^4.1.1",
     "webpack-cli": "^4.7.0",
-    "cache-loader": "^4.1.0",
     "xgettext-js": "^3.0.0",
-    "yarn": "^1.22.10"
+    "yarn": "^1.22.11"
   },
   "dependencies": {
     "@sentry/browser": "^6.3.6",

--- a/src/components/Throbber/Throbber.styl
+++ b/src/components/Throbber/Throbber.styl
@@ -42,7 +42,7 @@
       width: 4px;
       height: 7px;
       border-radius: 20%;
-      background: #fff;
+      themed(background,shade0);
     }
     .lds-spinner div:nth-child(1) {
       transform: rotate(0deg);

--- a/src/views/docs/GoResources.tsx
+++ b/src/views/docs/GoResources.tsx
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 2012-2020  Online-Go.com
  *
  * This program is free software: you can redistribute it and/or modify
@@ -328,6 +328,7 @@ export let GoResources = (props) => {
                 {scramble(
                 <span><Flag country={us}/> <a rel="noopener" href="http://www.usgo.org/">American Go Association</a></span>,
                 <span><Flag country={"gb"}/> <a rel="noopener" href="http://britgo.org/">British Go Association</a></span>,
+                <span><Flag country={"ie"}/> <a rel="noopener" href="https://www.irish-go.org">Irish Go Association</a></span>,
                 <span><Flag country={ca}/> <a rel="noopener" href="http://go-canada.org/">Canadian Go Association</a></span>,
                 <span><Flag country={de}/> <a rel="noopener" href="http://dgob.de/">Deutscher Go-Bund</a></span>,
                 <span><Flag country={au}/> <a rel="noopener" href="http://www.australiango.asn.au/">Australian Go Association</a></span>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9208,10 +9208,10 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn@^1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
+yarn@^1.22.11:
+  version "1.22.11"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.11.tgz#d0104043e7349046e0e2aec977c24be106925ed6"
+  integrity sha512-AWje4bzqO9RUn3sdnM5N8n4ZJ0BqCc/kqFJvpOI5/EVkINXui0yuvU7NDCEF//+WaxHuNay2uOHxA4+tq1P3cg==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Fixes 
In light theme while the OJE, joseki explorer is loading the throbber spinner is white like the background, hence is invisible, unlike in dark theme. Changed the background of spinner to use themed(background,shade0), which at least has some contrast to the theme background.

## Proposed Changes

  - Add a link to the Irish Go Association in the Other Go resources page, with Ireland flag beside the link.

### Comment/Question

I'm not sure why the yarn version is different from the main repository in package.json and yarn.lock. I'm using npm 6.14.14, node.js v14.17.5 . Is there another version I should use instead? The cache loader line just seems to have been moved automatically (alphabetically), but not changed.
