### PR TITLE
Overview.tsx cleanups

### DIFF
--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -41,7 +41,7 @@ interface CachedSchema {
 }
 
 export interface ConfigSchema {
-    user: any;
+    user: rest_api.UserConfig;
     cdn: string;
     cdn_release: string;
     cdn_host: string;

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -41,7 +41,7 @@ interface CachedSchema {
 }
 
 export interface ConfigSchema {
-    user: rest_api.UserConfig;
+    user: any;
     cdn: string;
     cdn_release: string;
     cdn_host: string;

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -33,7 +33,7 @@ interface CachedSchema {
 
     // TODO: examine these endpoints and write interfaces for these.
     config: ConfigSchema /* /login */;
-    ladders: any /* /me/ladders */;
+    ladders: rest_api.me.Ladder[];
     challenge_list: any /* /me/challenges */;
     blocks: any /* /me/blocks */;
     friends: any /* ui/friends */;

--- a/src/models/overview.d.ts
+++ b/src/models/overview.d.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022  Ben Jones
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare namespace rest_api {
+    namespace me {
+        /**
+         * One result from `me/ladders`
+         */
+        interface Ladder {
+            id: number;
+            name: string;
+            board_size: number;
+            group: {
+                id: number;
+                name: string;
+                icon: string; // URL
+            };
+            size: number;
+            player_rank: number;
+            player_is_member_of_group: boolean;
+        }
+    }
+}

--- a/src/models/overview.d.ts
+++ b/src/models/overview.d.ts
@@ -33,5 +33,22 @@ declare namespace rest_api {
             player_rank: number;
             player_is_member_of_group: boolean;
         }
+
+        interface Invitation {
+            id: number;
+            group: {
+                id: number;
+                name: string;
+                summary: string;
+                require_invitation: boolean;
+                is_public: boolean;
+                hide_details: boolean;
+                member_count: number;
+                icon: string; // URL
+            };
+            message: "This is an invitation to join our group!";
+            is_invitation: boolean;
+            user: number;
+        }
     }
 }

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -34,6 +34,7 @@ import { ProfileCard } from "ProfileCard";
 import { notification_manager } from "Notifications";
 import { ActiveAnnouncements } from "Announcements";
 import { FabX } from "material";
+import { ActiveTournamentList } from "src/lib/types";
 
 declare let ogs_missing_translation_count;
 
@@ -303,33 +304,27 @@ export class GroupList extends React.PureComponent<{}, any> {
         );
     }
 }
-export class TournamentList extends React.PureComponent<{}, any> {
-    constructor(props) {
+
+interface TournamentListState {
+    my_tournaments: ActiveTournamentList;
+}
+
+export class TournamentList extends React.PureComponent<{}, TournamentListState> {
+    constructor(props: {}) {
         super(props);
         this.state = {
             my_tournaments: [],
-            open_tournaments: [],
-            resolved: false,
         };
     }
 
     componentDidMount() {
         data.watch(cached.active_tournaments, this.update);
-        /*
-        get("tournaments", {started__isnull: true, group__isnull: true, ordering: "name"}).then((res) => {
-            this.setState({"open_tournaments": res.results, resolved: true});
-        }).catch((err) => {
-            this.setState({resolved: true});
-            console.info("Caught", err);
-        });
-        */
     }
-    update = (tournaments) => {
+    update = (tournaments: ActiveTournamentList) => {
         this.setState({ my_tournaments: tournaments });
     };
 
     componentWillUnmount() {
-        abort_requests_in_flight("me/tournaments");
         data.unwatch(cached.active_tournaments, this.update);
     }
     render() {
@@ -340,7 +335,6 @@ export class TournamentList extends React.PureComponent<{}, any> {
                         <img src={tournament.icon} /> {tournament.name}
                     </Link>
                 ))}
-                {(this.state.my_tournaments.length === 0 || null) && null}
             </div>
         );
     }

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -36,12 +36,22 @@ import { ActiveAnnouncements } from "Announcements";
 import { FabX } from "material";
 import { ActiveTournamentList } from "src/lib/types";
 
-declare let ogs_missing_translation_count;
+declare let ogs_missing_translation_count: number;
 
-export class Overview extends React.Component<{}, any> {
+type UserType = rest_api.UserConfig;
+type ActiveGameType = rest_api.players.full.Game;
+
+interface OverviewState {
+    boards_to_move_on: number;
+    user: UserType;
+    resolved: boolean;
+    overview: { active_games: Array<ActiveGameType> };
+    show_translation_dialog: boolean;
+}
+export class Overview extends React.Component<{}, OverviewState> {
     private static defaultTitle = "OGS";
 
-    constructor(props) {
+    constructor(props: {}) {
         super(props);
 
         let show_translation_dialog = false;
@@ -73,7 +83,7 @@ export class Overview extends React.Component<{}, any> {
         window.document.title = `${count}${Overview.defaultTitle}`;
     }
 
-    setBoardsToMoveOn = (boardsToMoveOn) => {
+    setBoardsToMoveOn = (boardsToMoveOn: number) => {
         this.setState({ boards_to_move_on: boardsToMoveOn });
     };
 
@@ -88,14 +98,14 @@ export class Overview extends React.Component<{}, any> {
         this.setTitle();
     }
 
-    updateUser = (user) => {
+    updateUser = (user: UserType) => {
         this.setState({ user: user });
     };
 
-    refresh() {
+    refresh(): Promise<void> {
         abort_requests_in_flight("ui/overview");
         return get("ui/overview")
-            .then((overview) => {
+            .then((overview: OverviewState["overview"]) => {
                 this.setState({ overview: overview, resolved: true });
             })
             .catch((err) => {
@@ -141,14 +151,7 @@ export class Overview extends React.Component<{}, any> {
                                     {_("Active Games")} ({this.state.overview.active_games.length})
                                 </h2>
                                 <GameList
-                                    list={
-                                        // GameList is expecting rengo info on the game (like in ObserveGamesComponent) but here that information is on game.json, so we have to promote it ...
-                                        this.state.overview.active_games.map((game) => ({
-                                            rengo: game.json.rengo,
-                                            rengo_teams: game.json.rengo_teams,
-                                            ...game,
-                                        }))
-                                    }
+                                    list={this.state.overview.active_games}
                                     player={user}
                                     emptyMessage={_(
                                         'You\'re not currently playing any games. Start a new game with the "Create a new game" or "Look for open games" buttons above.',

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -250,13 +250,16 @@ export class Overview extends React.Component<{}, OverviewState> {
     };
 }
 
-export class GroupList extends React.PureComponent<{}, any> {
-    constructor(props) {
+interface GroupState {
+    groups: Array<any>;
+    invitations: Array<any>;
+}
+export class GroupList extends React.PureComponent<{}, GroupState> {
+    constructor(props: {}) {
         super(props);
         this.state = {
             groups: [],
             invitations: [],
-            resolved: false,
         };
     }
 
@@ -276,12 +279,12 @@ export class GroupList extends React.PureComponent<{}, any> {
         data.unwatch(cached.groups, this.updateGroups);
         data.unwatch(cached.group_invitations, this.updateGroupInvitations);
     }
-    acceptInvite(invite) {
+    acceptInvite(invite: { id: number }) {
         post("me/groups/invitations", { request_id: invite.id })
             .then(() => 0)
             .catch(() => 0);
     }
-    rejectInvite(invite) {
+    rejectInvite(invite: { id: number }) {
         post("me/groups/invitations", { request_id: invite.id, delete: true })
             .then(() => 0)
             .catch(() => 0);

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -34,7 +34,7 @@ import { ProfileCard } from "ProfileCard";
 import { notification_manager } from "Notifications";
 import { ActiveAnnouncements } from "Announcements";
 import { FabX } from "material";
-import { ActiveTournamentList } from "src/lib/types";
+import { ActiveTournamentList, Group } from "src/lib/types";
 
 declare let ogs_missing_translation_count: number;
 
@@ -42,8 +42,8 @@ type UserType = rest_api.UserConfig;
 type ActiveGameType = rest_api.players.full.Game;
 
 interface OverviewState {
-    boards_to_move_on: number;
-    user: UserType;
+    boards_to_move_on?: number;
+    user?: UserType;
     resolved: boolean;
     overview: { active_games: Array<ActiveGameType> };
     show_translation_dialog: boolean;
@@ -79,11 +79,11 @@ export class Overview extends React.Component<{}, OverviewState> {
     }
 
     setTitle() {
-        const count = this.state.boards_to_move_on > 0 ? `(${this.state.boards_to_move_on}) ` : "";
+        const count = this.state.boards_to_move_on ? `(${this.state.boards_to_move_on}) ` : "";
         window.document.title = `${count}${Overview.defaultTitle}`;
     }
 
-    setBoardsToMoveOn = (boardsToMoveOn: number) => {
+    setBoardsToMoveOn = (boardsToMoveOn?: number) => {
         this.setState({ boards_to_move_on: boardsToMoveOn });
     };
 
@@ -250,9 +250,10 @@ export class Overview extends React.Component<{}, OverviewState> {
     };
 }
 
+type InvitationType = rest_api.me.Invitation;
 interface GroupState {
-    groups: Array<any>;
-    invitations: Array<any>;
+    groups: Group[];
+    invitations: InvitationType[];
 }
 export class GroupList extends React.PureComponent<{}, GroupState> {
     constructor(props: {}) {
@@ -268,10 +269,10 @@ export class GroupList extends React.PureComponent<{}, GroupState> {
         data.watch(cached.group_invitations, this.updateGroupInvitations);
     }
 
-    updateGroups = (groups) => {
+    updateGroups = (groups: Group[]) => {
         this.setState({ groups: groups });
     };
-    updateGroupInvitations = (invitations) => {
+    updateGroupInvitations = (invitations: InvitationType[]) => {
         this.setState({ invitations: invitations });
     };
 

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -345,25 +345,27 @@ export class TournamentList extends React.PureComponent<{}, TournamentListState>
         );
     }
 }
-export class LadderList extends React.PureComponent<{}, any> {
-    constructor(props) {
+
+type LadderType = rest_api.me.Ladder;
+interface LadderListState {
+    ladders: LadderType[];
+}
+
+export class LadderList extends React.PureComponent<{}, LadderListState> {
+    constructor(props: {}) {
         super(props);
-        this.state = {
-            ladders: [],
-            resolved: false,
-        };
+        this.state = { ladders: [] };
     }
 
     componentDidMount() {
         data.watch(cached.ladders, this.update);
     }
 
-    update = (ladders) => {
+    update = (ladders: LadderType[]) => {
         this.setState({ ladders: ladders });
     };
 
     componentWillUnmount() {
-        abort_requests_in_flight("me/ladders");
         data.unwatch(cached.ladders, this.update);
     }
     render() {


### PR DESCRIPTION
This (hopefully) doesn't have any visible changes, but now Overview.tsx is compliant with TS strict mode.

## Proposed Changes

  - Remove some unused variables/code
  - Add types
  - Remove some `abort_requests_in_flight()` calls
      - This may have a functional effect, but I don't think we should be unsubscribing from these fetches from the Overview components now that the fetches are initiated by cached.ts