### PR TITLE
Don't default to "un" flag on Game page

### DIFF
--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -301,7 +301,7 @@ function PlayerCard({
                             </div>
                         )}
                         <div className="player-flag">
-                            <Flag country={player.country ?? "un"} />
+                            <Flag country={player.country} />
                         </div>
                         <ChatPresenceIndicator channel={chat_channel} userId={player.id} />
                     </div>


### PR DESCRIPTION
Fixes #1816 

See also #1819.

This PR returns to previous behavior. If this is the PR we go with, further investigation is needed into why we aren't seeing country data in non-rengo games.