### PR TITLE
TournamentsList updates

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -21,9 +21,9 @@ import {post, get} from "requests";
 import {deepCompare} from "misc";
 import * as data from "data";
 
-interface PaginatedTableColumnProperties {
+interface PaginatedTableColumnProperties<EntryT> {
     cellProps?: any;
-    render: (row) => any | string;
+    render: (row: EntryT) => JSX.Element | string | number;
     header: string;
     headerProps?: any;
     sortable?: boolean;
@@ -32,20 +32,20 @@ interface PaginatedTableColumnProperties {
     orderBy?: Array<string>;
 }
 
-type SourceFunction = (filter: any, sorting: Array<string>) => Promise<any>;
-type GroupFunction = (data: Array<any>) => Array<any>;
+type PaginatedObject<EntryT> = { results: EntryT[]; count: number };
+type SourceFunction<EntryT> = (filter: any, sorting: Array<string>) => Promise<PaginatedObject<EntryT>>;
 
-interface PaginatedTableProperties {
-    source: string | SourceFunction;
+interface PaginatedTableProperties<EntryT> {
+    source: string | SourceFunction<EntryT>;
     method?: "get" | "post";
     pageSize?: number;
-    columns: Array<PaginatedTableColumnProperties>;
+    columns: Array<PaginatedTableColumnProperties<EntryT>>;
     aliases?: string;
     name?: string;
     className: string;
     filter?: any;
     orderBy?: Array<string>;
-    groom?: ((data: Array<any>) => Array<any>);
+    groom?: ((data: Array<EntryT>) => Array<EntryT>);
     onRowClick?: (row, ev) => any;
     debug?: boolean;
     pageSizeOptions?: Array<number>;
@@ -63,12 +63,12 @@ interface PaginatedTableState {
     orderBy: string[];
 }
 
-export class PaginatedTable extends React.Component<PaginatedTableProperties, PaginatedTableState> {
+export class PaginatedTable<EntryT = any> extends React.Component<PaginatedTableProperties<EntryT>, PaginatedTableState> {
     filter: any = {};
     sorting: Array<string> = [];
     source_url: string;
     source_method: string;
-    source_function: SourceFunction;
+    source_function: SourceFunction<EntryT>;
 
     constructor(props) {
         super(props);
@@ -104,7 +104,7 @@ export class PaginatedTable extends React.Component<PaginatedTableProperties, Pa
             this.source_method = this.props.method || "get";
             this.source_function = this.ajax_loader.bind(this);
         } else {
-            this.source_function = this.props.source as SourceFunction;
+            this.source_function = this.props.source;
         }
     };
 
@@ -122,7 +122,7 @@ export class PaginatedTable extends React.Component<PaginatedTableProperties, Pa
         this.setPage(Math.max(0, ((this.state.page - 1) * old_page_size) / page_size) + 1, true);
     }
 
-    ajax_loader(filter: any, sorting: Array<string>): Promise<any> {
+    ajax_loader(filter: any, sorting: Array<string>): Promise<EntryT> {
         const query = {
             page_size: this.state.page_size,
             page: this.state.page,

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -35,17 +35,17 @@ interface PaginatedTableColumnProperties<EntryT> {
 type PaginatedObject<EntryT> = { results: EntryT[]; count: number };
 type SourceFunction<EntryT> = (filter: any, sorting: Array<string>) => Promise<PaginatedObject<EntryT>>;
 
-interface PaginatedTableProperties<EntryT> {
-    source: string | SourceFunction<EntryT>;
+interface PaginatedTableProperties<RawEntryT, GroomedEntryT = RawEntryT> {
+    source: string | SourceFunction<RawEntryT>;
     method?: "get" | "post";
     pageSize?: number;
-    columns: Array<PaginatedTableColumnProperties<EntryT>>;
+    columns: Array<PaginatedTableColumnProperties<GroomedEntryT>>;
     aliases?: string;
     name?: string;
     className: string;
     filter?: any;
     orderBy?: Array<string>;
-    groom?: ((data: Array<EntryT>) => Array<EntryT>);
+    groom?: ((data: Array<RawEntryT>) => Array<GroomedEntryT>);
     onRowClick?: (row, ev) => any;
     debug?: boolean;
     pageSizeOptions?: Array<number>;
@@ -63,12 +63,12 @@ interface PaginatedTableState {
     orderBy: string[];
 }
 
-export class PaginatedTable<EntryT = any> extends React.Component<PaginatedTableProperties<EntryT>, PaginatedTableState> {
+export class PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT> extends React.Component<PaginatedTableProperties<RawEntryT, GroomedEntryT>, PaginatedTableState> {
     filter: any = {};
     sorting: Array<string> = [];
     source_url: string;
     source_method: string;
-    source_function: SourceFunction<EntryT>;
+    source_function: SourceFunction<RawEntryT>;
 
     constructor(props) {
         super(props);
@@ -122,7 +122,7 @@ export class PaginatedTable<EntryT = any> extends React.Component<PaginatedTable
         this.setPage(Math.max(0, ((this.state.page - 1) * old_page_size) / page_size) + 1, true);
     }
 
-    ajax_loader(filter: any, sorting: Array<string>): Promise<EntryT> {
+    ajax_loader(filter: any, sorting: Array<string>): Promise<RawEntryT> {
         const query = {
             page_size: this.state.page_size,
             page: this.state.page,

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -64,7 +64,6 @@ interface PaginatedTableState {
 }
 
 export class PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT> extends React.Component<PaginatedTableProperties<RawEntryT, GroomedEntryT>, PaginatedTableState> {
-    filter: any = {};
     sorting: Array<string> = [];
     source_url: string;
     source_method: string;
@@ -86,7 +85,6 @@ export class PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT> extends 
         this.setState({
             page_size: this.props.pageSize || (this.props.name ? data.get(`paginated-table.${this.props.name}.page_size`) : 0) || 10,
         });
-        this.filter = this.props.filter || {};
         this.update_source();
         setTimeout(() => this.update(), 1);
     }
@@ -172,7 +170,7 @@ export class PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT> extends 
         }
         this.updating = true;
         this.needs_another_update = false;
-        this.source_function(this.filter, this.sorting)
+        this.source_function(this.props.filter, this.sorting)
         .then((res) => {
             const new_rows = this.props.groom ? this.props.groom(res.results || []) : res.results || [];
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -93,7 +93,7 @@ const defaults = {
 
     "supporter.currency": "auto",
     "supporter.interval": "month",
-    "tournaments-tab": "correspondence",
+    "tournaments-tab": "schedule",
     "tournaments-show-all": false,
     "translation-dialog-dismissed": 0,
     "translation-dialog-never-show": false,

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -94,6 +94,7 @@ const defaults = {
     "supporter.currency": "auto",
     "supporter.interval": "month",
     "tournaments-tab": "correspondence",
+    "tournaments-show-all": false,
     "translation-dialog-dismissed": 0,
     "translation-dialog-never-show": false,
     "unicode-filter": false,

--- a/src/models/tournaments.d.ts
+++ b/src/models/tournaments.d.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2021  Ben Jones
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare namespace rest_api {
+
+/**
+ * One element of `results` from `tournaments/`
+ *
+ * This is a work in progress. Trust these values at your own risk.
+ * */
+export interface Tournament {
+    "id": number;
+    "name": string;
+    "director": {
+        "id": number;
+        "username": string;
+        "country": string;
+        "icon": string; // URL
+        "ratings": {
+            "version": number;
+            "overall": {
+                "rating": number;
+                "deviation": number;
+                "volatility": number;
+            };
+        };
+        "ranking": number;
+        "professional": boolean;
+        "ui_class": string;
+    };
+    "description": "Automatic Sitewide Tournament";
+    "schedule": {
+        "id": number;
+        "name": string;
+        "rrule": string;
+        "active": boolean;
+        "created": string; // Date
+        "last_run": string; // Date
+        "lead_time_seconds": number;
+        "tournament_type": string;
+        "handicap": number;
+        "rules": string;
+        "size": number;
+        "time_control_parameters": {};
+        "min_ranking": number;
+        "max_ranking": number;
+        "analysis_enabled": boolean;
+        "exclude_provisional": boolean;
+        "players_start": number;
+        "first_pairing_method": string;
+        "subsequent_pairing_method": string;
+        "settings": {
+            "num_rounds": string; // number
+            "upper_bar": string; // number
+            "lower_bar": string; // number
+            "group_size": string; // number
+            "maximum_players": number;
+        };
+        "next_run": string; // Date
+        "base_points": string; // number
+    };
+    "title"?: string;
+    "tournament_type": string;
+    "handicap": number;
+    "rules": string;
+    "time_per_move": number;
+    "time_control_parameters": {
+        "time_control": string;
+        "period_time": number;
+        "main_time": number;
+        "periods": number;
+    };
+    "is_open": boolean;
+    "exclude_provisional": boolean;
+    "group": {
+        "id": number;
+        "name": string;
+        "summary": string;
+        "require_invitation": boolean;
+        "is_public": boolean;
+        "hide_details": boolean;
+        "member_count": number;
+        "icon": string;  // URL
+    };
+    "auto_start_on_max": boolean;
+    "time_start": string; // Date
+    "players_start": number;
+    "first_pairing_method": string;
+    "subsequent_pairing_method": string;
+    "min_ranking": number;
+    "max_ranking": number;
+    "analysis_enabled": boolean;
+    "exclusivity": string;
+    "started": string; // Date
+    "ended": string; // Date
+    "start_waiting": string; // Date
+    "board_size": number;
+    "active_round": number;
+    "icon": string; // URL
+    "player_count": number;
+}
+
+}

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -640,33 +640,21 @@ export class Group extends React.PureComponent<GroupProperties, any> {
                             {(group.has_open_tournaments || null) &&
                             <div>
                                 <h3>{_("Open Tournaments")}</h3>
-                                <TournamentList filter={{
-                                    started__isnull: true,
-                                    ended__isnull: true,
-                                    group: this.props.match.params.group_id,
-                                }}/>
+                                <TournamentList phase='open' group={this.props.match.params.group_id}/>
                             </div>
                             }
 
                             {(group.has_active_tournaments || null) &&
                             <div>
                                 <h3>{_("Active Tournaments")}</h3>
-                                <TournamentList filter={{
-                                    started__isnull: false,
-                                    ended__isnull: true,
-                                    group: this.props.match.params.group_id,
-                                }}/>
+                                <TournamentList phase='active' group={this.props.match.params.group_id}/>
                             </div>
                             }
 
                             {(group.has_finished_tournaments || null) &&
                             <div>
                                 <h3>{_("Finished Tournaments")}</h3>
-                                <TournamentList filter={{
-                                    started__isnull: false,
-                                    ended__isnull: false,
-                                    group: this.props.match.params.group_id,
-                                }}/>
+                                <TournamentList phase='finished' group={this.props.match.params.group_id}/>
                             </div>
                             }
                         </Card>

--- a/src/views/TournamentList/TournamentList.styl
+++ b/src/views/TournamentList/TournamentList.styl
@@ -98,4 +98,17 @@
     .nobr {
         white-space: nowrap;
     }
+
+    .open-tourney-header {
+        display: flex;
+        justify-content: space-between;
+        div {
+            color: #919191;
+            font-size: 12pt;
+            align-self: flex-end;
+        }
+        .Toggle {
+            margin: 10px;
+        }
+    }
 }

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -17,17 +17,15 @@
 
 import * as React from "react";
 import {Link} from "react-router-dom";
-import {browserHistory} from "ogsHistory";
 import {_, pgettext, interpolate} from "translate";
-import {post, get} from "requests";
-import {Card} from "material";
+import {get} from "requests";
 import * as preferences from "preferences";
 import {errorAlerter} from "misc";
 import {shortTimeControl, shortShortTimeControl} from "TimeControl";
 import {computeAverageMoveTime} from 'goban';
 import {PaginatedTable} from "PaginatedTable";
 import * as moment from "moment";
-import {TOURNAMENT_TYPE_NAMES, TOURNAMENT_PAIRING_METHODS, rankRestrictionText, shortRankRestrictionText} from "Tournament";
+import {TOURNAMENT_TYPE_NAMES, shortRankRestrictionText} from "Tournament";
 import tooltip from "tooltip";
 
 interface TournamentListProperties {
@@ -212,9 +210,6 @@ export class TournamentList extends React.PureComponent<TournamentListProperties
 
     constructor(props) {
         super(props);
-        // TODO: remove this.
-        this.state = {
-        };
     }
 
     render() {
@@ -230,8 +225,10 @@ export class TournamentList extends React.PureComponent<TournamentListProperties
                     filter={filter}
                     orderBy={["-started", "time_start", "name"]}
                     columns={[
-                        {header: _("Tournament"),  className: () => "name",
-                            render: (tournament) => (
+                        {
+                            header: _("Tournament"),
+                            className: () => "name",
+                            render: (tournament: rest_api.Tournament) => (
                                 <div className="tournament-name">
                                     <i className={timeIcon(tournament.time_per_move) + (tournament.group ? " group-tourny" : " site-tourny")} />
                                     {tournament.group

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -34,13 +34,15 @@ interface TournamentListProperties {
 
 interface TournamentListMainViewState {
     tab: 'schedule'|'live'|'archive'|'correspondence';
+    show_all: boolean;
 }
 
 export class TournamentListMainView extends React.PureComponent<{}, TournamentListMainViewState> {
     constructor(props) {
         super(props);
         this.state = {
-            tab: preferences.get("tournaments-tab")
+            tab: preferences.get("tournaments-tab"),
+            show_all: false,
         };
     }
 
@@ -60,6 +62,32 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
 
     render() {
         const tab = this.state.tab;
+
+        const open_tournaments_filters: {live: object; correspondence: object} = {
+            live: {
+                started__isnull: true,
+                ended__isnull: true,
+                time_per_move__lt: 3600,
+                time_per_move__gt: 0,
+            },
+            correspondence: {
+                started__isnull: true,
+                ended__isnull: true,
+                time_per_move__gte: 3600,
+            }
+        };
+
+        if (!this.state.show_all) {
+            for (const key in open_tournaments_filters) {
+                Object.assign(
+                    open_tournaments_filters[key],
+                    {
+                        time_start__gte: (new Date()).toISOString(),
+                        exclusivity: "open",
+                    }
+                );
+            }
+        }
 
         return (
 
@@ -92,13 +120,7 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
                     {tab === "live" && (
                         <div>
                             <h3>{_("Open Tournaments")}</h3>
-                            <TournamentList filter={{
-                                time_start__gte: (new Date()).toISOString(),
-                                started__isnull: true,
-                                ended__isnull: true,
-                                time_per_move__lt: 3600,
-                                time_per_move__gt: 0,
-                            }}/>
+                            <TournamentList filter={open_tournaments_filters.live}/>
 
                             <h3>{_("Active Tournaments")}</h3>
                             <TournamentList filter={{
@@ -112,12 +134,7 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
                     {tab === "correspondence" && (
                         <div>
                             <h3>{_("Open Tournaments")}</h3>
-                            <TournamentList filter={{
-                                time_start__gte: (new Date()).toISOString(),
-                                started__isnull: true,
-                                ended__isnull: true,
-                                time_per_move__gte: 3600,
-                            }}/>
+                            <TournamentList filter={open_tournaments_filters.correspondence}/>
 
                             <h3>{_("Active Tournaments")}</h3>
                             <TournamentList filter={{

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -72,6 +72,23 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
     render() {
         const tab = this.state.tab;
 
+        const frag_open_tournament = (speed: 'live'|'correspondence') => (
+            <React.Fragment>
+                <div className="open-tourney-header">
+                    <h3>{_("Open Tournaments")}</h3>
+                    <div>
+                        {_("Show all")}
+                        <Toggle height={14} width={30} checked={this.state.show_all} onChange={tf => this.toggleShowAll(tf)} />
+                    </div>
+                </div>
+                <TournamentList
+                    phase='open'
+                    speed={speed}
+                    hide_stale={!this.state.show_all}
+                    hide_exclusive={!this.state.show_all}
+                />
+            </React.Fragment>);
+
         return (
 
             <div className="page-width">
@@ -102,14 +119,7 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
                     {tab === "schedule" && <Schedule/>}
                     {tab === "live" && (
                         <div>
-                            <h3>{_("Open Tournaments")}</h3>
-                            <Toggle checked={this.state.show_all} onChange={tf => this.toggleShowAll(tf)} />
-                            <TournamentList
-                                phase='open'
-                                speed='live'
-                                hide_stale={!this.state.show_all}
-                                hide_exclusive={!this.state.show_all}
-                            />
+                            {frag_open_tournament('live')}
 
                             <h3>{_("Active Tournaments")}</h3>
                             <TournamentList phase='active' speed='live'/>
@@ -117,14 +127,7 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
                     )}
                     {tab === "correspondence" && (
                         <div>
-                            <h3>{_("Open Tournaments")}</h3>
-                            <Toggle checked={this.state.show_all} onChange={tf => this.toggleShowAll(tf)} />
-                            <TournamentList
-                                phase='open'
-                                speed='correspondence'
-                                hide_stale={!this.state.show_all}
-                                hide_exclusive={!this.state.show_all}
-                            />
+                            {frag_open_tournament('correspondence')}
 
                             <h3>{_("Active Tournaments")}</h3>
                             <TournamentList phase='active' speed='correspondence'/>

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -47,7 +47,7 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
         super(props);
         this.state = {
             tab: preferences.get("tournaments-tab"),
-            show_all: false,
+            show_all: preferences.get("tournaments-show-all"),
         };
     }
 

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -30,13 +30,15 @@ import * as moment from "moment";
 import {TOURNAMENT_TYPE_NAMES, TOURNAMENT_PAIRING_METHODS, rankRestrictionText, shortRankRestrictionText} from "Tournament";
 import tooltip from "tooltip";
 
-interface TournamentListMainViewProperties {
-}
 interface TournamentListProperties {
     filter: any;
 }
 
-export class TournamentListMainView extends React.PureComponent<TournamentListProperties, any> {
+interface TournamentListMainViewState {
+    tab: 'schedule'|'live'|'archive'|'correspondence';
+}
+
+export class TournamentListMainView extends React.PureComponent<{}, TournamentListMainViewState> {
     constructor(props) {
         super(props);
         this.state = {
@@ -203,13 +205,14 @@ class Schedule extends React.PureComponent<{}, any> {
         );
     }
 }
-export class TournamentList extends React.PureComponent<TournamentListProperties, any> {
+export class TournamentList extends React.PureComponent<TournamentListProperties> {
     refs: {
         table;
     };
 
     constructor(props) {
         super(props);
+        // TODO: remove this.
         this.state = {
         };
     }

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -93,6 +93,7 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
                         <div>
                             <h3>{_("Open Tournaments")}</h3>
                             <TournamentList filter={{
+                                time_start__gte: (new Date()).toISOString(),
                                 started__isnull: true,
                                 ended__isnull: true,
                                 time_per_move__lt: 3600,
@@ -112,6 +113,7 @@ export class TournamentListMainView extends React.PureComponent<{}, TournamentLi
                         <div>
                             <h3>{_("Open Tournaments")}</h3>
                             <TournamentList filter={{
+                                time_start__gte: (new Date()).toISOString(),
                                 started__isnull: true,
                                 ended__isnull: true,
                                 time_per_move__gte: 3600,
@@ -217,7 +219,7 @@ export class TournamentList extends React.PureComponent<TournamentListProperties
 
         return (
             <div className="TournamentList">
-                <PaginatedTable<rest_api.Tournament>
+                <PaginatedTable
                     className="TournamentList-table"
                     ref="table"
                     name="game-history"

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -217,7 +217,7 @@ export class TournamentList extends React.PureComponent<TournamentListProperties
 
         return (
             <div className="TournamentList">
-                <PaginatedTable
+                <PaginatedTable<rest_api.Tournament>
                     className="TournamentList-table"
                     ref="table"
                     name="game-history"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
                 "src/lib/*",
                 "src/components/*",
                 "src/views/*",
-                "src/data/*",
-                "src/compatibility/*",
+                "src/models/*",
                 "src/*"
             ],
             "requests": [
@@ -26,7 +25,7 @@
         },
 
         "forceConsistentCasingInFileNames": true,
-        
+
         "noImplicitAny": false,
         "noImplicitReturns": false,
         "noImplicitThis": false,


### PR DESCRIPTION
Fixes #1143 (@kobakitty please verify)

## Proposed Changes
  - Add a toggle that removes stale or exclusive tournaments (default: don't show stale/exclusive).
      - arbitrary filtering was way easier than I thought it would be.  Cool API!
  - Make Schedule the default tab, since it has the official tournaments.
  - Add template args to `PaginatedTable` for tighter types.
  - Add a **models/** dir that can be a home for various types such as types for important API calls. (pretty much just a proof of concept right now)

## Screenshots
<img width="400" alt="Screen Shot 2021-12-19 at 1 59 09 AM" src="https://user-images.githubusercontent.com/25233703/146666958-c02645a3-62af-4ac9-9f21-94f95e34a924.png">
<img width="400" alt="Screen Shot 2021-12-19 at 1 59 41 AM" src="https://user-images.githubusercontent.com/25233703/146666960-64a9cd8c-7aca-4986-9ace-aecb0db9f5cb.png">
