### PR TITLE
Fixup Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.1
+FROM node:latest
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -13,4 +13,3 @@ COPY . /usr/src/app
 
 EXPOSE 8080
 CMD [ "npm", "run", "dev" ]
-


### PR DESCRIPTION
It looks like the node version needs to be updated in order to build the image successfully:
```
error @typescript-eslint/eslint-plugin@5.10.0: The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.17.0 || >=16.0.0". Got "10.15.1"
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command '/bin/sh -c yarn install' returned a non-zero code: 1
```