### PR TITLE
Add board size and ranked filters to game history

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -113,6 +113,9 @@ export const defaults = {
     "moderator.join-games-anonymously": true,
 
     "table-color-default-on": false,
+
+    "game-history-size-filter": "all",
+    "game-history-ranked-filter": "all",
 };
 
 defaults["profanity-filter"][current_language] = true;

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -63,6 +63,37 @@ interface GroomedGame {
 
 export function GameHistoryTable(props: GameHistoryProps) {
     const [player_filter, setPlayerFilter] = React.useState<number>(null);
+    const [game_history_board_size_filter, setGameHistoryBoardSizeFilter] = React.useState<string>(
+        preferences.get("game-history-size-filter"),
+    );
+    const [game_history_ranked_filter, setGameHistoryRankedFilter] = React.useState<string>(
+        preferences.get("game-history-ranked-filter"),
+    );
+
+    function getBoardSize(size_filter: string): number {
+        switch (size_filter) {
+            case "9x9":
+                return 9;
+            case "13x13":
+                return 13;
+            case "19x19":
+                return 19;
+        }
+    }
+
+    function toggleBoardSizeFilter(size_filter: string) {
+        const new_size_filter =
+            game_history_board_size_filter === size_filter ? "all" : size_filter;
+        setGameHistoryBoardSizeFilter(new_size_filter);
+        preferences.set("game-history-size-filter", new_size_filter);
+    }
+
+    function toggleRankedFilter(ranked_filter: string) {
+        const new_ranked_filter =
+            game_history_ranked_filter === ranked_filter ? "all" : ranked_filter;
+        setGameHistoryRankedFilter(new_ranked_filter);
+        preferences.set("game-history-ranked-filter", new_ranked_filter);
+    }
 
     function game_history_groomer(results: rest_api.Game[]): GroomedGame[] {
         const ret = [];
@@ -136,6 +167,62 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 }}
                             />
                         </div>
+                        <div>
+                            <div className="btn-group">
+                                <button
+                                    className={
+                                        game_history_board_size_filter === "9x9"
+                                            ? "primary sm"
+                                            : "sm"
+                                    }
+                                    onClick={() => toggleBoardSizeFilter("9x9")}
+                                >
+                                    {_("9x9")}
+                                </button>
+                                <button
+                                    className={
+                                        game_history_board_size_filter === "13x13"
+                                            ? "primary sm"
+                                            : "sm"
+                                    }
+                                    onClick={() => toggleBoardSizeFilter("13x13")}
+                                >
+                                    {_("13x13")}
+                                </button>
+                                <button
+                                    className={
+                                        game_history_board_size_filter === "19x19"
+                                            ? "primary sm"
+                                            : "sm"
+                                    }
+                                    onClick={() => toggleBoardSizeFilter("19x19")}
+                                >
+                                    {_("19x19")}
+                                </button>
+                            </div>
+                            <div className="btn-group">
+                                <button
+                                    className={
+                                        game_history_ranked_filter === "ranked"
+                                            ? "primary sm"
+                                            : "sm"
+                                    }
+                                    onClick={() => toggleRankedFilter("ranked")}
+                                >
+                                    {_("Ranked")}
+                                </button>
+                                <button
+                                    className={
+                                        game_history_ranked_filter === "unranked"
+                                            ? "primary sm"
+                                            : "sm"
+                                    }
+                                    onClick={() => toggleRankedFilter("unranked")}
+                                >
+                                    {_("Unranked")}
+                                </button>
+                            </div>
+                        </div>
                     </div>
                     <PaginatedTable
                         className="game-history-table"
@@ -147,6 +234,14 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             ended__isnull: false,
                             ...(player_filter !== null && {
                                 alt_player: player_filter,
+                            }),
+                            ...(game_history_board_size_filter !== "all" && {
+                                height: getBoardSize(game_history_board_size_filter),
+                                width: getBoardSize(game_history_board_size_filter),
+                            }),
+                            ...(game_history_ranked_filter !== "all" && {
+                                ranked: game_history_ranked_filter === "ranked",
+                                annulled: false, // Assume the user wants to filter annulled games
                             }),
                         }}
                         orderBy={["-ended"]}

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -430,6 +430,7 @@
     .game-options {
         display: flex;
         justify-content: space-between;
+        align-items: self-start;
         width: 100%;
 
         .rengo-selector > * {


### PR DESCRIPTION
Previous discussion about filtering games in the Game History can be found in this [forum thread](https://forums.online-go.com/t/feature-request-filter-game-history/38657/8). I decided to give this feature a go and add it in a way I found useful.

In the Game History table, I added two button sets for a board size filter and a ranked games filter. The top of the table looks like:
[ Player name search ] [ 9x9 | 13x13 | 19x19 ] [ Ranked | Unranked ]

For each filter, the filter is only active if a button is pressed, and only one button may be pressed at a time.

One peculiarity in this change is that annulled games are filtered out when either the Ranked or Unranked button is pressed. I don't know whether this is a good idea or not, but I found it to be more practical than adding another button.

## Proposed Changes

  - Added a board size filter and a ranked filter to the Game History table to the right of the Player filter in the user profile page.
  - Added preferences for the board size filter and ranked filter.
  - Changed the css so that the Player Search filter is aligned to the top when the page is narrower.
