### PR TITLE
Prettier everything but write

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,6 @@ module.exports = {
         "browser": true,
         "es6": true
     },
-    "extends": [
-        "prettier",
-    ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": "tsconfig.json",
@@ -18,7 +15,8 @@ module.exports = {
     ],
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "prettier"
     ],
     "rules": {
         // Recommended rules with errors
@@ -63,11 +61,6 @@ module.exports = {
         "@typescript-eslint/prefer-namespace-keyword": "error",
         "@typescript-eslint/semi": "error",
         "@typescript-eslint/type-annotation-spacing": "error",
-        "brace-style": [
-            "error",
-            "1tbs",
-            { "allowSingleLine": true }
-        ],
         "computed-property-spacing": ["error", "never"],
         "curly": "error",
         "eol-last": "error",
@@ -88,15 +81,6 @@ module.exports = {
             "undefined"
         ],
         "id-match": "error",
-        "indent": [
-            "error",
-            4,
-            {
-                "SwitchCase": 1,
-                "MemberExpression": "off",
-                "ignoredNodes": ["ConditionalExpression"]
-            }
-        ],
         "jsdoc/check-alignment": "error",
         "jsdoc/require-asterisk-prefix": "error",
         "linebreak-style": [
@@ -131,10 +115,6 @@ module.exports = {
         "prefer-arrow-callback": [
             "error",
             { "allowNamedFunctions": true }
-        ],
-        "space-before-function-paren": [
-            "error",
-            "never"
         ],
         "use-isnan": "error",
         "@typescript-eslint/tslint/config": [

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
+# Uncomment these lines once we have a prettified codebase
+#      - name: Prettier
+#        run: npm run prettier:check
+
       - name: Webpack
         run: npx webpack --optimization-minimize --devtool=source-map
         

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "scripts": {
     "dev": "supervisor -w Gulpfile.js,webpack.config.js,tsconfig.json supervisor -w Gulpfile.js -x gulp --",
-    "prettytsx": "prettier --write 'src/**/*.tsx'",
-    "prettyts": "prettier --write 'src/**/*.ts'",
+    "prettier": "prettier --write \"src/**/*.{ts,tsx}\"",
+    "prettier:check": "prettier --check \"src/**/*.{ts,tsx}\"",
     "webpack": "webpack",
     "webpack-watch": "webpack --watch --progress --color",
     "yarn": "yarn",
@@ -125,7 +125,8 @@
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
-      "eslint"
+      "eslint",
+      "prettier --check"
     ]
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,12 +1,5 @@
-// prettier.config.js or .prettierrc.js
 module.exports = {
     trailingComma: "all",
     tabWidth: 4,
-    semi: true,
-    singleQuote: true,
-    printWidth: 140,
-    quoteProps: "consistent",
-    bracketSpacing: true,
-    jsxBracketSameLine: false,
-    arrowParens: "avoid",
+    printWidth: 120,
 };

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -268,14 +268,34 @@ export class LadderComponent extends React.PureComponent<LadderComponentProperti
 function canChallengeTooltip(obj: any): string {
     if (obj.reason_code) {
         switch (obj.reason_code) {
-            case 0x001: return pgettext("Can't challenge player in ladder because: ", "Can't challenge yourself");
-            case 0x002: return pgettext("Can't challenge player in ladder because: ", "Player is a lower rank than you");
-            case 0x003: return pgettext("Can't challenge player in ladder because: ", "Player is not in the ladder");
-            case 0x004: return pgettext("Can't challenge player in ladder because: ", "Player's rank is too high");
-            case 0x005: return interpolate(pgettext("Can't challenge player in ladder because: ", "Already playing {{number}} games you've initiated"), {"number": obj.reason_parameter });
-            case 0x006: return pgettext("Can't challenge player in ladder because: ", "Already playing a game against this person");
-            case 0x007: return pgettext("Can't challenge player in ladder because: ", "Last challenge within 7 days");
-            case 0x008: return pgettext("Can't challenge player in ladder because: ", "Player already has the maximum number of challenges");
+            case 0x001:
+                return pgettext("Can't challenge player in ladder because: ", "Can't challenge yourself");
+            case 0x002:
+                return pgettext("Can't challenge player in ladder because: ", "Player is a lower rank than you");
+            case 0x003:
+                return pgettext("Can't challenge player in ladder because: ", "Player is not in the ladder");
+            case 0x004:
+                return pgettext("Can't challenge player in ladder because: ", "Player's rank is too high");
+            case 0x005:
+                return interpolate(
+                    pgettext(
+                        "Can't challenge player in ladder because: ",
+                        "Already playing {{number}} games you've initiated",
+                    ),
+                    { number: obj.reason_parameter }, // eslint-disable-line id-denylist
+                );
+            case 0x006:
+                return pgettext(
+                    "Can't challenge player in ladder because: ",
+                    "Already playing a game against this person",
+                );
+            case 0x007:
+                return pgettext("Can't challenge player in ladder because: ", "Last challenge within 7 days");
+            case 0x008:
+                return pgettext(
+                    "Can't challenge player in ladder because: ",
+                    "Player already has the maximum number of challenges",
+                );
         }
     }
 

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -236,9 +236,9 @@ export function resolveChannelDisplayName(channel: string): string {
             }
         });
     } else if (channel.startsWith("game-")) {
-        return interpolate(_("Game {{number}}"), {"number": channel.substring(5)});
+        return interpolate(_("Game {{number}}"), { number: channel.substring(5) });  // eslint-disable-line id-denylist
     } else if (channel.startsWith("review-")) {
-        return interpolate(_("Review {{number}}"), {"number": channel.substring(7)});
+        return interpolate(_("Review {{number}}"), { number: channel.substring(7) });  // eslint-disable-line id-denylist
     }
     return "<error>";
 }

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -187,7 +187,7 @@ export function getOutcomeTranslation(outcome: string) {
 
     if (/[0-9.]+/.test(outcome)) {
         const num = outcome.match(/([0-9.]+)/)[1];
-        return interpolate(pgettext("Game outcome", "{{number}} points"), {"number": num});
+        return interpolate(pgettext("Game outcome", "{{number}} points"), { number: num }); // eslint-disable-line id-denylist
     }
 
     return outcome;

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -538,14 +538,34 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
 function canChallengeTooltip(obj: any): string {
     if (obj.reason_code) {
         switch (obj.reason_code) {
-            case 0x001: return pgettext("Can't challenge player in ladder because: ", "Can't challenge yourself");
-            case 0x002: return pgettext("Can't challenge player in ladder because: ", "Player is a lower rank than you");
-            case 0x003: return pgettext("Can't challenge player in ladder because: ", "Player is not in the ladder");
-            case 0x004: return pgettext("Can't challenge player in ladder because: ", "Player's rank is too high");
-            case 0x005: return interpolate(pgettext("Can't challenge player in ladder because: ", "Already playing {{number}} games you've initiated"), {"number": obj.reason_parameter });
-            case 0x006: return pgettext("Can't challenge player in ladder because: ", "Already playing a game against this person");
-            case 0x007: return pgettext("Can't challenge player in ladder because: ", "Last challenge within 7 days");
-            case 0x008: return pgettext("Can't challenge player in ladder because: ", "Player already has the maximum number of challenges");
+            case 0x001:
+                return pgettext("Can't challenge player in ladder because: ", "Can't challenge yourself");
+            case 0x002:
+                return pgettext("Can't challenge player in ladder because: ", "Player is a lower rank than you");
+            case 0x003:
+                return pgettext("Can't challenge player in ladder because: ", "Player is not in the ladder");
+            case 0x004:
+                return pgettext("Can't challenge player in ladder because: ", "Player's rank is too high");
+            case 0x005:
+                return interpolate(
+                    pgettext(
+                        "Can't challenge player in ladder because: ",
+                        "Already playing {{number}} games you've initiated",
+                    ),
+                    { number: obj.reason_parameter },  // eslint-disable-line id-denylist
+                );
+            case 0x006:
+                return pgettext(
+                    "Can't challenge player in ladder because: ",
+                    "Already playing a game against this person",
+                );
+            case 0x007:
+                return pgettext("Can't challenge player in ladder because: ", "Last challenge within 7 days");
+            case 0x008:
+                return pgettext(
+                    "Can't challenge player in ladder because: ",
+                    "Player already has the maximum number of challenges",
+                );
         }
     }
 


### PR DESCRIPTION
This PR should make it possible to run prettier globally when we have an open window.  To perform this global write, this command should work:

```
    npm run prettier
```

## Proposed Changes

  - Remove unused and un-recommended rules from the Prettier config.
  - Remove ESLint formatting rules (and fix the duplicate `extends` field)
  - Disable eslint on lines that will trigger `id-denylist`
  - Add prettier to `lint-staged` and a (commented out) step in the GitHub workflow

## Things I haven't done
  - Turn on the prettier check in GitHub workflow
  - Run prettier --write (obviously 🙂)
  - Added IDE specific configs
