### PR TITLE
The rest of the RouteComponentProps types

### DIFF
--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -29,7 +29,7 @@ interface Events {}
 type ACLModalProperties =
     | { game_id: number }
     | { review_id: number }
-    | { puzzle_collection_id?: number };
+    | { puzzle_collection_id?: number | string };
 
 export class ACLModal extends Modal<Events, ACLModalProperties, any> {
     player_autocomplete_ref = React.createRef<PlayerAutocompleteRef>();

--- a/src/components/AIReviewStream/AIReviewStream.tsx
+++ b/src/components/AIReviewStream/AIReviewStream.tsx
@@ -19,13 +19,14 @@ import * as React from "react";
 import * as data from "data";
 import { ai_socket } from "sockets";
 import { MoveTree } from "goban";
+import { IdType } from "src/lib/types";
 
 const analysis_requests_made: { [id: string]: boolean } = {};
 
 interface AIReviewStreamProperties {
     uuid?: string;
-    game_id?: number | string;
-    ai_review_id?: number | string;
+    game_id?: IdType;
+    ai_review_id?: IdType;
     callback: (data: any) => any;
 }
 

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -31,7 +31,7 @@ interface PaginatedTableColumnProperties<EntryT> {
     orderBy?: Array<string>;
 }
 
-interface Filter {
+export interface Filter {
     [key: string]: string | number | boolean;
 }
 

--- a/src/components/PlayerAutocomplete/PlayerAutocomplete.tsx
+++ b/src/components/PlayerAutocomplete/PlayerAutocomplete.tsx
@@ -20,12 +20,13 @@ import { _ } from "translate";
 import { get, abort_requests_in_flight } from "requests";
 import * as player_cache from "player_cache";
 import * as Autosuggest from "react-autosuggest";
+import { IdType } from "src/lib/types";
 
 interface PlayerAutocompleteProperties {
     onComplete: (user: player_cache.PlayerCacheEntry | null) => void;
     playerId?: number;
     placeholder?: string;
-    ladderId?: number;
+    ladderId?: IdType;
 }
 
 export interface PlayerAutocompleteRef {

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -16,6 +16,7 @@
  */
 
 import { deepCompare } from "misc";
+import { IdType } from "./types";
 
 export function api1ify(path) {
     if (path.indexOf("/api/v") === 0) {
@@ -68,7 +69,7 @@ type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 interface RequestFunction {
     (url: string): Promise<any>;
     (url: string, id_or_data: number | any): Promise<any>;
-    (url: string, id: number, data: any): Promise<any>;
+    (url: string, id: IdType, data: any): Promise<any>;
 }
 
 export function request(method: Method): RequestFunction {

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -76,7 +76,7 @@ export function request(method: Method): RequestFunction {
     return (url, ...rest) => {
         initialize();
 
-        let id: number | string | undefined;
+        let id: IdType | undefined;
         let data: any;
         switch (typeof rest[0]) {
             case "number":

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,3 +117,9 @@ export interface AutomatchPreferencesBase {
         value: "enabled" | "disabled";
     };
 }
+
+// Many times an id is a number, but it doesn't matter if it is a string as
+// far as the code is concerned.  Example:
+//
+//
+export type IdType = number | string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -121,5 +121,8 @@ export interface AutomatchPreferencesBase {
 // Many times an id is a number, but it doesn't matter if it is a string as
 // far as the code is concerned.  Example:
 //
+//     const players = get(`ladders/${props.ladderId}/players/`);
 //
+// The format string does not care whether ladderId was a number or a number formatted as a string,
+// so IdType is a good type for ladderId.
 export type IdType = number | string;

--- a/src/views/ChatView/ChatView.tsx
+++ b/src/views/ChatView/ChatView.tsx
@@ -23,14 +23,9 @@ import { useState, useEffect, useCallback } from "react";
 //import {errorAlerter} from "misc";
 //import {Chat} from "Chat";
 import { ChatChannelList, ChatLog, ChatUsersList } from "Chat";
+import { RouteComponentProps } from "react-router";
 
-interface ChatViewProperties {
-    match: {
-        params: {
-            channel: string;
-        };
-    };
-}
+type ChatViewProperties = RouteComponentProps<{ channel: string }>;
 
 export function ChatView(props: ChatViewProperties): JSX.Element {
     const channel = props.match.params.channel;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -20,7 +20,7 @@ import device from "device";
 import * as preferences from "preferences";
 import * as React from "react";
 import ReactResizeDetector from "react-resize-detector";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { browserHistory } from "ogsHistory";
 import { _, ngettext, pgettext, interpolate, current_language } from "translate";
 import { post, get, api1, del } from "requests";
@@ -74,15 +74,11 @@ import swal from "sweetalert2";
 
 const win = $(window);
 
-interface GameProperties {
-    match: {
-        params: {
-            game_id?: string;
-            review_id?: string;
-            move_number?: string;
-        };
-    };
-}
+type GameProperties = RouteComponentProps<{
+    game_id?: string;
+    review_id?: string;
+    move_number?: string;
+}>;
 
 interface GameState {
     view_mode: ViewMode;

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -40,7 +40,7 @@ import swal from "sweetalert2";
 import { PlayerCacheEntry } from "player_cache";
 
 type GroupProperties = RouteComponentProps<{
-    group_id: any; // string treated as a number
+    group_id: string;
 }>;
 
 // API: group/%id%/

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { browserHistory } from "ogsHistory";
 import { _ } from "translate";
 import { post, del, put, get } from "requests";
@@ -39,11 +39,9 @@ import { localize_time_strings } from "localize-time";
 import swal from "sweetalert2";
 import { PlayerCacheEntry } from "player_cache";
 
-interface GroupProperties {
-    match: {
-        params: any;
-    };
-}
+type GroupProperties = RouteComponentProps<{
+    group_id: any; // string treated as a number
+}>;
 
 // API: group/%id%/
 interface GroupInfo {

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -18,7 +18,7 @@
 /* A page for looking up and playing against josekis stored in the OGS OJE*/
 
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import ReactResizeDetector from "react-resize-detector";
 import * as queryString from "query-string";
 
@@ -145,12 +145,7 @@ const ColorMap = {
 
 type MoveType = "bad" | "good" | "computer" | "complete";
 
-interface JosekiProps {
-    match: {
-        params: any;
-    };
-    location: any;
-}
+type JosekiProps = RouteComponentProps<{ pos: string }>;
 
 interface MoveTypeWithComment {
     type: MoveType;

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -39,6 +39,7 @@ import { JosekiSourceModal } from "JosekiSourceModal";
 import { JosekiVariationFilter } from "JosekiVariationFilter";
 import { JosekiTagSelector } from "JosekiTagSelector";
 import { Throbber } from "Throbber";
+import { IdType } from "src/lib/types";
 
 const server_url = data.get("joseki-url", "/oje/");
 
@@ -180,7 +181,7 @@ interface JosekiState {
     joseki_source?: {
         url: string;
         description: string;
-        id?: string | number;
+        id?: IdType;
     };
     tags: any[];
 

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -28,13 +28,14 @@ import { close_all_popovers, popover } from "popover";
 import { browserHistory } from "ogsHistory";
 import swal from "sweetalert2";
 import { RouteComponentProps } from "react-router-dom";
+import { IdType } from "src/lib/types";
 
 type LadderProperties = RouteComponentProps<{
-    ladder_id: any; // string treated as a number
+    ladder_id: string;
 }>;
 
 interface LadderState {
-    ladder_id: number;
+    ladder_id: IdType;
     ladder: {
         group: any; // doesn't appear this member is used
         name: string;

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -27,12 +27,11 @@ import { PlayerAutocomplete } from "PlayerAutocomplete";
 import { close_all_popovers, popover } from "popover";
 import { browserHistory } from "ogsHistory";
 import swal from "sweetalert2";
+import { RouteComponentProps } from "react-router-dom";
 
-interface LadderProperties {
-    match: {
-        params: any;
-    };
-}
+type LadderProperties = RouteComponentProps<{
+    ladder_id: any; // string treated as a number
+}>;
 
 interface LadderState {
     ladder_id: number;

--- a/src/views/LearningHub/LearningHub.tsx
+++ b/src/views/LearningHub/LearningHub.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import * as data from "data";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { CardLink } from "material";
 import { _, pgettext } from "translate";
 import { sections, allsections } from "./sections";
@@ -28,14 +28,10 @@ import { browserHistory } from "ogsHistory";
 import { MiniGoban } from "MiniGoban";
 import swal from "sweetalert2";
 
-interface LearningHubProperties {
-    match: {
-        params: {
-            section: string;
-            page: number;
-        };
-    };
-}
+type LearningHubProperties = RouteComponentProps<{
+    section: string;
+    page: string;
+}>;
 
 export class LearningHub extends React.PureComponent<LearningHubProperties> {
     constructor(props) {

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -26,10 +26,11 @@ import { Player } from "Player";
 import { Card } from "material";
 import * as Dropzone from "react-dropzone";
 import * as moment from "moment";
+import { IdType } from "src/lib/types";
 
 type LibraryPlayerProperties = RouteComponentProps<{
-    player_id: any; // string treated as a number
-    collection_id: any; // string treated as a number
+    player_id: string;
+    collection_id: string;
 }>;
 
 interface Collection {
@@ -44,8 +45,8 @@ interface Collection {
 }
 
 interface LibraryPlayerState {
-    player_id: number;
-    collection_id: number;
+    player_id: IdType;
+    collection_id: IdType;
     collections?: { [id: number]: Collection };
     games_checked: {};
     new_collection_name: string;
@@ -100,7 +101,7 @@ export class LibraryPlayer extends React.PureComponent<
     componentWillUnmount() {
         abort_requests_in_flight("library/");
     }
-    refresh(player_id: number) {
+    refresh(player_id: IdType) {
         const promise = get("library/%%", player_id);
 
         promise

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import * as data from "data";
 import { _, interpolate } from "translate";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { browserHistory } from "ogsHistory";
 import { abort_requests_in_flight, post, get } from "requests";
 import { errorAlerter, ignore, getOutcomeTranslation } from "misc";
@@ -27,11 +27,10 @@ import { Card } from "material";
 import * as Dropzone from "react-dropzone";
 import * as moment from "moment";
 
-interface LibraryPlayerProperties {
-    match: {
-        params: any;
-    };
-}
+type LibraryPlayerProperties = RouteComponentProps<{
+    player_id: any; // string treated as a number
+    collection_id: any; // string treated as a number
+}>;
 
 interface Collection {
     id: number;

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import ReactResizeDetector from "react-resize-detector";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { browserHistory } from "ogsHistory";
 import { _, pgettext, interpolate } from "translate";
 import { post, get, put, del } from "requests";
@@ -38,13 +38,7 @@ import { PuzzleNavigation } from "./PuzzleNavigation";
 import { PuzzleEditor } from "./PuzzleEditing";
 import swal from "sweetalert2";
 
-interface PuzzleProperties {
-    match: {
-        params: {
-            puzzle_id: string;
-        };
-    };
-}
+type PuzzleProperties = RouteComponentProps<{ puzzle_id: string }>;
 
 interface PuzzleState {
     puzzle?: any;

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -30,7 +30,7 @@ export function PuzzleCollection({
         params: { collection_id },
     },
 }: RouteComponentProps<{
-    collection_id: any; // string treated as a number
+    collection_id: string;
 }>): JSX.Element {
     const [collection, setCollection] = React.useState(null);
     const [name, setName] = React.useState(null);

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -23,14 +23,15 @@ import { get, del, put, abort_requests_in_flight } from "requests";
 import { SortablePuzzleList } from "./SortablePuzzleList";
 import { openACLModal } from "ACLModal";
 import swal from "sweetalert2";
+import { RouteComponentProps } from "react-router-dom";
 
 export function PuzzleCollection({
     match: {
         params: { collection_id },
     },
-}: {
-    match: { params: { collection_id: number } };
-}): JSX.Element {
+}: RouteComponentProps<{
+    collection_id: any; // string treated as a number
+}>): JSX.Element {
     const [collection, setCollection] = React.useState(null);
     const [name, setName] = React.useState(null);
     const [puzzle_is_private, setPrivate] = React.useState(false);

--- a/src/views/PuzzleCollection/PuzzleCollectionList.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollectionList.tsx
@@ -26,14 +26,13 @@ import { StarRating } from "StarRating";
 import { Player } from "Player";
 import { MiniGoban } from "MiniGoban";
 import swal from "sweetalert2";
+import { RouteComponentProps } from "react-router";
 
 export function PuzzleCollectionList({
     match: {
         params: { player_id },
     },
-}: {
-    match: { params: { player_id: number } };
-}): JSX.Element {
+}: RouteComponentProps<{ player_id: string }>): JSX.Element {
     return (
         <div className="page-width">
             <div className="PuzzleList container">

--- a/src/views/PuzzleCollection/SortablePuzzleList.tsx
+++ b/src/views/PuzzleCollection/SortablePuzzleList.tsx
@@ -35,7 +35,7 @@ interface PuzzleEntry {
 }
 
 interface SortablePuzzleListProperties {
-    collection: number;
+    collection: number | string;
 }
 interface SortablePuzzleListState {
     entries: Array<PuzzleEntry>;

--- a/src/views/PuzzleCollection/SortablePuzzleList.tsx
+++ b/src/views/PuzzleCollection/SortablePuzzleList.tsx
@@ -23,6 +23,7 @@ import { longRankString } from "rank_utils";
 import { MiniGoban } from "MiniGoban";
 import { SortableContainer, SortableElement } from "react-sortable-hoc";
 import arrayMove from "array-move";
+import { IdType } from "src/lib/types";
 
 interface PuzzleEntry {
     id: number;
@@ -35,7 +36,7 @@ interface PuzzleEntry {
 }
 
 interface SortablePuzzleListProperties {
-    collection: number | string;
+    collection: IdType;
 }
 interface SortablePuzzleListState {
     entries: Array<PuzzleEntry>;

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -23,7 +23,7 @@ import * as moment from "moment";
 import Select from "react-select";
 import ITC from "ITC";
 import { ValidPreference } from "preferences";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { _, pgettext, interpolate } from "translate";
 import { post, get, put, del, abort_requests_in_flight, getCookie } from "requests";
 import { errorAlerter, errorLogger, ignore, Timeout, dup } from "misc";
@@ -116,13 +116,7 @@ interface SettingGroupProps {
     updateSelfReportedAccountLinkages: (link: any) => void;
 }
 
-interface SettingsProperties {
-    match: {
-        params: {
-            category: string;
-        };
-    };
-}
+type SettingsProperties = RouteComponentProps<{ category: string }>;
 
 export function Settings({
     match: {

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { LoadingPage } from "Loading";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { browserHistory } from "ogsHistory";
 import { _, pgettext, interpolate } from "translate";
 import { abort_requests_in_flight, del, put, post, get } from "requests";
@@ -51,11 +51,10 @@ let logspam_debounce: any;
 
 const ranks = amateurRanks();
 
-interface TournamentProperties {
-    match: {
-        params: any;
-    };
-}
+type TournamentProperties = RouteComponentProps<{
+    tournament_id: string;
+    group_id: string;
+}>;
 
 interface TournamentState {
     new_tournament_group_id: number;

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -23,18 +23,19 @@ import * as preferences from "preferences";
 import { errorAlerter } from "misc";
 import { shortShortTimeControl } from "TimeControl";
 import { computeAverageMoveTime } from "goban";
-import { PaginatedTable } from "PaginatedTable";
+import { PaginatedTable, Filter } from "PaginatedTable";
 import * as moment from "moment";
 import { TOURNAMENT_TYPE_NAMES, shortRankRestrictionText } from "Tournament";
 import tooltip from "tooltip";
 import { Toggle } from "Toggle";
+import { IdType } from "src/lib/types";
 
 interface TournamentListProperties {
     phase: "open" | "active" | "finished";
     speed?: "live" | "correspondence";
     hide_stale?: boolean; // Hides tournaments that were supposed to have started already
     hide_exclusive?: boolean; // Hides tournaments that are invite-only or members-only
-    group?: number;
+    group?: IdType;
 }
 
 interface TournamentListMainViewState {
@@ -245,9 +246,9 @@ export class TournamentList extends React.PureComponent<TournamentListProperties
         speed?: "live" | "correspondence",
         hide_stale?: boolean,
         hide_exclusive?: boolean,
-        group?: number,
+        group?: IdType,
     ) {
-        const filter: { [key: string]: any } = {};
+        const filter: Filter = {};
         switch (phase) {
             case "open":
                 filter["started__isnull"] = true;

--- a/src/views/TournamentRecord/TournamentRecord.tsx
+++ b/src/views/TournamentRecord/TournamentRecord.tsx
@@ -24,17 +24,14 @@ import { Player } from "Player";
 import { ignore, errorAlerter, dup } from "misc";
 import { rankString, allRanks } from "rank_utils";
 import { createDemoBoard } from "ChallengeModal";
+import { RouteComponentProps } from "react-router-dom";
 
 window["dup"] = dup;
 
 import swal from "sweetalert2";
 const ranks = allRanks();
 
-interface TournamentRecordProperties {
-    match: {
-        params: any;
-    };
-}
+type TournamentRecordProperties = RouteComponentProps<{ tournament_record_id: string }>;
 
 interface Round {
     updated: boolean;

--- a/src/views/Tutorial/Tutorial.tsx
+++ b/src/views/Tutorial/Tutorial.tsx
@@ -16,18 +16,16 @@
  */
 
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { Markdown } from "Markdown";
 import { browserHistory } from "ogsHistory";
 import { _ } from "translate";
 import { InstructionalGoban } from "./InstructionalGoban";
 import { openNewGameModal } from "NewGameModal";
 
-interface TutorialProperties {
-    match: {
-        params: any;
-    };
-}
+type TutorialProperties = RouteComponentProps<{
+    step: any; // string treated as a number
+}>;
 
 const NUM_PAGES = 12;
 declare let ogs_current_language;

--- a/src/views/Tutorial/Tutorial.tsx
+++ b/src/views/Tutorial/Tutorial.tsx
@@ -24,7 +24,7 @@ import { InstructionalGoban } from "./InstructionalGoban";
 import { openNewGameModal } from "NewGameModal";
 
 type TutorialProperties = RouteComponentProps<{
-    step: any; // string treated as a number
+    step: string;
 }>;
 
 const NUM_PAGES = 12;
@@ -36,7 +36,7 @@ export class Tutorial extends React.PureComponent<TutorialProperties> {
     }
 
     render() {
-        const page_number = parseInt(this.props.match.params.step || 0);
+        const page_number = parseInt(this.props.match.params.step) || 0;
 
         switch (page_number) {
             case 0:


### PR DESCRIPTION
## Proposed Changes

Replace instances of:

```
interface SomeComponentProps {
    match: {
        params: {
            id: string;
        };
    };
}
```

with:

```
type SomeComponentProps = RouteComponentProps<{ id: string }>
```

### Motivation

It's a little more succinct, but more importantly it becomes clear that the structure of props is dictated by React Router.

### Note

~A lot of `params` are treated as numbers even though they are strings.  It doesn't seem to matter, but TS complains, so I made those `any` with an explanatory comment.~

`IdType = string | number` has been introduced to deal with these numbery strings.
