### PR TITLE
Fix OJE caching root

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -441,6 +441,8 @@ export class Joseki extends React.Component<JosekiProps, any> {
                 if ((this.waiting_for === "root" && target_node.placement === "root") ||
                     (this.waiting_for === target_node.node_id.toString()) ) {
                     this.processNewMoves(node_id, target_node);
+                    // caching this one is important, because node_id could be "root", which needs to be cached this way
+                    this.cached_positions = {[node_id]: target_node, ...this.cached_positions};
                 }
                 else {
                     console.log("Ignoring server response ", target_node, " looking for ", this.waiting_for);


### PR DESCRIPTION
Fixes the problem where when you press double back arrow to get to the empty board, it re-fetches the result, even though we cached it.   That's because double back arrow requests "root" (because we don't know the empty board node-id) but we cached it by the resulting node-id.

## Proposed Changes

Cache all immediate fetches immediately, by the requested node-id (instead of by fetched-node-id via the pre-fetch result that comes next), ensuring there is an entry for "root".
