### PR TITLE
Add optional UIPush parameter to PaginatedTable, cleanup LadderComponent

### DIFF
--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -23,9 +23,6 @@ import { PaginatedTable } from "PaginatedTable";
 
 interface LadderComponentProperties {
     ladderId: number;
-    pageSize?: number;
-    pageSizeOptions?: Array<number>;
-    hidePageControls?: boolean;
 }
 
 export class LadderComponent extends React.PureComponent<LadderComponentProperties> {
@@ -42,9 +39,8 @@ export class LadderComponent extends React.PureComponent<LadderComponentProperti
                     className="ladder"
                     name="ladder"
                     source={`ladders/${this.props.ladderId}/players?no_challenge_information=1`}
-                    pageSize={this.props.pageSize}
-                    pageSizeOptions={this.props.pageSizeOptions}
-                    hidePageControls={this.props.hidePageControls}
+                    pageSize={10}
+                    hidePageControls={true}
                     uiPushProps={{
                         event: "players-updated",
                         channel: `ladder-${this.props.ladderId}`,

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -22,7 +22,6 @@ import { get } from "requests";
 import { errorAlerter } from "misc";
 import { Player } from "Player";
 import { PaginatedTable, PaginatedTableRef } from "PaginatedTable";
-import { UIPush } from "UIPush";
 
 interface LadderComponentProperties {
     ladderId: number;
@@ -92,20 +91,17 @@ export class LadderComponent extends React.PureComponent<
             <div className="LadderComponent">
                 <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
 
-                <UIPush
-                    event="players-updated"
-                    channel={`ladder-${this.props.ladderId}`}
-                    action={this.updatePlayers}
-                />
-
                 <PaginatedTable
                     className="ladder"
                     name="ladder"
-                    ref={this.ladder_table_ref}
                     source={`ladders/${this.props.ladderId}/players?no_challenge_information=1`}
                     pageSize={this.state.page_size}
                     pageSizeOptions={this.props.pageSizeOptions}
                     hidePageControls={this.props.hidePageControls}
+                    uiPushProps={{
+                        event: "players-updated",
+                        channel: `ladder-${this.props.ladderId}`,
+                    }}
                     columns={[
                         { header: _("Rank"), className: "rank-column", render: (lp) => lp.rank },
                         {

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -18,10 +18,8 @@
 import * as React from "react";
 import ReactResizeDetector from "react-resize-detector";
 import { _ } from "translate";
-import { get } from "requests";
-import { errorAlerter } from "misc";
 import { Player } from "Player";
-import { PaginatedTable, PaginatedTableRef } from "PaginatedTable";
+import { PaginatedTable } from "PaginatedTable";
 
 interface LadderComponentProperties {
     ladderId: number;
@@ -30,63 +28,12 @@ interface LadderComponentProperties {
     hidePageControls?: boolean;
 }
 
-interface Ladder {
-    player_rank: number;
-    name: string;
-    size: number;
-}
-
-interface LadderComponentState {
-    ladder_id: number;
-    page_size: number;
-    ladder?: Ladder;
-}
-
-export class LadderComponent extends React.PureComponent<
-    LadderComponentProperties,
-    LadderComponentState
-> {
-    ladder_table_ref = React.createRef<PaginatedTableRef>();
-
-    constructor(props: LadderComponentProperties) {
-        super(props);
-        this.state = {
-            ladder_id: props.ladderId,
-            page_size: props.pageSize || 20,
-            ladder: null,
-        };
-    }
-
-    componentDidMount() {
-        this.reload();
-    }
-    componentDidUpdate(old_props) {
-        if (this.props.ladderId !== old_props.ladderId) {
-            this.reload();
-        }
-    }
-
+export class LadderComponent extends React.PureComponent<LadderComponentProperties> {
     onResize = () => {
         this.forceUpdate();
     };
 
-    reload = () => {
-        get("ladders/%%", this.props.ladderId)
-            .then((ladder) => this.setState({ ladder: ladder }))
-            .catch(errorAlerter);
-
-        this.updatePlayers();
-    };
-
-    updatePlayers = () => {
-        this.ladder_table_ref.current?.refresh();
-    };
-
     render() {
-        if (!this.state.ladder) {
-            return null;
-        }
-
         return (
             <div className="LadderComponent">
                 <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
@@ -95,7 +42,7 @@ export class LadderComponent extends React.PureComponent<
                     className="ladder"
                     name="ladder"
                     source={`ladders/${this.props.ladderId}/players?no_challenge_information=1`}
-                    pageSize={this.state.page_size}
+                    pageSize={this.props.pageSize}
                     pageSizeOptions={this.props.pageSizeOptions}
                     hidePageControls={this.props.hidePageControls}
                     uiPushProps={{

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -58,6 +58,7 @@ interface PaginatedTableProperties<RawEntryT, GroomedEntryT = RawEntryT> {
     startingPage?: number;
     fillBlankRows?: boolean;
     hidePageControls?: boolean;
+    /** If provided, the table will listen for this push event and refresh its data accordingly */
     uiPushProps?: { event: string; channel: string };
 }
 

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { _ } from "translate";
 import { post, get } from "requests";
 import * as data from "data";
+import { UIPush } from "../UIPush";
 
 interface PaginatedTableColumnProperties<EntryT> {
     cellProps?: any;
@@ -57,6 +58,7 @@ interface PaginatedTableProperties<RawEntryT, GroomedEntryT = RawEntryT> {
     startingPage?: number;
     fillBlankRows?: boolean;
     hidePageControls?: boolean;
+    uiPushProps?: { event: string; channel: string };
 }
 
 export interface PaginatedTableRef {
@@ -69,7 +71,7 @@ export const PaginatedTable = React.forwardRef<PaginatedTableRef, PaginatedTable
 
 function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
     props: PaginatedTableProperties<RawEntryT, GroomedEntryT>,
-    ref,
+    ref: React.ForwardedRef<PaginatedTableRef>,
 ): JSX.Element {
     const table_name = props.name || "default";
     const [rows, setRows]: [any[], (x: any[]) => void] = React.useState([]);
@@ -303,6 +305,15 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
 
     return (
         <div className={`PaginatedTable ${extra_classes} ${loading ? "loading" : ""}`}>
+            {props.uiPushProps && (
+                <UIPush
+                    event={props.uiPushProps.event}
+                    channel={props.uiPushProps.channel}
+                    action={() => {
+                        refresh(true);
+                    }}
+                />
+            )}
             <div className="loading-overlay">{_("Loading")}</div>
             <table className={extra_classes}>
                 <thead>

--- a/src/views/LadderList/LadderList.tsx
+++ b/src/views/LadderList/LadderList.tsx
@@ -108,11 +108,7 @@ export class LadderList extends React.PureComponent<{}, LadderListState> {
                                 })}
                             </h4>
 
-                            <LadderComponent
-                                pageSize={10}
-                                ladderId={ladder.id}
-                                hidePageControls={true}
-                            />
+                            <LadderComponent ladderId={ladder.id} />
                         </Card>
                     ))}
                 </div>


### PR DESCRIPTION
One of the main uses for the PaginatedTable ref seems to be to watch for UIPush notifications and update the table accordingly.  Since this is the case, rather than having the caller set up a ref and a UIPush and connecting everything, why not just tell PaginatedTable what event to watch for?

As a proof of concept, I tried out this new prop on LadderComponent, and finished up cleanup while I was in there.

## Proposed Changes

  - uiPushProps prop for PaginatedTable
  - cleanup LadderComponent, and use the uiPushProps prop

Tested:

I opened two browsers at the ladders page, joined and unjoined.  It seems to work about as well as before, and, in fact, I seem to have found an existing bug: #1674 
