### PR TITLE
Ai summary table

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack-bundle-analyzer": "^4.1.1",
     "webpack-cli": "^4.9.0",
     "xgettext-js": "^3.0.0",
-    "yarn": "^1.22.11"
+    "yarn": "^1.22.17"
   },
   "dependencies": {
     "@sentry/browser": "^6.13.2",

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -22,6 +22,7 @@ import {current_language} from "translate";
 const defaults = {
     "ai-review-enabled": true,
     "ai-review-use-score": false,
+    "ai-summary-table-show":false,
     "always-disable-analysis": false,
     "asked-to-enable-desktop-notifications": false,
     "auto-advance-after-submit": true,

--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -57,7 +57,6 @@ if (window.location.hostname.indexOf('dev.beta') >= 0 && window['websocket_host'
 } else {
     ai_host = `${window.location.protocol}//${window.location.hostname}:13284`;
 }
-//ai_host = 'https://ai.online-go.com';
 
 export const ai_socket = ai_host ? io(ai_host, ai_config) : io(ai_config);
 

--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -57,7 +57,7 @@ if (window.location.hostname.indexOf('dev.beta') >= 0 && window['websocket_host'
 } else {
     ai_host = `${window.location.protocol}//${window.location.hostname}:13284`;
 }
-
+//ai_host = 'https://ai.online-go.com';
 
 export const ai_socket = ai_host ? io(ai_host, ai_config) : io(ai_config);
 

--- a/src/views/Game/AIReview.styl
+++ b/src/views/Game/AIReview.styl
@@ -306,7 +306,7 @@
 
 .ai-summary-toggler {
     display: flex;
-    
+
     span {
         margin-left: 0.5rem;
     }

--- a/src/views/Game/AIReview.styl
+++ b/src/views/Game/AIReview.styl
@@ -296,10 +296,19 @@
 .ai-summary-table{
     text-align: center;
     margin: 1rem;
-    border-spacing:1rem;
 }
 
 .ai-summary-container{
-    /*width: 80%;*/
-    /*margin: auto;*/
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+}
+
+.ai-summary-toggler{
+    display: flex;
+    margin:1rem;
+
+    span {
+        margin-left: 0.5rem;
+    }
 }

--- a/src/views/Game/AIReview.styl
+++ b/src/views/Game/AIReview.styl
@@ -293,22 +293,25 @@
     border: 1px solid red;
 }
 
-.ai-summary-table{
+.ai-summary-table {
     text-align: center;
     margin: 1rem;
 }
 
-.ai-summary-container{
+.ai-summary-container {
     display: flex;
     align-items: center;
     flex-direction: column;
 }
 
-.ai-summary-toggler{
+.ai-summary-toggler {
     display: flex;
-    margin:1rem;
-
+    
     span {
         margin-left: 0.5rem;
     }
+}
+
+.worst-moves-summary-toggle-container {
+    display: inline-flex;    
 }

--- a/src/views/Game/AIReview.styl
+++ b/src/views/Game/AIReview.styl
@@ -293,4 +293,13 @@
     border: 1px solid red;
 }
 
+.ai-summary-table{
+    text-align: center;
+    margin: 1rem;
+    border-spacing:1rem;
+}
 
+.ai-summary-container{
+    /*width: 80%;*/
+    /*margin: auto;*/
+}

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1359,11 +1359,11 @@ class AiSummaryTable extends React.Component<AiSummaryTableProperties, AiSummary
                         }
                         {(this.props.pending_entries > 0) &&
                             <React.Fragment>
-                            <tr>
-                                <td colSpan={2}>{"Moves Pending"}</td><td colSpan={3}>{this.props.pending_entries}</td>
-                            </tr>
-                            <tr><td colSpan={5}><progress value = {this.props.max_entries - this.props.pending_entries} 
-                                max = {this.props.max_entries}></progress></td></tr>
+                                <tr>
+                                    <td colSpan={2}>{"Moves Pending"}</td><td colSpan={3}>{this.props.pending_entries}</td>
+                                </tr>
+                                <tr><td colSpan={5}><progress value = {this.props.max_entries - this.props.pending_entries}
+                                    max = {this.props.max_entries}></progress></td></tr>
                             </React.Fragment>}
                         <tr><td colSpan={5}>{"Average score loss per move"}</td></tr>
                         <tr><td colSpan={2}>{"Black"}</td><td colSpan={3}>{this.props.avg_loss[0]}</td></tr>

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1194,7 +1194,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                         </span>
                     </div>
                 }
-                { (data.get("user").is_moderator && ((this.ai_review?.type === "full" ) || (this.ai_review?.type === "fast" )) && this.ai_review?.engine === "katago") &&
+                { (data.get("user").is_moderator && this.ai_review?.engine === "katago") &&
                 <div>
                     <AiSummaryTable headinglist = {["Type", "Black", "%", "White", "%"]} bodylist = {this.table_rows} avg_loss = {this.avg_score_loss} />
                 </div>

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1196,7 +1196,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                 }
                 { (data.get("user").is_moderator && this.ai_review?.engine === "katago") &&
                 <div>
-                    <AiSummaryTable headinglist = {["Type", "Black", "%", "White", "%"]} bodylist = {this.table_rows} avg_loss = {this.avg_score_loss} />
+                    <AiSummaryTable headinglist = {[_("Type"), _("Black"), "%", _("White"), "%"]} bodylist = {this.table_rows} avg_loss = {this.avg_score_loss} />
                 </div>
                 }
             </div>

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -67,6 +67,7 @@ interface AIReviewState {
     updatecount: number;
     worst_moves_shown: number;
     table_set: boolean;
+    table_hidden: boolean;
 }
 
 export class AIReview extends React.Component<AIReviewProperties, AIReviewState> {
@@ -89,6 +90,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             // See https://forums.online-go.com/t/top-3-moves-score-a-better-metric/32702/15
             worst_moves_shown: 3,
             table_set: false,
+            table_hidden : preferences.get('ai-summary-table-show'),
         };
         this.state = state;
         window['aireview'] = this;
@@ -1152,23 +1154,34 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                                         }}>{pgettext("Display the game score that the AI estimates", "Score")}</span>
                                     </div>
                                 }
-                                {this.renderWorstMoveList(worst_move_list)}
+                                <div className = "worst-moves-summary-toggle-container">
+                                    {this.renderWorstMoveList(worst_move_list)}
+                                    <div className = 'ai-summary-toggler'>
+                                        <span><i className="fa fa-table"></i></span>
+                                        <span>
+                                            <Toggle checked={this.state.table_hidden} onChange={b => {
+                                                preferences.set('ai-summary-table-show', b);
+                                                this.setState({table_hidden: b});
+                                                //console.log(this.state.table_hidden);
+                                            }}/>
+                                        </span>
+                                    </div>
+                                </div>
                             </React.Fragment>
                         }
 
                         {((this.ai_review?.type === 'fast') || null) &&
-                            <div className='key-moves'>
-                                {show_full_ai_review_button &&
-                                    <div>
-                                        <button
-                                            className='primary'
-                                            onClick={() => this.startNewAIReview("full", "katago")}>
-                                            {_("Full AI Review")}
-                                        </button>
-                                    </div>
-                                }
-                            </div>
-                        }
+                        <div className='key-moves'>
+                            {show_full_ai_review_button &&
+                                <div>
+                                    <button
+                                        className='primary'
+                                        onClick={() => this.startNewAIReview("full", "katago")}>
+                                        {_("Full AI Review")}
+                                    </button>
+                                </div>
+                            }
+                        </div>}
                     </React.Fragment>
                 }
 
@@ -1196,7 +1209,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                 }
                 { (data.get("user").is_moderator && this.ai_review?.engine === "katago") &&
                 <div>
-                    <AiSummaryTable headinglist = {[_("Type"), _("Black"), "%", _("White"), "%"]} bodylist = {this.table_rows} avg_loss = {this.avg_score_loss} />
+                    <AiSummaryTable headinglist = {[_("Type"), _("Black"), "%", _("White"), "%"]} bodylist = {this.table_rows} avg_loss = {this.avg_score_loss} table_hidden = {this.state.table_hidden} />
                 </div>
                 }
             </div>
@@ -1300,27 +1313,13 @@ function extractShortNetworkVersion(network: string): string {
 class AiSummaryTable extends React.Component<AiSummaryTableProperties, AiSummaryTableState>{
     constructor(props: AiSummaryTableProperties) {
         super(props);
-        const state: AiSummaryTableState = {
-            table_hidden : preferences.get('ai-summary-table-show'),
-        };
-        this.state = state;
     }
 
     render(): JSX.Element {
 
         return(
             <div className = "ai-summary-container">
-                <div className = 'ai-summary-toggler'>
-                    <span>{((this.state.table_hidden) ? "Show" : "Hide") + " summary table " }</span>
-                    <span>
-                        <Toggle checked={this.state.table_hidden} onChange={b => {
-                            preferences.set('ai-summary-table-show', b);
-                            this.setState({table_hidden: b});
-                            //console.log(this.state.table_hidden);
-                        }}/>
-                    </span>
-                </div>
-                <table className = "ai-summary-table" style = {{display: this.state.table_hidden ? "block" : "none"}}>
+                <table className = "ai-summary-table" style = {{display: this.props.table_hidden ? "block" : "none"}}>
                     <thead>
                         <tr>
                             {this.props.headinglist.map( (head, index) => {
@@ -1353,7 +1352,6 @@ class AiSummaryTable extends React.Component<AiSummaryTableProperties, AiSummary
 }
 
 interface AiSummaryTableState {
-    table_hidden: boolean;
 }
 
 interface AiSummaryTableProperties {
@@ -1363,4 +1361,5 @@ interface AiSummaryTableProperties {
     bodylist: string[][];
     /** values for the average score loss */
     avg_loss: number[];
+    table_hidden: boolean;
 }

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -724,7 +724,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
 
     private AiSummaryTableRowList(){
         const summary_moves_list = [ ["", "", "", ""], ["", "", "", ""], ["", "", "", ""], ["", "", "", ""], ["", "", "", ""], ["", "", "", ""] ];
-        const ai_table_rows = [["Excellent"], ["Great"], ["Good"], ["Inaccuracy"], ["Mistake"], ["Blunder"]];
+        const ai_table_rows = [[_("Excellent")], [_("Great")], [_("Good")], [_("Inaccuracy")], [_("Mistake")], [_("Blunder")]];
         const default_table_rows = [["", "", "", "", ""]];
         const avg_score_loss = [0, 0];
         if (!this.ai_review ) {

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -710,13 +710,13 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
     }
 
     private getPlayerColorsMoveList(){
-        let init_move = this.props.game.goban.engine.move_tree;
-        let move_list = [];
+        const init_move = this.props.game.goban.engine.move_tree;
+        const move_list = [];
         let cur_move = init_move.trunk_next;
 
         while (cur_move !== undefined){
-           move_list.push(cur_move.player);
-           cur_move = cur_move.trunk_next; 
+            move_list.push(cur_move.player);
+            cur_move = cur_move.trunk_next;
         }
         return move_list;
 
@@ -727,6 +727,17 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         const ai_table_rows = [["Excellent"], ["Great"], ["Good"], ["Inaccuracy"], ["Mistake"], ["Blunder"]];
         const default_table_rows = [["", "", "", "", ""]];
         const avg_score_loss = [0, 0];
+        if (!this.ai_review ) {
+            return {"ai_table_rows" : default_table_rows, avg_score_loss};
+        }
+
+        if (this.ai_review.engine !== "katago"){
+            this.setState({
+                table_set: true
+            });
+            return {"ai_table_rows" : default_table_rows, avg_score_loss};
+        }
+
         const handicap = this.props.game.goban.engine.handicap;
         //only useful when there's free placement, handicap = 1 no offset needed.
         let hoffset = this.handicapOffset();
@@ -736,24 +747,24 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         //forked games might have white stones on the board.
         const other_game_type = this.props.game.goban.engine.initial_state.white !== "";
 
-        if (!this.ai_review ) {
-            return {"ai_table_rows" : default_table_rows, avg_score_loss};
-        }
-
         if (this.ai_review?.type === "fast" ){
             const scores = this.ai_review?.scores;
             const is_uploaded = (this.props.game.goban.config.original_sgf !== undefined);
             //one more ai review point than moves in the game, since initial board gets a score.
+
+            if (scores === undefined){
+                return {"ai_table_rows" : default_table_rows, avg_score_loss};
+            }
             const check1 = !is_uploaded &&
             (this.props.game.goban.config.moves.length !== (this.ai_review?.scores.length - 1));
             // extra initial ! in all_moves which matches extra empty board score, except in handicap games for some reason.
             // so subtract 1 if black goes second == bplayer
             const check2 = is_uploaded &&
             ((this.props.game.goban.config["all_moves"].split("!").length - bplayer) !== this.ai_review?.scores.length);
-
-            if (scores === undefined || check1 || check2){
+            if (check1 || check2){
                 return {"ai_table_rows" : default_table_rows, avg_score_loss};
             }
+
             // we don't need the first two rows, as they're for full reviews.
             ai_table_rows.splice(0, 2);
             summary_moves_list.splice(0, 2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10483,10 +10483,10 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn@^1.22.11:
-  version "1.22.11"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.11.tgz#d0104043e7349046e0e2aec977c24be106925ed6"
-  integrity sha512-AWje4bzqO9RUn3sdnM5N8n4ZJ0BqCc/kqFJvpOI5/EVkINXui0yuvU7NDCEF//+WaxHuNay2uOHxA4+tq1P3cg==
+yarn@^1.22.17:
+  version "1.22.17"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.17.tgz#bf910747d22497b573131f7341c0e1d15c74036c"
+  integrity sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ==
 
 yeast@0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,10 +4881,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-goban@=0.5.56:
-  version "0.5.56"
-  resolved "https://registry.yarnpkg.com/goban/-/goban-0.5.56.tgz#04da491132df0044ad269580f584235389309d6a"
-  integrity sha512-IGWoaqsNExiEj4YHLNkz0V04h8E4qCu7ZN0cx4fYe/dnTe2uLe+Wu0fb6I5WdN+EHebat44JOddK8f8MiZt0xA==
+goban@=0.5.59:
+  version "0.5.59"
+  resolved "https://registry.yarnpkg.com/goban/-/goban-0.5.59.tgz#0fc0a32578a4b390227347deb2995efe2cef2459"
+  integrity sha512-lsCDHK942quBvKtrVO7onH3rQNUUhipQslMz0EXsW0FDqjEJSaDVtcYigwKHWssYhoOIayVps2AXGfWUojzoUQ==
 
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.4"


### PR DESCRIPTION
Fixes:
When a game ends with consecutive passes, there's a console error which results from empty branches in the AI review having their (non existent) move coordinates checked. So added in a mv === undefined check.


## Proposed Changes
Adding in a new AISummaryTable component to the AIReview which tries to summarise the data according to score loss, and categorise the types of moves as Excellent = blue move, Great = one of the green moves, Good = some positive score change move or mistake <1 point, Inaccuracy <2 point mistake, Mistake <5 points loss, Blunder >=5 point loss.

  - It currently only shows for katago reviews (full or fast, but fast omits the Excellent and Great categories).
  - It currently only shows for moderators, in order to test and tune before showing it to everybody.
  - It should work on finished games and uploaded games, and now forked games.
  - Added a preference to remember if the user wants the table hidden or not and a toggle for that.

There's still an issue where if the user opens a game page and then navigates away quickly, there's a setState error ("Can't perform a React state update on an unmounted component."). A similar issues happens with PaginatedTable on profile pages (for moderators) and for the Tournaments list pages, but I don't know how to fix these issues yet.

