### PR TITLE
Add in a link to the group page from a group ladder

### DIFF
--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -23,6 +23,7 @@ import * as data from "data";
 import { List, AutoSizer } from "react-virtualized";
 import { Player } from "Player";
 import { UIPush } from "UIPush";
+import { shouldOpenNewTab } from "misc";
 import { PlayerAutocomplete } from "PlayerAutocomplete";
 import { close_all_popovers, popover } from "popover";
 import { browserHistory } from "ogsHistory";
@@ -132,8 +133,20 @@ export class Ladder extends React.PureComponent<LadderProperties, LadderState> {
         }
     };
 
+    goToGroup = (ev) => {
+        close_all_popovers();
+
+        const url: string = "/group/" + this.state.ladder?.group.id;
+        if (shouldOpenNewTab(ev)) {
+            window.open(url, "_blank");
+        } else {
+            browserHistory.push(url);
+        }
+    };
+
     render() {
         const user = data.get("user");
+        const group_text = pgettext("Go to the main page for this group.", "Group Page");
 
         return (
             <div className="Ladder-container">
@@ -145,6 +158,13 @@ export class Ladder extends React.PureComponent<LadderProperties, LadderState> {
                     />
 
                     <div className="Ladder-header">
+                        <button
+                            className="xs noshadow"
+                            onAuxClick={this.goToGroup}
+                            onClick={this.goToGroup}
+                        >
+                            <i className="fa fa-users" /> {group_text}
+                        </button>
                         <h2>{this.state.ladder && this.state.ladder.name}</h2>
 
                         <PlayerAutocomplete

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -158,14 +158,15 @@ export class Ladder extends React.PureComponent<LadderProperties, LadderState> {
                     />
 
                     <div className="Ladder-header">
-                        {console.log(this.state.ladder)}
-                        {this.state.ladder && this.state.ladder?.group !== null && (<button
-                            className="xs noshadow"
-                            onAuxClick={this.goToGroup}
-                            onClick={this.goToGroup}
-                        >
-                            <i className="fa fa-users" /> {group_text}
-                        </button>)}
+                        {this.state.ladder && this.state.ladder?.group !== null && (
+                            <button
+                                className="xs noshadow"
+                                onAuxClick={this.goToGroup}
+                                onClick={this.goToGroup}
+                            >
+                                <i className="fa fa-users" /> {group_text}
+                            </button>
+                        )}
                         <h2>{this.state.ladder && this.state.ladder.name}</h2>
 
                         <PlayerAutocomplete

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -158,13 +158,14 @@ export class Ladder extends React.PureComponent<LadderProperties, LadderState> {
                     />
 
                     <div className="Ladder-header">
-                        <button
+                        {console.log(this.state.ladder)}
+                        {this.state.ladder && this.state.ladder?.group !== null && (<button
                             className="xs noshadow"
                             onAuxClick={this.goToGroup}
                             onClick={this.goToGroup}
                         >
                             <i className="fa fa-users" /> {group_text}
-                        </button>
+                        </button>)}
                         <h2>{this.state.ladder && this.state.ladder.name}</h2>
 
                         <PlayerAutocomplete


### PR DESCRIPTION
Fixes #518

## Proposed Changes

- Adds in a link to the group page from a ladder which is part of a group.
- Reuses the button from the group chat channels for familiarity, and code from ChatDetails.tsx, specifically copying the `goToGroup` function from there.
- Doesn't show for site ladders that aren't associated with a group.

The main use case I think will be if you are playing a game in group ladder, and click the tournament icon from the sidebar/dock and then would like to go to the group from that ladder page. If you navigate to the ladder from the group page itself, there's always the back button.

![image](https://user-images.githubusercontent.com/26803867/158922988-277cfeda-f583-4e28-b500-8d54b468c52a.png)

![image](https://user-images.githubusercontent.com/26803867/158923002-c992490c-5480-433c-a5a7-8c2adc935844.png)

