### PR TITLE
Have eslint run our prettier checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,8 @@ module.exports = {
         "eslint-plugin-jsdoc",
         "@typescript-eslint",
         "@typescript-eslint/tslint",
-        "unused-imports"
+        "unused-imports",
+        "prettier"
     ],
     "extends": [
         "eslint:recommended",
@@ -120,6 +121,7 @@ module.exports = {
             "error",
             { "allowNamedFunctions": true }
         ],
+        "prettier/prettier": "error",
         "unused-imports/no-unused-imports": "error",
         "use-isnan": "error",
         "@typescript-eslint/tslint/config": [

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/sanitize-html": "^1.22.0",
     "array-move": "^2.2.1",
     "d3": "^5.15.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "eventemitter3": "^4.0.7",
     "howler": "^2.2.1",
     "jquery": "^3.6.0",
@@ -126,8 +127,7 @@
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
-      "eslint",
-      "prettier --check"
+      "eslint"
     ]
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,6 +27,7 @@ import {
     ScoreEstimateRequest,
     ScoreEstimateResponse,
 } from "goban";
+
 import { sfx } from "sfx";
 import { post } from "requests";
 import { ai_host } from "sockets";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,6 +4092,13 @@ eslint-plugin-prefer-arrow@^1.2.3:
   resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz#e7fbb3fa4cd84ff1015b9c51ad86550e55041041"
   integrity sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==
 
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-unicorn@^36.0.0:
   version "36.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-36.0.0.tgz#db50e1426839e401d33c5a279f49d4a5bbb640d8"
@@ -4499,6 +4506,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.7"
@@ -8160,6 +8172,13 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
Having eslint run our prettier checks gets us some prettier output in
our gulp build loop window so we know when prettier is failing before a
commit.  The gulp-prettier plugin seemed to do the same but with less
information (no line numbers for instance, although I assume I just
didn't have it configured right), and overall it was slower, probably
because it had to run a full prettier check after a full eslint check,
and either eslint's caching is applied to the prettier checks when
eslint does it, or it's run in parallel, or both, I'm not sure - but
this seemed to be the better option, but I'm open to being corrected.

@benjaminpjones @dsaxton 
