### PR TITLE
Some dev improvements

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -75,7 +75,7 @@ function livereload_server(done) {
     done();
 }
 function watch_eslint(done) {
-    gulp.watch(ts_sources, eslint);
+    gulp.watch(ts_sources, { ignoreInitial: false }, eslint);
     done();
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,5 +43,6 @@
     },
     "files": [
         "./src/main.tsx"
-    ]
+    ],
+    "include": ["src"]
 }


### PR DESCRIPTION
Fixes some eslint-related issues that @GreenAsJade found.

## Proposed Changes

  - Add `'include': ['src']` to tsconfig.  This fixes the issue where new files in `src` would trigger lint errors before they were included elsewhere.
  - Run eslint once at start of gulp script.  Turns out `gulp.watch` has a setting for that!
