### PR TITLE
Remove two string refs from the Group News table.

### DIFF
--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -655,7 +655,7 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
                                     {header: _("News"), className: "none", render: (entry) =>
                                         <div>
                                             {this.state.editing_news && this.state.editing_news.id === entry.id
-                                                ? <h2><input ref='editing_news_title' value={this.state.editing_news.title} style={{width:'100%'}} onChange={this.updateNewsTitle}/></h2>
+                                                ? <h2><input value={this.state.editing_news.title} style={{width:'100%'}} onChange={this.updateNewsTitle}/></h2>
                                                 : <h2>{localize_time_strings(entry.title)}</h2>
                                             }
                                             <i>{moment(entry.posted).format("llll")} - <Player icon user={entry.author} /></i>
@@ -669,7 +669,7 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
                                                 </div>
                                             }
                                             {this.state.editing_news && this.state.editing_news.id === entry.id
-                                                ? <textarea rows={7} ref='editing_news_body' value={this.state.editing_news.content} onChange={this.updateNewsContent} />
+                                                ? <textarea rows={7} value={this.state.editing_news.content} onChange={this.updateNewsContent} />
                                                 : <Markdown source={entry.content} />
                                             }
                                         </div>


### PR DESCRIPTION
Fixes #1614 

## Proposed Changes

  - Remove two string refs (I could not find associated ref variables, so I don't think this will have a functional effect besides fixing the error)

Related: Perhaps the "Loading..." overlay should be suppressed for news editing.  It is displayed every time the user types:

<img width="1221" alt="Screen Shot 2022-01-10 at 8 26 18 AM" src="https://user-images.githubusercontent.com/25233703/148801991-d0ce10d3-2ffc-47f4-853a-bb1f2cfb5404.png">
