### PR TITLE
More key moves

### DIFF
--- a/src/views/Game/AIReview.styl
+++ b/src/views/Game/AIReview.styl
@@ -179,6 +179,7 @@
         user-select: none;
         display: inline-flex;
         width: 100%;
+        text-align: center;
 
         .move-list {
             flex: 1;
@@ -191,7 +192,6 @@
             border: 1px solid #888;
             width: 2.5rem;
             display: inline-block;
-            text-align: center;
             cursor: pointer;
         }
 
@@ -203,8 +203,9 @@
     .win-score-toggler {
         display: inline-flex;
         width: 100%;
-        margin-bottom: 0.5rem;
-
+        padding-top: 0.5rem;        
+        padding-bottom: 0;
+        
         span {
             padding-left: 0.5rem;
             padding-right: 0.5rem;
@@ -314,4 +315,5 @@
 
 .worst-moves-summary-toggle-container {
     display: inline-flex;    
+    width: 100%;
 }

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -90,7 +90,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             use_score: preferences.get('ai-review-use-score'),
             // TODO: allow users to view more than 3 of these key moves
             // See https://forums.online-go.com/t/top-3-moves-score-a-better-metric/32702/15
-            worst_moves_shown: 3,
+            worst_moves_shown: 6,
             table_set: false,
             table_hidden : preferences.get('ai-summary-table-show'),
         };
@@ -1024,7 +1024,29 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         const trunk_move = cur_move.getBranchPoint();
         const move_number = trunk_move.move_number;
         const variation_move_number = cur_move.move_number !== trunk_move.move_number ? cur_move.move_number : -1;
-        const worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review);
+        
+        let worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review, 100);
+
+        // let worst_move_list = new Array();
+
+        // let black_moves = 0;
+        // let white_moves = 0
+        // for (let i = 0; i < worst_move_list.length; i++) {
+        //     const move = worst_move_list[i];
+        //     if (move.player === 1 && black_moves < 3) {
+        //         worst_move_list.push(move)
+        //         black_moves++;
+        //     }
+        //     if (move.player === 2 && white_moves < 3) {
+        //         worst_move_list.push(move)
+        //         white_moves++;
+        //     }
+        // }
+
+        const worst_black_moves = worst_move_list.filter(move => (move.player === 1))
+        const worst_white_moves = worst_move_list.filter(move => move.player === 2)
+
+        worst_move_list = worst_black_moves.slice(0,3).concat(worst_white_moves.slice(0,3))
 
         console.log(this.ai_review);
         console.log(worst_move_list);
@@ -1248,13 +1270,13 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             return null;
         }
 
-        const more_ct = Math.max(0, lst.length - 3);
+        const more_ct = Math.max(0, lst.length - this.state.worst_moves_shown);
 
         return (
             <div className='worst-move-list-container'>
                 <div className='move-list'>
                     {pgettext("Moves that were the biggest mistakes, according to the AI", "Key moves")}:
-                    {lst.slice(0, 3).map((de, idx) => {
+                    {lst.slice(0, this.state.worst_moves_shown).map((de, idx) => {
                         const pretty_coords = this.props.game.goban.engine.prettyCoords(de.move.x, de.move.y);
                         return (
                             <span

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1026,6 +1026,9 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         const variation_move_number = cur_move.move_number !== trunk_move.move_number ? cur_move.move_number : -1;
         const worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review);
 
+        console.log(this.ai_review);
+        console.log(worst_move_list);
+
         return (
             <div className='AIReview'>
                 <UIPush event="ai-review" channel={`game-${this.props.game.game_id}`} action={this.ai_review_update} />

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1179,6 +1179,21 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                                             .map(m => m.move_number - 1)
                                     }
                                 />
+                                <div className = "worst-moves-summary-toggle-container">
+                                    {this.renderWorstMoveList(worst_move_list)}
+                                    {(user.is_moderator || null) &&
+                                        <div className = 'ai-summary-toggler'>
+                                            <span><i className="fa fa-table"></i></span>
+                                            <span>
+                                                <Toggle checked={this.state.table_hidden} onChange={b => {
+                                                    preferences.set('ai-summary-table-show', b);
+                                                    this.setState({table_hidden: b});
+                                                    //console.log(this.state.table_hidden);
+                                                }}/>
+                                            </span>
+                                        </div>
+                                    }
+                                </div>                                    
                                 {this.ai_review.scores &&
                                     <div className='win-score-toggler'>
                                         <span className='win-toggle' onClick={() => {
@@ -1199,21 +1214,6 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                                         }}>{pgettext("Display the game score that the AI estimates", "Score")}</span>
                                     </div>
                                 }
-                                <div className = "worst-moves-summary-toggle-container">
-                                    {this.renderWorstMoveList(worst_move_list)}
-                                    {(user.is_moderator || null) &&
-                                        <div className = 'ai-summary-toggler'>
-                                            <span><i className="fa fa-table"></i></span>
-                                            <span>
-                                                <Toggle checked={this.state.table_hidden} onChange={b => {
-                                                    preferences.set('ai-summary-table-show', b);
-                                                    this.setState({table_hidden: b});
-                                                    //console.log(this.state.table_hidden);
-                                                }}/>
-                                            </span>
-                                        </div>
-                                    }
-                                </div>
                             </React.Fragment>
                         }
 
@@ -1272,10 +1272,12 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
 
         const more_ct = Math.max(0, lst.length - this.state.worst_moves_shown);
 
+        /* {pgettext("Moves that were the biggest mistakes, according to the AI", "Key moves")}: */
+
         return (
             <div className='worst-move-list-container'>
                 <div className='move-list'>
-                    {pgettext("Moves that were the biggest mistakes, according to the AI", "Key moves")}:
+                    
                     {lst.slice(0, this.state.worst_moves_shown).map((de, idx) => {
                         const pretty_coords = this.props.game.goban.engine.prettyCoords(de.move.x, de.move.y);
                         return (

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1025,31 +1025,11 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         const move_number = trunk_move.move_number;
         const variation_move_number = cur_move.move_number !== trunk_move.move_number ? cur_move.move_number : -1;
         
-        let orig_worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review, 100);
-
-        let worst_move_list = new Array();
-
         let black_moves = 0;
         let white_moves = 0
-        for (let i = 0; i < orig_worst_move_list.length; i++) {
-            const move = orig_worst_move_list[i];
-            if (move.player === 1 && black_moves < 3) {
-                worst_move_list.push(move)
-                black_moves++;
-            }
-            if (move.player === 2 && white_moves < 3) {
-                worst_move_list.push(move)
-                white_moves++;
-            }
-        }
 
-        // const worst_black_moves = worst_move_list.filter(move => (move.player === 1))
-        // const worst_white_moves = worst_move_list.filter(move => move.player === 2)
-
-        // worst_move_list = worst_black_moves.slice(0,3).concat(worst_white_moves.slice(0,3))
-
-        console.log(this.ai_review);
-        console.log(worst_move_list);
+        let worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review, 100);
+        worst_move_list = worst_move_list.filter(move => move.player === 1 && black_moves++ < 3 || move.player === 2 && white_moves++ < 3)
 
         return (
             <div className='AIReview'>

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1025,28 +1025,28 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         const move_number = trunk_move.move_number;
         const variation_move_number = cur_move.move_number !== trunk_move.move_number ? cur_move.move_number : -1;
         
-        let worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review, 100);
+        let orig_worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review, 100);
 
-        // let worst_move_list = new Array();
+        let worst_move_list = new Array();
 
-        // let black_moves = 0;
-        // let white_moves = 0
-        // for (let i = 0; i < worst_move_list.length; i++) {
-        //     const move = worst_move_list[i];
-        //     if (move.player === 1 && black_moves < 3) {
-        //         worst_move_list.push(move)
-        //         black_moves++;
-        //     }
-        //     if (move.player === 2 && white_moves < 3) {
-        //         worst_move_list.push(move)
-        //         white_moves++;
-        //     }
-        // }
+        let black_moves = 0;
+        let white_moves = 0
+        for (let i = 0; i < orig_worst_move_list.length; i++) {
+            const move = orig_worst_move_list[i];
+            if (move.player === 1 && black_moves < 3) {
+                worst_move_list.push(move)
+                black_moves++;
+            }
+            if (move.player === 2 && white_moves < 3) {
+                worst_move_list.push(move)
+                white_moves++;
+            }
+        }
 
-        const worst_black_moves = worst_move_list.filter(move => (move.player === 1))
-        const worst_white_moves = worst_move_list.filter(move => move.player === 2)
+        // const worst_black_moves = worst_move_list.filter(move => (move.player === 1))
+        // const worst_white_moves = worst_move_list.filter(move => move.player === 2)
 
-        worst_move_list = worst_black_moves.slice(0,3).concat(worst_white_moves.slice(0,3))
+        // worst_move_list = worst_black_moves.slice(0,3).concat(worst_white_moves.slice(0,3))
 
         console.log(this.ai_review);
         console.log(worst_move_list);

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -92,7 +92,7 @@ goban-view-bar-width=400px
         align-items: flex-start;
         flex-direction: column;
         justify-content: center;
-        padding-top: 1rem;
+        padding-top: 0.5rem;
         max-width: 100vw;
         //height: 23rem;
         //min-height: 5rem;


### PR DESCRIPTION
Fixes this [forum comment](https://forums.online-go.com/t/top-3-moves-score-a-better-metric/32702/14):

> Those 6 moves are readily available, but I’m not exactly sure the best way to expose in the UI.")

## Proposed Changes

- shows six key moves, three from each player
- key-moves is now above win-score-toggler
- removed "Key moves:" label

before:

![Screen Shot 2021-12-30 at 8 51 47 PM](https://user-images.githubusercontent.com/195001/147829330-61a66b57-3ada-42b9-815b-42c12d4ea18d.png)

after:

![Screen Shot 2021-12-30 at 8 50 44 PM](https://user-images.githubusercontent.com/195001/147829339-e6746298-c80f-4149-bd6d-985f6e6b58c1.png)

## Background

When a game finishes, the AI review shows three buttons representing the moves that made the biggest difference in the game. A month ago, there was a non-functional "+n moves" label:

<img width="344" alt="143656382-e12d5279-ab2d-4658-b5a6-94265fd2c1b6" src="https://user-images.githubusercontent.com/195001/147829309-8faa80cd-555a-410f-8288-a7d4368e7ac3.png">

Then, the label was removed as part of work towards creating an AI summary table.