### PR TITLE
Make sure sorted_players doesn't contain undefined values.

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -2571,9 +2571,10 @@ export class Tournament extends React.PureComponent<TournamentProperties, Tourna
                                             <div>
                                                 {selected_round.groups.map((group, idx) => {
                                                     // (if we had ramda library, we'd use that non-mutating sort instead of this funky spread-copy...)
-                                                    const sorted_players = [...group.players].sort(
-                                                        sortDropoutsToBottom,
-                                                    );
+
+                                                    const sorted_players = [...group.players]
+                                                        .filter((p) => p.player)
+                                                        .sort(sortDropoutsToBottom);
 
                                                     return (
                                                         <div key={idx} className="round-group">


### PR DESCRIPTION
Addresses #1713

I can see the tournament now, but not sure if this is the "right" fix.  The issue is that a couple of the players are no longer returned from the players/%%/players/all endpoint and therefore places that expect a player may get `undefined` instead.  The real question is why aren't these players populated?  They don't appear to be deleted players or anything...

`DavidHall` (id: 527014)  and `DQuad` (id: 371) are the missing players in the tournament from the bug: https://online-go.com/termination-api/tournament/85113/players

Sharing this patch in case it helps debug. (also better than showing nothing 😄)

## Proposed Changes

  - For round robin tournaments, filter out undefined values from the players array.


<details><summary>screenshot</summary>
<img width="613" alt="Screen Shot 2022-02-18 at 6 21 33 PM" src="https://user-images.githubusercontent.com/25233703/154782415-358bb781-c1f3-4277-8243-3c7e9bf1edbf.png">
</details>

