### PR TITLE
Add stale action

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,8 +10,8 @@ jobs:
     - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This issue is stale because it has been open for some time with no activity."
-        stale-pr-label: "stale"
+        stale-issue-message: "This issue is stale because it has been open for some time with no activity."
+        stale-issue-label: "stale"
         days-before-issue-stale: 730
         days-before-issue-close: -1
         remove-stale-when-updated: false

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: "This issue is stale because it has been open for some time with no activity."
         stale-issue-label: "stale"
-        days-before-issue-stale: 730
-        days-before-issue-close: -1
+        days-before-issue-stale: 90
+        days-before-issue-close: 730
         remove-issue-stale-when-updated: false
         debug-only: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,18 @@
+name: "Stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: "This issue is stale because it has been open for some time with no activity."
+        stale-pr-label: "stale"
+        days-before-issue-stale: 730
+        days-before-issue-close: -1
+        remove-stale-when-updated: false
+        debug-only: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,5 +14,5 @@ jobs:
         stale-issue-label: "stale"
         days-before-issue-stale: 730
         days-before-issue-close: -1
-        remove-stale-when-updated: false
+        remove-issue-stale-when-updated: false
         debug-only: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,9 +10,17 @@ jobs:
     - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: "This issue is stale because it has been open for some time with no activity."
+        stale-issue-message: "This issue has been marked stale and will be closed soon without further activity. To keep the issue open, please respond to the comment to keep the discussion going."
+        close-issue-message: "This issue has been automatically closed due to inactivity. Please feel free to re-open it if the issue persists."
         stale-issue-label: "stale"
-        days-before-issue-stale: 90
-        days-before-issue-close: 730
-        remove-issue-stale-when-updated: false
+        stale-pr-message: "This pull request has been marked stale and will be closed soon without further activity. Please update the PR or respond to this comment if you're still interested in working on this."
+        close-pr-message: "This pull request has been automatically closed due to inactivity. Please feel free to re-open it if you still want to work on it."
+        stale-pr-label: "stale"
+        days-before-issue-stale: 730
+        days-before-issue-close: 15
+        days-before-pr-stale: 30
+        days-before-pr-close: 15
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true
+        operations-per-run: 1000 # turn down when debug only is turned off
         debug-only: true


### PR DESCRIPTION
Adding an initial GitHub action for marking issues as stale. This is in "dry-run" mode right now (`debug-only: true`) so it won't actually modify issues yet (that way we can settle on what the best parameters would be beforehand).

Also, I think the `stale` label would need to already exist in order for this to work.

For reference: https://github.com/actions/stale