### PR TITLE
Pulled types for react-select and react-virtualized out of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,6 @@
         "@types/react": "^18.0.5",
         "@types/react-autosuggest": "^10.1.5",
         "@types/react-dom": "^18.0.1",
-        "@types/react-select": "^5.0.1",
-        "@types/react-virtualized": "^9.21.21",
         "@types/react-router-dom": "^5.3.2",
         "@types/sanitize-html": "^1.22.0",
         "array-move": "^2.2.1",


### PR DESCRIPTION
Fixes type errors and warnings

## Proposed Changes

 Remove @types for react-select (because the message says to do that) and react-virtualized (because there are type errors due to react now defining the needful).
