### PR TITLE
Wrap joseki description in AutoTranslate

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -397,7 +397,7 @@ function getPreferredLanguage(req, supported_languages) {
     try {
         languages = req.headers['accept-language'].split(',').map(s => s.replace(/;q=.*/, '').trim().toLowerCase());
     } catch (e) {
-        trace.error(e);
+        console.trace(e);
     }
 
     try {

--- a/src/components/AutoTranslate/AutoTranslate.tsx
+++ b/src/components/AutoTranslate/AutoTranslate.tsx
@@ -40,7 +40,8 @@ export function AutoTranslate({
     className,
     markdown,
 }: AutoTranslateProps): JSX.Element {
-    const need_translation = !source_language || source_language.toLowerCase() !== current_language;
+    const need_translation =
+        source !== "" && (!source_language || source_language.toLowerCase() !== current_language);
 
     const [translation, setTranslation] = React.useState<Translation>(
         need_translation

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -29,6 +29,7 @@ import { _, interpolate, npgettext } from "translate";
 import { KBShortcut } from "KBShortcut";
 import { PersistentElement } from "PersistentElement";
 import { Goban, GoMath, GobanConfig } from "goban";
+import { AutoTranslate } from "AutoTranslate";
 import { Markdown } from "Markdown";
 
 import { Player } from "Player";
@@ -1770,7 +1771,7 @@ class ExplorePane extends React.Component<ExploreProps, ExploreState> {
                 <div className="description-column">
                     {this.props.position_type !== "new" ? (
                         <div className="position-description">
-                            <Markdown source={description} />
+                            <AutoTranslate source={description} markdown />
                         </div>
                     ) : (
                         "" // "(new)"
@@ -1842,7 +1843,7 @@ class ExplorePane extends React.Component<ExploreProps, ExploreState> {
                                                 {comment.date.toDateString()}
                                             </div>
                                         </div>
-                                        <Markdown
+                                        <AutoTranslate
                                             className="comment-text"
                                             source={applyJosekiMarkdown(comment.comment)}
                                         />


### PR DESCRIPTION
...  and defend Autotranslate against empty requests


## Proposed Changes
 * Use AutoTranslate on Joseki Descriptions
 * Fix error message generation in Gulpfile
 * Don't request translation of empty strings
 