### PR TITLE
GobanThemePicker: Cleanup & tooltips

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -27,13 +27,22 @@ interface GobanThemePickerProperties {
     size?: number;
 }
 
+interface GobanThemePickerState {
+    size: number;
+    board: string;
+    white: string;
+    black: string;
+    boardCustom: string;
+    lineCustom: string;
+    whiteCustom: string;
+    blackCustom: string;
+    urlCustom: string;
+}
+export class GobanThemePicker extends React.PureComponent<GobanThemePickerProperties, GobanThemePickerState> {
+    canvases: {[k: string]: JQuery[]} = {};
+    selectTheme: {[k: string]: {[k: string]: () => void}} = {};
 
-
-export class GobanThemePicker extends React.PureComponent<GobanThemePickerProperties, any> {
-    canvases: any = {};
-    selectTheme: any = {};
-
-    constructor(props) {
+    constructor(props: GobanThemePickerProperties) {
         super(props);
 
         const selected = getSelectedThemes();
@@ -81,11 +90,11 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
     componentWillUnmount() {
     }
 
-    getCustom(key) {
+    getCustom(key: string): string {
         return data.get(`custom.${key}`);
     }
-    setCustom(key, event) {
-        if (event.target.value) {
+    setCustom(key: string, event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.ChangeEvent<HTMLInputElement>) {
+        if ('value' in event.target) {
             data.set(`custom.${key}`, event.target.value);
         } else {
             data.remove(`custom.${key}`);
@@ -190,7 +199,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
         for (let i = 0; i < GoThemesSorted.board.length; ++i) {
             const theme = GoThemesSorted.board[i];
             const canvas = this.canvases.board[i];
-            const ctx = canvas[0].getContext("2d");
+            const ctx = (canvas[0] as HTMLCanvasElement).getContext("2d");
             ctx.clearRect(0, 0, square_size, square_size);
 
             ctx.beginPath();
@@ -213,11 +222,10 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
             ctx.fillText("A", xx + 0.5, yy + 0.5);
         }
 
-        const plain_board = new (GoThemes["board"]["Plain"])();
         for (let i = 0; i < GoThemesSorted.white.length; ++i) {
             const theme = GoThemesSorted.white[i];
             const canvas = this.canvases.white[i];
-            const ctx = canvas[0].getContext("2d");
+            const ctx = (canvas[0] as HTMLCanvasElement).getContext("2d");
             const radius = Math.round(square_size / 2.2);
             const stones = theme.preRenderWhite(radius, 23434);
             ctx.clearRect(0, 0, square_size, square_size);

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -122,7 +122,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
             <div className="GobanThemePicker">
                 <div className="theme-set">
                     {GoThemesSorted.board.map((theme, idx) => (
-                        <div key={theme.theme_name}
+                        <div key={theme.theme_name} title={_(theme.theme_name)}
                             className={"selector" + (this.state.board === theme.theme_name ? " active" : "")}
                             style={{
                                 ...theme.styles,
@@ -156,7 +156,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
 
                 <div className="theme-set">
                     {GoThemesSorted.white.map((theme, idx) => (
-                        <div key={theme.theme_name}
+                        <div key={theme.theme_name} title={_(theme.theme_name)}
                             className={"selector" + (this.state.white === theme.theme_name ? " active" : "")}
                             style={theme.styles}
                             onClick={this.selectTheme["white"][theme.theme_name]}
@@ -174,7 +174,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
 
                 <div className="theme-set">
                     {GoThemesSorted.black.map((theme, idx) => (
-                        <div key={theme.theme_name}
+                        <div key={theme.theme_name} title={_(theme.theme_name)}
                             className={"selector" + (this.state.black === theme.theme_name ? " active" : "")}
                             style={theme.styles}
                             onClick={this.selectTheme["black"][theme.theme_name]}

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -16,19 +16,14 @@
  */
 
 import * as React from "react";
-import {_, pgettext, interpolate} from "translate";
-import {post, get} from "requests";
-import {errorAlerter} from "misc";
-import {GoThemes, GoThemesSorted} from "goban";
+import {_, pgettext} from "translate";
+import {GoThemesSorted} from "goban";
 import {getSelectedThemes} from "preferences";
 import * as preferences from "preferences";
 import {PersistentElement} from "PersistentElement";
 import * as data from "data";
 
 interface GobanThemePickerProperties {
-    // id?: any,
-    // user?: any,
-    // callback?: ()=>any,
     size?: number;
 }
 
@@ -82,8 +77,7 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
     componentDidMount() {
         setTimeout(() => this.renderPickers(), 50);
     }
-    //UNSAFE_componentWillReceiveProps(next_props) { }
-    //componentDidUpdate(old_props, old_state) { }
+
     componentWillUnmount() {
     }
 
@@ -191,7 +185,6 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
     }
 
     renderPickers() {
-        const start = new Date();
         const square_size = this.state.size;
 
         for (let i = 0; i < GoThemesSorted.board.length; ++i) {
@@ -234,14 +227,11 @@ export class GobanThemePicker extends React.PureComponent<GobanThemePickerProper
         for (let i = 0; i < GoThemesSorted.black.length; ++i) {
             const theme = GoThemesSorted.black[i];
             const canvas = this.canvases.black[i];
-            const ctx = canvas[0].getContext("2d");
+            const ctx = (canvas[0] as HTMLCanvasElement).getContext("2d");
             const radius = Math.round(square_size / 2.2);
             const stones = theme.preRenderBlack(radius, 23434);
             ctx.clearRect(0, 0, square_size, square_size);
             theme.placeBlackStone(ctx, ctx, stones[0], square_size / 2, square_size / 2, radius);
         }
-
-        const end = new Date();
-        //console.info("Render time: ", (end.getTime() - start.getTime()))
     }
 }

--- a/src/components/PersistentElement/PersistentElement.tsx
+++ b/src/components/PersistentElement/PersistentElement.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 
 interface PersistentElementProps {
-    elt: HTMLElement;
+    elt: HTMLElement | JQuery;
     className?: string;
     extra_props?: object;  // hash of new props to put on the element
 }


### PR DESCRIPTION
I think I was digging around `GobanCore`, and came here because I wanted to see how `preRender[white|black]` and `place[White|Black]Stones` were used externally.  Anyway, it always helps me to figure out what types are floating around..

## Proposed Changes

- Removed unused stuff (unused variables, imports, commented code)
- Added types to everything
- Added tooltip (screenshot below)
  
<img width="280" alt="Screen Shot 2021-12-01 at 10 26 03 PM" src="https://user-images.githubusercontent.com/25233703/144352421-e74fb496-71f3-4e7f-a9d6-14af88c63b47.png">


If the tooltips are disagreeable, I can take that out. But the theme names are already translated, so I figured why not...
