### PR TITLE
Give the balance buttons to moderators

### DIFF
--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
@@ -194,7 +194,7 @@ export class RengoTeamManagementPane extends React.PureComponent<
                         </div>
                     ))}
 
-                    {(own_challenge || null) && (
+                    {(own_challenge || this.props.moderator || null) && (
                         <div className="rengo-balancer-buttons">
                             {has_assigned_players ? (
                                 <button


### PR DESCRIPTION
Fixes moderators finding it hard to deal with abandonned or otherwise un-admined rengo challenges

## Proposed Changes

Simply make the buttons available - the back-end doesn't mind.   (It turns out the backend already assumed moderators would be allowed to do /team actions)
