### PR TITLE
Add State Types to all React.Components

### DIFF
--- a/src/components/DismissableNotification/DismissableNotification.tsx
+++ b/src/components/DismissableNotification/DismissableNotification.tsx
@@ -19,14 +19,17 @@ import * as React from "react";
 import * as data from "data";
 
 
-export interface DismissableNotificationInterface {
+interface DismissableNotificationProperties {
     dismissedKey: string;
     className?: string;
-    children: any;
 }
 
-export class DismissableNotification extends React.Component<DismissableNotificationInterface, any> {
-    constructor(props) {
+interface DismissableNotificationState {
+    dismissed: boolean;
+}
+
+export class DismissableNotification extends React.Component<DismissableNotificationProperties, DismissableNotificationState> {
+    constructor(props: DismissableNotificationProperties) {
         super(props);
         this.state = {
             dismissed: data.get(`dismissed.${props.dismissedKey}`, false)

--- a/src/components/Dock/Dock.tsx
+++ b/src/components/Dock/Dock.tsx
@@ -19,8 +19,11 @@ import * as React from "react";
 import * as preferences from "preferences";
 import { MAX_DOCK_DELAY } from 'Settings';
 
-export class Dock extends React.Component<any, any> {
-    constructor(props) {
+interface DockProperties { className?: string }
+interface DockState { dock_delay: number }
+
+export class Dock extends React.Component<DockProperties, DockState> {
+    constructor(props: DockProperties) {
         super(props);
         this.state = {
             dock_delay: preferences.get("dock-delay")

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -34,6 +34,9 @@ interface GobanLineSummaryProps {
     width?: number;
     height?: number;
 }
+
+// This state is very similar to MiniGobanState.
+// TODO (ben): Possibly pull shared members into a common type.
 interface GobanLineSummaryState {
     black_score: string;
     white_score: string;
@@ -45,7 +48,7 @@ interface GobanLineSummaryState {
     white_name?: string;
     paused?: string;
     // It looks like these (black|white)_pause_text are never used.
-    // TODO: Verify and remove.
+    // TODO (ben): Verify and remove.
     black_pause_text?: string;
     white_pause_text?: string;
 

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -34,9 +34,31 @@ interface GobanLineSummaryProps {
     width?: number;
     height?: number;
 }
+interface GobanLineSummaryState {
+    black_score: string;
+    white_score: string;
 
-export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any> {
-    goban;
+    move_number?: number;
+    game_name?: string;
+
+    black_name?: string;
+    white_name?: string;
+    paused?: string;
+    // It looks like these (black|white)_pause_text are never used.
+    // TODO: Verify and remove.
+    black_pause_text?: string;
+    white_pause_text?: string;
+
+    current_users_move?: boolean;
+    black_to_move_cls?: string;
+    white_to_move_cls?: string;
+
+    in_stone_removal_phase?: boolean;
+    finished?: boolean;
+}
+
+export class GobanLineSummary extends React.Component<GobanLineSummaryProps, GobanLineSummaryState> {
+    goban: Goban;
 
     constructor(props) {
         super(props);
@@ -75,7 +97,13 @@ export class GobanLineSummary extends React.Component<GobanLineSummaryProps, any
             this.sync_state();
         });
 
-        this.goban.on("pause-text", (new_text) => this.setState({
+        // It appears "pause-text" is not part of the Goban event emitter.
+        // TODO: Verify and remove.
+        interface PauseText {
+            white_pause_text: string;
+            black_pause_text: string;
+        }
+        this.goban.on("pause-text" as any, (new_text: PauseText) => this.setState({
             "white_pause_text": new_text.white_pause_text,
             "black_pause_text": new_text.black_pause_text,
         }));

--- a/src/components/KBShortcut/KBShortcut.tsx
+++ b/src/components/KBShortcut/KBShortcut.tsx
@@ -40,7 +40,7 @@ interface KBProps {
     priority?: number;
 }
 
-export class KBShortcut extends React.Component<KBProps, any> {
+export class KBShortcut extends React.Component<KBProps> {
     binding: Binding;
 
     constructor(props) {

--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -47,7 +47,36 @@ interface MiniGobanProps {
     title?: boolean;
 }
 
-export class MiniGoban extends React.Component<MiniGobanProps, any> {
+// This state is very similar to GobanLineSummaryState.
+// TODO (ben): Possibly pull shared members into a common type.
+interface MiniGobanState {
+    // Paused text does not appear to be used.
+    // TODO (ben): Verify and remove.
+    black_pause_text?: string;
+    white_pause_text?: string;
+    paused?: string;
+
+    white_points: string;
+    black_points: string;
+    black_name?: string;
+    white_name?: string;
+
+    game_name?: string;
+    game_date?: string;
+    game_result?: string;
+
+    black_rank?: string;
+    white_rank?: string;
+
+    current_users_move?: boolean;
+    in_stone_removal_phase?: boolean;
+    finished?: boolean;
+
+    black_to_move_cls?: string;
+    white_to_move_cls?: string;
+}
+
+export class MiniGoban extends React.Component<MiniGobanProps, MiniGobanState> {
     public goban_div: HTMLDivElement;
     goban;
 
@@ -98,6 +127,8 @@ export class MiniGoban extends React.Component<MiniGobanProps, any> {
             }
         });
 
+        // Goban does not appear to emit this event.
+        // TODO: Verify and remove.
         this.goban.on("pause-text", (new_text) => this.setState({
             "white_pause_text": new_text.white_pause_text,
             "black_pause_text": new_text.black_pause_text,

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -52,12 +52,18 @@ interface PaginatedTableProperties {
     startingPage?: number;
     fillBlankRows?: boolean;
     hidePageControls?: boolean;
-    // id?: any,
-    // user?: any,
-    // callback?: ()=>any,
 }
 
-export class PaginatedTable extends React.Component<PaginatedTableProperties, any> {
+interface PaginatedTableState {
+    rows: any[];
+    total: number;
+    page: number;
+    num_pages: number;
+    page_size: number;
+    orderBy: string[];
+}
+
+export class PaginatedTable extends React.Component<PaginatedTableProperties, PaginatedTableState> {
     filter: any = {};
     sorting: Array<string> = [];
     source_url: string;
@@ -212,7 +218,9 @@ export class PaginatedTable extends React.Component<PaginatedTableProperties, an
 
     _setPage = (ev) => {
         if ((ev.target as any).value === "") {
-            this.setState({page: ""});
+            // TODO (bpj): investigate whether "" is really an appropriate for
+            // `page`, which is usually treated as a number.
+            this.setState({page: "" as any});
             return;
         }
         const n = parseInt(ev.target.value);

--- a/src/components/PersistentElement/PersistentElement.tsx
+++ b/src/components/PersistentElement/PersistentElement.tsx
@@ -23,7 +23,7 @@ interface PersistentElementProps {
     extra_props?: object;  // hash of new props to put on the element
 }
 
-export class PersistentElement extends React.Component<PersistentElementProps, any> {
+export class PersistentElement extends React.Component<PersistentElementProps> {
     container: HTMLDivElement;
 
     componentDidMount() {

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -28,9 +28,10 @@ interface ProfileCardInterface {
     user: any;
 }
 
-export class ProfileCard extends React.Component<ProfileCardInterface, any> {
+export class ProfileCard extends React.Component<ProfileCardInterface> {
     constructor(props) {
         super(props);
+        // TODO: Remove this
         this.state = {
 
         };

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -45,6 +45,13 @@ interface RatingsChartProperties {
     updateChartSize: (height: number, width: number) => void; // callback with actual chart size on resize
 }
 
+interface RatingsChartState {
+    loading: boolean;
+    nodata: boolean;
+    hovered_date?: Date;
+    hovered_month?: Date;
+    date_extents: Date[];
+}
 
 const date_bisector = d3.bisector((d: RatingEntry) => { return d.ended; }).left;
 const format_date = (d: Date) => moment(d).format('ll');
@@ -59,7 +66,7 @@ const win_loss_bars_height = 65;
 const height   = chart_height - margin.top - margin.bottom;
 const secondary_charts_height  = chart_height - margin2.top - margin2.bottom;
 
-export class RatingsChart extends React.Component<RatingsChartProperties, any> {
+export class RatingsChart extends React.Component<RatingsChartProperties, RatingsChartState> {
     container = null;
     chart_div;
     svg;

--- a/src/components/RatingsChartByGame/RatingsChartByGame.tsx
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.tsx
@@ -48,6 +48,16 @@ interface RatingsChartProperties {
     updateChartSize: (height: number, width: number) => void;   // callback with the size of the actual chart within this component (for client to position stuff relative to that)
 }
 
+// This is similar to RatingsChartState (from RatingsChart)
+// TODO (bpj): investigate sharing the interface
+interface RatingsChartState {
+    loading: boolean;
+    nodata: boolean;
+    subselect_extents: number[];
+    hovered_game_id?: number;
+    show_pie?: boolean;
+}
+
 const margin   = {top: 30, right: 20, bottom: 110, left: 20}; // Margins around the rating chart with respect to the whole space
 const margin2  = {top: 320, right: 20, bottom: 30, left: 20}; // Margins around the subselect chart with respect to the whole space
 
@@ -66,7 +76,7 @@ const pie_restore_delay = 1500;  // long enough to go click on the minigoban if 
 
 const format_date = (d: Date) => moment(d).format('ll');
 
-export class RatingsChartByGame extends React.Component<RatingsChartProperties, any> {
+export class RatingsChartByGame extends React.Component<RatingsChartProperties, RatingsChartState> {
     container = null;
     chart_div;
     svg;
@@ -80,7 +90,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
     dateLegend;   //  We use this to tell them what date was associated with the game they moused over
     dateLegendBackground;
     dateLegendText;
-    subselect_extents;
+    subselect_extents: number[];
     range_label;
     legend_label;
 
@@ -796,7 +806,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
     }
 
     computeWinLossNumbers() {
-        let subselect_extents = [];
+        let subselect_extents: number[] = [];
 
         if (this.state.subselect_extents && this.state.subselect_extents.length === 2) {
             subselect_extents = this.state.subselect_extents;

--- a/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
+++ b/src/components/ServerTimeDisplay/ServerTimeDisplay.tsx
@@ -19,9 +19,10 @@ import * as React from "react";
 import * as moment from "moment";
 import {_, interpolate} from "translate";
 
-interface ServerTimeDisplayProperties {}
-
-export class ServerTimeDisplay extends React.Component<ServerTimeDisplayProperties, any> {
+interface ServerTimeState {
+    time: moment.Moment;
+}
+export class ServerTimeDisplay extends React.Component<{}, ServerTimeState> {
 
     intervalID;
 

--- a/src/components/UIPush/UIPush.tsx
+++ b/src/components/UIPush/UIPush.tsx
@@ -111,7 +111,7 @@ class UIPushManager {
 
 export const push_manager = new UIPushManager();
 
-export class UIPush extends React.Component<UIPushProperties, any> {
+export class UIPush extends React.Component<UIPushProperties> {
     handler: Handler = null;
     channel: string = null; // I'm here
 

--- a/src/views/Game/AIReviewChart.tsx
+++ b/src/views/Game/AIReviewChart.tsx
@@ -44,7 +44,7 @@ const INITIAL_WIDTH = 600 - MARGIN.left - MARGIN.right;
 const INITIAL_HEIGHT = 100 - MARGIN.top - MARGIN.bottom;
 const simplex = new JSNoise.Module.Simplex();
 
-export class AIReviewChart extends React.Component<AIReviewChartProperties, any> {
+export class AIReviewChart extends React.Component<AIReviewChartProperties> {
     container?: HTMLElement;
     chart_div: HTMLElement;
     svg?: d3.Selection<SVGSVGElement, unknown, null, undefined>;

--- a/src/views/Game/Chat.tsx
+++ b/src/views/Game/Chat.tsx
@@ -357,7 +357,7 @@ function unhighlight_position(event) {
     }
 }
 
-export class GameChatLine extends React.Component<GameChatLineProperties, any> {
+export class GameChatLine extends React.Component<GameChatLineProperties> {
     //scrolled_to_bottom:any = {"malkovich": true, "main": true};
 
     constructor(props) {

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -249,7 +249,17 @@ interface LadderRowProperties {
     invalidationCount: number;
 }
 
-export class LadderRow extends React.Component<LadderRowProperties, any> {
+interface LadderRowState {
+    row?: {
+        incoming_challenges;
+        outgoing_challenges;
+        can_challenge: {challengeable: boolean};
+        rank: number;
+        player;
+    };
+}
+
+export class LadderRow extends React.Component<LadderRowProperties, LadderRowState> {
     unmounted: boolean = false;
 
     constructor(props) {

--- a/src/views/LearningHub/InstructionalGoban.tsx
+++ b/src/views/LearningHub/InstructionalGoban.tsx
@@ -31,12 +31,13 @@ interface InstructionalGobanProps {
     config: any;
 }
 
-export class InstructionalGoban extends React.Component<InstructionalGobanProps, any> {
+export class InstructionalGoban extends React.Component<InstructionalGobanProps> {
     goban_div: HTMLDivElement;
     goban;
 
     constructor(props) {
         super(props);
+        // TODO: Remove this (state unused)
         this.state = {
         };
 

--- a/src/views/LearningHub/LearningPage.tsx
+++ b/src/views/LearningHub/LearningPage.tsx
@@ -32,7 +32,7 @@ interface LearningPageProperties {
     nextSection: string;
 }
 
-export abstract class LearningPage extends React.Component<LearningPageProperties, any> {
+export abstract class LearningPage extends React.Component<LearningPageProperties> {
     instructional_goban?: InstructionalGoban;
     _config: any;
     correct_answer_triggered: boolean = false;
@@ -63,6 +63,8 @@ export abstract class LearningPage extends React.Component<LearningPagePropertie
             },
 
         }, this.config());
+        // State appears to be unused.
+        // TODO: remove this and instances of SetState
         this.state = {
             show_reset: false,
             show_next: false,

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -39,13 +39,27 @@ import {SupporterGoals} from "SupporterGoals";
 import {boundedRankString} from "rank_utils";
 import * as player_cache from "player_cache";
 import swal from 'sweetalert2';
+import { Size } from "src/lib/types";
 
 const CHALLENGE_LIST_FREEZE_PERIOD = 1000; // Freeze challenge list for this period while they move their mouse on it
 
-interface PlayProperties {
+interface PlayState {
+    live_list: Array<any>;
+    correspondence_list: Array<any>;
+    showLoadingSpinnerForCorrespondence: boolean;
+    show_all_challenges: boolean;
+    show_ranked_challenges: boolean;
+    show_unranked_challenges: boolean;
+    show_19x19_challenges: boolean;
+    show_13x13_challenges: boolean;
+    show_9x9_challenges: boolean;
+    show_other_boardsize_challenges: boolean;
+    automatch_size_options: Size[];
+    freeze_challenge_list: boolean; // Don't change the challenge list while they are trying to point the mouse at it
+    pending_challenges: Array<any>; // challenges received while frozen
 }
 
-export class Play extends React.Component<PlayProperties, any> {
+export class Play extends React.Component<{}, PlayState> {
     ref_container: HTMLDivElement;
     canvas: HTMLCanvasElement;
 

--- a/src/views/Tutorial/InstructionalGoban.tsx
+++ b/src/views/Tutorial/InstructionalGoban.tsx
@@ -29,7 +29,7 @@ interface InstructionalGobanProps {
     config: any;
 }
 
-export class InstructionalGoban extends React.Component<InstructionalGobanProps, any> {
+export class InstructionalGoban extends React.Component<InstructionalGobanProps> {
     goban_div: HTMLDivElement;
     goban: Goban;
 


### PR DESCRIPTION
Pretty much all of these were marked as `any`.  Note, this is only `React.Component`s, there are plenty of `React.PureComponent`s that can possibly be updated in the same way.  I did not make logic changes in this PR, but left some comments about code that looks either unnecessary or mis-annotated and could be updated in the future.

## Proposed Changes

Add a `*State` interface for every `React.Component` that had state typed as `any`. In some cases, I just deleted `any` from the template arguments, since the default is `{}` and that is more appropriate for components that do not update state:

```diff
-class SomeComponent extends React.Component<SomeProps, any> {
+class SomeComponent extends React.Component<SomeProps, SomeState> {
    // this.state is now a SomeState

-class SomeComponent extends React.Component<SomeProps, any> {
+class SomeComponent extends React.Component<SomeProps> {
    // this.state is now a {}
```
