### PR TITLE
Allow rengo auto handicap option in ChallengeModal

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1144,7 +1144,6 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                                         className="challenge-dropdown form-control"
                                     >
                                         <option
-                                            disabled={challenge.game.rengo}
                                             value="-1"
                                             /*{disabled={!this.state.conf.handicap_enabled}}*/
                                         >


### PR DESCRIPTION
Fixes players feeling that their rengo games are uneven and they can't do much about it.

## Proposed Changes

In the client, let them select auto.  Needs the corresponding back-end PR to do the calculation.