### PR TITLE
Table check engine and Median score loss

### DIFF
--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -901,8 +901,8 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                 wtotal += movecounters[num_rows + j];
             }
 
-            avg_score_loss[0] = btotal > 0 ? Math.round((10 * avg_score_loss[0]) / btotal) / 10 : 0;
-            avg_score_loss[1] = wtotal > 0 ? Math.round((10 * avg_score_loss[1]) / wtotal) / 10 : 0;
+            avg_score_loss[0] = btotal > 0 ? Number((avg_score_loss[0] / btotal).toFixed(1)) : 0;
+            avg_score_loss[1] = wtotal > 0 ? Number((avg_score_loss[1] / wtotal).toFixed(1)) : 0;
 
             score_loss_list[0].sort((a, b) => {
                 return a - b;
@@ -913,23 +913,23 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
 
             median_score_loss[0] =
                 this.medianList(score_loss_list[0]) !== undefined
-                    ? Math.round(10 * this.medianList(score_loss_list[0])) / 10
+                    ? Number(this.medianList(score_loss_list[0]).toFixed(1))
                     : 0;
             median_score_loss[1] =
                 this.medianList(score_loss_list[1]) !== undefined
-                    ? Math.round(10 * this.medianList(score_loss_list[1])) / 10
+                    ? Number(this.medianList(score_loss_list[1]).toFixed(1))
                     : 0;
 
             for (let j = 0; j < num_rows; j++) {
                 summary_moves_list[j][0] = movecounters[j].toString();
                 summary_moves_list[j][1] =
                     btotal > 0
-                        ? (Math.round((1000 * movecounters[j]) / btotal) / 10).toString()
+                        ? ((100 * movecounters[j]) / btotal).toFixed(1)
                         : "";
                 summary_moves_list[j][2] = movecounters[num_rows + j].toString();
                 summary_moves_list[j][3] =
                     wtotal > 0
-                        ? (Math.round((1000 * movecounters[num_rows + j]) / wtotal) / 10).toString()
+                        ? ((100 * movecounters[num_rows + j]) / wtotal).toFixed(1)
                         : "";
             }
 
@@ -1048,8 +1048,8 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                 wtotal += movecounters[num_rows + j];
             }
 
-            avg_score_loss[0] = btotal > 0 ? Math.round((10 * avg_score_loss[0]) / btotal) / 10 : 0;
-            avg_score_loss[1] = wtotal > 0 ? Math.round((10 * avg_score_loss[1]) / wtotal) / 10 : 0;
+            avg_score_loss[0] = btotal > 0 ? Number((avg_score_loss[0] / btotal).toFixed(1)) : 0;
+            avg_score_loss[1] = wtotal > 0 ? Number((avg_score_loss[1] / wtotal).toFixed(1)) : 0;
 
             score_loss_list[0].sort((a, b) => {
                 return a - b;
@@ -1060,23 +1060,23 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
 
             median_score_loss[0] =
                 this.medianList(score_loss_list[0]) !== undefined
-                    ? Math.round(10 * this.medianList(score_loss_list[0])) / 10
+                    ? Number(this.medianList(score_loss_list[0]).toFixed(1))
                     : 0;
             median_score_loss[1] =
                 this.medianList(score_loss_list[1]) !== undefined
-                    ? Math.round(10 * this.medianList(score_loss_list[1])) / 10
+                    ? Number(this.medianList(score_loss_list[1]).toFixed(1))
                     : 0;
 
             for (let j = 0; j < num_rows; j++) {
                 summary_moves_list[j][0] = movecounters[j].toString();
                 summary_moves_list[j][1] =
                     btotal > 0
-                        ? (Math.round((1000 * movecounters[j]) / btotal) / 10).toString()
+                        ? ((100 * movecounters[j]) / btotal).toFixed(1)
                         : "";
                 summary_moves_list[j][2] = movecounters[num_rows + j].toString();
                 summary_moves_list[j][3] =
                     wtotal > 0
-                        ? (Math.round((1000 * movecounters[num_rows + j]) / wtotal) / 10).toString()
+                        ? ((100 * movecounters[num_rows + j]) / wtotal).toFixed(1)
                         : "";
             }
 

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -850,7 +850,12 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                 is_uploaded &&
                 this.props.game.goban.config["all_moves"].split("!").length - bplayer !==
                     this.ai_review?.scores.length;
-            if (check1 || check2) {
+
+            // if there's less than 4 moves the worst moves doesn't seem to return 3 moves, otherwise look for these three moves.
+            const check3 =
+                this.ai_review?.moves === undefined ||
+                (Object.keys(this.ai_review?.moves).length !== 3 && scores.length > 4);
+            if (check1 || check2 || check3) {
                 return {
                     ai_table_rows: default_table_rows,
                     avg_score_loss,
@@ -869,6 +874,11 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             let wtotal = 0;
             let btotal = 0;
             const score_loss_list = [[], []];
+            const worst_move_keys = Object.keys(this.ai_review?.moves);
+
+            for (let j = 0; j < worst_move_keys.length; j++) {
+                scores[worst_move_keys[j]] = this.ai_review?.moves[worst_move_keys[j]].score;
+            }
 
             for (let j = hoffset; j < scores.length - 1; j++) {
                 let scorediff = scores[j + 1] - scores[j];
@@ -923,14 +933,10 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             for (let j = 0; j < num_rows; j++) {
                 summary_moves_list[j][0] = movecounters[j].toString();
                 summary_moves_list[j][1] =
-                    btotal > 0
-                        ? ((100 * movecounters[j]) / btotal).toFixed(1)
-                        : "";
+                    btotal > 0 ? ((100 * movecounters[j]) / btotal).toFixed(1) : "";
                 summary_moves_list[j][2] = movecounters[num_rows + j].toString();
                 summary_moves_list[j][3] =
-                    wtotal > 0
-                        ? ((100 * movecounters[num_rows + j]) / wtotal).toFixed(1)
-                        : "";
+                    wtotal > 0 ? ((100 * movecounters[num_rows + j]) / wtotal).toFixed(1) : "";
             }
 
             for (let j = 0; j < ai_table_rows.length; j++) {
@@ -940,6 +946,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             this.setState({
                 table_set: true,
             });
+
             return {
                 ai_table_rows,
                 avg_score_loss,
@@ -1070,14 +1077,10 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
             for (let j = 0; j < num_rows; j++) {
                 summary_moves_list[j][0] = movecounters[j].toString();
                 summary_moves_list[j][1] =
-                    btotal > 0
-                        ? ((100 * movecounters[j]) / btotal).toFixed(1)
-                        : "";
+                    btotal > 0 ? ((100 * movecounters[j]) / btotal).toFixed(1) : "";
                 summary_moves_list[j][2] = movecounters[num_rows + j].toString();
                 summary_moves_list[j][3] =
-                    wtotal > 0
-                        ? ((100 * movecounters[num_rows + j]) / wtotal).toFixed(1)
-                        : "";
+                    wtotal > 0 ? ((100 * movecounters[num_rows + j]) / wtotal).toFixed(1) : "";
             }
 
             for (let j = 0; j < ai_table_rows.length; j++) {


### PR DESCRIPTION
The name of the engine at  `/api/v1/games/{id}/ai_reviews` recently changed from `katago` to `katago:fast` which stopped the Review table from populating automatically as it looked for `katago`. So

## Proposed Changes

  - check if the engine contains `katago` instead of `katago` exactly.
  - added in new table rows to compute the median score loss of the players, and a function to compute the median score loss of a list of numbers (private to AIReview for the moment).
