### PR TITLE
Load some parts of the profile page early.

### DIFF
--- a/src/models/user.d.ts
+++ b/src/models/user.d.ts
@@ -23,6 +23,16 @@ declare namespace rest_api {
         volatility: number;
     }
 
+    type RatingsBySizeAndSpeed = {
+        version: number;
+        overall: RatingsConfig;
+    } & {
+        [game_type in
+            | import("../lib/types").Size
+            | import("../lib/types").Speed
+            | `${import("../lib/types").Speed}-${import("../lib/types").Size}`]: RatingsConfig;
+    };
+
     /**
      * The type of `config.user` passed back by the `ui/config` endpoint.
      */
@@ -31,15 +41,7 @@ declare namespace rest_api {
         id: number;
         username: string;
         registration_date: string; // Date
-        ratings: {
-            version: number;
-            overall: RatingsConfig;
-        } & {
-            [game_type in
-                | import("../lib/types").Size
-                | import("../lib/types").Speed
-                | `${import("../lib/types").Speed}-${import("../lib/types").Size}`]: RatingsConfig;
-        };
+        ratings: RatingsBySizeAndSpeed;
         country: string; // country code
         professional: boolean;
         ranking: number;
@@ -73,7 +75,7 @@ declare namespace rest_api {
         hidden_ids: boolean;
     };
 
-    interface PlayerDetails {
+    interface FullPlayerDetail {
         user: {
             id: number;
             username: string;
@@ -92,10 +94,10 @@ declare namespace rest_api {
             };
             country: string; // country code
             language: string;
-            name: any | null;
-            first_name: any | null;
-            last_name: any | null;
-            real_name_is_private: true;
+            name: string | null;
+            first_name: string | null;
+            last_name: string | null;
+            real_name_is_private: boolean;
             about: string;
             supporter: boolean;
             ui_class_extra: null;
@@ -109,7 +111,7 @@ declare namespace rest_api {
             bot_apikey?: any;
             website: string;
             icon: string; // URL
-            registration_date: "2018-04-09T13:04:44.987830Z";
+            registration_date: string; // ISO Date
             vacation_left: number;
             on_vacation: boolean;
             self_reported_account_linkages?: AccountLinks;
@@ -161,5 +163,46 @@ declare namespace rest_api {
         };
         achievements: any[];
         ip?: string;
+    }
+
+    interface PlayerDetail {
+        related: { [key: string]: string };
+        id: number;
+        username: string;
+        professional: boolean;
+        ranking: number;
+        country: string;
+        language: string;
+        about: string;
+        supporter: boolean;
+        is_bot: boolean;
+        bot_ai: string | null;
+        bot_owner: number | null;
+        website: string;
+        registration_date: string; // ISO Date
+        name: string;
+        timeout_provisional: boolean;
+        ratings: {
+            version: number;
+            overall: RatingsConfig;
+        };
+        is_friend: boolean;
+        aga_id: null;
+        ui_class: string;
+        icon: string;
+    }
+
+    namespace termination_api {
+        interface Player {
+            id: number;
+            country: string;
+            username: string;
+            "icon-url": string;
+            ui_class: string;
+            ratings: RatingsBySizeAndSpeed;
+            rating: number;
+            ranking: number;
+            pro: number;
+        }
     }
 }

--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -33,8 +33,8 @@ const inlineBlock = { display: "inline-flex", alignItems: "center" };
 
 export interface AvatarCardEditableFields {
     username: string;
-    first_name: string;
-    last_name: string;
+    first_name: string | null;
+    last_name: string | null;
     real_name_is_private: boolean;
     country: string;
     website: string;
@@ -49,7 +49,7 @@ interface AvatarCardUserType extends AvatarCardEditableFields {
     supporter: boolean;
     ui_class_extra: string | null;
     on_vacation: boolean;
-    name: string;
+    name: string | null;
     is_bot: boolean;
     is_tournament_moderator: boolean;
     bot_ai: string;
@@ -330,6 +330,7 @@ function AvatarSubtext({ user, global_user }: { user: AvatarCardUserType; global
     );
 
     React.useEffect(() => {
+        setVacationLeftText(getVacationLeftText(user.vacation_left));
         const interval_start = Date.now();
         const vacation_update_interval = setInterval(() => {
             if (user) {
@@ -344,7 +345,7 @@ function AvatarSubtext({ user, global_user }: { user: AvatarCardUserType; global
         return () => {
             clearInterval(vacation_update_interval);
         };
-    }, [user.id]);
+    }, [user.id, user.vacation_left]);
 
     return (
         <div className="avatar-subtext">

--- a/src/views/User/VersusCard.tsx
+++ b/src/views/User/VersusCard.tsx
@@ -20,7 +20,7 @@ import { interpolate } from "translate";
 import * as moment from "moment";
 import * as React from "react";
 
-type VersusCardProps = rest_api.PlayerDetails["vs"] & { username: string };
+type VersusCardProps = rest_api.FullPlayerDetail["vs"] & { username: string };
 
 function toPrettyDate(date: string) {
     return moment(new Date(date)).format("ll");


### PR DESCRIPTION
Improves the UX for slower-loading pages

## Proposed Changes

  - get user data from **api/v1/players/%%** and **termination-api/player/%%**.
  - display the available data before the slower **api/v1/players/%%/full** fetch returns.
  - Clean up/add some types in user.d.ts

Demo:

https://user-images.githubusercontent.com/25233703/162365605-2238d853-866a-47c0-8da2-d0262ff28417.mov

cc: @Sofia-mal
