### PR TITLE
Add the real time API documentation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Online-go provides several resources that allows you to interact with the projec
 * https://online-go.com/developer to access documentation.
 * https://github.com/online-go/online-go.com/wiki to get started and how to use the website.
 * https://ogs.docs.apiary.io/# for API documentation.
+* https://ogs.readme.io/docs/real-time-api for real time API documentation
 * https://online-go.com/oauth2/applications/ OAuth2 Application Manager (you must be signed into an account on OGS.)
 
 # Social Media


### PR DESCRIPTION
## Proposed Changes

  - Adds the real time API documentation to README.md

---

There is no mention of the real time API in the main [API documentation](https://ogs.docs.apiary.io/). As far as I can tell, this is the only documentation for the real time API.

The real time API documentation is still linked in the [gtp2ogs repo](https://github.com/online-go/gtp2ogs/blob/devel/docs/DEV.md#doc), so I think it is also appropriate to add here.

---

Side note: Are the [readme.io docs](https://ogs.readme.io/) deprecated? If so, I think the site should be taken offline after moving any remaining documentation over to apiary. It was confusing to track down all the APIs needed to build a client.

Also, thank you for making OGS! Love this site.