### PR TITLE
Remove cache-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@typescript-eslint/parser": "^5.14.0",
         "autoprefixer": "^10.4.2",
         "body-parser": "^1.16.1",
-        "cache-loader": "^4.1.0",
+
         "cssnano": "^5.0.8",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
@@ -84,7 +84,6 @@
         "@types/react": "^18.0.5",
         "@types/react-autosuggest": "^10.1.5",
         "@types/react-dom": "^18.0.1",
-        "@types/react-select": "^5.0.1",
         "@types/react-virtualized": "^9.21.21",
         "@types/react-router-dom": "^5.3.2",
         "@types/sanitize-html": "^1.22.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,7 +107,8 @@ module.exports = (env, argv) => {
                     test: /\.tsx?$/,
                     exclude: /node_modules/,
                     use: [
-                        { loader: 'cache-loader' },
+                        // cache is set to true for development in webpack 5 https://webpack.js.org/configuration/cache/
+                        // { loader: 'cache-loader' },
                         {
                             loader: "ts-loader",
                             options: {


### PR DESCRIPTION
Fixes cache-loader dependency issues brought with webpack 5.0.

(Removing react-select types snuck in here too: this is deprecated because react-select apparently comes with types now)

## Proposed Changes

Dump cache-loader.  

I _think_ that webpack 5 is doing what we want anyhow, though this definitely should be checked.