### PR TITLE
Remove unused imports plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,7 @@ module.exports = {
     "plugins": [
         "eslint-plugin-jsdoc",
         "@typescript-eslint",
-        "@typescript-eslint/tslint",
-        "unused-imports"
+        "@typescript-eslint/tslint"
     ],
     "extends": [
         "eslint:recommended",
@@ -39,7 +38,6 @@ module.exports = {
         "no-self-assign": "off", // 2 errors
         "no-useless-escape": "off", // 24 errors
         "prefer-spread": "off", // 7 errors
-        "unused-imports/no-unused-vars": "off",
 
         //==============================================================
 
@@ -120,7 +118,6 @@ module.exports = {
             "error",
             { "allowNamedFunctions": true }
         ],
-        "unused-imports/no-unused-imports": "error",
         "use-isnan": "error",
         "@typescript-eslint/tslint/config": [
             "error",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint-plugin-jsdoc": "^37.0.3",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-unicorn": "^36.0.0",
-    "eslint-plugin-unused-imports": "^2.0.0",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0",
     "fork-ts-checker-webpack-plugin": "^6.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,18 +4110,6 @@ eslint-plugin-unicorn@^36.0.0:
     safe-regex "^2.1.1"
     semver "^7.3.5"
 
-eslint-plugin-unused-imports@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
-  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
-  dependencies:
-    eslint-rule-composer "^0.3.0"
-
-eslint-rule-composer@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
-  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
-
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
@anoek I just realized that `@typescript-eslint/no-unused-vars` actually covers unused imports as well (hence why the number of errors from that plugin went down so much after cleaning those up) so actually I think we can remove `unused-imports/no-unused-imports`. :man_facepalming: 

(Adding an extra import and running with both turned on shows output below)

```
   21:26  error  'api1ify' is defined but never used                     @typescript-eslint/no-unused-vars
   21:26  error  'api1ify' is defined but never used                     unused-imports/no-unused-imports
```