### PR TITLE
Make OJE position saving work again, for extended sequences

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -561,10 +561,10 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
                         this.setState({ throb: false });
                     });
             } else {
-                console.log("(not prefetching, we already did this one)");
+                // console.log("(not prefetching, we already did this one)");
             }
         } else {
-            console.log("(not prefetching here, we have one already in flight)");
+            // console.log("(not prefetching here, we have one already in flight)");
         }
     };
 
@@ -585,9 +585,9 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
 
         this.processNewJosekiPosition(dto);
 
-        const elapsed = new Date().valueOf() - this.last_click;
+        // const elapsed = new Date().valueOf() - this.last_click;
 
-        console.log("displayed result in", elapsed / 1000);
+        // console.log("displayed result in", elapsed / 1000);
 
         if (this.state.count_details_open) {
             this.showVariationCounts(node_id);
@@ -1540,12 +1540,12 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
             })
                 .then((res) => res.json())
                 .then((body) => {
-                    // console.log("Server response to sequence POST:", body);
-                    this.processNewJosekiPosition(body);
+                    //console.log("Server response to sequence POST:", body);
 
                     // Now we can save the fields that apply only to the final position
 
-                    fetch(position_url(this.state.current_node_id), {
+                    console.log("resulting node_id:", body.node_id);
+                    fetch(position_url(body.node_id), {
                         method: "put",
                         mode: "cors",
                         headers: oje_headers(),


### PR DESCRIPTION
Fixes "Save" not working properly

## Proposed Changes

Instead of using the updated State from the position creation after "processNewPosition", just use the raw node id received from the server.

Goodness knows how this ever worked - it was highly dependent on when State is actually updated.
