### PR TITLE
Enables no-empty-function eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,31 +1,21 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es6": true
+    env: {
+        browser: true,
+        es6: true,
     },
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "project": "tsconfig.json",
-        "sourceType": "module"
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        project: "tsconfig.json",
+        sourceType: "module",
     },
-    "plugins": [
-        "eslint-plugin-jsdoc",
-        "@typescript-eslint",
-        "@typescript-eslint/tslint",
-        "prettier"
-    ],
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
-    "rules": {
+    plugins: ["eslint-plugin-jsdoc", "@typescript-eslint", "@typescript-eslint/tslint", "prettier"],
+    extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+    rules: {
         // Recommended rules with errors
         // TODO: Fix these and re-enable them
 
         "@typescript-eslint/ban-types": "off", // 35 errors
         "@typescript-eslint/explicit-module-boundary-types": "off", // 2074 warnings
-        "@typescript-eslint/no-empty-function": "off", // 14 errors
         "@typescript-eslint/no-empty-interface": "off", // 45 errors
         "@typescript-eslint/no-explicit-any": "off", // 535 warnings
         "@typescript-eslint/no-namespace": "off", // 1 error
@@ -41,36 +31,33 @@ module.exports = {
 
         //==============================================================
 
-
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/consistent-type-assertions": "error",
         "@typescript-eslint/member-delimiter-style": "error",
+        "@typescript-eslint/no-empty-function": "error",
         "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-inferrable-types": [
             "error",
             {
-                "ignoreParameters": true,
-                "ignoreProperties": true
-            }
+                ignoreParameters: true,
+                ignoreProperties: true,
+            },
         ],
         "@typescript-eslint/no-unused-vars": [
             "error",
             {
-                "varsIgnorePattern": "^_[a-zA-Z_]",
-                "argsIgnorePattern": "^_[a-zA-Z_]"
-            }
+                varsIgnorePattern: "^_[a-zA-Z_]",
+                argsIgnorePattern: "^_[a-zA-Z_]",
+            },
         ],
         "@typescript-eslint/no-var-requires": "error",
         "@typescript-eslint/prefer-namespace-keyword": "error",
         "@typescript-eslint/semi": "error",
         "@typescript-eslint/type-annotation-spacing": "error",
         "computed-property-spacing": ["error", "never"],
-        "curly": "error",
+        curly: "error",
         "eol-last": "error",
-        "eqeqeq": [
-            "error",
-            "smart"
-        ],
+        eqeqeq: ["error", "smart"],
         "id-denylist": [
             "error",
             "any",
@@ -81,15 +68,12 @@ module.exports = {
             "Boolean",
             "boolean",
             "Undefined",
-            "undefined"
+            "undefined",
         ],
         "id-match": "error",
         "jsdoc/check-alignment": "error",
         "jsdoc/require-asterisk-prefix": "error",
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
+        "linebreak-style": ["error", "unix"],
         "no-caller": "error",
         "no-cond-assign": "error",
         "no-debugger": "error",
@@ -97,8 +81,8 @@ module.exports = {
         "no-fallthrough": [
             "error",
             {
-                "commentPattern": "break[\\s\\w]*omitted"
-            }
+                commentPattern: "break[\\s\\w]*omitted",
+            },
         ],
         // Using the typescript-eslint version of this rule because of class
         // properties, which are not yet supported in ESLint.  For more info,
@@ -107,8 +91,8 @@ module.exports = {
         "no-multiple-empty-lines": [
             "error",
             {
-                "max": 3
-            }
+                max: 3,
+            },
         ],
         "no-new-wrappers": "error",
         "no-tabs": "error",
@@ -117,50 +101,41 @@ module.exports = {
         "no-unsafe-finally": "error",
         "no-unused-labels": "error",
         "no-var": "error",
-        "one-var": [
-            "error",
-            "never"
-        ],
-        "prefer-arrow-callback": [
-            "error",
-            { "allowNamedFunctions": true }
-        ],
+        "one-var": ["error", "never"],
+        "prefer-arrow-callback": ["error", { allowNamedFunctions: true }],
         "prettier/prettier": "error",
         "use-isnan": "error",
         "@typescript-eslint/tslint/config": [
             "error",
             {
-                "rules": {
-                    "file-header": [
-                        true,
-                        "[Cc]opyright ([(][Cc][)])?\\s*\\d{4}"
-                    ],
+                rules: {
+                    "file-header": [true, "[Cc]opyright ([(][Cc][)])?\\s*\\d{4}"],
                     "import-spacing": true,
-                    "whitespace": [
+                    whitespace: [
                         true,
                         "check-branch",
                         "check-decl",
                         "check-operator",
-                        "check-separator"
-                    ]
-                }
-            }
-        ]
+                        "check-separator",
+                    ],
+                },
+            },
+        ],
     },
-    "overrides": [
+    overrides: [
         {
-            "files": ["*.test.ts", "*.test.tsx"],
+            files: ["*.test.ts", "*.test.tsx"],
             // since test files are not part of tsconfig.json,
             // parserOptions.project must be unset
-            "parserOptions": {
-                "project": null,
+            parserOptions: {
+                project: null,
             },
-            "rules": {
+            rules: {
                 // rules that depend on type information (and therefore
                 // parserOptions.project)
                 "@typescript-eslint/no-floating-promises": "off",
                 "@typescript-eslint/tslint/config": "off",
-            }
-        }
-    ]
+            },
+        },
+    ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/consistent-type-assertions": "error",
         "@typescript-eslint/member-delimiter-style": "error",
-        "@typescript-eslint/no-empty-function": "error",
         "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-inferrable-types": [
             "error",

--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -63,7 +63,6 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
         this.refresh();
     }
 
-    componentWillUnmount() {}
     refresh = () => {
         get(this.url)
             .then((acl) => this.setState({ acl: acl }))

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -92,8 +92,6 @@ export class GobanThemePicker extends React.PureComponent<
         setTimeout(() => this.renderPickers(), 50);
     }
 
-    componentWillUnmount() {}
-
     getCustom(key: keyof CustomGobanThemeSchema): string {
         return data.get(`custom.${key}`);
     }

--- a/src/components/ModNoteModal/ModNoteModal.tsx
+++ b/src/components/ModNoteModal/ModNoteModal.tsx
@@ -43,9 +43,7 @@ export class ModNoteModal extends Modal<Events, ModNoteModalProperties, any> {
     submitNote = () => {
         put(`players/${this.props.player_id}/moderate`, {
             moderation_note: this.state.current_draft,
-        })
-            .then(() => {})
-            .catch(errorAlerter);
+        }).catch(errorAlerter);
 
         this.close();
     };

--- a/src/components/ModNoteModal/ModNoteModal.tsx
+++ b/src/components/ModNoteModal/ModNoteModal.tsx
@@ -40,11 +40,14 @@ export class ModNoteModal extends Modal<Events, ModNoteModalProperties, any> {
         };
     }
 
-    submitNote = () => {
-        put(`players/${this.props.player_id}/moderate`, {
-            moderation_note: this.state.current_draft,
-        }).catch(errorAlerter);
-
+    submitNote = async () => {
+        try {
+            await put(`players/${this.props.player_id}/moderate`, {
+                moderation_note: this.state.current_draft,
+            });
+        } catch (e) {
+            errorAlerter(e);
+        }
         this.close();
     };
 

--- a/src/components/ModNoteModal/ModNoteModal.tsx
+++ b/src/components/ModNoteModal/ModNoteModal.tsx
@@ -41,14 +41,17 @@ export class ModNoteModal extends Modal<Events, ModNoteModalProperties, any> {
     }
 
     submitNote = async () => {
+        this.close();
         try {
             await put(`players/${this.props.player_id}/moderate`, {
                 moderation_note: this.state.current_draft,
             });
         } catch (e) {
+            // since errorAlerter doesn't access the state of ModNoteModal,
+            // it's okay for this action to happen after the modal is
+            // closed
             errorAlerter(e);
         }
-        this.close();
     };
 
     updateDraft = (e) => {

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -140,7 +140,6 @@ export class PlayerDetails extends React.PureComponent<
             }, 1);
         }
     }
-    componentWillUnmount() {}
 
     close_all_modals_and_popovers = () => {
         close_all_popovers();

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -164,8 +164,6 @@ export function Report(props: ReportProperties): JSX.Element {
         }
     }
 
-    function save() {}
-
     function canSubmit() {
         if (!category) {
             return false;
@@ -299,10 +297,15 @@ export function Report(props: ReportProperties): JSX.Element {
                     {_("Close")}
                 </button>
                 {report_id ? (
-                    <button className="primary" onClick={save}>
-                        {" "}
-                        {_("Save")}
-                    </button>
+                    <>
+                        {/*
+                        save() is noop & so removed for eslint; commenting for now
+                        <button className="primary" onClick={save}>
+                            {" "}
+                            {_("Save")}
+                        </button>
+                        */}
+                    </>
                 ) : (
                     <button className="primary" onClick={createReport} disabled={!canSubmit()}>
                         {" "}

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -125,7 +125,6 @@ export const report_categories: Array<ReportDescription> = [
 
 export function Report(props: ReportProperties): JSX.Element {
     const {
-        report_id,
         reported_user_id,
         onClose,
         reported_conversation,
@@ -296,22 +295,10 @@ export function Report(props: ReportProperties): JSX.Element {
                 <button className="default" onClick={close}>
                     {_("Close")}
                 </button>
-                {report_id ? (
-                    <>
-                        {/*
-                        save() is noop & so removed for eslint; commenting for now
-                        <button className="primary" onClick={save}>
-                            {" "}
-                            {_("Save")}
-                        </button>
-                        */}
-                    </>
-                ) : (
-                    <button className="primary" onClick={createReport} disabled={!canSubmit()}>
-                        {" "}
-                        {_("Report User")}
-                    </button>
-                )}
+                <button className="primary" onClick={createReport} disabled={!canSubmit()}>
+                    {" "}
+                    {_("Report User")}
+                </button>
             </div>
         </Card>
     );

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -154,7 +154,6 @@ export class SeekGraph extends TypedEventEmitter<Events> {
         }
 
         this.socket.on("connect", this.onConnect);
-        this.socket.on("disconnect", this.onDisconnect);
         this.socket.on("seekgraph/global", this.onSeekgraphGlobal);
         this.canvas.on("mousemove", this.onPointerMove);
         this.canvas.on("mouseout", this.onPointerOut);
@@ -171,7 +170,6 @@ export class SeekGraph extends TypedEventEmitter<Events> {
         }
         return bounded_rank(user);
     }
-    onDisconnect = () => {};
     onConnect = () => {
         this.connected = true;
         this.socket.send("seek_graph/connect", { channel: "global" });
@@ -322,7 +320,6 @@ export class SeekGraph extends TypedEventEmitter<Events> {
         }
 
         this.socket.off("connect", this.onConnect);
-        this.socket.off("disconnect", this.onDisconnect);
         this.socket.off("seekgraph/global", this.onSeekgraphGlobal);
 
         $(document).off("touchend", this.onTouchEnd);

--- a/src/lib/sfx.ts
+++ b/src/lib/sfx.ts
@@ -350,7 +350,6 @@ export class SFXManager {
         [id: string]: SFXSprite;
     } = {};
 
-    constructor() {}
     public enable(): void {
         this.enabled = true;
         this.sync();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -188,7 +188,9 @@ data.watch("config.user", (user) => {
 
     if (last_username && last_username !== user.username) {
         last_username = user.username;
-        forceReactUpdate();
+        if (forceReactUpdate) {
+            forceReactUpdate();
+        }
     }
     last_username = user.username;
 });
@@ -329,7 +331,7 @@ init_tabcomplete();
 const svg_loader = document.getElementById("loading-svg-container");
 svg_loader.parentNode.removeChild(svg_loader);
 
-let forceReactUpdate: () => void = () => {};
+let forceReactUpdate: () => void; // = () => {};
 
 function ForceReactUpdateWrapper(props): JSX.Element {
     const [update, setUpdate] = React.useState(1);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -331,7 +331,7 @@ init_tabcomplete();
 const svg_loader = document.getElementById("loading-svg-container");
 svg_loader.parentNode.removeChild(svg_loader);
 
-let forceReactUpdate: () => void; // = () => {};
+let forceReactUpdate: () => void;
 
 function ForceReactUpdateWrapper(props): JSX.Element {
     const [update, setUpdate] = React.useState(1);

--- a/src/views/AppealsCenter/AppealsCenter.tsx
+++ b/src/views/AppealsCenter/AppealsCenter.tsx
@@ -28,8 +28,6 @@ export function AppealsCenter(): JSX.Element {
     const user = data.get("user");
     const [show_all, set_show_all] = React.useState(false);
 
-    React.useEffect(() => {}, []);
-
     if (!user.is_moderator) {
         return null;
     }

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -123,7 +123,6 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             this.max_entries = ai_table_out.max_entries;
         }
     }
-    componentWillUnmount() {}
 
     getGameId(props?: AIReviewProperties) {
         if (!props) {

--- a/src/views/Game/Chat.tsx
+++ b/src/views/Game/Chat.tsx
@@ -189,7 +189,6 @@ export class GameChat extends React.PureComponent<GameChatProperties, GameChatSt
             show_player_list: !this.state.show_player_list,
         });
     };
-    togglePlayerListSortOrder = () => {};
 
     sendQuickChat = (msg: string) => {
         this.props.gameview.goban.sendChat(msg, this.state.chat_log);

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -199,7 +199,6 @@ export class Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
             this.fetchPuzzle(parseInt(next_props.match.params.puzzle_id));
         }
     }
-    componentWillUnmount() {}
     componentDidUpdate() {
         this.onResize();
     }

--- a/src/views/Puzzle/PuzzleNavigation.ts
+++ b/src/views/Puzzle/PuzzleNavigation.ts
@@ -20,8 +20,6 @@ import { Goban } from "goban";
 export class PuzzleNavigation {
     _goban: Goban;
 
-    constructor() {}
-
     set goban(newValue: Goban) {
         this._goban = newValue;
     }

--- a/src/views/Supporter/Supporter.tsx
+++ b/src/views/Supporter/Supporter.tsx
@@ -179,7 +179,7 @@ function load_checkout_libraries(): void {
             document.head.appendChild(script);
         });
 
-        paddle_js_promise.then(() => {}).catch(ignore);
+        paddle_js_promise.catch(ignore);
     }
 }
 

--- a/src/views/Supporter/Supporter.tsx
+++ b/src/views/Supporter/Supporter.tsx
@@ -178,8 +178,6 @@ function load_checkout_libraries(): void {
             };
             document.head.appendChild(script);
         });
-
-        paddle_js_promise.catch(ignore);
     }
 }
 

--- a/src/views/User/ModTools.tsx
+++ b/src/views/User/ModTools.tsx
@@ -44,9 +44,13 @@ export function ModTools(props: ModToolsProps): JSX.Element {
             return;
         }
 
-        put(`players/${props.user_id}/moderate`, {
-            moderation_note: txt,
-        }).catch(errorAlerter);
+        try {
+            await put(`players/${props.user_id}/moderate`, {
+                moderation_note: txt,
+            });
+        } catch (e) {
+            errorAlerter(e);
+        }
 
         moderator_note.current.value = "";
     };

--- a/src/views/User/ModTools.tsx
+++ b/src/views/User/ModTools.tsx
@@ -44,6 +44,8 @@ export function ModTools(props: ModToolsProps): JSX.Element {
             return;
         }
 
+        moderator_note.current.value = "";
+
         try {
             await put(`players/${props.user_id}/moderate`, {
                 moderation_note: txt,
@@ -51,8 +53,6 @@ export function ModTools(props: ModToolsProps): JSX.Element {
         } catch (e) {
             errorAlerter(e);
         }
-
-        moderator_note.current.value = "";
     };
 
     const moderator_log_anchor = React.useRef<HTMLDivElement>(null);

--- a/src/views/User/ModTools.tsx
+++ b/src/views/User/ModTools.tsx
@@ -36,7 +36,7 @@ interface ModToolsProps {
 
 export function ModTools(props: ModToolsProps): JSX.Element {
     const moderator_note = React.useRef<HTMLTextAreaElement>(null);
-    const addModeratorNote = () => {
+    const addModeratorNote = async () => {
         const txt = moderator_note.current.value.trim();
 
         if (txt.length < 2) {
@@ -46,9 +46,7 @@ export function ModTools(props: ModToolsProps): JSX.Element {
 
         put(`players/${props.user_id}/moderate`, {
             moderation_note: txt,
-        })
-            .then(() => {})
-            .catch(errorAlerter);
+        }).catch(errorAlerter);
 
         moderator_note.current.value = "";
     };


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Enables no-empty-function eslint rule
  - Removes empty componentWillUnmount lifecycle methods
  - Changes promise `.then` chains to async/await when `then` was noop but catch was significant
  - removed a no-op `catch` from `Supporter.tsx`
  - `submitNote` in `ModNoteModal.tsx` changed: `close` event emitter moved to before promise is invoked via `await` - this preserves the ux of closing the modal while waiting for xhr to complete. Was a little worried about preserving a callback after a component had been unmounted, but it doesn't look like `errorAlerter` relies on `ModNoteModal` itself
  - removed no-op `save` method on `<Report />`; commented out the `Save` button, since clicking it is a no-op. 
  - autoformatter caught `.eslintrc.js` - I hope these superficial changes are okay to include in this PR; if not, I'll open a separate one
