### PR TITLE
Turn off the "undo" button if it is a rengo game.

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1338,6 +1338,7 @@ export function Game(): JSX.Element {
             <span className="play-buttons">
                 <span>
                     {((cur_move_number >= 1 &&
+                        !goban?.current?.engine.rengo &&
                         player_not_to_move === data.get("user").id &&
                         !(
                             goban.current.engine.undo_requested >=


### PR DESCRIPTION
Fixes people complaining that undo doesn't work.

## Proposed Changes

Detect rengo on the goban engine and turn off Undo button.

Things for reviewer attention:

A one line change, but is this a legit way of defending against goban and its ref not being ready?   And is there anywhere else that would care?
