### PR TITLE
Moderator rengo kick

### DIFF
--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.styl
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.styl
@@ -87,6 +87,10 @@
             themed color shade2;
             border-radius: 0.5rem;
         }
+
+        .fa.kick {
+            themed color reject; // deliberate choice of red rather than danger, which is orange
+        }
     }
 
     .rengo-balancer-buttons {

--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
@@ -135,7 +135,7 @@ export class RengoTeamManagementPane extends React.PureComponent<
                             {(this.props.moderator || null) && (
                                 <React.Fragment>
                                     <i
-                                        className="fa fa-user-times unassign"
+                                        className="fa fa-user-times kick"
                                         onClick={this._kickRengoUser.bind(self, n)}
                                     />
                                 </React.Fragment>
@@ -175,7 +175,7 @@ export class RengoTeamManagementPane extends React.PureComponent<
                             {(this.props.moderator || null) && (
                                 <React.Fragment>
                                     <i
-                                        className="fa fa-user-times unassign"
+                                        className="fa fa-user-times kick"
                                         onClick={this._kickRengoUser.bind(self, n)}
                                     />
                                 </React.Fragment>
@@ -215,7 +215,7 @@ export class RengoTeamManagementPane extends React.PureComponent<
                             {(this.props.moderator || null) && (
                                 <React.Fragment>
                                     <i
-                                        className="fa fa-user-times unassign"
+                                        className="fa fa-user-times kick"
                                         onClick={this._kickRengoUser.bind(self, n)}
                                     />
                                 </React.Fragment>

--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
@@ -31,6 +31,7 @@ interface RengoTeamManagementPaneProps {
     moderator: boolean;
     show_chat: boolean;
     assignToTeam: (player_id: number, team: string, challenge: Challenge, done: () => void) => void;
+    kickRengoUser: (player_id: number, done: () => void) => void;
 }
 
 interface RengoTeamManagementPaneState {
@@ -56,6 +57,11 @@ export class RengoTeamManagementPane extends React.PureComponent<
     _assignToTeam = (player_id: number, team: string, challenge: Challenge) => {
         this.setState({ assignment_pending: true });
         this.props.assignToTeam(player_id, team, challenge, this.done.bind(self));
+    };
+
+    _kickRengoUser = (player_id: number) => {
+        this.setState({ assignment_pending: true });
+        this.props.kickRengoUser(player_id, this.done.bind(self));
     };
 
     render = () => {
@@ -126,6 +132,14 @@ export class RengoTeamManagementPane extends React.PureComponent<
                                     />
                                 </React.Fragment>
                             )}
+                            {(this.props.moderator || null) && (
+                                <React.Fragment>
+                                    <i
+                                        className="fa fa-user-times unassign"
+                                        onClick={this._kickRengoUser.bind(self, n)}
+                                    />
+                                </React.Fragment>
+                            )}
                             <Player user={n} rank={true} key={i} />
                         </div>
                     ))}
@@ -158,6 +172,14 @@ export class RengoTeamManagementPane extends React.PureComponent<
                                     />
                                 </React.Fragment>
                             )}
+                            {(this.props.moderator || null) && (
+                                <React.Fragment>
+                                    <i
+                                        className="fa fa-user-times unassign"
+                                        onClick={this._kickRengoUser.bind(self, n)}
+                                    />
+                                </React.Fragment>
+                            )}
                             <Player user={n} rank={true} key={i} />
                         </div>
                     ))}
@@ -187,6 +209,14 @@ export class RengoTeamManagementPane extends React.PureComponent<
                                             "rengo_white_team",
                                             the_challenge,
                                         )}
+                                    />
+                                </React.Fragment>
+                            )}
+                            {(this.props.moderator || null) && (
+                                <React.Fragment>
+                                    <i
+                                        className="fa fa-user-times unassign"
+                                        onClick={this._kickRengoUser.bind(self, n)}
                                     />
                                 </React.Fragment>
                             )}

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -747,6 +747,7 @@ export class Play extends React.Component<{}, PlayState> {
                             moderator={user.is_moderator}
                             show_chat={false}
                             assignToTeam={this.assignToTeam}
+                            kickRengoUser={this.kickRengoUser}
                         />
                     </RengoManagementPane>
                 </div>
@@ -1239,6 +1240,7 @@ export class Play extends React.Component<{}, PlayState> {
                                 moderator={user.is_moderator}
                                 show_chat={true}
                                 assignToTeam={this.assignToTeam}
+                                kickRengoUser={this.kickRengoUser}
                             />
                         </RengoManagementPane>
                     </Card>
@@ -1354,6 +1356,16 @@ export class Play extends React.Component<{}, PlayState> {
             [assignment]: [player_id], // back end expects an array of changes, but we only ever send one at a time.
         })
             .then(signal_done) // tell caller that we got the response from the server now.
+            .catch((err) => {
+                errorAlerter(err);
+            });
+    };
+
+    kickRengoUser = (player_id: number, signal_done?: () => void) => {
+        put("challenges", {
+            rengo_kick: player_id,
+        })
+            .then(signal_done)
             .catch((err) => {
                 errorAlerter(err);
             });


### PR DESCRIPTION
Fixes moderators needing a way to eject someone from all rengo challenges

## Proposed Changes

GIve moderators a boot-someone-out-of-all-rengo-challenges button.

(Note: the positioning of the button doesn't make it entirely clear that it will eject the person from _all_ rengo challenges, but I couldn't think of a way to make that clear, and really moderators kind of know what they are doing, plus it's not the end of the world if someone is accidentally kicked from rengo challenges)

Requires https://github.com/online-go/ogs/pull/1734

![Screen Shot 2022-04-24 at 5 03 21 pm (2)](https://user-images.githubusercontent.com/61894/164965553-3a0e4702-314d-4c01-a1b1-18b5122b43e8.png)

