### PR TITLE
Don't show 'Support OGS' if not logged in.

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -545,12 +545,14 @@ export class NavBar extends React.PureComponent<{}, any> {
                             </li>
 
                             {user && <li className="divider"></li>}
-                            <li>
-                                <Link to="/supporter">
-                                    <i className="fa fa-star"></i>
-                                    {_("Support OGS")}
-                                </Link>
-                            </li>
+                            {user && (
+                                <li>
+                                    <Link to="/supporter">
+                                        <i className="fa fa-star"></i>
+                                        {_("Support OGS")}
+                                    </Link>
+                                </li>
+                            )}
                             {user && (
                                 <li>
                                     <Link to={`/user/view/${user.id}`}>


### PR DESCRIPTION
The new support OGS page doesn't show for anonymous users.  This makes sense because there are no more one-off donations.  But if that's the case, I don't think that page should be linked from the menu.

<img width="434" alt="Screen Shot 2022-03-27 at 1 01 25 AM" src="https://user-images.githubusercontent.com/25233703/160273093-a4f1a9c1-9b8a-4c7d-bd5d-a5b53d3c6181.png">

Forum thread: https://forums.online-go.com/t/support-page-unavailable-without-login/41438

## Proposed Changes

  - Remove 'Support OGS' from the side menu if user is not logged in.


