### PR TITLE
Tournament: show final results for finished tournaments

### DIFF
--- a/src/views/Tournament/Tournament.styl
+++ b/src/views/Tournament/Tournament.styl
@@ -398,6 +398,7 @@
         border: 2px solid transparent;
         themed border-color fg
         width: 24rem;
+        max-width: 85vw;
         margin-left: auto;
         margin-right: auto;
         padding: 1rem;
@@ -417,11 +418,12 @@
             display: inline-flex;
             align-items: center;
             font-weight: bold;
-            width: 15rem;
             line-height: 2em;
         }
         .final-results-place {
             width: 9rem;
+            line-height: 1em;
+            padding-right: 0.5em;
             img {
               margin-right: 0.5em;
             }

--- a/src/views/Tournament/Tournament.styl
+++ b/src/views/Tournament/Tournament.styl
@@ -394,4 +394,38 @@
         }
     }
 
+    .final-results {
+        border: 2px solid transparent;
+        themed border-color fg
+        width: 24rem;
+        margin-left: auto;
+        margin-right: auto;
+        padding: 1rem;
+        margin-top: 0.5rem;
+
+        h2 {
+            margin-top: 0;
+            font-size: larger;
+            text-align: center;
+        }
+        > div {
+            display: flex;
+            align-items: center;
+        }
+        > div > span {
+            height: 2em;
+            display: inline-flex;
+            align-items: center;
+            font-weight: bold;
+            width: 15rem;
+            line-height: 2em;
+        }
+        .final-results-place {
+            width: 9rem;
+            img {
+              margin-right: 0.5em;
+            }
+        }
+    }
+
 }

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1228,6 +1228,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
             const rank_restriction_text = rankRestrictionText(tournament.min_ranking, tournament.max_ranking);
             const provisional_players_text = tournament.exclude_provisional ? _("Not allowed") : _("Allowed");
             const analysis_mode_text = tournament.analysis_enabled ? _("Allowed") : _("Not allowed");
+            const cdn_release = data.get("config.cdn_release");
             //let scheduled_rounds_text = tournament.scheduled_rounds ? pgettext("In a tournament, rounds will be scheduled to start at specific times", "Rounds are scheduled") : pgettext("In a tournament, the next round will start when the last finishes", "Rounds will automatically start when the last round finishes");
 
             let min_bar = "";
@@ -1695,7 +1696,28 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
                 </div>
                     }
 
-
+              {!loading && tournament.ended &&
+               <div className="final-results">
+               <h2>{_("Final results")}:</h2>
+               {
+                 Object.keys(players).map((id) => players[id])
+                   .filter((p) => p.rank <= 3)
+                   .sort((a,b) => (a.rank > b.rank) ? 1 : -1)
+                   .map((player) => (
+                     <div>
+                       <span className="final-results-place">
+                         <img className="trophy" src={`${cdn_release}/img/trophies/${trophyFilename(tournament, player.rank)}`} title="" />
+                         {nthPlace(player.rank)}
+                       </span>
+                       <span>
+                         <Player icon user={player} />
+                       </span>
+                     </div>
+                   )
+                   )
+               }
+               </div>
+              }
 
                     {!loading && !tournament.started &&
                 <div className={"bottom-details not-started"}>
@@ -2461,4 +2483,30 @@ function fromNow(t) {
         return pgettext("Tournament begins very shortly", "very shortly");
     }
     return moment(d).fromNow();
+}
+
+function nthPlace(n) {
+  switch(n)
+  {
+    case 1:
+      return _("First place");
+    case 2:
+      return _("Second place");
+    case 3:
+      return _("Third place");
+  }
+}
+
+function trophyFilename(tournament, rank)
+{
+  var size = tournament.board_size;
+  switch (rank)
+  {
+    case 1:
+      return `gold_tourn_${size}.png`;
+    case 2:
+      return `silver_tourn_${size}.png`;
+    case 3:
+      return `bronze_tourn_${size}.png`;
+  }
 }

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1696,28 +1696,28 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
                 </div>
                     }
 
-              {!loading && tournament.ended &&
-               <div className="final-results">
-               <h2>{_("Final results")}:</h2>
-               {
-                 Object.keys(players).map((id) => players[id])
-                   .filter((p) => p.rank <= 3)
-                   .sort((a,b) => (a.rank > b.rank) ? 1 : -1)
-                   .map((player) => (
-                     <div>
-                       <span className="final-results-place">
-                         <img className="trophy" src={`${cdn_release}/img/trophies/${trophyFilename(tournament, player.rank)}`} title="" />
-                         {nthPlace(player.rank)}
-                       </span>
-                       <span>
-                         <Player icon user={player} />
-                       </span>
-                     </div>
-                   )
-                   )
-               }
-               </div>
-              }
+                    {!loading && tournament.ended &&
+                            <div className="final-results">
+                                <h2>{_("Final results")}:</h2>
+                                {
+                                    Object.keys(players).map((id) => players[id])
+                                .filter((p) => p.rank <= 3)
+                                .sort((a, b) => (a.rank > b.rank) ? 1 : -1)
+                                .map((player) => (
+                                    <div>
+                                        <span className="final-results-place">
+                                            <img className="trophy" src={`${cdn_release}/img/trophies/${trophyFilename(tournament, player.rank)}`} title="" />
+                                            {nthPlace(player.rank)}
+                                        </span>
+                                        <span>
+                                            <Player icon user={player} />
+                                        </span>
+                                    </div>
+                                )
+                                )
+                                }
+                            </div>
+                    }
 
                     {!loading && !tournament.started &&
                 <div className={"bottom-details not-started"}>
@@ -2486,27 +2486,24 @@ function fromNow(t) {
 }
 
 function nthPlace(n) {
-  switch(n)
-  {
-    case 1:
-      return _("First place");
-    case 2:
-      return _("Second place");
-    case 3:
-      return _("Third place");
-  }
+    switch (n) {
+        case 1:
+            return _("First place");
+        case 2:
+            return _("Second place");
+        case 3:
+            return _("Third place");
+    }
 }
 
-function trophyFilename(tournament, rank)
-{
-  var size = tournament.board_size;
-  switch (rank)
-  {
-    case 1:
-      return `gold_tourn_${size}.png`;
-    case 2:
-      return `silver_tourn_${size}.png`;
-    case 3:
-      return `bronze_tourn_${size}.png`;
-  }
+function trophyFilename(tournament, rank) {
+    const size = tournament.board_size;
+    switch (rank) {
+        case 1:
+            return `gold_tourn_${size}.png`;
+        case 2:
+            return `silver_tourn_${size}.png`;
+        case 3:
+            return `bronze_tourn_${size}.png`;
+    }
 }

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1696,12 +1696,12 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
                 </div>
                     }
 
-                    {!loading && tournament.ended &&
+                    {!loading && tournament.tournament_type !== "opengotha" && tournament.ended &&
                             <div className="final-results">
                                 <h2>{_("Final results")}:</h2>
                                 {
                                     Object.keys(players).map((id) => players[id])
-                                .filter((p) => p.rank <= 3)
+                                .filter((p) => p.rank > 0 && p.rank <= 3)
                                 .sort((a, b) => (a.rank > b.rank) ? 1 : -1)
                                 .map((player) => (
                                     <div>

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1709,9 +1709,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
                                             <img className="trophy" src={`${cdn_release}/img/trophies/${trophyFilename(tournament, player.rank)}`} title="" />
                                             {nthPlace(player.rank)}
                                         </span>
-                                        <span>
-                                            <Player icon user={player} />
-                                        </span>
+                                        <Player icon user={player} />
                                     </div>
                                 )
                                 )


### PR DESCRIPTION
See this thread:

https://forums.online-go.com/t/tournaments-should-show-winners/33767/9

## Proposed Changes

  - Shows "Final results" with a list of the winners (top 3) of the tournament.
  - Each winner is shown with the corresponding trophy:

![image](https://user-images.githubusercontent.com/466760/147373030-81bdfdaf-8b04-4312-bd73-368bc0d0afbf.png)

## Remaining issues

- I had to compute trophy filenames since these don't seem to be available in the API; they won't work for the special title tournaments or non-standard sizes.
- Someone should check how I did the styling.
- This introduces a new loop over players which could be slow for large tournaments.
- I didn't implement hover text on the trophies since it seemed redundant.
- Maybe should be a bit narrower for mobile.