### PR TITLE
Try to fix display issue for old Apple devices

### DIFF
--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -38,8 +38,6 @@
 }
 
 .MainGobanView .players {
-    display: flex;
-    flex-direction: column;
 
     .rengo-team-members {
         display: flex;


### PR DESCRIPTION
Old Apple devices and/or versions of Safari seemed to have issue with this, meaning buttons went under the player card, or the board went over the player card

Fixes https://forums.online-go.com/t/board-position-covers-names-rank-score/40679?u=shinuito

Tested with Xcode simulating iOS 12.4 below.

Further tests with updated browsers seem to indicate that it doesn't change the layout on recent Safari, Chrome, Firefox on Mac for example. Likely a remnant of css from rengo from before the team members were moved from below the player cards to inside them.

(images are a bit choppy, trying to remove backgrounds, poorly, from screenshots, and poorly scaling to not take up too much space in Github).

<img src="https://user-images.githubusercontent.com/26803867/148818426-fbb72fbd-8b8f-4a6a-8722-080037df3e9a.png" height="400" width="200"><img src="https://user-images.githubusercontent.com/26803867/148818459-026aefa6-c8ef-4bc7-ba1c-a4a30d468cff.png" height="400" width="200">

iPad Air

<img src="https://user-images.githubusercontent.com/26803867/148818539-aa3a1469-1f43-483d-85f8-9e2b349ab8e3.png" height="300" width="500">
<img src="https://user-images.githubusercontent.com/26803867/148818556-ecca6faa-416a-4c59-b0e5-922ceef17033.png" height="300" width="500">

and in portrait mode

<img src="https://user-images.githubusercontent.com/26803867/148819329-719e7dbf-0f9f-4926-9e91-438962501dd0.png" height="400" width="500">

<img src="https://user-images.githubusercontent.com/26803867/148819339-80d2cf90-bdb6-439b-ade6-4bf281bb0b1b.png" height="400" width="500">

