### PR TITLE
Move 'Balance teams' button from RengoManagementPane to RengoTeamManagementPane

### DIFF
--- a/src/components/RengoManagementPane/RengoManagementPane.tsx
+++ b/src/components/RengoManagementPane/RengoManagementPane.tsx
@@ -17,7 +17,6 @@
 
 import * as React from "react";
 
-import { balanceTeams, unassignPlayers } from "rengo_balancer";
 import { _, pgettext, interpolate } from "translate";
 
 interface RengoManagementPaneProperties {
@@ -71,10 +70,6 @@ export class RengoManagementPane extends React.PureComponent<
             the_challenge.rengo_black_team.length -
             the_challenge.rengo_white_team.length;
 
-        const count_assigned_players =
-            the_challenge.rengo_black_team.length + the_challenge.rengo_white_team.length;
-        const has_assigned_players = count_assigned_players > 0;
-
         return (
             <div className="RengoManagementPane">
                 {!the_challenge.rengo_auto_start && (
@@ -114,23 +109,6 @@ export class RengoManagementPane extends React.PureComponent<
                                 <span />
                             )}
 
-                            {has_assigned_players ? (
-                                <button
-                                    className="sm"
-                                    onClick={unassignPlayers.bind(self, the_challenge)}
-                                    disabled={!has_assigned_players}
-                                >
-                                    {_("Unassign players")}
-                                </button>
-                            ) : (
-                                <button
-                                    className="sm"
-                                    onClick={balanceTeams.bind(self, the_challenge)}
-                                    disabled={has_assigned_players}
-                                >
-                                    {_("Balance teams")}
-                                </button>
-                            )}
                             <button
                                 className="success sm"
                                 onClick={this.props.startRengoChallenge.bind(self, the_challenge)}

--- a/src/components/RengoManagementPane/RengoManagementPane.tsx
+++ b/src/components/RengoManagementPane/RengoManagementPane.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 
-import { balanceTeams } from "rengo_balancer";
+import { balanceTeams, unassignPlayers } from "rengo_balancer";
 import { _, pgettext, interpolate } from "translate";
 
 interface RengoManagementPaneProperties {
@@ -29,7 +29,6 @@ interface RengoManagementPaneProperties {
     cancelChallenge: (challenge: any) => void;
     withdrawFromRengoChallenge: (challenge: any) => void;
     joinRengoChallenge: (challenge: any) => void;
-    unassignPlayers: (challenge: any) => void;
     dontShowCancelButton?: boolean;
 }
 
@@ -118,7 +117,7 @@ export class RengoManagementPane extends React.PureComponent<
                             {has_assigned_players ? (
                                 <button
                                     className="sm"
-                                    onClick={this.props.unassignPlayers.bind(self, the_challenge)}
+                                    onClick={unassignPlayers.bind(self, the_challenge)}
                                     disabled={!has_assigned_players}
                                 >
                                     {_("Unassign players")}

--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.styl
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.styl
@@ -89,4 +89,8 @@
         }
     }
 
+    .rengo-balancer-buttons {
+        margin-top: 0.5rem;
+        display: flex;
+    }
 }

--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
@@ -16,6 +16,7 @@
  */
 
 import * as React from "react";
+import { balanceTeams, unassignPlayers } from "rengo_balancer";
 import { _ } from "translate";
 
 import { Player } from "Player";
@@ -80,6 +81,8 @@ export class RengoTeamManagementPane extends React.PureComponent<
             // This should be at most transitory, since the creator is added as a player on creation!
             return <div className="no-rengo-players-to-admin">{_("(none yet - standby!)")}</div>;
         }
+
+        const has_assigned_players = black_team.length + white_team.length > 0;
 
         return (
             <div className="RengoTeamManagementPane">
@@ -183,7 +186,28 @@ export class RengoTeamManagementPane extends React.PureComponent<
                             <Player user={n} rank={true} key={i} />
                         </div>
                     ))}
+
+                    <div className="rengo-balancer-buttons">
+                        {has_assigned_players ? (
+                            <button
+                                className="sm"
+                                onClick={unassignPlayers.bind(self, the_challenge)}
+                                disabled={!has_assigned_players}
+                            >
+                                {_("Unassign players")}
+                            </button>
+                        ) : (
+                            <button
+                                className="sm"
+                                onClick={balanceTeams.bind(self, the_challenge)}
+                                disabled={has_assigned_players}
+                            >
+                                {_("Balance teams")}
+                            </button>
+                        )}
+                    </div>
                 </div>
+
                 {this.props.show_chat && (
                     <div className="rengo-challenge-chat">
                         <EmbeddedChatCard

--- a/src/lib/rengo_balancer.ts
+++ b/src/lib/rengo_balancer.ts
@@ -161,3 +161,9 @@ export async function balanceTeams(challenge: Challenge) {
         assign_white: white.map(user_id),
     }).catch(errorAlerter);
 }
+
+export function unassignPlayers(challenge: Challenge) {
+    put("challenges/%%/team", challenge.challenge_id, {
+        unassign: challenge.rengo_participants,
+    }).catch(errorAlerter);
+}

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -739,7 +739,6 @@ export class Play extends React.Component<{}, PlayState> {
                         cancelChallenge={this.cancelOpenChallenge}
                         withdrawFromRengoChallenge={this.unNominateForRengoChallenge}
                         joinRengoChallenge={nominateForRengoChallenge}
-                        unassignPlayers={unassignPlayers}
                     >
                         <RengoTeamManagementPane
                             challenge_id={rengo_challenge_to_show.challenge_id}
@@ -1230,7 +1229,6 @@ export class Play extends React.Component<{}, PlayState> {
                             cancelChallenge={this.cancelOpenChallenge}
                             withdrawFromRengoChallenge={this.unNominateForRengoChallenge}
                             joinRengoChallenge={nominateForRengoChallenge}
-                            unassignPlayers={unassignPlayers}
                             dontShowCancelButton={true}
                         >
                             <RengoTeamManagementPane
@@ -1419,10 +1417,4 @@ function time_per_move_challenge_sort(A: Challenge, B: Challenge) {
     } else {
         return challenge_sort(A, B);
     }
-}
-
-function unassignPlayers(challenge: Challenge) {
-    put("challenges/%%/team", challenge.challenge_id, {
-        unassign: challenge.rengo_participants,
-    }).catch(errorAlerter);
 }


### PR DESCRIPTION
## Issues

Rengo challenge chat may cause the unassign/balance button to leave the viewport on mobile.

![before](https://user-images.githubusercontent.com/99894371/155878736-460b9e58-c2eb-4901-8345-d5f8a6962459.png)

## Proposed Changes

Move 'Balance teams' button from `RengoManagementPane` to `RengoTeamManagementPane` so it looks like this:

![after](https://user-images.githubusercontent.com/99894371/155878742-9f75233a-eac4-4e55-b9dd-dfa908ea2f51.png)