### PR TITLE
Alternative display for highlighting whose turn it is

### DIFF
--- a/src/views/Game/AIReview.styl
+++ b/src/views/Game/AIReview.styl
@@ -16,6 +16,7 @@
  */
 
 .AIReview {
+    margin-top: 0.7rem;
     .reviewing, .pending {
         text-align: center;
         width: 100%;

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -94,12 +94,34 @@ goban-view-bar-width=400px
         font-size: smaller;
     }
 
-    .black.player-container.their-turn {
-        box-shadow: 4px 6px 20px rgb(100 100 100) !important;
+
+    .black.player-container.their-turn, .white.player-container.their-turn {
+        position: relative;
+
+        &::after {
+            position: absolute;
+            content: "▲";
+            border-bottom: 0.15rem solid #000;
+            height: 0.15rem;;
+            bottom: -0.25rem;
+            themed border-color primary
+            themed color primary
+            font-size: 0.6rem;
+            display: block;
+            z-index: 1000;
+            width: 100%;
+            left: 0;
+            right: 0.1rem;
+        }
     }
 
-    .white.player-container.their-turn {
-        box-shadow: -2px 6px 20px rgb(130 130 130) !important;
+    &.portrait {
+        .black.player-container.their-turn, .white.player-container.their-turn {
+            &::after {
+                // in portrait mode, the arrow overlaps the board
+                content: "";
+            }
+        }
     }
 
     .play-controls {

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -96,32 +96,7 @@ goban-view-bar-width=400px
 
 
     .black.player-container.their-turn, .white.player-container.their-turn {
-        position: relative;
-
-        &::after {
-            position: absolute;
-            content: "▲";
-            border-bottom: 0.15rem solid #000;
-            height: 0.15rem;;
-            bottom: -0.25rem;
-            themed border-color primary
-            themed color primary
-            font-size: 0.6rem;
-            display: block;
-            z-index: 1000;
-            width: 100%;
-            left: 0;
-            right: 0.1rem;
-        }
-    }
-
-    &.portrait {
-        .black.player-container.their-turn, .white.player-container.their-turn {
-            &::after {
-                // in portrait mode, the arrow overlaps the board
-                content: "";
-            }
-        }
+        box-shadow: 0 3px 5px 1px rgba(50,50,50,0.51) !important;
     }
 
     .play-controls {

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -22,10 +22,16 @@
 // used in Game and GameInfoModal
 
 .rengo-header-block {
+    margin-top: 0.7rem;
     display: flex;
     flex-direction: column;
     justify-content: space-around;
+}
 
+.MainGobanView.portrait {
+    .rengo-header-block {
+        margin-top: 0.15rem;
+    }
 }
 
 .rengo-header {


### PR DESCRIPTION
This patch replaces the drop shadow with an underscored blue line with a
small arrow as the turn indicator, up for aesthetic discussion. I'm not sure this is the best it can be, so if anyone has any ideas lets hear them :)

Relates to #1600



There's some places the current drop shadow looks a bit funky, so this PR is attempting to fix those with an alternative look.

## Old issues: 

1. Shadow overlaps neighboring player box (Might be fixable with a z index thing, I'm not sure)
![image](https://user-images.githubusercontent.com/168460/148948968-ccf10d51-9977-4423-987c-774f07d9e529.png)

2. Shadow gets clipped as it attempts to extend past the bounds of the containing box (I don't think this is fixable, not easily at anyrate). It also drops shadow deep into the "Black to Move" text, which could be fixed with margin, but that has some downsides too.
![image](https://user-images.githubusercontent.com/168460/148949271-01429d34-af21-4d86-87ed-4e033b4ff9be.png)

3. Similarly, on non rengo games the whose turn is it is not present, so there's not much room to see whose turn it is
![image](https://user-images.githubusercontent.com/168460/148949511-3f698abd-5c49-4462-9e87-01783347151c.png)
![image](https://user-images.githubusercontent.com/168460/148949710-40800fa4-d4bc-435f-a57f-160a0031fbd4.png)



## Proposed Changes:

This PR replaces the shadow with a blue line and triangle (triangle only in landscape mode, not portrait):

![image](https://user-images.githubusercontent.com/168460/148950164-c6571174-bb67-44a2-8721-ef5bdb2837dd.png)

![image](https://user-images.githubusercontent.com/168460/148950259-a47de07f-db74-4206-a52b-c68578a2ee06.png)

![image](https://user-images.githubusercontent.com/168460/148950335-3a15bd8c-48e1-4109-89e8-615da9338491.png)

![image](https://user-images.githubusercontent.com/168460/148950732-f6c41e07-2249-4ff0-a682-cd34c5493e59.png)






  -
  -
  -
