### PR TITLE
Bugfix: you should always be able to turn off rengo, and ranked

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -688,7 +688,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                     <div className="checkbox">
                         <input type="checkbox"
                             id="rengo-option"
-                            disabled={this.state.challenge.game.private || this.state.challenge.game.ranked}
+                            disabled={!this.state.challenge.game.rengo && (this.state.challenge.game.private || this.state.challenge.game.ranked) }
                             checked={this.state.challenge.game.rengo} onChange={this.update_rengo}/>
                     </div>
                 </div>
@@ -714,7 +714,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                             <div className="checkbox">
                                 <input type="checkbox"
                                     id="challenge-ranked"
-                                    disabled={this.state.challenge.game.private || this.state.challenge.game.rengo}
+                                    disabled={!this.state.challenge.game.ranked && (this.state.challenge.game.private || this.state.challenge.game.rengo)}
                                     checked={this.state.challenge.game.ranked} onChange={this.update_ranked}/>
                             </div>
                         </div>


### PR DESCRIPTION
... in the Challenge modal

Fixes a lockup Sofia found due to a previous bug.

IE she had found the way to get ranked and rengo checked, and this was saved in her challenge modal data.

## Proposed Changes

Don't disable ranked or rengo if they are checked.
