### PR TITLE
Don't allow challenges to be rengo if they are ranked or private.

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -145,7 +145,9 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
         });
 
         // make sure rengo=true doesn't persist into the wrong kinds of challenges
-        challenge.game.rengo = this.props.mode === "open" ? challenge.game.rengo : false;
+        if (challenge.game.ranked || challenge.game.private || this.props.mode !== "open") {
+            challenge.game.rengo = false;
+        }
 
         /* fix dirty data */
         if (isNaN(challenge.min_ranking) || challenge.min_ranking < 0 || challenge.min_ranking > 36) {


### PR DESCRIPTION
The alternative discussed in #1623

## Proposed changes

There is already some handling in the constructor of ChallengeModal for bogus configs.  This just adds the constraint "rengo must not be private or ranked."
