### PR TITLE
Be unambiguous that Joseki Descriptions are (currently) in English

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1771,7 +1771,7 @@ class ExplorePane extends React.Component<ExploreProps, ExploreState> {
                 <div className="description-column">
                     {this.props.position_type !== "new" ? (
                         <div className="position-description">
-                            <AutoTranslate source={description} markdown />
+                            <AutoTranslate source={description} source_language={"en"} markdown />
                         </div>
                     ) : (
                         "" // "(new)"


### PR DESCRIPTION

Fixes  AutoTranslate wrongly deciding the source language when the position description is short.

## Proposed Changes

```
                            <AutoTranslate source={description} markdown />
                            <AutoTranslate source={description} source_language={"en"} markdown />
```