### PR TITLE
Clickable coordinates in game log

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.2",
     "xgettext-js": "^3.0.0",
-    "yarn": "^1.22.17"
+    "yarn": "^1.22.18"
   },
   "dependencies": {
     "@sentry/browser": "^6.16.1",

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1673,6 +1673,7 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
             this.goban.config,
             this.state[`historical_black`] || this.goban.engine.players.black,
             this.state[`historical_white`] || this.goban.engine.players.white,
+            this,
         );
     };
     toggleAnonymousModerator = () => {

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -257,6 +257,7 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
         this.nav_next_10 = this.nav_next_10.bind(this);
         this.nav_last = this.nav_last.bind(this);
         this.nav_play_pause = this.nav_play_pause.bind(this);
+        this.gameLogModalMarkCoords = this.gameLogModalMarkCoords.bind(this);
 
         this.reviewAdded = this.reviewAdded.bind(this);
         this.set_analyze_tool = {
@@ -1668,13 +1669,33 @@ export class Game extends React.PureComponent<GameProperties, GameState> {
         this.setState({ show_game_timing: !this.state.show_game_timing });
     };
 
+    gameLogModalMarkCoords(stones_string: string) {
+        for (let i = 0; i < this.goban.config.width; i++) {
+            for (let j = 0; j < this.goban.config.height; j++) {
+                this.goban.deleteCustomMark(i, j, "triangle", true);
+            }
+        }
+
+        const coordarray = stones_string.split(",").map((item) => item.trim());
+        for (let j = 0; j < coordarray.length; j++) {
+            const move = GoMath.decodeMoves(
+                coordarray[j],
+                this.goban.config.width,
+                this.goban.config.height,
+            )[0];
+            this.goban.setMark(move.x, move.y, "triangle", false);
+        }
+    }
+
     showLogModal = () => {
         openGameLogModal(
-            this.goban,
+            this.goban.config,
+            this.gameLogModalMarkCoords,
             this.state[`historical_black`] || this.goban.engine.players.black,
             this.state[`historical_white`] || this.goban.engine.players.white,
         );
     };
+
     toggleAnonymousModerator = () => {
         const channel = `game-${this.game_id}`;
         data.set(

--- a/src/views/Game/GameLogModal.tsx
+++ b/src/views/Game/GameLogModal.tsx
@@ -193,7 +193,7 @@ export class DrawCoordsButton extends React.Component<DCBProperties, {}> {
         for (let j = 0; j < coordarray.length; j++) {
             const move = GoMath.decodeMoves(coordarray[j], config.width, config.height)[0];
             console.log(move);
-            this.props.game.goban.setMark(move.x, move.y, "triangle", true);
+            this.props.game.goban.setMark(move.x, move.y, "triangle", false);
         }
         console.log(this.props.game);
         console.log(coordarray);

--- a/src/views/Game/GameLogModal.tsx
+++ b/src/views/Game/GameLogModal.tsx
@@ -59,7 +59,6 @@ export class GameLogModal extends Modal<Events, GameLogModalProperties, { log: A
 
     render() {
         const config = this.props.config;
-        //console.log(this.props.game);
         return (
             <div className="Modal GameLogModal" ref="modal">
                 <div className="header">
@@ -192,11 +191,8 @@ export class DrawCoordsButton extends React.Component<DCBProperties, {}> {
         const coordarray = stones_string.split(",").map((item) => item.trim());
         for (let j = 0; j < coordarray.length; j++) {
             const move = GoMath.decodeMoves(coordarray[j], config.width, config.height)[0];
-            console.log(move);
             this.props.game.goban.setMark(move.x, move.y, "triangle", false);
         }
-        console.log(this.props.game);
-        console.log(coordarray);
     }
 
     render() {
@@ -213,5 +209,4 @@ export class DrawCoordsButton extends React.Component<DCBProperties, {}> {
 
 export function openGameLogModal(config: any, black: any, white: any, game: Game): void {
     openModal(<GameLogModal config={config} black={black} white={white} game={game} fastDismiss />);
-    //console.log(game);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10982,10 +10982,10 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn@^1.22.17:
-  version "1.22.17"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.17.tgz#bf910747d22497b573131f7341c0e1d15c74036c"
-  integrity sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ==
+yarn@^1.22.18:
+  version "1.22.18"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.18.tgz#05b822ade8c672987bab8858635145da0850f78a"
+  integrity sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Proposed Changes

  - Changes the span for the coordinates in the game log to a clickable anchor tag. 
![image](https://user-images.githubusercontent.com/26803867/161169997-e2237577-8333-473c-8e20-456eeeeb47db.png)
![image](https://user-images.githubusercontent.com/26803867/161170007-05af5061-2c39-4fa5-be4a-0bc7e670a9be.png)

  - When the coordinates are clicked uses goban's `deleteCustomMark` to remove any existing triangles and then `setMark` to draw triangles at the coordinates locations.
 
<img src="https://user-images.githubusercontent.com/26803867/161170130-546c159b-2d1f-4105-9a12-32b3c38481cc.png" width="200" height="200"></img> <img src="https://user-images.githubusercontent.com/26803867/161170139-7d0b283d-c81d-4713-8baf-e84291a70f5d.png" width="200" height="200"></img>

In order to implement this, I passed game from Game.tsx through to GameLogModal down to the new "button". I couldn't think of a way to shortcut this if it's possible. I was following the same idea that AIReview was doing, in passing game as props and then calling the `setMark` and related functions.

Visually, there could be better options than to use the triangles, so any alternate suggestions welcome.

It should hopefully make visualising large areas and large numbers of captures easier when reading the log, e.g. below, although in this silly example, the marked area also happens to correspond to the blue squares marked neutral, but one could imagine big disputed areas

<img src="https://user-images.githubusercontent.com/26803867/161173255-03422c1c-26c9-4aa3-9094-beedbffce1a9.png" width="600" height="200"></img>
<img src="https://user-images.githubusercontent.com/26803867/161173274-3e170f61-1c99-4050-a8c2-3ff9d8dc7f32.png" width="200" height="200"></img>


