### PR TITLE
Tournament final results: do not bold player names since that messes up the emoji font

### DIFF
--- a/src/views/Tournament/Tournament.styl
+++ b/src/views/Tournament/Tournament.styl
@@ -417,13 +417,13 @@
             height: 2em;
             display: inline-flex;
             align-items: center;
-            font-weight: bold;
             line-height: 2em;
         }
         .final-results-place {
             width: 9rem;
             line-height: 1em;
             padding-right: 0.5em;
+            font-weight: bold;
             img {
               margin-right: 0.5em;
             }


### PR DESCRIPTION
Example: https://online-go.com/tournament/16820

Before / after:

![image](https://user-images.githubusercontent.com/466760/147414630-417ed235-36a3-47ee-a333-52b048866af5.png)
![image](https://user-images.githubusercontent.com/466760/147414634-3b9f28d1-ae25-46f2-9dbb-ac29a4b5106e.png)
