### PR TITLE
go to beta for ai in development environments

### DIFF
--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -55,7 +55,8 @@ if (
     console.log("AI Host set to: ", ai_host);
 } else if (
     window.location.hostname.indexOf("beta") >= 0 ||
-    window.location.hostname.indexOf("dev") >= 0
+    window.location.hostname.indexOf("dev") >= 0 ||
+    window.location.hostname.indexOf("localhost") >= 0
 ) {
     ai_host = "https://beta-ai.online-go.com";
 } else if (window.location.hostname.indexOf("online-go.com") >= 0) {

--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -54,9 +54,9 @@ if (
     ai_host = `http://localhost:13284`;
     console.log("AI Host set to: ", ai_host);
 } else if (
+    process.env.NODE_ENV === "development" || // note that jest in the CI has "test" for this.  The CI doesn't work with beta.
     window.location.hostname.indexOf("beta") >= 0 ||
-    window.location.hostname.indexOf("dev") >= 0 ||
-    window.location.hostname.indexOf("localhost") >= 0
+    window.location.hostname.indexOf("dev") >= 0
 ) {
     ai_host = "https://beta-ai.online-go.com";
 } else if (window.location.hostname.indexOf("online-go.com") >= 0) {


### PR DESCRIPTION
Fixes ongoing web socket messages in the consle.

## Proposed Changes

~~If we're pointing at localhost, use beta ai server.~~

If we have NODE_ENV=development, then go to the beta ai server
