### PR TITLE
bot choice is now saved as integer to match bots_list()

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -555,7 +555,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
     };
 
     /* update bindings  */
-    update_conf_bot_id          = (ev) => this.upstate("conf.bot_id", ev);
+    update_conf_bot_id          = (ev) => this.upstate("conf.bot_id", parseInt((ev.target as HTMLSelectElement).value));
     update_challenge_game_name  = (ev) => this.upstate("challenge.game.name", ev);
     update_private              = (ev) => this.upstate([["challenge.game.private", ev], ["challenge.game.ranked", false]]);
     update_rengo                = (ev) => this.upstate([["challenge.game.rengo", ev], ["challenge.game.ranked", false]]);


### PR DESCRIPTION
Fixes #1603

## Proposed Changes

- bot choice is now saved as integer, not string

## Steps to Test

1. Go to "Play"
2. Click "Computer"
3. Select an AI Player other than amybot-beginner
4. Click "Play" again at any point in the future

Notice: Your previous bot choice will already been selected.

## Code Notes

The bot choice was being forgotten because its HTML Option element stores `bot_id` as a string, whereas our `bots_list()` has ids that are all integers. Now, when the state updates from an Option event, it will run `parseInt` before storing.

I did a code search to see if there was anywhere that might depend on `bot_id` being a string, but couldn't see anything obvious.