### PR TITLE
Bugfix and cleanup: AvatarCard

### DIFF
--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -62,6 +62,7 @@ interface AvatarCardUserType extends AvatarCardEditableFields {
 interface AvatarCardProps {
     user: AvatarCardUserType;
     force_show_ratings: boolean;
+    editing: boolean;
 
     /** called when the edit button is clicked */
     onEdit: () => void;
@@ -73,13 +74,12 @@ interface AvatarCardProps {
 
 export function AvatarCard({
     user,
+    force_show_ratings,
+    editing,
     onEdit,
     onSave,
-    force_show_ratings,
     openModerateUser,
 }: AvatarCardProps) {
-    const [editing, setEditing] = React.useState(false);
-
     const [new_username, setNewUsername] = React.useState(user.username);
     const [new_first_name, setNewFirstName] = React.useState(user.first_name);
     const [new_last_name, setNewLastName] = React.useState(user.last_name);
@@ -104,7 +104,6 @@ export function AvatarCard({
             }
             promise
                 .then(() => {
-                    setEditing(false);
                     onSave({
                         username: new_username,
                         first_name: new_first_name,
@@ -116,7 +115,6 @@ export function AvatarCard({
                 })
                 .catch(ignore);
         } else {
-            setEditing(true);
             setNewUsername(user.username);
             setNewFirstName(user.first_name);
             setNewLastName(user.last_name);

--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -56,6 +56,7 @@ interface AvatarCardUserType extends AvatarCardEditableFields {
     bot_owner: player_cache.PlayerCacheEntry | null;
     vacation_left: number;
     professional: boolean;
+    icon?: string;
 }
 
 interface AvatarCardProps {
@@ -145,6 +146,7 @@ export function AvatarCard({
                 put("players/%%/icon", user.id, file)
                     .then((res) => {
                         console.log("Upload successful", res);
+                        user.icon = res.icon;
                         player_cache.update({
                             id: user.id,
                             icon: res.icon,
@@ -159,6 +161,7 @@ export function AvatarCard({
         del("players/%%/icon", user.id)
             .then((res) => {
                 console.log("Cleared icon", res);
+                user.icon = res.icon;
                 player_cache.update({
                     id: user.id,
                     icon: res.icon,

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -90,6 +90,7 @@ export interface UserInfo {
     bot_owner: player_cache.PlayerCacheEntry;
     professional: boolean;
     ip_shadowbanned?: boolean;
+    icon?: string;
 }
 
 interface UserState {

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -103,7 +103,6 @@ interface UserState {
         location: string[];
     };
     vacation_left?: number;
-    vacation_left_text: string;
     syncRating: null;
     host_ip_settings?: {
         id: number;
@@ -112,7 +111,6 @@ interface UserState {
         ban_affects_all: boolean;
         chatban_affects_all: boolean;
     };
-    new_icon: { preview: string };
     bot_apikey: null;
     bot_ai?: string;
     editing: boolean;
@@ -152,10 +150,8 @@ export class User extends React.PureComponent<UserProperties, UserState> {
             ratings: {},
             ip: null,
             vacation_left: null,
-            vacation_left_text: "",
             syncRating: null,
             host_ip_settings: null,
-            new_icon: null,
             bot_apikey: null,
             bot_ai: null,
             editing: /edit/.test(window.location.hash),

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -482,6 +482,7 @@ export class User extends React.PureComponent<UserProperties, UserState> {
                             <AvatarCard
                                 user={user}
                                 force_show_ratings={this.state.temporary_show_ratings}
+                                editing={this.state.editing}
                                 openModerateUser={this.openModerateUser}
                                 onEdit={() => this.setState({ editing: true })}
                                 onSave={this.saveEditChanges.bind(this)}


### PR DESCRIPTION
Fixes #1742.  I'm not entirely sure what changed in #1730 that caused the breakage, but basically, we are calling `player_cache.update()` with `User.state.user` which has `user.icon` set to the outdated icon from the initial fetch.  Setting `user.icon` when modifying the icon seems to fix this.

Full disclosure: there is no good way to test the "updateIcon" codepath since I get a 500 error when saving a new icon from `localhost`.  However, the "clearIcon" path is basically the same and I was able to test that successfully.

## Proposed Changes

  - Fix a bug where the old icon got rendered when the user saves a new icon.
  - Move editing state variable into props.
  - Delete a couple of unused state properties in User.tsx.
