### PR TITLE
ChallengeModal.tsx: set komi to 5.5 if it is not defined

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -161,7 +161,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
         }
 
         challenge.game.initial_state = null;
-        if (!challenge.game.komi) {
+        if (typeof challenge.game.komi !== "number" && !challenge.game.komi) {
             challenge.game.komi = 5.5;
         }
 

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -161,7 +161,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
         }
 
         challenge.game.initial_state = null;
-        if (challenge.game.komi == null) {
+        if (!challenge.game.komi) {
             challenge.game.komi = 5.5;
         }
 


### PR DESCRIPTION
Fixes #1727 

In the end of the day the problem seems to be unrelated to https://github.com/online-go/online-go.com/pull/1721
It seems that there's a confusion on the `komi` property.
In `challenges.d.ts` it is defined as a `number` whereas we clearly send a string to the backend.

The constructor of `ChallengeModal` contains code to "fix dirty data", so I guess it's the right place to check if the `komi` is "valid". 

Maybe we could even parse it and check if it is a `float`. What do you think?

The only thing I don't understand (yet) is why the default komi is set to the empty string, as I had this value on my local environment already, even though I cannot see traces of it on the code.

## Proposed Changes

  - Replace `null` check by truthy check, so that the empty string is replaced by the valid default handicap
 