### PR TITLE
Use createRef for omnisearch_input

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -95,8 +95,8 @@ export class NavBar extends React.PureComponent<{}, any> {
     refs: {
         input: any;
         notification_list: NotificationList;
-        omnisearch_input;
     };
+    omnisearch_input_ref = React.createRef<HTMLInputElement>();
 
     constructor(props) {
         super(props);
@@ -148,7 +148,7 @@ export class NavBar extends React.PureComponent<{}, any> {
     toggleLeftNav(ev?) {
         if (!this.state.left_nav_active) {
             if (ev && ev.type === "keydown") {
-                this.refs.omnisearch_input.focus();
+                this.omnisearch_input_ref.current.focus();
             }
         } else {
             this.clearOmnisearch();
@@ -188,7 +188,7 @@ export class NavBar extends React.PureComponent<{}, any> {
             omnisearch_tournaments: [],
             omnisearch_sitemap: [],
         });
-        $(this.refs.omnisearch_input).blur();
+        $(this.omnisearch_input_ref.current).blur();
     }
     abortOmnisearch() {
         abort_requests_in_flight("ui/omniSearch");
@@ -267,7 +267,7 @@ export class NavBar extends React.PureComponent<{}, any> {
 
         let omnisearch_searching = false;
         try {
-            omnisearch_searching = !!this.refs.omnisearch_input.value.trim();
+            omnisearch_searching = !!this.omnisearch_input_ref.current.value.trim();
         } catch (e) {
             // ignore
         }
@@ -408,7 +408,7 @@ export class NavBar extends React.PureComponent<{}, any> {
                     <div className="search-row">
                         <i className="fa fa-search" />
                         <input
-                            ref="omnisearch_input"
+                            ref={this.omnisearch_input_ref}
                             type="text"
                             className="OmniSearch-input"
                             value={this.state.omnisearch_string}


### PR DESCRIPTION
Strict mode doesn't seem to like this: `Warning: A string ref, "omnisearch_input", has been found within a strict mode tree. String refs are a source of potential bugs and should be avoided.`

xref: https://github.com/online-go/online-go.com/issues/1629