### PR TITLE
Remove some more table refs in favor of uiPushProps

### DIFF
--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -105,7 +105,6 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
         new_news_body;
     };
 
-    members_ref = React.createRef<PaginatedTableRef>();
     news_ref = React.createRef<PaginatedTableRef>();
     tournament_ref = React.createRef<PaginatedTableRef>();
 
@@ -224,9 +223,6 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
 
     refreshGroup = () => {
         this.resolve(this.state.group_id);
-    };
-    refreshPlayerList = () => {
-        this.members_ref.current?.refresh();
     };
 
     toggleEdit = () => {
@@ -475,11 +471,6 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
 
         return (
             <div className="Group container">
-                <UIPush
-                    event="players-updated"
-                    channel={`group-${group.id}`}
-                    action={this.refreshPlayerList}
-                />
                 <UIPush
                     event="reload-group"
                     channel={`group-${group.id}`}
@@ -1028,7 +1019,10 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
                             <PaginatedTable
                                 className="members"
                                 name="members"
-                                ref={this.members_ref}
+                                uiPushProps={{
+                                    event: "players-updated",
+                                    channel: `group-${group.id}`,
+                                }}
                                 source={`groups/${group.id}/members`}
                                 groom={(u_arr) => u_arr.map((u) => player_cache.update(u.user))}
                                 columns={[

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -106,7 +106,6 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
     };
 
     news_ref = React.createRef<PaginatedTableRef>();
-    tournament_ref = React.createRef<PaginatedTableRef>();
 
     constructor(props) {
         super(props);
@@ -937,7 +936,6 @@ export class Group extends React.PureComponent<GroupProperties, GroupState> {
                                     <PaginatedTable
                                         className="TournamentRecord-table"
                                         name="tournament-record-table"
-                                        ref={this.tournament_ref}
                                         source={`tournament_records/?group=${group.id}`}
                                         orderBy={["-created"]}
                                         columns={[

--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -19,9 +19,8 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { _ } from "translate";
 import { post, put } from "requests";
-import { PaginatedTable, PaginatedTableRef } from "PaginatedTable";
+import { PaginatedTable } from "PaginatedTable";
 import { Card } from "material";
-import { UIPush } from "UIPush";
 import { SearchInput } from "misc-ui";
 import { Player } from "Player";
 import * as moment from "moment";
@@ -183,9 +182,6 @@ interface ModeratorState {
 }
 
 export class Moderator extends React.PureComponent<{}, ModeratorState> {
-    modlog_ref = React.createRef<PaginatedTableRef>();
-    userlog_ref = React.createRef<PaginatedTableRef>();
-
     constructor(props) {
         super(props);
         this.state = {
@@ -197,19 +193,9 @@ export class Moderator extends React.PureComponent<{}, ModeratorState> {
         window.document.title = _("Moderator Center");
     }
 
-    refreshModlog = () => {
-        this.modlog_ref.current?.refresh();
-    };
-    refreshUserlog = () => {
-        this.userlog_ref.current?.refresh();
-    };
-
     render() {
         return (
             <div className="Moderator">
-                <UIPush event="modlog-updated" channel="moderators" action={this.refreshModlog} />
-                <UIPush event="new-user" channel="moderators" action={this.refreshUserlog} />
-
                 <Card>
                     <div className="hsearch">
                         <h2>{_("New Users")}</h2>
@@ -233,7 +219,7 @@ export class Moderator extends React.PureComponent<{}, ModeratorState> {
                         className="userlog"
                         name="userlog"
                         source={`moderation/recent_users`}
-                        ref={this.userlog_ref}
+                        uiPushProps={{ event: "new-user", channel: "moderators" }}
                         orderBy={["-timestamp"]}
                         filter={{
                             ...(this.state.newuserany_filter !== "" && {
@@ -364,7 +350,6 @@ export class Moderator extends React.PureComponent<{}, ModeratorState> {
                         className=""
                         name="modlog"
                         source={`moderation/`}
-                        ref={this.modlog_ref}
                         orderBy={["-timestamp"]}
                         filter={{
                             ...(this.state.playerusernameistartswith_filter !== "" && {
@@ -372,6 +357,7 @@ export class Moderator extends React.PureComponent<{}, ModeratorState> {
                                     this.state.playerusernameistartswith_filter,
                             }),
                         }}
+                        uiPushProps={{ event: "modlog-updated", channel: "moderators" }}
                         columns={[
                             {
                                 header: _("Time"),

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -42,7 +42,7 @@ import {
 } from "rank_utils";
 import { durationString, daysOnlyDurationString } from "TimeControl";
 import { openModerateUserModal } from "ModerateUser";
-import { PaginatedTable, PaginatedTableRef } from "PaginatedTable";
+import { PaginatedTable } from "PaginatedTable";
 import { errorAlerter, shouldOpenNewTab } from "misc";
 import * as player_cache from "player_cache";
 import { getPrivateChat } from "PrivateChat";
@@ -53,7 +53,6 @@ import { Flag } from "Flag";
 import { Markdown } from "Markdown";
 import { RatingsChart } from "RatingsChart";
 import { RatingsChartByGame } from "RatingsChartByGame";
-import { UIPush } from "UIPush";
 import { associations } from "associations";
 import { browserHistory } from "ogsHistory";
 import { chat_markup } from "Chat";
@@ -200,7 +199,6 @@ export class User extends React.PureComponent<UserProperties, UserState> {
         vacation_left;
         bot_ai;
     };
-    moderator_log_table_ref = React.createRef<PaginatedTableRef>();
     user_id: number;
     vacation_left: string;
     original_username: string;
@@ -1269,11 +1267,6 @@ export class User extends React.PureComponent<UserProperties, UserState> {
                                     ]}
                                 />
                                 <b>Mod log</b>
-                                <UIPush
-                                    event={`modlog-${this.user_id}-updated`}
-                                    channel="moderators"
-                                    action={() => this.moderator_log_table_ref.current?.refresh()}
-                                />
                                 <div id="leave-moderator-note" ref={this.moderator_log_anchor}>
                                     <textarea
                                         ref={(x) => (this.moderator_note = x)}
@@ -1286,7 +1279,10 @@ export class User extends React.PureComponent<UserProperties, UserState> {
                                     className="moderator-log"
                                     name="moderator-log"
                                     source={`moderation?player_id=${this.user_id}`}
-                                    ref={this.moderator_log_table_ref}
+                                    uiPushProps={{
+                                        event: `modlog-${this.user_id}-updated`,
+                                        channel: "moderators",
+                                    }}
                                     columns={[
                                         {
                                             header: "",


### PR DESCRIPTION
Follow-up to #1675 

## Proposed Changes

  - Update any PaginatedTable + UIPush combos to just use uiPushProps
  - remove refs where possible

Tested: players table on the Groups page

Given that everything else was mod stuff, I didn't test that, but the changes are pretty straight-forward so I don't think there's a whole lot that can go wrong.
