### PR TITLE
TimeControlPicker.tsx: update_periods: avoid NaN parseInt

### DIFF
--- a/src/components/TimeControl/TimeControlPicker.tsx
+++ b/src/components/TimeControl/TimeControlPicker.tsx
@@ -167,7 +167,7 @@ export class TimeControlPicker extends React.PureComponent<
     //update_main_time            = (ev)=>this.syncTimeControl({main_time: ev.target.value});
     update_period_time = (ev) => this.syncTimeControl({ period_time: parseInt(ev.target.value) });
     update_periods = (ev) =>
-        this.syncTimeControl({ periods: Math.max(1, Math.min(300, parseInt(ev.target.value))) });
+        this.syncTimeControl({ periods: Math.max(1, Math.min(300, parseInt(ev.target.value) || 1)) });
     //update_period_time          = (ev)=>this.syncTimeControl({period_time: ev.target.value});
     update_stones_per_period = (ev) =>
         this.syncTimeControl({ stones_per_period: parseInt(ev.target.value) });


### PR DESCRIPTION
Fixes #1628

## Proposed Changes

  - Default the number of periods to 1 when it's falsy (0 or NaN)

Notice that parseInt returns NaN when the value is not a number.
Users using third party extensions will still be able to create invalid games.