### PR TITLE
Added "shift-X" keyboard shortcuts for analysis in Game view

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -4191,7 +4191,6 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
                 <KBShortcut shortcut="home" action={this.nav_first} />
                 <KBShortcut shortcut="end" action={this.nav_last} />
                 <KBShortcut shortcut="escape" action={this.handleEscapeKey} />
-
                 <KBShortcut shortcut="f1" action={this.set_analyze_tool.stone_null} />
                 <KBShortcut shortcut="f2" action={this.set_analyze_tool.stone_black} />
                 {/* <KBShortcut shortcut='f3' action='console.log("Should be entering scoring mode");'></KBShortcut> */}
@@ -4207,6 +4206,13 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
                     <KBShortcut shortcut="f10" action={this.set_analyze_tool.clear_and_sync} />
                 )}
                 <KBShortcut shortcut="del" action={this.set_analyze_tool.delete_branch} />
+                <KBShortcut shortcut="shift-z" action={this.toggleZenMode} />
+                <KBShortcut shortcut="shift-c" action={this.toggleCoordinates} />
+                <KBShortcut shortcut="shift-i" action={this.toggleAIReview} />
+                <KBShortcut shortcut="shift-a" action={this.gameAnalyze} />
+                <KBShortcut shortcut="shift-r" action={this.startReview} />
+                <KBShortcut shortcut="shift-e" action={this.estimateScore} />
+                <KBShortcut shortcut="shift-p" action={this.goban_setModeDeferredPlay} />
             </div>
         );
     }


### PR DESCRIPTION
Quality of life improvement for in-game/after-game analysis: i.e., keyboard shortcuts

## Proposed Changes

  - Add "shift-X" shortcuts for some options in the Game view Dock and for starting/stopping Analyze mode
  - These shortcuts are...
    - "Zen mode" : Shift-z
    - "Toggle coordinates" : Shift-c
    - **"Enable/Disable AI review" : Shift-i**
    - "Analyze game" : Shift-a
    - "Review this game" : Shift-r
    - "Estimate score" : Shift-e
    - "Back to Game" : Shift-p

## Notes

  - I became a site supporter recently and am using the AI analysis a lot after my games.  I noticed I really wanted the ability to toggle it on and off easily: for each move I like to try to figure out what the correct move would have been, and then I reference AI each time.
  - Navigating my mouse to the "Disable AI review" and "Enable AI review" button in the Dock takes too much mental energy for me.
  - I checked https://ogs.readme.io/docs/reviews-and-demos#keyboard-shortcuts and also didn't find this in the open Issues on GitHub so I decided to see if I could add it myself :D 
  - I tried adding "shift-X" shortcuts for the majority of the options in the Dock, but things like "Game information", "Fork game", and "Link to game" seem to open modals which, with this simple implementation, would open on top of each other if the shortcuts were executed in succession without closing them.

## TL;DR
  - The main shortcut I am interested in is "Enable/Disable AI review" but I thought these other analysis shortcuts would be nice as well.  This is my first time making a PR to a public codebase like this–please lmk if I missed a step in the process or something!