### PR TITLE
Add options to save/manage/apply preferred settings for games.

### DIFF
--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -207,6 +207,8 @@ export interface DataSchema
     "announcement.last-type": string;
     "demo.settings": DemoSettings;
 
+    "preferred-game-settings": rest_api.ChallengeDetails[];
+
     [player_notes_key: `player-notes.${number}.${number}`]: string;
     [learning_hub_key: `learning-hub.${string}`]: { [page_number: number]: true };
     [moderator_join_game_publicly_key: `moderator.join-game-publicly.${string}`]: boolean;


### PR DESCRIPTION
## Context
I saw the request for this feature on the forums (https://forums.online-go.com/t/the-possibility-to-save-prefered-settings-for-games/41477). This is also a popular feature request on the iOS app, so I want to get this implemented on the web client first in order to share the data structure with the app later.

I'm a bit hesitant on putting everything on the modal though, since it is a bit too crowded, especially on mobile; but I don't have a better idea for that yet.

## Proposed Changes
- Add options to save, manage, and apply preferred settings to the Challenge Modal (Custom game, direct challenge, computer).
- Preferred settings are stored in the generic data store with `Replication.REMOTE_OVERWRITES_LOCAL`.
<img width="806" alt="Screen Shot 2022-02-18 at 15 42 05" src="https://user-images.githubusercontent.com/1177495/154648580-c99a06f2-af34-4825-9085-d9ed95012f55.png">

