### PR TITLE
Move PaginatedTable to use the filter on props

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -154,17 +154,7 @@ export class PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT> extends 
         return post(this.source_url, query); // TODO: Check the URLs and typify the result again
     }
 
-
     needs_another_update: boolean = false;
-    filter_updated() {
-        this.setPage(1);
-        if (this.updating) {
-            this.needs_another_update = true;
-        } else {
-            this.update();
-        }
-    }
-
     updating: boolean = false;
     update() {
         if (this.updating) {
@@ -172,7 +162,7 @@ export class PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT> extends 
         }
         this.updating = true;
         this.needs_another_update = false;
-        this.source_function(this.filter, this.sorting)
+        this.source_function(this.props.filter, this.sorting)
         .then((res) => {
             const new_rows = this.props.groom ? this.props.groom(res.results || []) : res.results || [];
 

--- a/src/components/PlayerAutocomplete/PlayerAutocomplete.tsx
+++ b/src/components/PlayerAutocomplete/PlayerAutocomplete.tsx
@@ -124,7 +124,8 @@ export class PlayerAutocomplete extends React.PureComponent<PlayerAutocompletePr
                 }
             })
             .catch((err) => {
-                console.log(err);
+                // I'm not sure these logs are helpful: we get to here if they type ahead fast
+                // console.log(err);
             });
         } else {
             this.setState({

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -101,6 +101,7 @@ export const global_channels: Array<ChannelInformation> = [
     {"id": "global-english"    , "name": "English"    , "country": "us"           , language: "en"}    ,
     {"id": "global-help"       , "name": "Help"       , "country": "un"}          ,
     {"id": "global-offtopic"   , "name": "Off Topic"  , "country": "un"}          ,
+    {"id": "global-rengo"      , "name": "Rengo"      , "country": "un"}          ,
     {"id": "global-japanese"   , "name": "日本語 "    , "country": "jp"           , language: "ja"}    ,
     {"id": "global-zh-hans"    , "name": "中文"       , "country": "cn"           , language: ["zh", "zh_hans", "zh_cn"]}    ,
     {"id": "global-zh-hant"    , "name": "廣東話"     , "country": "hk"           , language: ["zh-hk", "zh_hk", "zh_hant", "zh_tw"]} ,

--- a/src/views/GroupList/GroupList.tsx
+++ b/src/views/GroupList/GroupList.tsx
@@ -24,8 +24,11 @@ import {PaginatedTable} from "PaginatedTable";
 import {SearchInput} from "misc-ui";
 import {navigateTo} from "misc";
 
+interface GroupListState {
+    name_contains_filter: string;
+}
 
-export class GroupList extends React.PureComponent {
+export class GroupList extends React.PureComponent<{}, GroupListState> {
     refs: {
         table;
     };
@@ -33,6 +36,7 @@ export class GroupList extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {
+            name_contains_filter: "",
         };
     }
     componentDidMount() {
@@ -52,8 +56,7 @@ export class GroupList extends React.PureComponent {
                             <SearchInput
                                 placeholder={_("Search")}
                                 onChange={(event) => {
-                                    this.refs.table.filter.name__icontains = (event.target as HTMLInputElement).value.trim();
-                                    this.refs.table.filter_updated();
+                                    this.setState({name_contains_filter: (event.target as HTMLInputElement).value.trim()});
                                 }}
                             />
                         </div>
@@ -66,7 +69,9 @@ export class GroupList extends React.PureComponent {
                             name="game-history"
                             source={`groups/`}
                             orderBy={["-member_count"]}
-                            filter={{ "name__icontains": "" }}
+                            filter={{
+                                ...(this.state.name_contains_filter !== "" && {'name__icontains': this.state.name_contains_filter})
+                            }}
                             onRowClick={(row, ev) => navigateTo(`/group/${row.id}`, ev)}
                             columns={[
                                 {header: "",  className: "group-icon-header",

--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -35,8 +35,12 @@ const greylist = ["yopmail.com", "vsprint.com", "xplanningzx.com", "mailsac.com"
 
 const greylist2 = [".xyz", ".life", ".website"];
 
+interface ModeratorState {
+    newuserany_filter: string;
+    playerusernameistartswith_filter: string;
+}
 
-export class Moderator extends React.PureComponent {
+export class Moderator extends React.PureComponent<{}, ModeratorState> {
     refs: {
         modlog;
         userlog;
@@ -45,6 +49,8 @@ export class Moderator extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {
+            newuserany_filter: "",
+            playerusernameistartswith_filter: "",
         };
     }
     componentDidMount() {
@@ -70,9 +76,7 @@ export class Moderator extends React.PureComponent {
                         <SearchInput
                             placeholder={_("Search")}
                             onChange={(event) => {
-                            //this.refs.userlog.filter.username__istartswith = (event.target as HTMLInputElement).value.trim();
-                                this.refs.userlog.filter.newuserany = (event.target as HTMLInputElement).value.trim();
-                                this.refs.userlog.filter_updated();
+                                this.setState({newuserany_filter: (event.target as HTMLInputElement).value.trim()});
                             }}
                         />
                     </div>
@@ -87,7 +91,9 @@ export class Moderator extends React.PureComponent {
                         name="userlog"
                         source={`moderation/recent_users`}
                         orderBy={["-timestamp"]}
-                        filter={{ "newuserany": "" }}
+                        filter={{
+                            ...(this.state.newuserany_filter !== "" && {newuserany: this.state.newuserany_filter})
+                        }}
                         columns={[
                             {header: _("Time"),  className: () => "timestamp",
                                 render: (X) => (moment(new Date(X.registration_date)).format("YYYY-MM-DD HH:mm")) },
@@ -122,9 +128,7 @@ export class Moderator extends React.PureComponent {
                             className="pull-right"
                             placeholder={_("Search")}
                             onChange={(event) => {
-                                this.refs.modlog.filter.playerusernameistartswith = (event.target as HTMLInputElement).value.trim();
-                                //this.refs.modlog.filter.useruserany = (event.target as HTMLInputElement).value.trim();
-                                this.refs.modlog.filter_updated();
+                                this.setState({playerusernameistartswith_filter: (event.target as HTMLInputElement).value.trim()});
                             }}
                         />
                     </div>
@@ -135,7 +139,9 @@ export class Moderator extends React.PureComponent {
                         name="modlog"
                         source={`moderation/`}
                         orderBy={["-timestamp"]}
-                        filter={{ "playerusernameistartswith": "" }}
+                        filter={{
+                            ...(this.state.playerusernameistartswith_filter !== "" && {playernameistartswith: this.state.playerusernameistartswith_filter}),
+                        }}
                         columns={[
                             {header: _("Time"),  className: () => "timestamp ",
                                 render: (X) => (moment(new Date(X.timestamp)).format("YYYY-MM-DD HH:mm")) },

--- a/src/views/PuzzleList/PuzzleList.tsx
+++ b/src/views/PuzzleList/PuzzleList.tsx
@@ -30,16 +30,22 @@ import {navigateTo, unitify} from "misc";
 import * as data from "data";
 import * as moment from "moment";
 
-export class PuzzleList extends React.PureComponent {
+interface PuzzleListState {
+    name_contains_filter: string;  // string to be used for filtering search results by name
+}
+
+export class PuzzleList extends React.PureComponent<{}, PuzzleListState> {
     refs: {
         table;
     };
 
     constructor(props) {
         super(props);
-        // TODO: Delete this.
-        this.state = { };
+        this.state = {
+            'name_contains_filter': "",
+        };
     }
+
     componentDidMount() {
         window.document.title = _("Puzzles");
     }
@@ -64,8 +70,7 @@ export class PuzzleList extends React.PureComponent {
                                 <SearchInput
                                     placeholder={_("Search")}
                                     onChange={(event) => {
-                                        this.refs.table.filter.name__icontains = (event.target as HTMLInputElement).value.trim();
-                                        this.refs.table.filter_updated();
+                                        this.setState({name_contains_filter: (event.target as HTMLInputElement).value.trim()});
                                     }}
                                 />
                             </div>
@@ -81,7 +86,8 @@ export class PuzzleList extends React.PureComponent {
                             ]}
                             filter={{
                                 "puzzle_count__gt": "0",
-                                "name__istartswith": ""
+                                "name__istartswith": "",
+                                ...(this.state.name_contains_filter !== "" && {'name__icontains': this.state.name_contains_filter})
                             }}
                             groom={
                                 (arr) => {

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -181,7 +181,10 @@ interface UserState {
     ladders?: any[];
     tournaments?: any[];
     groups?: any[];
+    games_alt_player_filter: number;
+    reviews_alt_player_filter: number;
 }
+
 export class User extends React.PureComponent<UserProperties, UserState> {
     refs: {
         vacation_left;
@@ -222,6 +225,8 @@ export class User extends React.PureComponent<UserProperties, UserState> {
             rating_graph_plot_by_games: preferences.get('rating-graph-plot-by-games'),
             show_graph_type_toggle: !preferences.get('rating-graph-always-use'),
             hovered_game_id: null,
+            games_alt_player_filter: null,
+            reviews_alt_player_filter: null,
         };
 
         try {
@@ -597,24 +602,6 @@ export class User extends React.PureComponent<UserProperties, UserState> {
             this.resolve(this.props);
         });
     };
-
-    updateGameSearch = (player) => {
-        if (player) {
-            this.refs.game_table.filter.alt_player = player.id;
-        } else {
-            delete this.refs.game_table.filter.alt_player;
-        }
-        this.refs.game_table.filter_updated();
-    };
-    updateReviewSearch = (player) => {
-        if (player) {
-            this.refs.review_table.filter.alt_player = player.id;
-        } else {
-            delete this.refs.review_table.filter.alt_player;
-        }
-        this.refs.review_table.filter_updated();
-    };
-
 
     addModeratorNote = () => {
         const txt = this.moderator_note.value.trim();
@@ -1037,7 +1024,11 @@ export class User extends React.PureComponent<UserProperties, UserState> {
                                 <Card>
                                     <div>{/* loading-container="game_history.settings().$loading" */}
                                         <div className="search">
-                                            <i className="fa fa-search"></i><PlayerAutocomplete onComplete={this.updateGameSearch}/>
+                                            <i className="fa fa-search"></i>
+                                            <PlayerAutocomplete onComplete={(player) => {
+                                                // happily, and importantly, if there isn't a player, then we get null
+                                                this.setState({games_alt_player_filter: player?.id});
+                                            }}/>
                                         </div>
 
                                         <PaginatedTable
@@ -1049,6 +1040,7 @@ export class User extends React.PureComponent<UserProperties, UserState> {
                                             filter={{
                                                 "source": "play",
                                                 "ended__isnull": false,
+                                                ...(this.state.games_alt_player_filter !== null && {"alt_player": this.state.games_alt_player_filter})
                                             }}
                                             orderBy={["-ended"]}
                                             groom={game_history_groomer}
@@ -1075,7 +1067,11 @@ export class User extends React.PureComponent<UserProperties, UserState> {
                                 <Card>
                                     <div>{/* loading-container="game_history.settings().$loading" */}
                                         <div className="search">
-                                            <i className="fa fa-search"></i><PlayerAutocomplete onComplete={this.updateReviewSearch}/>
+                                            <i className="fa fa-search"></i>
+                                            <PlayerAutocomplete onComplete={(player) => {
+                                                // happily, and importantly, if there isn't a player, then we get null
+                                                this.setState({reviews_alt_player_filter: player?.id});
+                                            }}/>
                                         </div>
 
                                         <PaginatedTable
@@ -1086,6 +1082,7 @@ export class User extends React.PureComponent<UserProperties, UserState> {
                                             source={`reviews/`}
                                             filter={{
                                                 "owner_id": this.user_id,
+                                                ...(this.state.reviews_alt_player_filter !== null && {"alt_player": this.state.reviews_alt_player_filter})
                                             }}
                                             orderBy={["-created"]}
                                             groom={review_history_groomer}


### PR DESCRIPTION
... get rid of PaginatedTable.filter_updated

Fixes #

Fixes the problem of wanting to update the filter, but needing to be able to have the URL param not included, but also wanting to use state changes -> prop changes to cause the table to update

## Proposed Changes

Use [this](https://amberley.dev/blog/2020-09-07-conditionally-add-to-array-or-obj/#conditionally-add-a-property-to-an-object) to let us put the necessary filter url param in place when we need to, but not have it there when it should not be, and do it based on the state of the instantiating component controlling the filter prop of the paginated table.
