### PR TITLE
Remove badukaires.com from GoResources.tsx

### DIFF
--- a/src/views/docs/GoResources.tsx
+++ b/src/views/docs/GoResources.tsx
@@ -960,12 +960,6 @@ export const GoResources = () => {
                             </span>,
                             <span>
                                 <Flag country={es} />{" "}
-                                <a rel="noopener" href="http://badukaires.com/">
-                                    Badukaires
-                                </a>
-                            </span>,
-                            <span>
-                                <Flag country={es} />{" "}
                                 <a rel="noopener" href="http://canbaduk.wordpress.com/">
                                     Canbaduk
                                 </a>


### PR DESCRIPTION
The domain now points to a spam site.