### PR TITLE
Remove rengo team list from Game Info Modal

### DIFF
--- a/src/views/Game/GameInfoModal.styl
+++ b/src/views/Game/GameInfoModal.styl
@@ -33,6 +33,7 @@
         display: flex;
         flex-direction: row;
         width: 100%;
+        overflow: scroll;
 
         .rengo-team-list {
             display: flex;

--- a/src/views/Game/GameInfoModal.tsx
+++ b/src/views/Game/GameInfoModal.tsx
@@ -156,18 +156,7 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, {}> {
 
     rengoTeamList = () => (
         <div className="rengo-teams-container">
-            <div className="rengo-team-list">
-                <span className="team-title">Black Team</span>
-                {this.props.config.rengo_teams.black.map((player) => (
-                    <Player disableCacheUpdate icon rank user={player} />
-                ))}
-            </div>
-            <div className="rengo-team-list">
-                <span className="team-title">White Team</span>
-                {this.props.config.rengo_teams.white.map((player) => (
-                    <Player disableCacheUpdate icon rank user={player} />
-                ))}
-            </div>
+            {/* this space intentionally left blank: it doesn't work out to try to show rengo teams in this small modal */}
         </div>
     );
 
@@ -216,6 +205,15 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, {}> {
                             <dd>
                                 <Player icon rank user={this.props.creatorId} />
                             </dd>
+                        )}
+                        {(config.rengo || null) && (
+                            <>
+                                <dt>{_("Participants")}</dt>
+                                <dd>
+                                    {config.rengo_teams.black.length +
+                                        config.rengo_teams.white.length}
+                                </dd>
+                            </>
                         )}
                         {!this.props.config.rengo && (
                             <React.Fragment>


### PR DESCRIPTION
Fixes the broken layout people are reporting, with large rengo teams overlapping the subsequent information in <920px screen height

## Proposed Changes

~~Let the rengo-team-container scroll.~~

Remove that list.  They are on the Game page anyhow.  Instead, tell them the count of participants.
