### PR TITLE
data.get: deduce type from default_value

### DIFF
--- a/src/components/AutomatchSettings/AutomatchSettings.tsx
+++ b/src/components/AutomatchSettings/AutomatchSettings.tsx
@@ -122,7 +122,7 @@ export class AutomatchSettings extends Modal<Events, AutomatchSettingsProperties
     constructor(props) {
         super(props);
         this.state = {
-            tab: data.get("automatch.last-tab", 'live'),
+            tab: data.get("automatch.last-tab", 'live') as Speed,
             blitz_settings: data.get("automatch.blitz", default_blitz),
             live_settings: data.get("automatch.live", default_live),
             correspondence_settings: data.get("automatch.correspondence", default_correspondence),

--- a/src/components/AutomatchSettings/AutomatchSettings.tsx
+++ b/src/components/AutomatchSettings/AutomatchSettings.tsx
@@ -16,16 +16,11 @@
  */
 
 import * as React from "react";
-import {browserHistory} from "ogsHistory";
-import {_, pgettext, interpolate} from "translate";
+import {_} from "translate";
 import {Modal, openModal} from "Modal";
-import {challenge, challengeComputer, createCorrespondence, createBlitz,
-    createLive, blitz_config, live_config, correspondence_config} from "ChallengeModal";
-import {shortShortTimeControl} from "TimeControl";
-import {errorAlerter, ignore, dup} from "misc";
-import * as preferences from "preferences";
+import {dup} from "misc";
 import * as data from "data";
-import {bot_count} from "bots";
+import { AutomatchPreferencesBase, Size, Speed } from "src/lib/types";
 
 interface Events {
 }
@@ -34,7 +29,17 @@ interface AutomatchSettingsProperties {
 }
 
 
-const default_blitz = {
+type AutomatchPreferences = AutomatchPreferencesBase & { size_options: Size[] };
+
+interface AutomatchSettingsState {
+    tab: Speed;
+    blitz_settings: AutomatchPreferences;
+    live_settings: AutomatchPreferences;
+    correspondence_settings: AutomatchPreferences;
+}
+
+
+const default_blitz: AutomatchPreferences = {
     upper_rank_diff: 3,
     lower_rank_diff: 3,
     size_options: ['19x19'],
@@ -53,7 +58,7 @@ const default_blitz = {
         value: 'disabled',
     },
 };
-const default_live = {
+const default_live: AutomatchPreferences = {
     upper_rank_diff: 3,
     lower_rank_diff: 3,
     size_options: ['19x19'],
@@ -72,7 +77,7 @@ const default_live = {
         value: 'enabled',
     },
 };
-const default_correspondence = {
+const default_correspondence: AutomatchPreferences = {
     upper_rank_diff: 3,
     lower_rank_diff: 3,
     size_options: ['19x19'],
@@ -113,7 +118,7 @@ export function getAutomatchSettings(speed: 'blitz'|'live'|'correspondence') {
     }
 }
 
-export class AutomatchSettings extends Modal<Events, AutomatchSettingsProperties, any> {
+export class AutomatchSettings extends Modal<Events, AutomatchSettingsProperties, AutomatchSettingsState> {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -47,6 +47,7 @@ import { profanity_filter } from "profanity_filter";
 import { popover } from "popover";
 import { ChatDetails } from "Chat";
 import swal from 'sweetalert2';
+import { GroupList } from "src/lib/types";
 
 interface ChatLogState {
     chat_log: Array<ChatMessage>;
@@ -188,7 +189,7 @@ function ChannelTopic(
     const [proxy, setProxy]: [ChatChannelProxy | null, (x: ChatChannelProxy) => void] = useState(null);
     const [title_hover, set_title_hover]: [string, (s: string) => void] = useState("");
 
-    const groups = data.get('cached.groups', []);
+    const groups = data.get<GroupList>('cached.groups', []);
 
     // member of group, or a moderator, or a tournament channel
     const topic_editable = user.is_moderator

--- a/src/lib/automatch_manager.tsx
+++ b/src/lib/automatch_manager.tsx
@@ -19,15 +19,9 @@ import * as React from "react";
 import {_, pgettext, interpolate} from "translate";
 import {termination_socket} from "sockets";
 import {TypedEventEmitter} from "TypedEventEmitter";
-import {sfx} from "sfx";
 import {browserHistory} from "ogsHistory";
-import * as data from "data";
-import * as preferences from "preferences";
 import {Toast, toast} from 'toast';
-
-export type Speed = 'blitz' | 'live' | 'correspondence';
-export type Size = '9x9' | '13x13' | '19x19';
-export type AutomatchCondition = 'required' | 'preferred' | 'no-preference';
+import { AutomatchPreferencesBase, Size, Speed } from "./types";
 
 interface Events {
     'start': any;
@@ -35,37 +29,10 @@ interface Events {
     'cancel': any;
 }
 
-export interface AutomatchPreferences {
+export type AutomatchPreferences = AutomatchPreferencesBase & {
     uuid: string;
-    timestamp?: number;
-    size_speed_options: Array<{speed: Speed; size: Size}>;
-    lower_rank_diff: number;
-    upper_rank_diff: number;
-    rules: {
-        condition: AutomatchCondition;
-        value: 'japanese' | 'chinese' | 'aga' | 'korean' | 'nz' | 'ing';
-    };
-    time_control: {
-        condition: AutomatchCondition;
-        value: {
-            system: 'byoyomi' | 'fischer' | 'simple' | 'canadian';
-            initial_time?: number;
-            time_increment?: number;
-            max_time?: number;
-            main_time?: number;
-            period_time?: number;
-            periods?: number;
-            stones_per_period?: number;
-            per_move?: number;
-            pause_on_weekends?: boolean;
-        };
-    };
-    handicap: {
-        condition: AutomatchCondition;
-        value: 'enabled' | 'disabled';
-    };
-}
-
+    size_speed_options: Array<{ size: Size; speed: Speed }>;
+};
 
 class AutomatchToast extends React.PureComponent<{}, any> {
     timer: any;

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -211,7 +211,7 @@ export type ValueType<T> = T extends string
 
 export function get<T>(key: string, default_value: T): ValueType<T>;
 export function get(key: string): any;
-export function get<T = any>(key: string, default_value?: T): T | undefined {
+export function get<T>(key: string, default_value?: T): T | undefined {
     if (key in store) {
         return store[key];
     }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -194,15 +194,29 @@ export function removeAll(): void {
     }
 }
 
-export function get(key: "cached.groups", default_value?: GroupList): GroupList;
-export function get(key: "cached.active_tournaments", default_value?: ActiveTournamentList): ActiveTournamentList;
-export function get(key: string, default_value?: any): any | undefined;
-export function get(key, default_value?): any | undefined {
+
+// Needed for type widening
+// See: https://stackoverflow.com/questions/67057855/wrong-automatic-return-type-deduction-in-typescript
+export type ValueType<T> = T extends string
+    ? string
+    : T extends number
+    ? number
+    : T extends boolean
+    ? boolean
+    : T extends undefined
+    ? undefined
+    : [T] extends [any]
+    ? T
+    : object;
+
+export function get<T>(key: string, default_value: T): ValueType<T>;
+export function get(key: string): any;
+export function get<T = any>(key: string, default_value?: T): T | undefined {
     if (key in store) {
         return store[key];
     }
     if (remote_get(key)) {
-        return remote_get(key);
+        return remote_get(key) as unknown as T;
     }
     if (key in defaults) {
         return defaults[key];

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -197,7 +197,7 @@ export function removeAll(): void {
 
 // Needed for type widening
 // See: https://stackoverflow.com/questions/67057855/wrong-automatic-return-type-deduction-in-typescript
-export type ValueType<T> = T extends string
+type ValueType<T> = T extends string
     ? string
     : T extends number
     ? number

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,8 @@ export type Speed = 'blitz' | 'live' | 'correspondence';
 export type Size = '9x9' | '13x13' | '19x19';
 export type AutomatchCondition = 'required' | 'preferred' | 'no-preference';
 
+// AutomatchSettings and automatch_manager handle size, speed and uuid
+// differently, but everything else is the same.  Hence a shared base.
 export interface AutomatchPreferencesBase {
     timestamp?: number;
     lower_rank_diff: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,3 +74,36 @@ export interface ActiveTournament {
 }
 
 export type ActiveTournamentList = Array<ActiveTournament>;
+
+export type Speed = 'blitz' | 'live' | 'correspondence';
+export type Size = '9x9' | '13x13' | '19x19';
+export type AutomatchCondition = 'required' | 'preferred' | 'no-preference';
+
+export interface AutomatchPreferencesBase {
+    timestamp?: number;
+    lower_rank_diff: number;
+    upper_rank_diff: number;
+    rules: {
+        condition: AutomatchCondition;
+        value: 'japanese' | 'chinese' | 'aga' | 'korean' | 'nz' | 'ing';
+    };
+    time_control: {
+        condition: AutomatchCondition;
+        value: {
+            system: 'byoyomi' | 'fischer' | 'simple' | 'canadian';
+            initial_time?: number;
+            time_increment?: number;
+            max_time?: number;
+            main_time?: number;
+            period_time?: number;
+            periods?: number;
+            stones_per_period?: number;
+            per_move?: number;
+            pause_on_weekends?: boolean;
+        };
+    };
+    handicap: {
+        condition: AutomatchCondition;
+        value: 'enabled' | 'disabled';
+    };
+}

--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -271,7 +271,7 @@ export class ColorTableToggle extends React.Component<{}, any> {
     }
 
     componentDidMount() {
-        const c = data.get("table-color-default-on", "");
+        const c = data.get("table-color-default-on", false);
         if (c === true) {
             this.setState(prevState => ({
                 onDefault: !prevState.onDefault


### PR DESCRIPTION
This PR makes it so that the output of `data.get` is typed if a default value is provided.  For example:

```
// some_bool is now boolean instead of any
const some_bool = data.get("bool-prop", false);
```

## Proposed Changes

  - type data.get
  - type the automatch defaults in AutomatchSettings
      - This was prompted by the update to `data.get`.

## A motivating example

This is the code that prompted this change. Before, `challenge` was typed as `any`.  Now, it's pretty accurately typed, without having touched that area of code.

<img width="698" alt="Screen Shot 2021-12-08 at 2 57 28 AM" src="https://user-images.githubusercontent.com/25233703/145173601-720cd4f6-a191-4b5a-9892-f84af5394487.png">

