### PR TITLE
A little more type safety for data.ts

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -312,7 +312,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
             this.refs.time_control_picker.saveSettings();
         }
         const speed = data.get("challenge.speed", "live");
-        data.set("challenge.challenge." + speed, next.challenge);
+        data.set(`challenge.challenge.${speed}`, next.challenge);
         data.set("challenge.bot", next.conf.bot_id);
         data.set("challenge.restrict_rank", next.conf.restrict_rank);
         data.set("demo.settings", next.demo);

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -36,6 +36,7 @@ import {
     watchChatSubscriptionChanged,
     unwatchChatSubscriptionChanged,
 } from "Chat";
+import { DataSchema } from "data_schema";
 
 interface ChatListProperties {
     show_unjoined?: boolean;
@@ -47,7 +48,7 @@ interface ChatListProperties {
     join_joined?: boolean;
     highlight_active_channel?: boolean;
     closing_toggle?: () => void;
-    collapse_state_store_name?: keyof data.DataSchema;
+    collapse_state_store_name?: keyof DataSchema;
     fakelink?: boolean;
     partFunc?: (channel: string, dont_autoset_active: boolean, dont_clear_joined: boolean) => void;
 }
@@ -64,7 +65,7 @@ interface ChatListState {
     join_subscriptions: boolean;
     join_joined: boolean;
     collapsed_channel_groups: { [channel_group: string]: boolean };
-    collapse_state_store_name: keyof data.DataSchema;
+    collapse_state_store_name: keyof DataSchema;
     highlight_active_channel: boolean;
     active_channel: string;
     fakelink: boolean;

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -47,7 +47,7 @@ interface ChatListProperties {
     join_joined?: boolean;
     highlight_active_channel?: boolean;
     closing_toggle?: () => void;
-    collapse_state_store_name?: string;
+    collapse_state_store_name?: keyof data.DataSchema;
     fakelink?: boolean;
     partFunc?: (channel: string, dont_autoset_active: boolean, dont_clear_joined: boolean) => void;
 }
@@ -64,7 +64,7 @@ interface ChatListState {
     join_subscriptions: boolean;
     join_joined: boolean;
     collapsed_channel_groups: { [channel_group: string]: boolean };
-    collapse_state_store_name: string;
+    collapse_state_store_name: keyof data.DataSchema;
     highlight_active_channel: boolean;
     active_channel: string;
     fakelink: boolean;

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -45,7 +45,6 @@ import { profanity_filter } from "profanity_filter";
 import { popover } from "popover";
 import { ChatDetails } from "Chat";
 import swal from "sweetalert2";
-import { GroupList } from "src/lib/types";
 
 interface ChatLogProperties {
     channel: string;
@@ -190,7 +189,7 @@ function ChannelTopic({
         useState(null);
     const [title_hover, set_title_hover]: [string, (s: string) => void] = useState("");
 
-    const groups = data.get<GroupList>("cached.groups", []);
+    const groups = data.get("cached.groups", []);
 
     // member of group, or a moderator, or a tournament channel
     const topic_editable =

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -325,7 +325,7 @@ class PrivateChat {
 
         if (send_itc) {
             //ITC.send("private-chat-open", {"user_id": this.user_id, "username": this.player.username});
-            data.set("pm.read-" + this.user_id, this.last_uid);
+            data.set(`pm.read-${this.user_id}`, this.last_uid);
         }
     }
     updateModeratorBanner() {
@@ -457,7 +457,7 @@ class PrivateChat {
                 user_id: this.user_id,
                 username: this.player.username,
             });
-            data.set("pm.close-" + this.user_id, this.last_uid);
+            data.set(`pm.close-${this.user_id}`, this.last_uid);
         }
         if (comm_socket && !dont_send_pm_close) {
             comm_socket.send("chat/pm/close", this.user_id);
@@ -614,7 +614,7 @@ class PrivateChat {
 
         this.last_uid = line.message.i + " " + line.message.t;
 
-        if (this.last_uid === data.get("pm.read-" + this.user_id, "-")) {
+        if (this.last_uid === data.get(`pm.read-${this.user_id}`, "-")) {
             this.removeHilight();
         }
     }

--- a/src/lib/cached.ts
+++ b/src/lib/cached.ts
@@ -188,7 +188,7 @@ export const cached = {
                 });
         },
     },
-};
+} as const;
 
 let current_user_id = 0;
 let refresh_debounce = setTimeout(refresh_all, 10);

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -98,55 +98,10 @@
  */
 
 import { TypedEventEmitter } from "TypedEventEmitter";
-import { GroupList, ActiveTournamentList } from "./types";
+import { DataSchema } from "data_schema";
 
 interface Events {
     [name: string]: any;
-}
-
-export interface DataSchema {
-    user: any;
-    bid: string;
-    theme: string;
-    debug: boolean;
-
-    // TODO: make a types for each of these that list the keys explicitly
-    cached: any;
-    [cached_key: `cached.${string}`]: any;
-    config: any;
-    [config_key: `config.${string}`]: any;
-    [chat_key: `chat.${string}`]: any;
-    [sound_key: `sound.${string}`]: any;
-    [preferences_key: `preferences.${string}`]: any;
-    [custom_key: `custom.${string}`]: any;
-    [chat_manager_key: `chat-manager.${string}`]: any;
-    [chat_indicator_key: `chat-indicator.${string}`]: any;
-    [time_control_key: `time_control.${string}`]: any;
-    [pm_key: `pm.${string}`]: any;
-    [player_notes_key: `player-notes.${string}`]: any;
-    [learning_hub_key: `learning-hub.${string}`]: any;
-    [moderator_key: `moderator.${string}`]: any;
-    [automatch_key: `automatch.${string}`]: any;
-    [puzzle_key: `puzzle.${string}`]: any;
-    [device_key: `device${string}`]: any;
-    [settings_key: `settings.${string}`]: any;
-    [paginated_table_key: `paginated-table.${string}`]: any;
-    [observed_games_key: `observed-games.${string}`]: any;
-    [announcements_key: `announcements.${string}`]: any; // probably should figure out why these are different
-    [announcement_key: `announcement.${string}`]: any;
-    [challenge_key: `challenge.${string}`]: any;
-    [dismissed_key: `dismissed.${string}`]: any;
-    [demo: `demo.${string}`]: any;
-
-    "last-visited-since-goals-shown": string;
-    "hours-visited-since-goals-shown": number;
-    "table-color-default-on": boolean;
-    "joseki-url": string;
-    "ad-override": boolean;
-    "email-banner-dismissed": boolean;
-    "cached.groups": GroupList;
-    "cached.active_tournaments": ActiveTournamentList;
-    "active-tournament": Announcement;
 }
 
 export enum Replication {
@@ -410,7 +365,6 @@ try {
 
 import ITC from "ITC";
 import { termination_socket } from "sockets";
-import { Announcement } from "src/components/Announcements";
 
 type RemoteStorableValue =
     | number

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -23,15 +23,32 @@
 import { GroupList, ActiveTournamentList } from "./types";
 import { Announcement } from "src/components/Announcements";
 
-export interface DataSchema {
+interface CachedSchema {
+    groups: GroupList;
+    active_tournaments: ActiveTournamentList;
+
+    // TODO: examine these endpoints and write interfaces for these.
+    config: any /* /login */;
+    ladders: any /* /me/ladders */;
+    challenge_list: any /* /me/challenges */;
+    blocks: any /* /me/blocks */;
+    friends: any /* ui/friends */;
+    group_invitations: any /* me/groups/invitations */;
+}
+
+type Prefixed<T, P extends string> = {
+    [K in keyof T as K extends string ? `${P}.${K}` : never]: T[K];
+};
+
+export interface DataSchema extends Prefixed<CachedSchema, "cached"> {
     user: any;
     bid: string;
     theme: string;
     debug: boolean;
 
+    cached: CachedSchema;
+
     // TODO: make a types for each of these that list the keys explicitly
-    cached: any;
-    [cached_key: `cached.${string}`]: any;
     config: any;
     [config_key: `config.${string}`]: any;
     [chat_key: `chat.${string}`]: any;
@@ -63,7 +80,5 @@ export interface DataSchema {
     "joseki-url": string;
     "ad-override": boolean;
     "email-banner-dismissed": boolean;
-    "cached.groups": GroupList;
-    "cached.active_tournaments": ActiveTournamentList;
     "active-tournament": Announcement;
 }

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -50,6 +50,10 @@ export interface ConfigSchema {
     user_jwt: string;
     stripe_pk: string;
     chat_auth: string;
+    superchat_auth: string;
+    notification_auth: string;
+    incident_auth: string;
+    aga_rankings_enabled: boolean;
 }
 
 /**
@@ -79,6 +83,7 @@ export interface DataSchema
     config: Partial<ConfigSchema>;
 
     // TODO: make a types for each of these that list the keys explicitly
+    // See commits e12715b and 43c5993 for examples of how to do this.
     [chat_key: `chat.${string}`]: any;
     [sound_key: `sound.${string}`]: any;
     [preferences_key: `preferences.${string}`]: any;

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -28,7 +28,7 @@ interface CachedSchema {
     active_tournaments: ActiveTournamentList;
 
     // TODO: examine these endpoints and write interfaces for these.
-    config: any /* /login */;
+    config: ConfigSchema /* /login */;
     ladders: any /* /me/ladders */;
     challenge_list: any /* /me/challenges */;
     blocks: any /* /me/blocks */;
@@ -36,21 +36,49 @@ interface CachedSchema {
     group_invitations: any /* me/groups/invitations */;
 }
 
+export interface ConfigSchema {
+    user: any;
+    cdn: string;
+    cdn_release: string;
+    cdn_host: string;
+    release: string;
+    version: string;
+    paypal_server: string;
+    paypal_this_server: string;
+    paypal_email: string;
+    billing_mor_locations: string[];
+    user_jwt: string;
+    stripe_pk: string;
+    chat_auth: string;
+}
+
+/**
+ * Prefixes every member of a type.
+ *
+ * Example:
+ *
+ * type fooType = Prefixed<{ bar: string; qux: number }, "foo">;
+ *
+ * is equivalent to
+ *
+ * type fooType = { "foo.bar": string; "foo.qux": number };
+ */
 type Prefixed<T, P extends string> = {
     [K in keyof T as K extends string ? `${P}.${K}` : never]: T[K];
 };
 
-export interface DataSchema extends Prefixed<CachedSchema, "cached"> {
+export interface DataSchema
+    extends Prefixed<CachedSchema, "cached">,
+        Prefixed<ConfigSchema, "config"> {
     user: any;
     bid: string;
     theme: string;
     debug: boolean;
 
-    cached: CachedSchema;
+    cached: Partial<CachedSchema>;
+    config: Partial<ConfigSchema>;
 
     // TODO: make a types for each of these that list the keys explicitly
-    config: any;
-    [config_key: `config.${string}`]: any;
     [chat_key: `chat.${string}`]: any;
     [sound_key: `sound.${string}`]: any;
     [preferences_key: `preferences.${string}`]: any;

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is the schema for the data functions (e.g. get(), set()).  It defines
+ * all the possible keys as well as the associated value types.
+ */
+
+import { GroupList, ActiveTournamentList } from "./types";
+import { Announcement } from "src/components/Announcements";
+
+export interface DataSchema {
+    user: any;
+    bid: string;
+    theme: string;
+    debug: boolean;
+
+    // TODO: make a types for each of these that list the keys explicitly
+    cached: any;
+    [cached_key: `cached.${string}`]: any;
+    config: any;
+    [config_key: `config.${string}`]: any;
+    [chat_key: `chat.${string}`]: any;
+    [sound_key: `sound.${string}`]: any;
+    [preferences_key: `preferences.${string}`]: any;
+    [custom_key: `custom.${string}`]: any;
+    [chat_manager_key: `chat-manager.${string}`]: any;
+    [chat_indicator_key: `chat-indicator.${string}`]: any;
+    [time_control_key: `time_control.${string}`]: any;
+    [pm_key: `pm.${string}`]: any;
+    [player_notes_key: `player-notes.${string}`]: any;
+    [learning_hub_key: `learning-hub.${string}`]: any;
+    [moderator_key: `moderator.${string}`]: any;
+    [automatch_key: `automatch.${string}`]: any;
+    [puzzle_key: `puzzle.${string}`]: any;
+    [device_key: `device${string}`]: any;
+    [settings_key: `settings.${string}`]: any;
+    [paginated_table_key: `paginated-table.${string}`]: any;
+    [observed_games_key: `observed-games.${string}`]: any;
+    [announcements_key: `announcements.${string}`]: any; // probably should figure out why these are different
+    [announcement_key: `announcement.${string}`]: any;
+    [challenge_key: `challenge.${string}`]: any;
+    [dismissed_key: `dismissed.${string}`]: any;
+    [demo: `demo.${string}`]: any;
+
+    "last-visited-since-goals-shown": string;
+    "hours-visited-since-goals-shown": number;
+    "table-color-default-on": boolean;
+    "joseki-url": string;
+    "ad-override": boolean;
+    "email-banner-dismissed": boolean;
+    "cached.groups": GroupList;
+    "cached.active_tournaments": ActiveTournamentList;
+    "active-tournament": Announcement;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -149,6 +149,7 @@ import { toast } from "toast";
 import cached from "cached";
 import * as moment from "moment";
 import swal from "sweetalert2";
+import { ConfigSchema } from "data_schema";
 
 import "debug";
 
@@ -163,10 +164,10 @@ data.watch(cached.config, (config) => {
      * that are depending on other parts of the config will fire without
      * having up to date information (in particular user / auth stuff) */
     for (const key in config) {
-        data.setWithoutEmit(`config.${key}`, config[key]);
+        data.setWithoutEmit(`config.${key as keyof ConfigSchema}`, config[key]);
     }
     for (const key in config) {
-        data.set(`config.${key}`, config[key]);
+        data.set(`config.${key as keyof ConfigSchema}`, config[key]);
     }
 });
 

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -257,8 +257,8 @@ export class GroupList extends React.PureComponent<{}, any> {
     }
 
     componentDidMount() {
-        data.watch(cached.groups, this.updateGroups);
-        data.watch(cached.group_invitations, this.updateGroupInvitations);
+        data.watch(cached.groups as any, this.updateGroups);
+        data.watch(cached.group_invitations as any, this.updateGroupInvitations);
     }
 
     updateGroups = (groups) => {
@@ -269,8 +269,8 @@ export class GroupList extends React.PureComponent<{}, any> {
     };
 
     componentWillUnmount() {
-        data.unwatch(cached.groups, this.updateGroups);
-        data.unwatch(cached.group_invitations, this.updateGroupInvitations);
+        data.unwatch(cached.groups as any, this.updateGroups);
+        data.unwatch(cached.group_invitations as any, this.updateGroupInvitations);
     }
     acceptInvite(invite) {
         post("me/groups/invitations", { request_id: invite.id })

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -257,8 +257,8 @@ export class GroupList extends React.PureComponent<{}, any> {
     }
 
     componentDidMount() {
-        data.watch(cached.groups as any, this.updateGroups);
-        data.watch(cached.group_invitations as any, this.updateGroupInvitations);
+        data.watch(cached.groups, this.updateGroups);
+        data.watch(cached.group_invitations, this.updateGroupInvitations);
     }
 
     updateGroups = (groups) => {
@@ -269,8 +269,8 @@ export class GroupList extends React.PureComponent<{}, any> {
     };
 
     componentWillUnmount() {
-        data.unwatch(cached.groups as any, this.updateGroups);
-        data.unwatch(cached.group_invitations as any, this.updateGroupInvitations);
+        data.unwatch(cached.groups, this.updateGroups);
+        data.unwatch(cached.group_invitations, this.updateGroupInvitations);
     }
     acceptInvite(invite) {
         post("me/groups/invitations", { request_id: invite.id })


### PR DESCRIPTION
`data` seems to be responsible for a lot of the missing types in the code base.  #1564 was an attempt to fix this by inferring types from the provided default value.  There are three problems with this approach:

1) Types were widened in some cases when they shouldn't be:

```
const tc = data.get("time_control.system", "fischer" as TimeControlSystem);
// tc now has type string, not TimeControlSystem
```

This could be fixed by removing type widening, but then the behavior could also be confusing:

```
const tc = data.get("time_control.system", "fischer");
// tc now has type "fischer", not TimeControlSystem or string
```

2) Types are not checked for consistency across separate calls:

```
data.set("foo", "bar");
const foo: number = data.get("foo", 8); // not good, but legal
```

3) A default value or template argument may not be provided at all!

```
const user = data.get("user"); 
// user now has type any
```

This PR is a proposal to make `data` more typesafe.

## Proposed Changes

  - Add `data_schema.ts` to document and enforce the types that get saved in `data.ts`.
  - Update the function signatures in `data.ts` to use the schema.
  - Changed some concatenated strings to template literals, because TS had a hard time picking up prefixes in the concatenated strings.