### PR TITLE
AI Review: use ΔScore in calculation of top 3 moves

### DIFF
--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -65,8 +65,6 @@ interface AIReviewState {
     ai_reviews: Array<JGOFAIReview>;
     selected_ai_review?: JGOFAIReview;
     updatecount: number;
-    top_moves: Array<JGOFAIReviewMove>;
-    worst_move_delta_filter: number;
 }
 
 export class AIReview extends React.Component<AIReviewProperties, AIReviewState> {
@@ -82,8 +80,6 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             reviewing: false,
             ai_reviews: [],
             updatecount: 0,
-            top_moves: [],
-            worst_move_delta_filter: 0.1,
             use_score: preferences.get('ai-review-use-score'),
         };
         this.state = state;
@@ -982,27 +978,9 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                         </span>
                     }
                 </div>
-
-                {/*
-                <span className='filter'>
-                    <select
-                        value={this.state.worst_move_delta_filter}
-                        onChange={this.setWorstMoveDeltaFilter}
-                        >
-                        <option value={0.1}>10</option>
-                        <option value={0.4}>40</option>
-                        <option value={0.5}>50</option>
-                    </select>
-                </span>
-                */}
-
             </div>
         );
     }
-
-    setWorstMoveDeltaFilter = (ev) => {
-        this.setState({worst_move_delta_filter: parseFloat(ev.target.value)});
-    };
 }
 
 function sanityCheck(ai_review: JGOFAIReview) {

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -39,8 +39,7 @@ import {
     JGOFIntersection,
     JGOFNumericPlayerColor,
     ColoredCircle,
-    computeWorstMoves,
-    MarkInterface,
+    getWorstMoves,
     AIReviewWorstMoveEntry
 } from 'goban';
 import swal from 'sweetalert2';
@@ -771,7 +770,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         const move_number = trunk_move.move_number;
         const variation_move_number = cur_move.move_number !== trunk_move.move_number ? cur_move.move_number : -1;
 
-        const worst_move_list = this.getWorstMoveList();
+        const worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review);
 
         return (
             <div className='AIReview'>
@@ -965,28 +964,6 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                 }
             </div>
         );
-    }
-
-    public getWorstMoveList(): AIReviewWorstMoveEntry[] {
-        const move_tree = this.props.game.goban.engine.move_tree;
-        let worst_moves: AIReviewWorstMoveEntry[];
-        let threshhold: number;
-
-        if (this.ai_review?.scores) {
-            worst_moves = computeWorstMoves(move_tree, this.ai_review, /*use_score=*/true);
-            threshhold = -5.0;
-        } else {
-            worst_moves = computeWorstMoves(move_tree, this.ai_review);
-            threshhold = -0.2;
-        }
-
-        const filtered_worst_moves = worst_moves.filter(de => de.delta <= -5.0);
-
-        if (filtered_worst_moves.length >= 3) {
-            return filtered_worst_moves;
-        }
-
-        return worst_moves.slice(0, 3);
     }
 
     public renderWorstMoveList(lst: AIReviewWorstMoveEntry[]): JSX.Element {

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -187,10 +187,16 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         if (!ai_review.win_rates) {
             ai_review.win_rates = [];
         }
+        if (!ai_review.scores) {
+            ai_review.scores = [];
+        }
 
         for (const k in ai_review.moves) {
             const move = ai_review.moves[k];
             ai_review.win_rates[move.move_number] = move.win_rate;
+            if (move.score !== undefined) {
+                ai_review.scores[move.move_number] = move.score;
+            }
         }
 
         /* For old reviews, we might not have all win rates, so fill in the missing entries */

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -83,6 +83,8 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             ai_reviews: [],
             updatecount: 0,
             use_score: preferences.get('ai-review-use-score'),
+            // TODO: allow users to view more than 3 of these key moves
+            // See https://forums.online-go.com/t/top-3-moves-score-a-better-metric/32702/15
             worst_moves_shown: 3,
         };
         this.state = state;

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -39,7 +39,8 @@ import {
     JGOFIntersection,
     JGOFNumericPlayerColor,
     ColoredCircle,
-    computeWorstMoves
+    computeWorstMoves,
+    MarkInterface
 } from 'goban';
 import swal from 'sweetalert2';
 
@@ -430,8 +431,8 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             next_score = scores[move_number + 1] || score;
         }
 
-        const marks: any = {};
-        const colored_circles = [];
+        const marks: MarkInterface = {};
+        const colored_circles: ColoredCircle[] = [];
         let heatmap: Array<Array<number>> | null = null;
         try {
             if ((cur_move.trunk || have_variation_results) && ai_review_move) { /* if we are on a trunk move that was AI reviewed */
@@ -633,7 +634,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
      * remaining AI sequence.
      * @returns true if we found some data, false otherwise
      */
-    private fillAIMarksBacktracking(cur_move: MoveTree, trunk_move: MoveTree, marks): boolean {
+    private fillAIMarksBacktracking(cur_move: MoveTree, trunk_move: MoveTree, marks: MarkInterface): boolean {
         for (let j = 0; j <= trunk_move.move_number; j++) { /* for each of the trunk moves starting from the nearest */
             const ai_review_move = this.ai_review.moves[trunk_move.move_number - j];
             if (!ai_review_move) {

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -66,6 +66,7 @@ interface AIReviewState {
     ai_reviews: Array<JGOFAIReview>;
     selected_ai_review?: JGOFAIReview;
     updatecount: number;
+    worst_moves_shown: number;
 }
 
 export class AIReview extends React.Component<AIReviewProperties, AIReviewState> {
@@ -82,6 +83,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             ai_reviews: [],
             updatecount: 0,
             use_score: preferences.get('ai-review-use-score'),
+            worst_moves_shown: 3,
         };
         this.state = state;
         window['aireview'] = this;
@@ -891,6 +893,11 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                                     variation_move_number={variation_move_number}
                                     setmove={this.props.game.nav_goto_move}
                                     use_score={this.state.use_score}
+                                    highlighted_moves={
+                                        worst_move_list
+                                            .slice(0, this.state.worst_moves_shown)
+                                            .map(m => m.move_number - 1)
+                                    }
                                 />
                                 {this.ai_review.scores &&
                                     <div className='win-score-toggler'>

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -438,7 +438,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             next_score = scores[move_number + 1] || score;
         }
 
-        const marks: MarkInterface = {};
+        const marks: {[mark: string]: string} = {};
         const colored_circles: ColoredCircle[] = [];
         let heatmap: Array<Array<number>> | null = null;
         try {
@@ -641,7 +641,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
      * remaining AI sequence.
      * @returns true if we found some data, false otherwise
      */
-    private fillAIMarksBacktracking(cur_move: MoveTree, trunk_move: MoveTree, marks: MarkInterface): boolean {
+    private fillAIMarksBacktracking(cur_move: MoveTree, trunk_move: MoveTree, marks: {[mark: string]: string}): boolean {
         for (let j = 0; j <= trunk_move.move_number; j++) { /* for each of the trunk moves starting from the nearest */
             const ai_review_move = this.ai_review.moves[trunk_move.move_number - j];
             if (!ai_review_move) {

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -23,11 +23,11 @@ import Select, { components } from 'react-select';
 import { UIPush } from "UIPush";
 import { AIReviewStream, ai_request_variation_analysis } from "AIReviewStream";
 import { openBecomeASiteSupporterModal } from "Supporter";
-import { deepCompare, errorAlerter, dup, errorLogger, Timeout } from 'misc';
+import { errorAlerter, errorLogger, Timeout } from 'misc';
 import { get, post } from 'requests';
 import { _, pgettext, interpolate } from "translate";
 import { Game } from './Game';
-import { close_all_popovers, popover } from "popover";
+import { close_all_popovers } from "popover";
 import { Errcode } from 'Errcode';
 import { AIReviewChart } from './AIReviewChart';
 import { Toggle } from 'Toggle';
@@ -39,8 +39,7 @@ import {
     JGOFIntersection,
     JGOFNumericPlayerColor,
     ColoredCircle,
-    computeWorstMoves,
-    AIReviewWorstMoveEntry,
+    computeWorstMoves
 } from 'goban';
 import swal from 'sweetalert2';
 

--- a/src/views/Game/AIReviewChart.tsx
+++ b/src/views/Game/AIReviewChart.tsx
@@ -34,6 +34,7 @@ interface AIReviewChartProperties {
     variation_entries: Array<AIReviewEntry>;
     setmove: (move_number: number) => void;
     use_score: boolean;
+    highlighted_moves?: number[];
 }
 
 const bisector = d3.bisector((d: AIReviewEntry) => { return d.move_number; }).left;
@@ -370,13 +371,24 @@ export class AIReviewChart extends React.Component<AIReviewChartProperties, any>
 
         const show_all = Object.keys(this.props.ai_review.moves).length <= 3;
         const circle_coords = entries.filter((x) => {
-            if (this.props.ai_review.moves[x.move_number]
-                && (show_all || (
-                    !this.props.ai_review.moves[x.move_number + 1]
-                        && x.move_number !== this.props.ai_review.win_rates.length - 1)
-                )
-            ) {
-                return true;
+            if (this.props.ai_review.moves[x.move_number]) {
+                // This was a fast review, so mark only the 3 key moves provided
+                // by the backend
+                if (show_all) {
+                    return true;
+                }
+
+                // The review is in progress, so mark discontinuities
+                if (!this.props.ai_review.moves[x.move_number + 1]
+                    && x.move_number !== this.props.ai_review.win_rates.length - 1) {
+                    return true;
+                }
+
+                // Highlighted moves are passed in. This is in the case of a
+                // full review where key moves have been calculated client-side
+                if (this.props.highlighted_moves?.includes(x.move_number)) {
+                    return true;
+                }
             }
 
             return false;

--- a/src/views/Game/AIReviewChart.tsx
+++ b/src/views/Game/AIReviewChart.tsx
@@ -16,14 +16,13 @@
  */
 
 import * as d3 from "d3";
-import * as moment from "moment";
 import * as React from "react";
 import * as JSNoise from 'js-noise';
 import * as data from "data";
 import ReactResizeDetector from 'react-resize-detector';
 import { AIReviewEntry } from './AIReview';
 import { PersistentElement } from 'PersistentElement';
-import { deepCompare, errorAlerter, dup, errorLogger } from 'misc';
+import { deepCompare } from 'misc';
 import { JGOFAIReview, } from 'goban';
 
 interface AIReviewChartProperties {


### PR DESCRIPTION
Fixes #1343

Depends on https://github.com/online-go/goban/pull/43

## Proposed Changes

  - Use score instead of win rate for calculating Key Moves
      - note: will fall back on win_rate if score is not provided
  - Show key moves as red dots for site supporter games
  - Cleanup: remove unused variables in AIReview.tsx

## Screenshots

Before:
<img width="342" alt="Screen Shot 2021-11-26 at 4 32 17 PM" src="https://user-images.githubusercontent.com/25233703/143656362-f9445c11-5c6f-4908-8843-d0d6d256987b.png">

After:
<img width="344" alt="Screen Shot 2021-11-26 at 4 32 31 PM" src="https://user-images.githubusercontent.com/25233703/143656382-e12d5279-ab2d-4658-b5a6-94265fd2c1b6.png">


