### PR TITLE
Remove UNSAFE_componentWillMount

### DIFF
--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -60,11 +60,9 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
         } else {
             throw new Error(`ACLModal created with invalid parameters`);
         }
-    }
-
-    UNSAFE_componentWillMount() {
         this.refresh();
     }
+
     componentWillUnmount() {
     }
     refresh = () => {

--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -68,7 +68,6 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
 
     componentWillUnmount() {
     }
-
     refresh = () => {
         get(this.url)
         .then((acl) => this.setState({acl: acl}))

--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -62,11 +62,11 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
         }
     }
 
-    componentWillUnmount() {
-    }
-
     componentDidMount() {
         this.refresh();
+    }
+
+    componentWillUnmount() {
     }
 
     refresh = () => {

--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -60,11 +60,15 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
         } else {
             throw new Error(`ACLModal created with invalid parameters`);
         }
-        this.refresh();
     }
 
     componentWillUnmount() {
     }
+
+    componentDidMount() {
+        this.refresh();
+    }
+
     refresh = () => {
         get(this.url)
         .then((acl) => this.setState({acl: acl}))


### PR DESCRIPTION
It seems some of these may have a simple fix of moving into the constructor according to https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

xref: https://github.com/online-go/online-go.com/issues/1629