### PR TITLE
Open correspondence rengo management pane on challenge creation

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,13 @@ export interface AutomatchPreferencesBase {
     };
 }
 
+// Payload of the ChallengeModal `created()` callback
+export interface ChallengeDetails {
+    challenge_id: number;
+    rengo: boolean;
+    live: boolean;
+}
+
 // Many times an id is a number, but it doesn't matter if it is a string as
 // far as the code is concerned.  Example:
 //


### PR DESCRIPTION
Fixes possibility of newbies not even realising they need to open that pane.

## Proposed Changes

  "Challenge created" callback in ChallengeModal, allowing Play to open the management pan.=e