### PR TITLE
Optimize OJE prefetch

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -441,6 +441,8 @@ export class Joseki extends React.Component<JosekiProps, any> {
                 if ((this.waiting_for === "root" && target_node.placement === "root") ||
                     (this.waiting_for === target_node.node_id.toString()) ) {
                     this.processNewMoves(node_id, target_node);
+                    // caching this one is important, because node_id could be "root", which needs to be cached this way
+                    this.cached_positions = {[node_id]: target_node, ...this.cached_positions};
                 }
                 else {
                     console.log("Ignoring server response ", target_node, " looking for ", this.waiting_for);

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -38,8 +38,6 @@ import {JosekiSourceModal} from "JosekiSourceModal";
 import {JosekiVariationFilter} from "JosekiVariationFilter";
 import {JosekiTagSelector} from "JosekiTagSelector";
 import {Throbber} from "Throbber";
-import { node } from "prop-types";
-import { scaleDivergingPow } from "d3";
 
 const server_url = data.get("joseki-url", "/godojo/");
 


### PR DESCRIPTION
Fixes some lagginess

## Proposed Changes

 - Keep track of what nodes have already been prefetched, don't do them again
 - Don't fire a second prefetch if one is in flight
 - Ensure that browser prioritisation funkiness doesn't result in prefetch hitting server before main fetch
 
