### PR TITLE
Re-enable some eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,11 +34,7 @@ module.exports = {
         "@typescript-eslint/no-unused-vars": "off", // 675 warnings
         "@typescript-eslint/triple-slash-reference": "off", // 1 error
 
-        "no-case-declarations": "off", // 3 errors
-        "no-constant-condition": "off", // 1 error
-        "no-empty": "off", // 30 errors
         "no-empty-pattern": "off", // 1 error
-        "no-fallthrough": "off", // 3 errors
         "no-misleading-character-class": "off", // 2 errors
         "no-prototype-builtins": "off", // 8 errors
         "no-self-assign": "off", // 2 errors
@@ -106,7 +102,19 @@ module.exports = {
         "no-caller": "error",
         "no-cond-assign": "error",
         "no-debugger": "error",
+        "no-empty": [
+            "error",
+            {
+                "allowEmptyCatch": true
+            }
+        ],
         "no-eval": "error",
+        "no-fallthrough": [
+            "error",
+            {
+                "commentPattern": "break[\\s\\w]*omitted"
+            }
+        ],
         // Using the typescript-eslint version of this rule because of class
         // properties, which are not yet supported in ESLint.  For more info,
         // see: https://github.com/typescript-eslint/typescript-eslint/issues/491

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,12 +102,6 @@ module.exports = {
         "no-caller": "error",
         "no-cond-assign": "error",
         "no-debugger": "error",
-        "no-empty": [
-            "error",
-            {
-                "allowEmptyCatch": true
-            }
-        ],
         "no-eval": "error",
         "no-fallthrough": [
             "error",

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -452,6 +452,7 @@ function ChatLines({channel, autoFocus, updateTitle, onShowChannels, onShowUsers
                 try {
                     div.scrollTop = div.scrollHeight;
                 } catch (e) {
+                    // ignore error
                 }
             } , 100);
         }

--- a/src/components/Errcode/Errcode.tsx
+++ b/src/components/Errcode/Errcode.tsx
@@ -80,6 +80,7 @@ export function format_message(props: MessageProps): string {
             }
         }
 
+        // break omitted
         case 'test':
             return "This is a test";
     }

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -733,6 +733,9 @@ class NotificationEntry extends React.Component<{notification}, any> {
 
     renderNotification() {
         const notification = this.props.notification;
+        let outcome: any;
+        let now: number;
+        let left: number;
 
         switch (notification.type) {
             case "test":
@@ -773,7 +776,7 @@ class NotificationEntry extends React.Component<{notification}, any> {
                 return <div>{_("Game has started")}: {notification.black} v {notification.white} - {notification.name}</div>;
 
             case "gameEnded":
-                let outcome = notification.outcome;
+                outcome = notification.outcome;
                 if (notification.black_lost && !notification.white_lost) {
                     outcome = interpolate(pgettext("Game outcome: <player that won> by <result>", "%s by %s"), [notification.white, outcome]);
                 }
@@ -796,8 +799,8 @@ class NotificationEntry extends React.Component<{notification}, any> {
                 );
 
             case "timecop":
-                const now = (Date.now()) / 1000;
-                const left = Math.floor(notification.time / 1000 - now);
+                now = (Date.now()) / 1000;
+                left = Math.floor(notification.time / 1000 - now);
                 return <div>{interpolate(_("You have {{time_left}} to make your move!"), {"time_left": formatTime(left)})}</div>;
 
             case "gameEnteredStoneRemoval":

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -451,6 +451,7 @@ class NotificationManager {
                         emitNotification(title, body);
                     }
                 } catch (e) {
+                    // ignore error
                 }
             }
 

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -734,9 +734,6 @@ class NotificationEntry extends React.Component<{notification}, any> {
 
     renderNotification() {
         const notification = this.props.notification;
-        let outcome: any;
-        let now: number;
-        let left: number;
 
         switch (notification.type) {
             case "test":
@@ -776,8 +773,8 @@ class NotificationEntry extends React.Component<{notification}, any> {
             case "gameStarted":
                 return <div>{_("Game has started")}: {notification.black} v {notification.white} - {notification.name}</div>;
 
-            case "gameEnded":
-                outcome = notification.outcome;
+            case "gameEnded": {
+                let outcome = notification.outcome;
                 if (notification.black_lost && !notification.white_lost) {
                     outcome = interpolate(pgettext("Game outcome: <player that won> by <result>", "%s by %s"), [notification.white, outcome]);
                 }
@@ -798,11 +795,13 @@ class NotificationEntry extends React.Component<{notification}, any> {
                         </div>
                     </div>
                 );
+            }
 
-            case "timecop":
-                now = (Date.now()) / 1000;
-                left = Math.floor(notification.time / 1000 - now);
+            case "timecop": {
+                const now = (Date.now()) / 1000;
+                const left = Math.floor(notification.time / 1000 - now);
                 return <div>{interpolate(_("You have {{time_left}} to make your move!"), {"time_left": formatTime(left)})}</div>;
+            }
 
             case "gameEnteredStoneRemoval":
                 return <div>{_("Game has entered the stone removal phase")}</div>;

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -560,7 +560,9 @@ export class SeekGraph extends TypedEventEmitter<Events> {
         ctx.moveTo(padding + 0.5 + live_line, h - (padding) + 0.5);
         ctx.lineTo(padding + 0.5 + live_line, 0);
         ctx.strokeStyle = "#aaaaaa";
-        try { ctx.setLineDash([2, 3]); } catch (e) {}
+        try { ctx.setLineDash([2, 3]); } catch (e) {
+            // ignore error
+        }
         ctx.stroke();
         ctx.restore();
 
@@ -581,6 +583,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
             metrics = ctx.measureText(word);
             ctx.fillText(word, padding + live_line + ((w - live_line - padding) - metrics.width) / 2, h - 2);
         } catch (e) {
+            // ignore error
         }
         ctx.restore();
     }
@@ -740,6 +743,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
                     try {
                         details_html += ", " + interpolate(pgettext("time control", "%s %s timing"), [shortShortTimeControl(C.time_control_parameters), timeControlSystemText(C.time_control)]);
                     } catch (err) {
+                        // ignore error
                     }
                 }
 

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -279,13 +279,16 @@ export function getPrintableError(err) {
     let obj = typeof(err) === "object" ? err : null;
     if (!obj) {
         console.error(obj);
-        try { obj = JSON.parse(err.responseText); } catch (e) { }
+        try { obj = JSON.parse(err.responseText); } catch (e) {
+            // ignore error
+        }
         if (!obj) {
             console.log(err);
             console.warn("Unable to process error message to a printable error string (1): ", err.responseText);
             try {
                 console.error(new Error().stack);
             } catch (e) {
+                // ignore error
             }
             return "An unknown error has occurred!";
         }
@@ -360,6 +363,7 @@ export function errorAlerter(...args) {
                 }
             }
         } catch (e) {
+            // ignore error
         }
         errcodeAlerter(errobj);
     } else {
@@ -629,12 +633,14 @@ try {
                 localStorage.removeItem("focused_window");
             }
         } catch (e) {
+            // ignore error
         }
     });
     if (document.hasFocus()) {
         try {
             localStorage.setItem("focused_window", focus_window_id);
         } catch (e) {
+            // ignore error
         }
     }
 } catch (e) {

--- a/src/lib/sfx.ts
+++ b/src/lib/sfx.ts
@@ -456,6 +456,7 @@ export class SFXManager {
                 }
             }
         } catch (e) {
+            // ignore error
         }
 
         to_check.push(lang);

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -71,6 +71,7 @@ function setPluralIdx(lang: string) {
         // Croatian and Serbian are not strictly the same as Russian and Polish, but since this function does not take a string,
         // we cannot properly handle decimals.
         // TODO: allow this function to take a string and handle this case accordingly
+        // break omitted
         case 'hr':    // Croatian
         case 'sr':    // Serbian
             pluralidx = (count: number) => {

--- a/src/views/Admin/MerchantLog.tsx
+++ b/src/views/Admin/MerchantLog.tsx
@@ -50,6 +50,7 @@ export class MerchantLog extends React.PureComponent<{}, any> {
                             try {
                                 return JSON.parse(X.request_body).type;
                             } catch (e) {
+                                // ignore error
                             }
                             return "";
                         }},
@@ -76,6 +77,7 @@ function clean_body(str: string): string {
         obj = JSON.parse(str);
         console.log(obj);
     } catch (e) {
+        // ignore error
     }
 
     try {
@@ -83,11 +85,13 @@ function clean_body(str: string): string {
             obj = parseQuery(str);
         }
     } catch (e) {
+        // ignore error
     }
 
     try {
         return orderedJsonStringify(obj);
     } catch (e) {
+        // ignore error
     }
 
     return JSON.stringify(obj, null, 1);

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1414,6 +1414,7 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
                 return;
             }
         } catch (e) {
+            // ignore error
         }
 
         if (this.goban && this.goban.mode === "analyze") {
@@ -2181,6 +2182,7 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
                 return;
             }
         } catch (e) {
+            // ignore error
         }
 
         if (this.goban.engine.cur_move.trunk) {
@@ -2206,6 +2208,7 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
                 return;
             }
         } catch (e) {
+            // ignore error
         }
 
         this.copied_node = this.goban.engine.cur_move;
@@ -2222,6 +2225,7 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
                 return;
             }
         } catch (e) {
+            // ignore error
         }
 
         if (this.copied_node) {
@@ -3214,7 +3218,9 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
             sgf_download_enabled = this.goban.engine.phase === 'finished' || !this.goban.isAnalysisDisabled(true);
             game_id = this.goban.engine.config.game_id;
 
-        } catch (e) {}
+        } catch (e) {
+            // ignore error
+        }
 
         let sgf_url = null;
         let sgf_with_comments_url = null;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1070,6 +1070,7 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
                         return;
                     }
 
+                // break omitted
                 case 'simple':
                 case 'absolute':
                 case 'fischer':

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -514,16 +514,19 @@ function AccountSettings(props: SettingGroupProps): JSX.Element {
                     try {
                         data.remove('user');
                     } catch (e) {
+                        // ignore error
                     }
 
                     try {
                         data.removePrefix('config');
                     } catch (e) {
+                        // ignore error
                     }
 
                     try {
                         data.removePrefix('preferences');
                     } catch (e) {
+                        // ignore error
                     }
 
                     window.location.href = "/";

--- a/src/views/Supporter/Supporter.tsx
+++ b/src/views/Supporter/Supporter.tsx
@@ -264,7 +264,7 @@ try {
     }
 
 } catch (e) {
-
+    // ignore error
 }
 /**** END DEPRECATED BRAINTREE CODE ****/
 

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -503,6 +503,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
                             console.warn("ID.", k, '=', id[k]);
                         }
                     } catch (e) {
+                        // ignore error
                     }
                     console.error('Tournament bind hover called with non numeric id');
                 }
@@ -1241,10 +1242,16 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
             try {
                 min_bar = rankString(parseInt(tournament.settings.lower_bar));
                 max_bar = rankString(parseInt(tournament.settings.upper_bar));
-            } catch (e) { }
+            } catch (e) {
+                // ignore error
+            }
             try { maximum_players = parseInt(tournament.settings.maximum_players as string); } catch (e) { console.error(e); }
-            try { num_rounds = parseInt(tournament.settings.num_rounds); } catch (e) { }
-            try { group_size = parseInt(tournament.settings.group_size); } catch (e) { }
+            try { num_rounds = parseInt(tournament.settings.num_rounds); } catch (e) {
+                // ignore error
+            }
+            try { group_size = parseInt(tournament.settings.group_size); } catch (e) {
+                // ignore error
+            }
 
             let tournament_exclusivity = "";
             switch (tournament.exclusivity) {
@@ -2311,7 +2318,7 @@ function OpenGothaTournamentRound({tournament, roundNotes, selectedRound, player
                                         black_won = 'win';
                                     }
                                 } catch (e) {
-
+                                    // ignore error
                                 }
 
                                 return (

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -206,6 +206,7 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
             elimination_tree: null,
         };
 
+        // eslint-disable-next-line no-constant-condition
         if (false) {
             // This is just for quick testing when I'm working on a particular
             // part of the tournament testing process. This is never intended

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -343,6 +343,7 @@ function speedIcon(e) {
 }
 function timeIcon(time_per_move) {
     if (time_per_move === 0) {
+        return "ogs-turtle";
     } else if (time_per_move < 20) {
         return "fa fa-bolt";
     } else if (time_per_move < 3600) {


### PR DESCRIPTION
Thanks @anoek for the excellent project, huge fan.

This PR just re-enables a few eslint rules, partly by disabling by line instead of project-wide. Let me know if you'd like any changes (e.g., is it fine to blanket allow empty catch clauses? That was almost all the no-empty errors.).