### PR TITLE
Hide rengo balance button from non-organisers

### DIFF
--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
@@ -25,6 +25,7 @@ import { EmbeddedChatCard } from "Chat";
 type Challenge = socket_api.seekgraph_global.Challenge;
 
 interface RengoTeamManagementPaneProps {
+    user: rest_api.UserConfig;
     challenge_list: Challenge[];
     challenge_id: number;
     moderator: boolean;
@@ -82,6 +83,12 @@ export class RengoTeamManagementPane extends React.PureComponent<
             return <div className="no-rengo-players-to-admin">{_("(none yet - standby!)")}</div>;
         }
 
+        const our_rengo_challenges = this.props.challenge_list.filter(
+            (c) => c.user_id === this.props.user.id,
+        );
+        const own_challenge = our_rengo_challenges.find(
+            (c) => c.challenge_id === this.props.challenge_id,
+        );
         const has_assigned_players = black_team.length + white_team.length > 0;
 
         return (
@@ -187,25 +194,27 @@ export class RengoTeamManagementPane extends React.PureComponent<
                         </div>
                     ))}
 
-                    <div className="rengo-balancer-buttons">
-                        {has_assigned_players ? (
-                            <button
-                                className="sm"
-                                onClick={unassignPlayers.bind(self, the_challenge)}
-                                disabled={!has_assigned_players}
-                            >
-                                {_("Unassign players")}
-                            </button>
-                        ) : (
-                            <button
-                                className="sm"
-                                onClick={balanceTeams.bind(self, the_challenge)}
-                                disabled={has_assigned_players}
-                            >
-                                {_("Balance teams")}
-                            </button>
-                        )}
-                    </div>
+                    {(own_challenge || null) && (
+                        <div className="rengo-balancer-buttons">
+                            {has_assigned_players ? (
+                                <button
+                                    className="sm"
+                                    onClick={unassignPlayers.bind(self, the_challenge)}
+                                    disabled={!has_assigned_players}
+                                >
+                                    {_("Unassign players")}
+                                </button>
+                            ) : (
+                                <button
+                                    className="sm"
+                                    onClick={balanceTeams.bind(self, the_challenge)}
+                                    disabled={has_assigned_players}
+                                >
+                                    {_("Balance teams")}
+                                </button>
+                            )}
+                        </div>
+                    )}
                 </div>
 
                 {this.props.show_chat && (

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -741,6 +741,7 @@ export class Play extends React.Component<{}, PlayState> {
                         joinRengoChallenge={nominateForRengoChallenge}
                     >
                         <RengoTeamManagementPane
+                            user={user}
                             challenge_id={rengo_challenge_to_show.challenge_id}
                             challenge_list={this.state.rengo_list}
                             moderator={user.is_moderator}
@@ -1232,6 +1233,7 @@ export class Play extends React.Component<{}, PlayState> {
                             dontShowCancelButton={true}
                         >
                             <RengoTeamManagementPane
+                                user={user}
                                 challenge_id={C.challenge_id}
                                 challenge_list={this.state.rengo_list}
                                 moderator={user.is_moderator}


### PR DESCRIPTION
In my previous pull request (#1732), I forgot to hide the balance button from non-organizers. 

## Proposed Changes

  - Only show the button to owner of rengo challenge.
