### PR TITLE
Cleanup: remove unused parameters from LadderComponent

### DIFF
--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -18,12 +18,11 @@
 import * as React from "react";
 import ReactResizeDetector from "react-resize-detector";
 import { _, interpolate } from "translate";
-import { post, get } from "requests";
+import { get } from "requests";
 import { errorAlerter } from "misc";
 import { Player } from "Player";
 import { PaginatedTable, PaginatedTableRef } from "PaginatedTable";
 import { UIPush } from "UIPush";
-import swal from "sweetalert2";
 
 interface LadderComponentProperties {
     ladderId: number;
@@ -85,31 +84,6 @@ export class LadderComponent extends React.PureComponent<
     updatePlayers = () => {
         this.ladder_table_ref.current?.refresh();
     };
-
-    challenge(ladder_player) {
-        console.log(ladder_player);
-        swal({
-            text: interpolate(
-                _(
-                    "Are you ready to start your game with {{player_name}}?",
-                ) /* translators: ladder challenge */,
-                { player_name: ladder_player.player.username },
-            ),
-            showCancelButton: true,
-            confirmButtonText: _("Yes!"),
-            cancelButtonText: _("No"),
-        })
-            .then(() => {
-                post("ladders/%%/players/challenge", this.props.ladderId, {
-                    player_id: ladder_player.player.id,
-                })
-                    .then(() => {
-                        this.updatePlayers();
-                    })
-                    .catch(errorAlerter);
-            })
-            .catch(() => 0);
-    }
 
     render() {
         if (!this.state.ladder) {

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -160,7 +160,6 @@ export class LadderComponent extends React.PureComponent<
                     hidePageControls={this.props.hidePageControls}
                     columns={[
                         { header: _("Rank"), className: "rank-column", render: (lp) => lp.rank },
-                        null,
                         {
                             header: _("Player"),
                             className: "player-column",
@@ -172,9 +171,6 @@ export class LadderComponent extends React.PureComponent<
                                 </div>
                             ),
                         },
-
-                        null,
-                        null,
                     ]}
                 />
             </div>

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import ReactResizeDetector from "react-resize-detector";
-import { _, interpolate } from "translate";
+import { _ } from "translate";
 import { get } from "requests";
 import { errorAlerter } from "misc";
 import { Player } from "Player";
@@ -29,8 +29,6 @@ interface LadderComponentProperties {
     pageSize?: number;
     pageSizeOptions?: Array<number>;
     hidePageControls?: boolean;
-    dontStartOnPlayersPage?: boolean /* default we will load whatever page the player is found on (based on ladder ranking), set to true to start on page 1 */;
-    showTitle?: boolean;
 }
 
 interface Ladder {
@@ -89,13 +87,6 @@ export class LadderComponent extends React.PureComponent<
         if (!this.state.ladder) {
             return null;
         }
-        let startingPage = 1;
-        if (!this.props.dontStartOnPlayersPage && this.state.ladder.player_rank > 0) {
-            startingPage = Math.max(
-                1,
-                Math.ceil(this.state.ladder.player_rank / this.state.page_size),
-            );
-        }
 
         return (
             <div className="LadderComponent">
@@ -107,28 +98,11 @@ export class LadderComponent extends React.PureComponent<
                     action={this.updatePlayers}
                 />
 
-                {(this.props.showTitle || null) && (
-                    <h4>
-                        {interpolate(_("{{ladder_name}} ladder"), {
-                            ladder_name: this.state.ladder.name,
-                        })}{" "}
-                    </h4>
-                )}
-
-                {(this.props.showTitle || null) && (
-                    <h4>
-                        {interpolate(_("{{ladder_size}} players"), {
-                            ladder_size: this.state.ladder.size,
-                        })}
-                    </h4>
-                )}
-
                 <PaginatedTable
                     className="ladder"
                     name="ladder"
                     ref={this.ladder_table_ref}
                     source={`ladders/${this.props.ladderId}/players?no_challenge_information=1`}
-                    startingPage={startingPage}
                     pageSize={this.state.page_size}
                     pageSizeOptions={this.props.pageSizeOptions}
                     hidePageControls={this.props.hidePageControls}

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -17,23 +17,18 @@
 
 import * as React from "react";
 import ReactResizeDetector from "react-resize-detector";
-import { Link } from "react-router-dom";
-import { _, pgettext, interpolate } from "translate";
+import { _, interpolate } from "translate";
 import { post, get } from "requests";
 import { errorAlerter } from "misc";
 import { Player } from "Player";
 import { PaginatedTable, PaginatedTableRef } from "PaginatedTable";
 import { UIPush } from "UIPush";
-import * as data from "data";
-import tooltip from "tooltip";
 import swal from "sweetalert2";
 
 interface LadderComponentProperties {
     ladderId: number;
     pageSize?: number;
     pageSizeOptions?: Array<number>;
-    fullView?: boolean;
-    showLinkToFullView?: boolean;
     hidePageControls?: boolean;
     dontStartOnPlayersPage?: boolean /* default we will load whatever page the player is found on (based on ladder ranking), set to true to start on page 1 */;
     showTitle?: boolean;
@@ -120,96 +115,11 @@ export class LadderComponent extends React.PureComponent<
         if (!this.state.ladder) {
             return null;
         }
-        const user = data.get("user");
-        const full_view = this.props.fullView;
         let startingPage = 1;
         if (!this.props.dontStartOnPlayersPage && this.state.ladder.player_rank > 0) {
             startingPage = Math.max(
                 1,
                 Math.ceil(this.state.ladder.player_rank / this.state.page_size),
-            );
-        }
-
-        const thin_view = $(window).width() < 800;
-        //let challenged_by = [];
-        //let challenging = [];
-
-        function by_ladder_rank(a, b) {
-            let ar = a.player.ladder_rank;
-            let br = b.player.ladder_rank;
-            if (ar < 0) {
-                ar = 1000000000;
-            }
-            if (br < 0) {
-                br = 1000000000;
-            }
-            return ar - br;
-        }
-
-        function challenged_by(lp: any, label: boolean) {
-            return (
-                <div className="inline-challenge-line">
-                    {((full_view && lp.incoming_challenges.length) || null) && (
-                        <div>
-                            {(label || null) && (
-                                <b>
-                                    {
-                                        _(
-                                            "Challenged by",
-                                        ) /* Translators: List of players that challenged this player in a ladder */
-                                    }
-                                    :{" "}
-                                </b>
-                            )}
-                            {lp.incoming_challenges.sort(by_ladder_rank).map((challenge, idx) => (
-                                <div key={idx}>
-                                    <Link
-                                        className="challenge-link"
-                                        to={`/game/${challenge.game_id}`}
-                                    >
-                                        <span className="challenge-rank">
-                                            #{challenge.player.ladder_rank}
-                                        </span>
-                                        <Player nolink user={challenge.player} />
-                                    </Link>
-                                </div>
-                            ))}
-                        </div>
-                    )}
-                </div>
-            );
-        }
-        function challenging(lp: any, label: boolean) {
-            return (
-                <div className="challenge-line">
-                    {((full_view && lp.outgoing_challenges.length) || null) && (
-                        <div>
-                            {(label || null) && (
-                                <b>
-                                    {
-                                        _(
-                                            "Challenging",
-                                        ) /* Translators: List of players that have been challenged by this player in a ladder */
-                                    }
-                                    :{" "}
-                                </b>
-                            )}
-                            {lp.outgoing_challenges.sort(by_ladder_rank).map((challenge, idx) => (
-                                <div key={idx}>
-                                    <Link
-                                        className="challenge-link"
-                                        to={`/game/${challenge.game_id}`}
-                                    >
-                                        <span className="challenge-rank">
-                                            #{challenge.player.ladder_rank}
-                                        </span>
-                                        <Player nolink user={challenge.player} />
-                                    </Link>
-                                </div>
-                            ))}
-                        </div>
-                    )}
-                </div>
             );
         }
 
@@ -230,13 +140,6 @@ export class LadderComponent extends React.PureComponent<
                         })}{" "}
                     </h4>
                 )}
-                {(this.props.showLinkToFullView || null) && (
-                    <div style={{ textAlign: "center" }}>
-                        <Link className="btn primary sm" to={`/ladder/${this.props.ladderId}`}>
-                            {_("Full View") /* translators: View details of the selected ladder */}
-                        </Link>
-                    </div>
-                )}
 
                 {(this.props.showTitle || null) && (
                     <h4>
@@ -250,42 +153,14 @@ export class LadderComponent extends React.PureComponent<
                     className="ladder"
                     name="ladder"
                     ref={this.ladder_table_ref}
-                    source={
-                        `ladders/${this.props.ladderId}/players` +
-                        (full_view ? "" : "?no_challenge_information=1")
-                    }
+                    source={`ladders/${this.props.ladderId}/players?no_challenge_information=1`}
                     startingPage={startingPage}
                     pageSize={this.state.page_size}
                     pageSizeOptions={this.props.pageSizeOptions}
                     hidePageControls={this.props.hidePageControls}
                     columns={[
                         { header: _("Rank"), className: "rank-column", render: (lp) => lp.rank },
-
-                        ((full_view && this.state.ladder.player_rank) > 0 || null) && {
-                            header: "",
-                            className: "challenge-column",
-                            render: (lp) =>
-                                ((lp.player.id !== user.id && lp.can_challenge) || null) &&
-                                (lp.can_challenge.challengeable ? (
-                                    <button
-                                        className="primary xs"
-                                        onClick={this.challenge.bind(this, lp)}
-                                    >
-                                        {_("Challenge")}
-                                    </button>
-                                ) : (
-                                    <span
-                                        className="not-challengable"
-                                        data-title={canChallengeTooltip(lp.can_challenge)}
-                                        onClick={tooltip}
-                                        onMouseOver={tooltip}
-                                        onMouseOut={tooltip}
-                                        onMouseMove={tooltip}
-                                    >
-                                        {_("Not challengable")}
-                                    </span>
-                                )),
-                        },
+                        null,
                         {
                             header: _("Player"),
                             className: "player-column",
@@ -294,85 +169,15 @@ export class LadderComponent extends React.PureComponent<
                                     <div className="primary-player">
                                         <Player flag user={lp.player} />
                                     </div>
-                                    {(thin_view || null) && challenged_by(lp, true)}
-                                    {(thin_view || null) && challenging(lp, true)}
                                 </div>
                             ),
                         },
 
-                        thin_view || !full_view
-                            ? null
-                            : {
-                                  header: _("Challenged By"),
-                                  className: "challenge-column",
-                                  render: (lp) => challenged_by(lp, false),
-                              },
-                        thin_view || !full_view
-                            ? null
-                            : {
-                                  header: _("Challenging"),
-                                  className: "challenge-column",
-                                  render: (lp) => challenging(lp, false),
-                              },
+                        null,
+                        null,
                     ]}
                 />
             </div>
         );
     }
-}
-
-function canChallengeTooltip(obj: any): string {
-    if (obj.reason_code) {
-        switch (obj.reason_code) {
-            case 0x001:
-                return pgettext(
-                    "Can't challenge player in ladder because: ",
-                    "Can't challenge yourself",
-                );
-            case 0x002:
-                return pgettext(
-                    "Can't challenge player in ladder because: ",
-                    "Player is a lower rank than you",
-                );
-            case 0x003:
-                return pgettext(
-                    "Can't challenge player in ladder because: ",
-                    "Player is not in the ladder",
-                );
-            case 0x004:
-                return pgettext(
-                    "Can't challenge player in ladder because: ",
-                    "Player's rank is too high",
-                );
-            case 0x005:
-                return interpolate(
-                    pgettext(
-                        "Can't challenge player in ladder because: ",
-                        "Already playing {{number}} games you've initiated",
-                    ),
-                    { number: obj.reason_parameter }, // eslint-disable-line id-denylist
-                );
-            case 0x006:
-                return pgettext(
-                    "Can't challenge player in ladder because: ",
-                    "Already playing a game against this person",
-                );
-            case 0x007:
-                return pgettext(
-                    "Can't challenge player in ladder because: ",
-                    "Last challenge within 7 days",
-                );
-            case 0x008:
-                return pgettext(
-                    "Can't challenge player in ladder because: ",
-                    "Player already has the maximum number of challenges",
-                );
-        }
-    }
-
-    if (obj.reason) {
-        return obj.reason;
-    }
-
-    return null;
 }

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -52,7 +52,7 @@ export class LadderComponent extends React.PureComponent<
 > {
     ladder_table_ref = React.createRef<PaginatedTableRef>();
 
-    constructor(props) {
+    constructor(props: LadderComponentProperties) {
         super(props);
         this.state = {
             ladder_id: props.ladderId,

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -1096,22 +1096,6 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
                                 </Link>
                             </div>
                         </Card>
-
-                        {/*
-                    {group.ladder_ids.map((ladder_id, idx) => (
-                        <Card key={idx}>
-                            <Link
-                            <LadderComponent
-                                pageSize={10}
-                                ladderId={ladder_id}
-                                showTitle={true}
-                                showLinkToFullView={true}
-                                hidePageControls={true}
-                                dontStartOnPlayersPage={true}
-                                />
-                        </Card>
-                    ))}
-                    */}
                     </div>
                 </div>
             </div>

--- a/src/views/LadderList/LadderList.tsx
+++ b/src/views/LadderList/LadderList.tsx
@@ -112,7 +112,6 @@ export class LadderList extends React.PureComponent<{}, LadderListState> {
                                 pageSize={10}
                                 ladderId={ladder.id}
                                 hidePageControls={true}
-                                dontStartOnPlayersPage={true}
                             />
                         </Card>
                     ))}

--- a/src/views/LadderList/LadderList.tsx
+++ b/src/views/LadderList/LadderList.tsx
@@ -39,7 +39,7 @@ interface LadderListState {
 }
 
 export class LadderList extends React.PureComponent<{}, LadderListState> {
-    constructor(props) {
+    constructor(props: {}) {
         super(props);
         this.state = {
             ladders: [],


### PR DESCRIPTION
Despite all the removed code, this change should be a no-op.  There was a lot of code in there about a "Full View".  Must have been replaced by `Ladder.tsx` or something.

Tested: Compared beta and localhost, no discernable changes.

View on beta:
<img width="1080" alt="Screen Shot 2022-01-25 at 11 09 22 PM" src="https://user-images.githubusercontent.com/25233703/151118704-439a09d2-eb02-473a-b82a-b6236ee248f1.png">

View on localhost:
<img width="1083" alt="Screen Shot 2022-01-25 at 11 08 41 PM" src="https://user-images.githubusercontent.com/25233703/151118712-a17caf29-ea02-4c9e-ae83-abc2d199d023.png">

