### PR TITLE
TimeControlPicker.tsx: sanitize value of numeric inputs

### DIFF
--- a/src/components/TimeControl/TimeControlPicker.tsx
+++ b/src/components/TimeControl/TimeControlPicker.tsx
@@ -484,7 +484,7 @@ export class TimeControlPicker extends React.PureComponent<
                                     min="1"
                                     max="300"
                                     className="challenge-dropdown form-control"
-                    value={(this.state as TimeControlTypes.ByoYomi).periods || 1}
+                                    value={(this.state as TimeControlTypes.ByoYomi).periods || 1}
                                     onChange={this.update_periods}
                                 />
                             </div>
@@ -545,7 +545,8 @@ export class TimeControlPicker extends React.PureComponent<
                                     max="50"
                                     className="challenge-dropdown form-control"
                                     value={
-                                        (this.state as TimeControlTypes.Canadian).stones_per_period || 1
+                                        (this.state as TimeControlTypes.Canadian)
+                                            .stones_per_period || 1
                                     }
                                     onChange={this.update_stones_per_period}
                                 />

--- a/src/components/TimeControl/TimeControlPicker.tsx
+++ b/src/components/TimeControl/TimeControlPicker.tsx
@@ -484,7 +484,7 @@ export class TimeControlPicker extends React.PureComponent<
                                     min="1"
                                     max="300"
                                     className="challenge-dropdown form-control"
-                                    value={(this.state as TimeControlTypes.ByoYomi).periods}
+                                    value={(this.state as TimeControlTypes.ByoYomi).periods || 1}
                                     onChange={this.update_periods}
                                 />
                             </div>
@@ -545,7 +545,7 @@ export class TimeControlPicker extends React.PureComponent<
                                     max="50"
                                     className="challenge-dropdown form-control"
                                     value={
-                                        (this.state as TimeControlTypes.Canadian).stones_per_period
+                                        (this.state as TimeControlTypes.Canadian).stones_per_period || 1
                                     }
                                     onChange={this.update_stones_per_period}
                                 />

--- a/src/components/TimeControl/TimeControlPicker.tsx
+++ b/src/components/TimeControl/TimeControlPicker.tsx
@@ -194,7 +194,7 @@ export class TimeControlPicker extends React.PureComponent<
     update_period_time = (ev) => this.syncTimeControl({ period_time: parseInt(ev.target.value) });
     update_periods = (ev) =>
         this.syncTimeControl({
-            periods: Math.max(1, Math.min(300, parseInt(ev.target.value) || 1)),
+            periods: parseInt(ev.target.value),
         });
     //update_period_time          = (ev)=>this.syncTimeControl({period_time: ev.target.value});
     update_stones_per_period = (ev) =>
@@ -484,7 +484,7 @@ export class TimeControlPicker extends React.PureComponent<
                                     min="1"
                                     max="300"
                                     className="challenge-dropdown form-control"
-                                    value={(this.state as TimeControlTypes.ByoYomi).periods || 1}
+                    value={(this.state as TimeControlTypes.ByoYomi).periods || 1}
                                     onChange={this.update_periods}
                                 />
                             </div>


### PR DESCRIPTION
Fixes #1628 

## Proposed Changes
 
  - Sanitize values of numeric input fields so that they match the min value if the stored value is falsy.
 
In fact the bug exists on both Canadian and byo-yomi rules. Hopefully the back-end blocks invalid Canadian challenges.

The point here is also starting a discussion on what is the best fix. 
Sanitizing all values in the localstorage before use seems to be a much better fix, but it is a much bigger change and we could also argue that its content is valid since we wrote it... (except when in this precise case).

