### PR TITLE
add getGameResultText on GameInfoModal 

### DIFF
--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -159,30 +159,9 @@ export class MiniGoban extends React.Component<MiniGobanProps, MiniGobanState> {
         }
 
         if (this.props.title) {
-
-            // we have to cook up a `result` object to pass to getGameResultText
-            let result: any;
-
-            if (this.goban.engine.winner === this.goban.engine.black_player_id) {
-                result = {
-                    black_lost: false,
-                    white_lost: true
-                };
-            } else if (this.goban.engine.winner === this.goban.engine.white_player_id) {
-                result = {
-                    black_lost: true,
-                    white_lost: false
-                };
-            } else {
-                result = {
-                    black_lost: true,
-                    white_lost: true
-                };
-            }
-
-            result.outcome = this.goban.engine.outcome;
-
-            const result_string = getGameResultText(result);
+            const result_string = getGameResultText(this.goban.engine.outcome,
+                this.goban.engine.winner !== this.goban.engine.white_player_id,
+                this.goban.engine.winner !== this.goban.engine.black_player_id);
 
             this.setState({
                 game_name: this.goban.engine.game_name || "",

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -193,26 +193,26 @@ export function getOutcomeTranslation(outcome: string) {
     return outcome;
 }
 
-export function getGameResultText(game) {
+export function getGameResultText(outcome: string, white_lost: boolean, black_lost: boolean): string {
     /* SGFs will encode the full result in the outcome */
-    if (/[+]/.test(game.outcome)) {
-        return game.outcome;
+    if (/[+]/.test(outcome)) {
+        return outcome;
     }
 
     let winner = "";
     let result = "";
-    if (game.white_lost && game.black_lost) {
+    if (white_lost && black_lost) {
         winner = _("Tie");
-    } else if (game.white_lost) {
+    } else if (white_lost) {
         winner = _("B");
-    } else if (game.black_lost) {
+    } else if (black_lost) {
         winner = _("W");
     } else {
         winner = _("Tie");
     }
 
-    game.outcome = game.outcome.replace(" points", "");
-    result += winner + "+"  + getOutcomeTranslation(game.outcome);
+    outcome = outcome.replace(" points", "");
+    result += winner + "+" + getOutcomeTranslation(outcome);
 
     return result;
 }

--- a/src/views/Game/GameInfoModal.tsx
+++ b/src/views/Game/GameInfoModal.tsx
@@ -24,7 +24,7 @@ import {openModal, Modal, ModalConstructorInput} from "Modal";
 import {timeControlDescription} from "TimeControl";
 import {Player} from "Player";
 import {handicapText} from "GameAcceptModal";
-import {errorAlerter, ignore, rulesText, yesno} from "misc";
+import {errorAlerter, ignore, rulesText, yesno, getGameResultText} from "misc";
 import {rankString} from 'rank_utils';
 import {browserHistory} from "ogsHistory";
 import swal from 'sweetalert2';
@@ -229,7 +229,9 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, {}> {
                         <dt>{_("Result")}</dt><dd>{
                         (editable && config.review_id && !config.game_id)
                             ? <input value={config.outcome} onChange={this.updateOutcome} />
-                            : <span>{config.outcome}</span>
+                                : <span>{getGameResultText(config.outcome,
+                                    config.winner !== config.white_player_id,
+                                    config.winner !== config.black_player_id)}</span>
                         }</dd>
                         <dt>{_("Komi")}</dt><dd>{config.komi.toFixed(1)}</dd>
                         <dt>{_("Analysis")}</dt><dd>{(config.original_disable_analysis ? _("Analysis and conditional moves disabled") : _("Analysis and conditional moves enabled"))}</dd>

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -64,20 +64,20 @@ const inlineBlock = {display: "inline-flex", "alignItems": "center"};
 const marginBottom0 = {marginBottom: "0"};
 
 function getGameResultRichText(game) {
-    let result = getGameResultText(game);
+    let resultText = getGameResultText(game.outcome, game.white_lost, game.black_lost);
 
     if (game.ranked) {
-        result += ", ";
-        result += _("ranked");
+        resultText += ", ";
+        resultText += _("ranked");
     }
     if (game.annulled) {
-        result = <span>
-            <span style={{textDecoration: 'line-through'}}>{result}</span>
+        return <span>
+            <span style={{textDecoration: 'line-through'}}>{resultText}</span>
             <span>, {_("annulled")}</span>
         </span>;
     }
 
-    return result;
+    return <>{resultText}</>;
 }
 
 function openUrlIfALinkWasNotClicked(ev, url: string) {


### PR DESCRIPTION
Fixes #1362 

## Proposed Changes
  - Use getGameResultText  in misc.ts to compute the string following the same style as in the user profile page (around [here](https://github.com/online-go/online-go.com/pull/1591/files?diff=split&w=1#diff-66a31d293aab8a1670fb4609c8c607d53df748b37db0d1d9ce4e0fc6d8262cecR169) and [here](https://github.com/online-go/online-go.com/pull/1591/files?diff=split&w=1#diff-66a31d293aab8a1670fb4609c8c607d53df748b37db0d1d9ce4e0fc6d8262cecR275)
  - my code is inspired on the code in MiniGoban.tsx, I merges both codes to avoid duplication
 
## Questions
 - What's the policy concerning prettier? I see it installed and it ran automatically by my IDE... but then it made lot's of changes... I see there's a build script `prettytsx` but it does lots of changes a little bit everywhere... not sure it runs very often.