### PR TITLE
Remove user switch for OJE backend

### DIFF
--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -199,7 +199,7 @@ export interface DataSchema
     "last-visited-since-goals-shown": string;
     "hours-visited-since-goals-shown": number;
     "table-color-default-on": boolean;
-    "joseki-url": string;
+    "oje-url": string;
     "ad-override": boolean;
     "email-banner-dismissed": boolean;
     "active-tournament": Announcement;

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -41,7 +41,7 @@ import { JosekiTagSelector } from "JosekiTagSelector";
 import { Throbber } from "Throbber";
 import { IdType } from "src/lib/types";
 
-const server_url = data.get("joseki-url", "/oje/");
+const server_url = data.get("oje-url", "/oje/");
 
 const prefetch_url = (node_id: string, variation_filter?: any, mode?: string) => {
     let prefetch_url = server_url + "positions?id=" + node_id;
@@ -1144,17 +1144,6 @@ export class Joseki extends React.Component<JosekiProps, JosekiState> {
         this.setState({ db_locked_down: new_status });
     };
 
-    toggleBackend = () => {
-        const current_setting = data.get("joseki-url", "unset");
-        if (current_setting === "/oje/" || current_setting === "unset") {
-            data.set("joseki-url", "/godojo/");
-        } else {
-            data.set("joseki-url", "/oje/");
-        }
-
-        window.location.assign("/joseki/");
-    };
-
     render() {
         /* console.log(
             "Joseki app rendering ",
@@ -1193,15 +1182,6 @@ export class Joseki extends React.Component<JosekiProps, JosekiState> {
                           <span>{tag["description"]}</span>
                       </div>
                   ));
-
-        let backend = "?";
-        const current_setting = data.get("joseki-url");
-        if (current_setting === "/oje/" || current_setting === undefined) {
-            backend = "new";
-        }
-        if (current_setting === "/godojo/") {
-            backend = "old";
-        }
 
         return (
             <div className={"Joseki"}>
@@ -1269,10 +1249,6 @@ export class Joseki extends React.Component<JosekiProps, JosekiState> {
                             >
                                 <i className="fa fa-question-circle-o"></i>
                             </a>
-                            <div className="backend-control">
-                                <i className="fa fa-exchange" onClick={this.toggleBackend}></i>
-                                <span>{backend}</span>
-                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
and  rename data-based selector so old… one is not used for anyone

Fixes anyone using the old one, which they aren't supposed to anymore.

## Proposed Changes

Took backend toggle out of UI, and renamed the key in `data` so that any old user settings of that are no longer used.