### PR TITLE
Tournaments: do not show wrong default data while loading

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1294,6 +1294,9 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
             null
             );
 
+            if (this.state.loading)
+                return "";
+
             return (
                 <div className="Tournament page-width">
                     <UIPush event="players-updated" channel={`tournament-${this.state.tournament_id}`} action={this.reloadTournament}/>

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1294,8 +1294,10 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
             null
             );
 
-            if (this.state.loading)
+            if (this.state.loading && !this.state.editing)
+            {
                 return "";
+            }
 
             return (
                 <div className="Tournament page-width">

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1294,8 +1294,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
             null
             );
 
-            if (this.state.loading && !this.state.editing)
-            {
+            if (this.state.loading && !this.state.editing) {
                 return "";
             }
 

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import {LoadingPage} from 'Loading';
 import {Link} from "react-router-dom";
 import {browserHistory} from "ogsHistory";
 import {_, pgettext, interpolate} from "translate";
@@ -1295,7 +1296,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
             );
 
             if (this.state.loading && !this.state.editing) {
-                return "";
+                return <LoadingPage />;
             }
 
             return (


### PR DESCRIPTION
## Proposed Changes

  - While a tournament is loading, do not show wrong default values

Fixes #1581, I think.  Not sure if this is the right place to put this line, but it seems to at least block anything from getting displayed while the tournament is loading. 

Of course it would be nicer if the OGS loading icon could continue bouncing up and down while the page is loading.

Merry Christmas OGS team! 🎅