### PR TITLE
Re-order key moves in AI review by move_number

### DIFF
--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1030,6 +1030,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
 
         let worst_move_list = getWorstMoves(this.props.game.goban.engine.move_tree, this.ai_review, 100);
         worst_move_list = worst_move_list.filter(move => move.player === 1 && black_moves++ < 3 || move.player === 2 && white_moves++ < 3);
+        worst_move_list.sort((a, b) => a.move_number - b.move_number);
 
         return (
             <div className='AIReview'>


### PR DESCRIPTION
## Proposed Change

- re-orders the key moves in the AI Review to be in the move order, not based on the review's internal metric

before:

![before-anno](https://user-images.githubusercontent.com/195001/148864829-3699c7d1-ea49-43dc-914d-7fb1ce33b754.png)

after:

![after-anno](https://user-images.githubusercontent.com/195001/148864844-afbca0d6-afe7-4c43-9c49-be65ee3fa92e.png)

## Context

@anoek had said in #1589 that he wanted to "help users who first see this intuitively understand what these bubbles with letter/number combinations mean."

This PR doesn't necessarily fix this, but having the key moves and the red dots in the same order further drives home the point that they refer to the same thing.

Players can also click through to see the story of the game unfold.

## Considered Alternatives

We don't show the underlying metric that the AI Review uses to score these moves to the user, nor would it be clear if we did. (I saw some healthy debate in the forums on ways to score these moves.)

## Code Notes

I had intended to get this into #1589, but I didn't want to change too much at once.