### PR TITLE
Set up unused import eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,8 @@ module.exports = {
     "plugins": [
         "eslint-plugin-jsdoc",
         "@typescript-eslint",
-        "@typescript-eslint/tslint"
+        "@typescript-eslint/tslint",
+        "unused-imports"
     ],
     "extends": [
         "eslint:recommended",
@@ -40,6 +41,8 @@ module.exports = {
         "no-self-assign": "off", // 2 errors
         "no-useless-escape": "off", // 24 errors
         "prefer-spread": "off", // 7 errors
+        "unused-imports/no-unused-imports": "off", // 301 errors
+        "unused-imports/no-unused-vars": "off",
 
         //==============================================================
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-jsdoc": "^37.0.3",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-unicorn": "^36.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0",
     "fork-ts-checker-webpack-plugin": "^6.3.4",

--- a/src/views/TournamentRecord/TournamentRecord.tsx
+++ b/src/views/TournamentRecord/TournamentRecord.tsx
@@ -16,15 +16,11 @@
  */
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
-import {Link} from "react-router-dom";
-import {browserHistory} from "ogsHistory";
-import {_, pgettext, interpolate} from "translate";
+import {_} from "translate";
 import {abort_requests_in_flight, del, put, post, get} from "requests";
 import {Markdown} from "Markdown";
 import {PaginatedTable, PaginatedTableRef} from "PaginatedTable";
 import {Player} from "Player";
-import * as moment from "moment";
 import * as data from "data";
 import {ignore, errorAlerter, dup} from "misc";
 import {rankString, allRanks} from "rank_utils";

--- a/src/views/Tutorial/InstructionalGoban.tsx
+++ b/src/views/Tutorial/InstructionalGoban.tsx
@@ -17,7 +17,6 @@
 
 
 import * as React from "react";
-import {post, get} from "requests";
 import {Goban} from "goban";
 import {PersistentElement} from "PersistentElement";
 
@@ -169,5 +168,3 @@ export class InstructionalGoban extends React.Component<InstructionalGobanProps>
         );
     }
 }
-
-

--- a/src/views/Tutorial/Tutorial.tsx
+++ b/src/views/Tutorial/Tutorial.tsx
@@ -20,9 +20,7 @@ import * as React from "react";
 import {Link} from "react-router-dom";
 import {Markdown} from "Markdown";
 import {browserHistory} from "ogsHistory";
-import {_, pgettext, interpolate} from "translate";
-import {Goban} from "goban";
-import {PersistentElement} from "PersistentElement";
+import {_} from "translate";
 import {InstructionalGoban} from "./InstructionalGoban";
 import {openNewGameModal} from "NewGameModal";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,6 +4110,18 @@ eslint-plugin-unicorn@^36.0.0:
     safe-regex "^2.1.1"
     semver "^7.3.5"
 
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
Setting up a rule to clean up some unused imports (in case there's interest in doing this) as well as removing a few. I didn't want to do too much to keep the diff small, but if we want it's easy to get rid of the rest.

Seems there's some overlap between this plugin and `@typescript-eslint/no-unused-vars` so the unused variable part can probably just be left off.

For reference: https://github.com/sweepline/eslint-plugin-unused-imports (for whatever reason it seems to work fine ignoring the part about React)