### PR TITLE
Tournaments: show number of players in the tournament after it starts

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1449,22 +1449,37 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
                         <tr>
                             <th >{_("Players")}</th>
                             <td>
-                                {!editing
-                                    ? <span>
-                                        {tournament.players_start}
-                                        {!tournament.settings.maximum_players
+                                {editing ?
+                                 <span>
+                                     <input ref="players_start" type="number" value={tournament.players_start} onChange={this.setPlayersStart} />
+                                         -
+                                     <input ref="max_players" type="number" value={tournament.settings.maximum_players} onChange={this.setMaximumPlayers} />
+                                 </span>
+                                 :
+                                 (!tournament.started ?
+                                 <span>
+                                     {tournament.players_start}
+                                     {!tournament.settings.maximum_players
                                              ? "+"
                                              : (
                                                  tournament.settings.maximum_players > tournament.players_start
                                                  ? "-" + tournament.settings.maximum_players
                                                  : ""
                                              )}
-                                    </span>
-                                    : <span>
-                                        <input ref="players_start" type="number" value={tournament.players_start} onChange={this.setPlayersStart} />
-                                         -
-                                        <input ref="max_players" type="number" value={tournament.settings.maximum_players} onChange={this.setMaximumPlayers} />
-                                    </span>
+                                 </span>
+                                 :
+                                     <span>
+                                         {this.state.sorted_players.length} (was {tournament.players_start}
+                                         {!tournament.settings.maximum_players
+                                             ? "+"
+                                             : (
+                                                 tournament.settings.maximum_players > tournament.players_start
+                                                 ? "-" + tournament.settings.maximum_players
+                                                 : ""
+                                             )}
+                                                             )
+                                     </span>
+                                   )
                                 }
                             </td>
                         </tr>


### PR DESCRIPTION
## Proposed Changes

  - After a tournament starts, show the number of players:

![image](https://user-images.githubusercontent.com/466760/147378086-4195a67f-fcf2-46ec-8711-508741cefe21.png)

I've kept the information from when it was open in case it's useful to players or directors.  (Without that information, "Starts when full" doesn't make much sense either.)

