### PR TITLE
Oje turn on tag filter by default

### DIFF
--- a/src/components/JosekiTagSelector/JosekiTagSelector.tsx
+++ b/src/components/JosekiTagSelector/JosekiTagSelector.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 
-import Select from "react-select";
+import Select, { MultiValue } from "react-select";
 
 export interface JosekiTag {
     value: string;
@@ -27,11 +27,11 @@ export interface JosekiTag {
 interface JosekiTagSelectorProps {
     available_tags: JosekiTag[];
     selected_tags: JosekiTag[];
-    on_tag_update: (newvalue: any) => void;
+    on_tag_update: (newvalue: MultiValue<JosekiTag>) => void;
 }
 
 export function JosekiTagSelector(props: JosekiTagSelectorProps) {
-    const onTagChange = (e) => {
+    const onTagChange = (e: MultiValue<JosekiTag>) => {
         props.on_tag_update(e);
     };
 

--- a/src/components/JosekiTagSelector/JosekiTagSelector.tsx
+++ b/src/components/JosekiTagSelector/JosekiTagSelector.tsx
@@ -25,16 +25,12 @@ export interface JosekiTag {
 }
 
 interface JosekiTagSelectorProps {
-    oje_headers: HeadersInit;
-    tag_list_url: string;
+    available_tags: JosekiTag[];
     selected_tags: JosekiTag[];
-    on_tag_update: any;
+    on_tag_update: (newvalue: any) => void;
 }
 
-interface JosekiTagSelectorState {
-    tag_list: JosekiTag[];
-    tag_map: {};
-}
+interface JosekiTagSelectorState {}
 
 export class JosekiTagSelector extends React.PureComponent<
     JosekiTagSelectorProps,
@@ -42,37 +38,7 @@ export class JosekiTagSelector extends React.PureComponent<
 > {
     constructor(props) {
         super(props);
-        this.state = {
-            tag_list: [],
-            tag_map: {},
-        };
     }
-
-    componentDidMount = () => {
-        fetch(this.props.tag_list_url, {
-            mode: "cors",
-            headers: this.props.oje_headers,
-        })
-            .then((res) => res.json())
-            .then((body) => {
-                // console.log("Server response to tag GET:", body);
-                const available_tags = body.tags.map((tag) => ({
-                    label: tag.description,
-                    value: tag.id,
-                }));
-                const tag_map = {};
-                for (const tag of available_tags) {
-                    tag_map[tag.value] = tag;
-                }
-                this.setState({
-                    tag_list: available_tags,
-                    tag_map: tag_map,
-                });
-            })
-            .catch((r) => {
-                console.log("Tags GET failed:", r);
-            });
-    };
 
     onTagChange = (e) => {
         this.props.on_tag_update(e);
@@ -81,15 +47,13 @@ export class JosekiTagSelector extends React.PureComponent<
     render() {
         // console.log("Tag selector render");
         // console.log("tags", this.state.tag_list);
-        // console.log("Selected tags: ", this.props.selected_tags);
-        // console.log("Tags list: ", this.state.tag_list);
-
+        console.log("Selected tags: ", this.props.selected_tags);
         return (
             <Select
                 className="joseki-tag-selector"
                 classNamePrefix="ogs-react-select"
                 value={this.props.selected_tags}
-                options={this.state.tag_list}
+                options={this.props.available_tags}
                 isMulti={true}
                 onChange={this.onTagChange}
                 getOptionLabel={(o) => o.label}

--- a/src/components/JosekiTagSelector/JosekiTagSelector.tsx
+++ b/src/components/JosekiTagSelector/JosekiTagSelector.tsx
@@ -30,48 +30,32 @@ interface JosekiTagSelectorProps {
     on_tag_update: (newvalue: any) => void;
 }
 
-interface JosekiTagSelectorState {}
-
-export class JosekiTagSelector extends React.PureComponent<
-    JosekiTagSelectorProps,
-    JosekiTagSelectorState
-> {
-    constructor(props) {
-        super(props);
-    }
-
-    onTagChange = (e) => {
-        this.props.on_tag_update(e);
+export function JosekiTagSelector(props: JosekiTagSelectorProps) {
+    const onTagChange = (e) => {
+        props.on_tag_update(e);
     };
 
-    render() {
-        // console.log("Tag selector render");
-        // console.log("tags", this.state.tag_list);
-        console.log("Selected tags: ", this.props.selected_tags);
-        return (
-            <Select
-                className="joseki-tag-selector"
-                classNamePrefix="ogs-react-select"
-                value={this.props.selected_tags}
-                options={this.props.available_tags}
-                isMulti={true}
-                onChange={this.onTagChange}
-                getOptionLabel={(o) => o.label}
-                getOptionValue={(o) => o.value}
-                components={{
-                    Option: ({ innerRef, innerProps, isFocused, isSelected, data }) => (
-                        <div
-                            ref={innerRef}
-                            {...innerProps}
-                            className={
-                                (isFocused ? "focused " : "") + (isSelected ? "selected" : "")
-                            }
-                        >
-                            {data.label}
-                        </div>
-                    ),
-                }}
-            />
-        );
-    }
+    return (
+        <Select
+            className="joseki-tag-selector"
+            classNamePrefix="ogs-react-select"
+            value={props.selected_tags}
+            options={props.available_tags}
+            isMulti={true}
+            onChange={onTagChange}
+            getOptionLabel={(o) => o.label}
+            getOptionValue={(o) => o.value}
+            components={{
+                Option: ({ innerRef, innerProps, isFocused, isSelected, data }) => (
+                    <div
+                        ref={innerRef}
+                        {...innerProps}
+                        className={(isFocused ? "focused " : "") + (isSelected ? "selected" : "")}
+                    >
+                        {data.label}
+                    </div>
+                ),
+            }}
+        />
+    );
 }

--- a/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
+++ b/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
@@ -38,11 +38,6 @@ interface JosekiVariationFilterState {
     contributor_list: (ResolvedContributor | UnresolvedContributor)[];
     tag_list: JosekiTag[];
     source_list: { id: string; description: string }[];
-    selected_filter: {
-        tags: JosekiTag[];
-        contributor: number;
-        source: number;
-    };
 }
 
 export class JosekiVariationFilter extends React.PureComponent<
@@ -55,11 +50,6 @@ export class JosekiVariationFilter extends React.PureComponent<
             contributor_list: [],
             tag_list: [],
             source_list: [],
-            selected_filter: {
-                tags: this.props.current_filter["tags"],
-                contributor: this.props.current_filter["contributor"],
-                source: this.props.current_filter["source"],
-            },
         };
     }
 
@@ -124,7 +114,7 @@ export class JosekiVariationFilter extends React.PureComponent<
     onTagChange = (tags: JosekiTag[]) => {
         console.log("Variation filter update:", tags);
         //const tags = (e === null || e.length === 0) ? null : e.map(t => typeof(t) === 'number' ? t : t.value);
-        const new_filter = { ...this.state.selected_filter, tags };
+        const new_filter = { ...this.props.current_filter, tags };
 
         // console.log("new tag filter", new_filter);
         this.props.set_variation_filter(new_filter); // tell parent the fiter changed, so the view needs to change
@@ -132,13 +122,13 @@ export class JosekiVariationFilter extends React.PureComponent<
 
     onContributorChange = (e) => {
         const val = e.target.value === "none" ? null : parseInt(e.target.value);
-        const new_filter = { ...this.state.selected_filter, contributor: val };
+        const new_filter = { ...this.props.current_filter, contributor: val };
         this.props.set_variation_filter(new_filter);
     };
 
     onSourceChange = (e) => {
         const val = e.target.value === "none" ? null : parseInt(e.target.value);
-        const new_filter = { ...this.state.selected_filter, source: val };
+        const new_filter = { ...this.props.current_filter, source: val };
         this.props.set_variation_filter(new_filter);
     };
 
@@ -184,12 +174,12 @@ export class JosekiVariationFilter extends React.PureComponent<
         );
 
         const current_contributor =
-            this.state.selected_filter.contributor === null
+            this.props.current_filter.contributor === null
                 ? "none"
-                : this.state.selected_filter.contributor;
+                : this.props.current_filter.contributor;
 
         const current_source =
-            this.state.selected_filter.source === null ? "none" : this.state.selected_filter.source;
+            this.props.current_filter.source === null ? "none" : this.props.current_filter.source;
 
         return (
             <div className="joseki-variation-filter">

--- a/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
+++ b/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
@@ -49,7 +49,7 @@ export function JosekiVariationFilter(props: JosekiVariationFilterProps) {
         })
             .then((res) => res.json())
             .then((body) => {
-                console.log("Server response to contributors GET:", body);
+                //console.log("Server response to contributors GET:", body);
                 const new_contributor_list: ContributorList = [];
                 body.forEach((id, idx) => {
                     //console.log("Looking up player", id, idx);

--- a/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
+++ b/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
@@ -22,13 +22,15 @@ import * as player_cache from "player_cache";
 import { JosekiTagSelector, JosekiTag } from "../JosekiTagSelector";
 import { PlayerCacheEntry } from "player_cache";
 
+export type JosekiFilter = { contributor: number; tags: JosekiTag[]; source: number };
+
 interface JosekiVariationFilterProps {
     oje_headers: HeadersInit;
     contributor_list_url: string;
     source_list_url: string;
     set_variation_filter: any;
     joseki_tags: JosekiTag[];
-    current_filter: { contributor: number; tags: JosekiTag[]; source: number };
+    current_filter: JosekiFilter;
 }
 
 type ResolvedContributor = { resolved: true; player: PlayerCacheEntry };

--- a/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
+++ b/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
@@ -25,9 +25,9 @@ import { PlayerCacheEntry } from "player_cache";
 interface JosekiVariationFilterProps {
     oje_headers: HeadersInit;
     contributor_list_url: string;
-    tag_list_url: string;
     source_list_url: string;
     set_variation_filter: any;
+    joseki_tags: JosekiTag[];
     current_filter: { contributor: number; tags: JosekiTag[]; source: number };
 }
 
@@ -121,35 +121,32 @@ export class JosekiVariationFilter extends React.PureComponent<
             });
     };
 
-    onTagChange = (tags) => {
-        // console.log("Variation filter update:", e);
+    onTagChange = (tags: JosekiTag[]) => {
+        console.log("Variation filter update:", tags);
         //const tags = (e === null || e.length === 0) ? null : e.map(t => typeof(t) === 'number' ? t : t.value);
         const new_filter = { ...this.state.selected_filter, tags };
 
         // console.log("new tag filter", new_filter);
-        this.props.set_variation_filter(new_filter);
-        this.setState({ selected_filter: new_filter });
+        this.props.set_variation_filter(new_filter); // tell parent the fiter changed, so the view needs to change
     };
 
     onContributorChange = (e) => {
         const val = e.target.value === "none" ? null : parseInt(e.target.value);
         const new_filter = { ...this.state.selected_filter, contributor: val };
         this.props.set_variation_filter(new_filter);
-        this.setState({ selected_filter: new_filter });
     };
 
     onSourceChange = (e) => {
         const val = e.target.value === "none" ? null : parseInt(e.target.value);
         const new_filter = { ...this.state.selected_filter, source: val };
         this.props.set_variation_filter(new_filter);
-        this.setState({ selected_filter: new_filter });
     };
 
     render() {
         // console.log("Variation filter render");
         // console.log("contributors", this.state.contributor_list);
         // console.log("sources", this.state.source_list);
-        // console.log(" filter", this.state.selected_filter);
+        console.log("on render, filter", this.props.current_filter);
 
         // console.log(this.state.contributor_list);
 
@@ -199,9 +196,8 @@ export class JosekiVariationFilter extends React.PureComponent<
                 <div className="filter-set">
                     <div className="filter-label">{_("Filter by Tag")}</div>
                     <JosekiTagSelector
-                        oje_headers={this.props.oje_headers}
-                        tag_list_url={this.props.tag_list_url}
-                        selected_tags={this.state.selected_filter.tags}
+                        available_tags={this.props.joseki_tags}
+                        selected_tags={this.props.current_filter?.tags || []}
                         on_tag_update={this.onTagChange}
                     />
                 </div>

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1167,7 +1167,7 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
     };
 
     render() {
-        console.log("Joseki app rendering ", this.state.variation_filter);
+        //console.log("Joseki app rendering ", this.state.variation_filter);
 
         const tenuki_type =
             this.state.pass_available &&
@@ -1772,7 +1772,7 @@ class ExplorePane extends React.Component<ExploreProps, ExploreState> {
 
         const description = applyJosekiMarkdown(this.props.description);
 
-        console.log("Explore Pane rendering", this.props.current_filter);
+        //console.log("Explore Pane rendering", this.props.current_filter);
 
         return (
             <div className="explore-pane">


### PR DESCRIPTION
From chat, as background:

 I'm leaning in the direction of having the "Joseki: settled" filter active when you arrive at OJE
 This will have the benefits of:
   - Making people more aware that the whole filtering feature is there
   - Not exposing everyone to every variation that isn't actually Joseki (in theory non-Joseki paths filtered out by this should be a very small subset of all the paths, because OJE is supposed to be "validated Joseki only")

## Proposed Changes

TL:DR: set the Filter to "Joseki" Tag by default, when the Joseki page loads.

Involved:
 - ripping the filter state out of the filter select components, to allow the initial value to be set
       -  fixing various initialisation sequence issues that result
 - converting them to Functional, because why not
 - typing to suit