### PR TITLE
Add faster simple correspondence timings.

### DIFF
--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -209,7 +209,7 @@ export const time_options = {
             max_time: gen(86400, 86400 * 28),
         },
         simple: {
-            per_move: gen(3600 * 8, 86400 * 28),
+            per_move: gen(3600 * 12, 86400 * 28),
         },
         canadian: {
             main_time: [zero].concat(gen(86400, 86400 * 28)),

--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -209,7 +209,7 @@ export const time_options = {
             max_time: gen(86400, 86400 * 28),
         },
         simple: {
-            per_move: gen(86400, 86400 * 28),
+            per_move: gen(3600 * 8, 86400 * 28),
         },
         canadian: {
             main_time: [zero].concat(gen(86400, 86400 * 28)),


### PR DESCRIPTION
Rengo has awakened interest in more simple time settings (see forums: https://forums.online-go.com/t/rengo-status/40415/468).

## Proposed Changes

  - Allow simple correspondence to be as fast as 8hr per move.