### PR TITLE
Moderator rengo team management

### DIFF
--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
@@ -26,6 +26,7 @@ type Challenge = socket_api.seekgraph_global.Challenge;
 interface RengoTeamManagementPaneProps {
     challenge_list: Challenge[];
     challenge_id: number;
+    moderator: boolean;
     assignToTeam: (player_id: number, team: string, challenge: Challenge, done: () => void) => void;
 }
 
@@ -92,7 +93,7 @@ export class RengoTeamManagementPane extends React.PureComponent<
                     )}
                     {black_team.map((n, i) => (
                         <div className="rengo-assignment-row" key={i}>
-                            {(the_challenge.user_challenge || null) && (
+                            {(the_challenge.user_challenge || this.props.moderator || null) && (
                                 <React.Fragment>
                                     <i
                                         className="fa fa-lg fa-times-circle-o unassign"
@@ -124,7 +125,7 @@ export class RengoTeamManagementPane extends React.PureComponent<
                     )}
                     {white_team.map((n, i) => (
                         <div className="rengo-assignment-row" key={i}>
-                            {(the_challenge.user_challenge || null) && (
+                            {(the_challenge.user_challenge || this.props.moderator || null) && (
                                 <React.Fragment>
                                     <i
                                         className="fa fa-lg fa-times-circle-o unassign"
@@ -156,7 +157,7 @@ export class RengoTeamManagementPane extends React.PureComponent<
                     )}
                     {nominees.map((n, i) => (
                         <div className="rengo-assignment-row" key={i}>
-                            {(the_challenge.user_challenge || null) && (
+                            {(the_challenge.user_challenge || this.props.moderator || null) && (
                                 <React.Fragment>
                                     <i
                                         className="fa fa-lg fa-arrow-up black"

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -685,6 +685,8 @@ export class Play extends React.Component<{}, PlayState> {
 
         const rengo_challenge_to_show = own_live_rengo_challenge || joined_live_rengo_challenge;
 
+        const user = data.get("user");
+
         //  Construction of the pane we need to show...
         if (automatch_manager.active_live_automatcher) {
             return (
@@ -733,7 +735,7 @@ export class Play extends React.Component<{}, PlayState> {
                         </div>
                     </div>
                     <RengoManagementPane
-                        user={data.get("user")}
+                        user={user}
                         challenge_id={rengo_challenge_to_show.challenge_id}
                         rengo_challenge_list={this.state.rengo_list}
                         startRengoChallenge={this.startOwnRengoChallenge}
@@ -744,6 +746,7 @@ export class Play extends React.Component<{}, PlayState> {
                         <RengoTeamManagementPane
                             challenge_id={rengo_challenge_to_show.challenge_id}
                             challenge_list={this.state.rengo_list}
+                            moderator={user.is_moderator}
                             assignToTeam={this.assignToTeam}
                         />
                     </RengoManagementPane>
@@ -1219,6 +1222,7 @@ export class Play extends React.Component<{}, PlayState> {
                             <RengoTeamManagementPane
                                 challenge_id={C.challenge_id}
                                 challenge_list={this.state.rengo_list}
+                                moderator={user.is_moderator}
                                 assignToTeam={this.assignToTeam}
                             />
                         </RengoManagementPane>


### PR DESCRIPTION
Fixes moderators being unable to start games that inadvertently got the same player on both teams, and being unable in general to assist with team makeup.

## Proposed Changes

Make team management controls available to moderators.

