### PR TITLE
Game history rengo merge

### DIFF
--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -308,6 +308,9 @@ export interface EffectiveOutcome {
     white_effective_stronger: boolean;
 }
 
+/**
+ * @returns a ratings object containing ratings adjusted for the handicap.
+ */
 export function effective_outcome(
     black_rating: number,
     white_rating: number,

--- a/src/models/games.d.ts
+++ b/src/models/games.d.ts
@@ -15,6 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 declare namespace rest_api {
+    /**
+     * One element of `results` from `player/%player_id%/games`
+     *
+     * This is a work in progress. Trust these values at your own risk.
+     * */
     interface Game {
         related: {
             detail: string; // route to full game info
@@ -38,7 +43,7 @@ declare namespace rest_api {
         komi: string; // floating point number
         time_control: import("../components/TimeControl").TimeControlTypes.TimeControlSystem;
 
-        // these don't appear to be populated with userful data
+        // these don't appear to be populated with useful data
         black_player_rank: number;
         black_player_rating: string; // floating point number
         white_player_rank: number;
@@ -58,10 +63,13 @@ declare namespace rest_api {
         started: string; // ISODate
         ended: string; // ISODate
         sgf_filename: string | null;
+        // Guaranteed to include the player of interest (even in rengo games)
         historical_ratings: {
             black: import("../lib/player_cache").PlayerCacheEntry;
             white: import("../lib/player_cache").PlayerCacheEntry;
         };
         rengo: boolean;
+        rengo_black_team?: number[];
+        rengo_white_team?: number[];
     }
 }

--- a/src/models/games.d.ts
+++ b/src/models/games.d.ts
@@ -14,37 +14,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-interface Ratings {
-    version: number;
-    overall: {
-        rating: number;
-        deviation: number;
-        volatility: number;
-    };
-}
-
-interface Player {
-    id: number;
-    username: string;
-    /** country code */
-    country: string;
-    /** image url */
-    icon: string;
-    ratings: Ratings;
-    ranking: number;
-    professional: boolean;
-    ui_class: string;
-}
-
 declare namespace rest_api {
     interface Game {
         related: {
             detail: string; // route to full game info
         };
         players: {
-            black: Player;
-            white: Player;
+            black: import("../lib/player_cache").PlayerCacheEntry;
+            white: import("../lib/player_cache").PlayerCacheEntry;
         };
         id: number;
         name: string;
@@ -82,8 +59,8 @@ declare namespace rest_api {
         ended: string; // ISODate
         sgf_filename: string | null;
         historical_ratings: {
-            black: Player;
-            white: Player;
+            black: import("../lib/player_cache").PlayerCacheEntry;
+            white: import("../lib/player_cache").PlayerCacheEntry;
         };
         rengo: boolean;
     }

--- a/src/models/games.d.ts
+++ b/src/models/games.d.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022  Ben Jones
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+interface Ratings {
+    version: number;
+    overall: {
+        rating: number;
+        deviation: number;
+        volatility: number;
+    };
+}
+
+interface Player {
+    id: number;
+    username: string;
+    /** country code */
+    country: string;
+    /** image url */
+    icon: string;
+    ratings: Ratings;
+    ranking: number;
+    professional: boolean;
+    ui_class: string;
+}
+
+declare namespace rest_api {
+    interface Game {
+        related: {
+            detail: string; // route to full game info
+        };
+        players: {
+            black: Player;
+            white: Player;
+        };
+        id: number;
+        name: string;
+        creator: number;
+        mode: "game";
+        source: "play";
+        black: number;
+        white: number;
+        width: number;
+        height: number;
+        rules: import("../lib/types").RuleSet;
+        ranked: boolean;
+        handicap: number;
+        komi: string; // floating point number
+        time_control: import("../components/TimeControl").TimeControlTypes.TimeControlSystem;
+
+        // these don't appear to be populated with userful data
+        black_player_rank: number;
+        black_player_rating: string; // floating point number
+        white_player_rank: number;
+        white_player_rating: string; // floating point number
+
+        time_per_move: number;
+        time_control_parameters: string; // TimeControl
+        disable_analysis: boolean;
+        tournament: number | null;
+        tournament_round: number;
+        ladder: number;
+        pause_on_weekends: boolean;
+        outcome: `${number} points` | "Cancellation" | "Resignation";
+        black_lost: boolean;
+        white_lost: boolean;
+        annulled: boolean;
+        started: string; // ISODate
+        ended: string; // ISODate
+        sgf_filename: string | null;
+        historical_ratings: {
+            black: Player;
+            white: Player;
+        };
+        rengo: boolean;
+    }
+}

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -98,6 +98,12 @@ export function GameHistoryTable(props: GameHistoryProps) {
                 item.player_won = black_won;
             }
 
+            if (r.rengo) {
+                // TODO: replace with a real "2v2" type string, pending api support
+                // currently the API does not give a list of players or even the number of players in the game
+                item.rengo_vs_string = "N/A (Rengo)" as any;
+            }
+
             item.result_class = getResultClass(r, props.user_id);
 
             const speed = getSpeed(r);
@@ -169,12 +175,15 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                               "user_info" + (X && X.annulled ? " annulled" : ""),
                                           render: (X: GG) => (
                                               <React.Fragment>
-                                                  {X.played_black ? (
-                                                      <span>⚫</span>
-                                                  ) : (
-                                                      <span>⚪</span>
-                                                  )}
-                                                  {maskedRank(`[${rankString(X.player)}]`)}
+                                                  <span>
+                                                      {X.played_black == null
+                                                          ? "❓" // Some rengo games don't tell us which team the user is on. Needs backend fix.
+                                                          : X.played_black
+                                                          ? "⚫"
+                                                          : "⚪"}
+                                                  </span>
+                                                  {X.played_black != null &&
+                                                      maskedRank(`[${rankString(X.player)}]`)}
                                               </React.Fragment>
                                           ),
                                       },
@@ -201,7 +210,14 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                           className: (X: GG) =>
                                               "player" + (X && X.annulled ? " annulled" : ""),
                                           render: (X: GG) => (
-                                              <Player user={X.opponent} disableCacheUpdate />
+                                              <>
+                                                  {X.rengo_vs_string || (
+                                                      <Player
+                                                          user={X.opponent}
+                                                          disableCacheUpdate
+                                                      />
+                                                  )}
+                                              </>
                                           ),
                                       },
                                       {

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -29,16 +29,37 @@ import { Player } from "Player";
 import { Link } from "react-router-dom";
 import { interpolate } from "translate";
 import * as preferences from "preferences";
+import { PlayerCacheEntry } from "src/lib/player_cache";
+import { TimeControl } from "src/components/TimeControl";
 
 interface GameHistoryProps {
     user_id: number;
+}
+/** Groomed game */
+interface GG {
+    annulled: boolean;
+    played_black: boolean;
+    player: PlayerCacheEntry;
+    player_won: boolean;
+    date: Date;
+    opponent: PlayerCacheEntry;
+    speed_icon_class: `speed-icon ${string}`;
+    speed: "Correspondence" | "Blitz" | "Live";
+    width: number;
+    height: number;
+    href: `/game/${number}`;
+    name: string;
+    black: PlayerCacheEntry;
+    white: PlayerCacheEntry;
+    result_class: `library-${"won" | "lost"}-result-vs-${"stronger" | "weaker"}`;
+    result: JSX.Element;
 }
 
 export function GameHistoryTable(props: GameHistoryProps) {
     const [player_filter, setPlayerFilter] = React.useState<number>(null);
     const [show_rengo, setShowRengo] = React.useState<boolean>(false);
 
-    function game_history_groomer(results) {
+    function game_history_groomer(results: rest_api.Game[]): GG[] {
         const ret = [];
         for (let i = 0; i < results.length; ++i) {
             const r = results[i];
@@ -120,7 +141,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
             }
 
             if ("time_control_parameters" in r) {
-                const tcp = JSON.parse(r.time_control_parameters);
+                const tcp = JSON.parse(r.time_control_parameters) as TimeControl;
                 if (tcp && "speed" in tcp) {
                     item.speed = tcp.speed[0].toUpperCase() + tcp.speed.slice(1); // capitalize string
                 }
@@ -208,9 +229,9 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 ? [
                                       {
                                           header: _("User"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "user_info" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => (
+                                          render: (X: GG) => (
                                               <React.Fragment>
                                                   {X.played_black ? (
                                                       <span>⚫</span>
@@ -223,10 +244,10 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                       },
                                       {
                                           header: _(""),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "winner_marker" +
                                               (X && X.annulled ? " annulled" : ""),
-                                          render: (X) =>
+                                          render: (X: GG) =>
                                               X.player_won ? (
                                                   <i className="fa fa-trophy game-history-winner" />
                                               ) : (
@@ -235,37 +256,37 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                       },
                                       {
                                           header: _("Date"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "date" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => moment(X.date).format("YYYY-MM-DD"),
+                                          render: (X: GG) => moment(X.date).format("YYYY-MM-DD"),
                                       },
                                       {
                                           header: _("Opponent"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "player" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => (
+                                          render: (X: GG) => (
                                               <Player user={X.opponent} disableCacheUpdate />
                                           ),
                                       },
                                       {
                                           header: _(""),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "speed" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => (
+                                          render: (X: GG) => (
                                               <i className={X.speed_icon_class} title={X.speed} />
                                           ),
                                       },
                                       {
                                           header: _("Size"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "board_size" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => `${X.width}x${X.height}`,
+                                          render: (X: GG) => `${X.width}x${X.height}`,
                                       },
                                       {
                                           header: _("Name"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "game_name" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => (
+                                          render: (X: GG) => (
                                               <Link to={X.href}>
                                                   {X.name ||
                                                       interpolate(
@@ -280,11 +301,11 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                       },
                                       {
                                           header: _("Result"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               X
                                                   ? X.result_class + (X.annulled ? " annulled" : "")
                                                   : "",
-                                          render: (X) => X.result,
+                                          render: (X: GG) => X.result,
                                       },
                                   ]
                                 : []),
@@ -293,48 +314,48 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 ? [
                                       {
                                           header: _("-"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "user_info" + (X && X.annulled ? " annulled" : ""),
                                           render: () => "",
                                       },
                                       {
                                           header: _(""),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "winner_marker" +
                                               (X && X.annulled ? " annulled" : ""),
                                           render: () => "",
                                       },
                                       {
                                           header: _("Date"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "date" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => moment(X.date).format("YYYY-MM-DD"),
+                                          render: (X: GG) => moment(X.date).format("YYYY-MM-DD"),
                                       },
                                       {
                                           header: _("-"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "player" + (X && X.annulled ? " annulled" : ""),
                                           render: () => "",
                                       },
                                       {
                                           header: _(""),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "speed" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => (
+                                          render: (X: GG) => (
                                               <i className={X.speed_icon_class} title={X.speed} />
                                           ),
                                       },
                                       {
                                           header: _("Size"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "board_size" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => `${X.width}x${X.height}`,
+                                          render: (X: GG) => `${X.width}x${X.height}`,
                                       },
                                       {
                                           header: _("Name"),
-                                          className: (X) =>
+                                          className: (X: GG) =>
                                               "game_name" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => (
+                                          render: (X: GG) => (
                                               <Link to={X.href}>
                                                   {X.name ||
                                                       interpolate(
@@ -349,8 +370,9 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                       },
                                       {
                                           header: _("Result"),
-                                          className: (X) => (X && X.annulled ? " annulled" : ""),
-                                          render: (X) => X.result,
+                                          className: (X: GG) =>
+                                              X && X.annulled ? " annulled" : "",
+                                          render: (X: GG) => X.result,
                                       },
                                   ]
                                 : []),

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -64,7 +64,6 @@ interface GG {
 
 export function GameHistoryTable(props: GameHistoryProps) {
     const [player_filter, setPlayerFilter] = React.useState<number>(null);
-    const [show_rengo, setShowRengo] = React.useState<boolean>(false);
 
     function game_history_groomer(results: rest_api.Game[]): GG[] {
         const ret = [];
@@ -140,14 +139,6 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 }}
                             />
                         </div>
-                        <div className="rengo-selector">
-                            <span>{_("Rengo")}</span>
-                            <input
-                                type="checkbox"
-                                checked={show_rengo}
-                                onChange={() => setShowRengo(!show_rengo)}
-                            />
-                        </div>
                     </div>
                     <PaginatedTable
                         className="game-history-table"
@@ -160,174 +151,94 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             ...(player_filter !== null && {
                                 alt_player: player_filter,
                             }),
-                            rengo: show_rengo,
                         }}
                         orderBy={["-ended"]}
                         groom={game_history_groomer}
                         onRowClick={(ref, ev) => openUrlIfALinkWasNotClicked(ev, ref.href)}
                         columns={[
-                            // normal table layout ...
-                            ...(!show_rengo
-                                ? [
-                                      {
-                                          header: _("User"),
-                                          className: (X: GG) =>
-                                              "user_info" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => (
-                                              <React.Fragment>
-                                                  <span>
-                                                      {X.played_black == null
-                                                          ? "❓" // Some rengo games don't tell us which team the user is on. Needs backend fix.
-                                                          : X.played_black
-                                                          ? "⚫"
-                                                          : "⚪"}
-                                                  </span>
-                                                  {X.played_black != null &&
-                                                      maskedRank(`[${rankString(X.player)}]`)}
-                                              </React.Fragment>
-                                          ),
-                                      },
-                                      {
-                                          header: _(""),
-                                          className: (X: GG) =>
-                                              "winner_marker" +
-                                              (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) =>
-                                              X.player_won ? (
-                                                  <i className="fa fa-trophy game-history-winner" />
-                                              ) : (
-                                                  ""
-                                              ),
-                                      },
-                                      {
-                                          header: _("Date"),
-                                          className: (X: GG) =>
-                                              "date" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => moment(X.date).format("YYYY-MM-DD"),
-                                      },
-                                      {
-                                          header: _("Opponent"),
-                                          className: (X: GG) =>
-                                              "player" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => (
-                                              <>
-                                                  {X.rengo_vs_string || (
-                                                      <Player
-                                                          user={X.opponent}
-                                                          disableCacheUpdate
-                                                      />
-                                                  )}
-                                              </>
-                                          ),
-                                      },
-                                      {
-                                          header: _(""),
-                                          className: (X: GG) =>
-                                              "speed" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => (
-                                              <i className={X.speed_icon_class} title={X.speed} />
-                                          ),
-                                      },
-                                      {
-                                          header: _("Size"),
-                                          className: (X: GG) =>
-                                              "board_size" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => `${X.width}x${X.height}`,
-                                      },
-                                      {
-                                          header: _("Name"),
-                                          className: (X: GG) =>
-                                              "game_name" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => (
-                                              <Link to={X.href}>
-                                                  {X.name ||
-                                                      interpolate(
-                                                          "{{black_username}} vs. {{white_username}}",
-                                                          {
-                                                              black_username: X.black.username,
-                                                              white_username: X.white.username,
-                                                          },
-                                                      )}
-                                              </Link>
-                                          ),
-                                      },
-                                      {
-                                          header: _("Result"),
-                                          className: (X: GG) =>
-                                              X
-                                                  ? X.result_class + (X.annulled ? " annulled" : "")
-                                                  : "",
-                                          render: (X: GG) => X.result,
-                                      },
-                                  ]
-                                : []),
-                            // .. and brute force hiding things that are too hard for a quick implemetation for rengo :o  ...
-                            ...(show_rengo
-                                ? [
-                                      {
-                                          header: _("-"),
-                                          className: (X: GG) =>
-                                              "user_info" + (X && X.annulled ? " annulled" : ""),
-                                          render: () => "",
-                                      },
-                                      {
-                                          header: _(""),
-                                          className: (X: GG) =>
-                                              "winner_marker" +
-                                              (X && X.annulled ? " annulled" : ""),
-                                          render: () => "",
-                                      },
-                                      {
-                                          header: _("Date"),
-                                          className: (X: GG) =>
-                                              "date" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => moment(X.date).format("YYYY-MM-DD"),
-                                      },
-                                      {
-                                          header: _("-"),
-                                          className: (X: GG) =>
-                                              "player" + (X && X.annulled ? " annulled" : ""),
-                                          render: () => "",
-                                      },
-                                      {
-                                          header: _(""),
-                                          className: (X: GG) =>
-                                              "speed" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => (
-                                              <i className={X.speed_icon_class} title={X.speed} />
-                                          ),
-                                      },
-                                      {
-                                          header: _("Size"),
-                                          className: (X: GG) =>
-                                              "board_size" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => `${X.width}x${X.height}`,
-                                      },
-                                      {
-                                          header: _("Name"),
-                                          className: (X: GG) =>
-                                              "game_name" + (X && X.annulled ? " annulled" : ""),
-                                          render: (X: GG) => (
-                                              <Link to={X.href}>
-                                                  {X.name ||
-                                                      interpolate(
-                                                          "{{black_username}} vs. {{white_username}}",
-                                                          {
-                                                              black_username: X.black.username,
-                                                              white_username: X.white.username,
-                                                          },
-                                                      )}
-                                              </Link>
-                                          ),
-                                      },
-                                      {
-                                          header: _("Result"),
-                                          className: (X: GG) =>
-                                              X && X.annulled ? " annulled" : "",
-                                          render: (X: GG) => X.result,
-                                      },
-                                  ]
-                                : []),
+                            {
+                                header: _("User"),
+                                className: (X: GG) =>
+                                    "user_info" + (X && X.annulled ? " annulled" : ""),
+                                render: (X: GG) => (
+                                    <React.Fragment>
+                                        <span>
+                                            {X.played_black == null
+                                                ? "❓" // Some rengo games don't tell us which team the user is on. Needs backend fix.
+                                                : X.played_black
+                                                ? "⚫"
+                                                : "⚪"}
+                                        </span>
+                                        {X.played_black != null &&
+                                            maskedRank(`[${rankString(X.player)}]`)}
+                                    </React.Fragment>
+                                ),
+                            },
+                            {
+                                header: _(""),
+                                className: (X: GG) =>
+                                    "winner_marker" + (X && X.annulled ? " annulled" : ""),
+                                render: (X: GG) =>
+                                    X.player_won ? (
+                                        <i className="fa fa-trophy game-history-winner" />
+                                    ) : (
+                                        ""
+                                    ),
+                            },
+                            {
+                                header: _("Date"),
+                                className: (X: GG) => "date" + (X && X.annulled ? " annulled" : ""),
+                                render: (X: GG) => moment(X.date).format("YYYY-MM-DD"),
+                            },
+                            {
+                                header: _("Opponent"),
+                                className: (X: GG) =>
+                                    "player" + (X && X.annulled ? " annulled" : ""),
+                                render: (X: GG) => (
+                                    <>
+                                        {X.rengo_vs_string || (
+                                            <Player user={X.opponent} disableCacheUpdate />
+                                        )}
+                                    </>
+                                ),
+                            },
+                            {
+                                header: _(""),
+                                className: (X: GG) =>
+                                    "speed" + (X && X.annulled ? " annulled" : ""),
+                                render: (X: GG) => (
+                                    <i className={X.speed_icon_class} title={X.speed} />
+                                ),
+                            },
+                            {
+                                header: _("Size"),
+                                className: (X: GG) =>
+                                    "board_size" + (X && X.annulled ? " annulled" : ""),
+                                render: (X: GG) => `${X.width}x${X.height}`,
+                            },
+                            {
+                                header: _("Name"),
+                                className: (X: GG) =>
+                                    "game_name" + (X && X.annulled ? " annulled" : ""),
+                                render: (X: GG) => (
+                                    <Link to={X.href}>
+                                        {X.name ||
+                                            interpolate(
+                                                "{{black_username}} vs. {{white_username}}",
+                                                {
+                                                    black_username: X.black.username,
+                                                    white_username: X.white.username,
+                                                },
+                                            )}
+                                    </Link>
+                                ),
+                            },
+                            {
+                                header: _("Result"),
+                                className: (X: GG) =>
+                                    X ? X.result_class + (X.annulled ? " annulled" : "") : "",
+                                render: (X: GG) => X.result,
+                            },
                         ]}
                     />
                 </div>


### PR DESCRIPTION
Implements https://forums.online-go.com/t/rengo-status/40415/483

## Proposed Changes

  - Refactor game_history_groomer: this function was really long (120 lines!), so I broke out some logical functions.  It's still pretty long but now it's half the length and fits on one "page".
  - Make the normal columns handle rengo games (sort of)
  - Remove the rengo-specific table
  - Add some types to the Game History table

## Notes

I could use some API support:

- player lists or at least number of players for rengo matches
- ~~Fix the game result fields (black_lost, white_lost)~~ i hear a fix is in flight :)
- include the player whose page we are on in the `game.players` and `game.historical_ratings` (currently it just picks a player at random from each team?)

<img width="858" alt="Screen Shot 2022-02-05 at 12 58 20 AM" src="https://user-images.githubusercontent.com/25233703/152635986-555052b8-6c95-4f85-9ac2-f17e04273583.png">

(screenshot from [Sophiam's page](https://beta.online-go.com/player/1775))
