### PR TITLE
Show console logs from rengo team balancer

### DIFF
--- a/src/components/RengoManagementPane/RengoManagementPane.tsx
+++ b/src/components/RengoManagementPane/RengoManagementPane.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 
-import { balanceTeams } from "rengo_balancer";
+import { balanceTeams, unassignPlayers } from "rengo_balancer";
 import { _, pgettext, interpolate } from "translate";
 
 interface RengoManagementPaneProperties {
@@ -29,7 +29,6 @@ interface RengoManagementPaneProperties {
     cancelChallenge: (challenge: any) => void;
     withdrawFromRengoChallenge: (challenge: any) => void;
     joinRengoChallenge: (challenge: any) => void;
-    unassignPlayers: (challenge: any) => void;
     dontShowCancelButton?: boolean;
 }
 
@@ -118,7 +117,7 @@ export class RengoManagementPane extends React.PureComponent<
                             {has_assigned_players ? (
                                 <button
                                     className="sm"
-                                    onClick={this.props.unassignPlayers.bind(self, the_challenge)}
+                                    onClick={unassignPlayers.bind(self, the_challenge)}
                                     disabled={!has_assigned_players}
                                 >
                                     {_("Unassign players")}

--- a/src/lib/rengo_balancer.ts
+++ b/src/lib/rengo_balancer.ts
@@ -22,17 +22,19 @@ import { put } from "requests";
 type Participant = {
     user_id: number;
     rating: number;
+    username?: string;
 };
 
 // Convert player IDs to Participants with ratings.
 function toParticipants(playerIDs: number[]): Promise<Participant[]> {
-    const required_fields = ["rating"];
+    const required_fields = ["username", "rating"];
     const promises = [];
     for (const id of playerIDs) {
         const promise = player_cache.fetch(id, required_fields).then((entry) => {
             return {
                 user_id: id,
                 rating: entry.rating,
+                username: entry.username,
             };
         });
         promises.push(promise);
@@ -155,10 +157,21 @@ type Challenge = socket_api.seekgraph_global.Challenge;
 export async function balanceTeams(challenge: Challenge) {
     const user_id = (p) => p.user_id;
     const participants = await toParticipants(challenge.rengo_participants);
-    const { black, white } = autoBalance(participants);
+    const result = autoBalance(participants);
+
+    console.log("Balancing teams...");
+    console.log("Black team:", result.black);
+    console.log("Average rating:", result.blackAverageRating);
+    console.log("White team:", result.white);
+    console.log("Average rating:", result.whiteAverageRating);
+    console.log(
+        "Rating difference:",
+        Math.abs(result.blackAverageRating - result.whiteAverageRating),
+    );
+
     put("challenges/%%/team", challenge.challenge_id, {
-        assign_black: black.map(user_id),
-        assign_white: white.map(user_id),
+        assign_black: result.black.map(user_id),
+        assign_white: result.white.map(user_id),
     }).catch(errorAlerter);
 }
 

--- a/src/lib/rengo_balancer.ts
+++ b/src/lib/rengo_balancer.ts
@@ -161,3 +161,9 @@ export async function balanceTeams(challenge: Challenge) {
         assign_white: white.map(user_id),
     }).catch(errorAlerter);
 }
+
+export function unassignPlayers(challenge: Challenge) {
+    put("challenges/%%/team", challenge.challenge_id, {
+        unassign: challenge.rengo_participants,
+    }).catch(errorAlerter);
+}

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -739,7 +739,6 @@ export class Play extends React.Component<{}, PlayState> {
                         cancelChallenge={this.cancelOpenChallenge}
                         withdrawFromRengoChallenge={this.unNominateForRengoChallenge}
                         joinRengoChallenge={nominateForRengoChallenge}
-                        unassignPlayers={unassignPlayers}
                     >
                         <RengoTeamManagementPane
                             challenge_id={rengo_challenge_to_show.challenge_id}
@@ -1230,7 +1229,6 @@ export class Play extends React.Component<{}, PlayState> {
                             cancelChallenge={this.cancelOpenChallenge}
                             withdrawFromRengoChallenge={this.unNominateForRengoChallenge}
                             joinRengoChallenge={nominateForRengoChallenge}
-                            unassignPlayers={unassignPlayers}
                             dontShowCancelButton={true}
                         >
                             <RengoTeamManagementPane
@@ -1419,10 +1417,4 @@ function time_per_move_challenge_sort(A: Challenge, B: Challenge) {
     } else {
         return challenge_sort(A, B);
     }
-}
-
-function unassignPlayers(challenge: Challenge) {
-    put("challenges/%%/team", challenge.challenge_id, {
-        unassign: challenge.rengo_participants,
-    }).catch(errorAlerter);
 }


### PR DESCRIPTION
## Proposed Changes

  1. Remove unnecessary props from RengoManagementPane
  2. Show console logs from rengo team balancer
  
## Context for (2)

The rengo balancer [doesn't seem to be working correctly](https://forums.online-go.com/t/rengo-status/40415/828). It's hard to test on the beta site, because there's not a lot of players with stable ranks there. The console logs would make it easier to find the problem.
