### PR TITLE
Allow longer live games using Fischer time settings

### DIFF
--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -120,9 +120,9 @@ export const time_options = {
     },
     "live": {
         "fischer": {
-            "initial_time": gen(30, 3600),
+            "initial_time": gen(30, 3600 * 4),
             "time_increment": gen(10, 1800),
-            "max_time": gen(30, 3600),
+            "max_time": gen(30, 3600 * 4).concat(gen(86400 * 28, 86400 * 28)),
         },
         "simple": {
             "per_move": gen(10, 3600),

--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -122,7 +122,7 @@ export const time_options = {
         "fischer": {
             "initial_time": gen(30, 3600 * 4),
             "time_increment": gen(10, 1800),
-            "max_time": gen(30, 3600 * 4).concat(gen(86400 * 28, 86400 * 28)),
+            "max_time": gen(30, 3600 * 4),
         },
         "simple": {
             "per_move": gen(10, 3600),


### PR DESCRIPTION
Fixes #839

## Proposed Changes

  - Allow *initial time* of up to 4 hours instead of up to 1 hour
  - Allow *max time* of up to 4 hours or 28 days instead of up to 1 hour

## Notes
The lack of longer time settings where mentioned by European professional Ali Jabarin as an "OGS bug" during a European Go Championship stream. He thought players should gain time that exceeds the 1 hour *initial time*, which was not possible because the highest *max time* was (prior to this change) also 1 hour. It sounded like he was expecting no max time at all. @BHydden considered this also as "real Fischer" on the OGS forum.

I've chosen 28 days as highest *max time*, because I think (for live games) it is close enough to infinite time or no max time and can still nicely be represented in the select list without any further changes.
