### PR TITLE
in Tournament.tsx, handle the case where minimum and maximum players are equal, instead of showing it incorrectly as e.g. "10+"

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1400,7 +1400,13 @@ export class Tournament extends React.PureComponent<TournamentProperties, any> {
                                 {!editing
                                     ? <span>
                                          {tournament.players_start}
-                                         {((tournament.settings.maximum_players && tournament.settings.maximum_players > tournament.players_start)) ? "-" + tournament.settings.maximum_players : "+"}
+                                         {!tournament.settings.maximum_players
+                                             ? "+"
+                                             : (
+                                                 tournament.settings.maximum_players > tournament.players_start
+                                                 ? "-" + tournament.settings.maximum_players
+                                                 : ""
+                                             )}
                                       </span>
                                     : <span>
                                          <input ref="players_start" type="number" value={tournament.players_start} onChange={this.setPlayersStart} />


### PR DESCRIPTION
This fixes a problem with display of tournaments that have equal numbers for minimum and maximum players , such as all the "start when full" tournaments in the [New Zealand Tournaments](https://online-go.com/group/3207) group. Here's an example of such a tournament on the beta site:

https://beta.online-go.com/tournament/138

Currently it shows up like this:

![image](https://user-images.githubusercontent.com/466760/134784522-ad2195d6-7e62-410a-9b13-88f9ff6beaba.png)

This change removes the "+" in the case where min and max are equal.