### PR TITLE
Remove `Flag` from PlayerCards altogether

### DIFF
--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -19,7 +19,6 @@ import * as React from "react";
 import { Goban, Score, PlayerScore } from "goban";
 import { icon_size_url } from "PlayerIcon";
 import { CountDown } from "./CountDown";
-import { Flag } from "Flag";
 import { ChatPresenceIndicator } from "ChatPresenceIndicator";
 import { Clock } from "Clock";
 import { Player } from "Player";
@@ -300,9 +299,6 @@ function PlayerCard({
                                 <CountDown to={auto_resign_expiration} />
                             </div>
                         )}
-                        <div className="player-flag">
-                            <Flag country={player.country ?? "un"} />
-                        </div>
                         <ChatPresenceIndicator channel={chat_channel} userId={player.id} />
                     </div>
                 )}


### PR DESCRIPTION
Fixes #1816 

See also #1818 

Nothing against displaying the flag, but recent behavior was that the Flag was *not* shown in normal games, but shows up in rengo.  I think I prefer removing the flag altogether, due to consistency.