### PR TITLE
Create usePreference hook

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -79,7 +79,10 @@ export class GobanThemePicker extends React.PureComponent<
                 ) as unknown as { [style_name: string]: string };
 
                 this.selectTheme[k][theme.theme_name] = () => {
-                    preferences.set(`goban-theme-${k}`, theme.theme_name);
+                    preferences.set(
+                        `goban-theme-${k}` as preferences.ValidPreference,
+                        theme.theme_name,
+                    );
                     const up = {};
                     up[k] = theme.theme_name;
                     this.setState(up);

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -17,6 +17,7 @@
 
 import * as data from "data";
 import { GobanSelectedThemes, GoThemes } from "goban";
+import React from "react";
 import { current_language } from "translate";
 import { DataSchema } from "./data_schema";
 
@@ -213,4 +214,24 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
             unwatch("goban-theme-white", call_cb);
         },
     };
+}
+
+export function usePreference<KeyT extends ValidPreference>(
+    key: KeyT,
+): [PreferencesType[KeyT], (v: PreferencesType[KeyT]) => void] {
+    const [value, stateSetter] = React.useState(get(key));
+
+    const setStateAndPreference = (v: PreferencesType[KeyT]) => {
+        stateSetter(v);
+        set(key, v);
+    };
+
+    // TODO: maybe add a watcher here for if a different component updates the value?
+    // Something like...
+    //
+    // React.useEffect(() => {
+    //     watch(key, stateSetter);
+    // }
+
+    return [value, setStateAndPreference];
 }

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -18,6 +18,7 @@
 import * as data from "data";
 import { GoThemes } from "goban";
 import { current_language } from "translate";
+import { DataSchema } from "./data_schema";
 
 export const defaults = {
     "ai-review-enabled": true,
@@ -48,7 +49,7 @@ export const defaults = {
     "label-positioning": "all",
     "label-positioning-puzzles": "all",
     language: "auto",
-    "move-tree-numbering": "move-number",
+    "move-tree-numbering": "move-number" as "none" | "move-coordinates" | "move-number",
     "new-game-board-size": 19,
     "notification-timeout": 10,
     "notify-on-incident-report": true,
@@ -94,7 +95,7 @@ export const defaults = {
 
     "supporter.currency": "auto",
     "supporter.interval": "month",
-    "tournaments-tab": "schedule",
+    "tournaments-tab": "schedule" as "schedule" | "live" | "archive" | "correspondence",
     "tournaments-show-all": false,
     "translation-dialog-dismissed": 0,
     "translation-dialog-never-show": false,
@@ -121,15 +122,17 @@ for (const k in defaults) {
     data.setDefault(`preferences.${k as ValidPreference}`, defaults[k]);
 }
 
-export type ValidPreference = keyof typeof defaults | `goban-theme-${string}`;
+export type ValidPreference = keyof typeof defaults;
 
-export function get(key: ValidPreference): any {
+export function get<T extends keyof typeof defaults>(key: T): DataSchema[`preferences.${T}`] {
     if (!(key in defaults)) {
         if ((key as string) === "sound-volume") {
             console.error(
                 "You have an extension installed that is not using the newer sound system, volume will not be controllable",
             );
-            return 1.0;
+            // This should never happen according to the type system, so we have
+            // to type it as any in order to suppress an error.
+            return 1.0 as any;
         }
 
         throw new Error(`Undefined default: ${key}`);

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -60,7 +60,7 @@ export const defaults = {
     "observed-games-force-list": false,
     "one-click-submit-correspondence": false,
     "one-click-submit-live": true,
-    "profanity-filter": { en: true },
+    "profanity-filter": { en: true } as { [cc: string]: true },
     "puzzle.randomize.color": true,
     "puzzle.randomize.transform": true,
     "puzzle.zoom": true,
@@ -124,7 +124,7 @@ for (const k in defaults) {
 
 export type ValidPreference = keyof typeof defaults;
 
-export function get<T extends keyof typeof defaults>(key: T): DataSchema[`preferences.${T}`] {
+export function get<KeyT extends ValidPreference>(key: KeyT): DataSchema[`preferences.${KeyT}`] {
     if (!(key in defaults)) {
         if ((key as string) === "sound-volume") {
             console.error(
@@ -139,7 +139,11 @@ export function get<T extends keyof typeof defaults>(key: T): DataSchema[`prefer
     }
     return data.get(`preferences.${key}`);
 }
-export function set(key: ValidPreference, value: any, replication?: data.Replication): any {
+export function set<KeyT extends ValidPreference>(
+    key: KeyT,
+    value: DataSchema[`preferences.${KeyT}`],
+    replication?: data.Replication,
+): DataSchema[`preferences.${KeyT}`] {
     return data.set(`preferences.${key}`, value, replication);
 }
 export function watch(

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -216,6 +216,12 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
     };
 }
 
+/**
+ * A custom React hook that returns a state variable and a function that can be
+ * used to set both the state and the preference at the same time.
+ *
+ * @param key a preference (as one would use in `preferences.get(key)`)
+ */
 export function usePreference<KeyT extends ValidPreference>(
     key: KeyT,
 ): [PreferencesType[KeyT], (v: PreferencesType[KeyT]) => void] {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -16,7 +16,7 @@
  */
 
 import * as data from "data";
-import { GoThemes } from "goban";
+import { GobanSelectedThemes, GoThemes } from "goban";
 import { current_language } from "translate";
 import { DataSchema } from "./data_schema";
 
@@ -146,9 +146,9 @@ export function set<KeyT extends ValidPreference>(
 ): DataSchema[`preferences.${KeyT}`] {
     return data.set(`preferences.${key}`, value, replication);
 }
-export function watch(
-    key: ValidPreference,
-    cb: (d: any) => void,
+export function watch<KeyT extends ValidPreference>(
+    key: KeyT,
+    cb: (d: DataSchema[`preferences.${KeyT}`]) => void,
     call_on_undefined?: boolean,
     dont_call_immediately?: boolean,
 ): void {
@@ -187,7 +187,7 @@ export function getSelectedThemes(): { board: string; black: string; white: stri
     };
 }
 
-export function watchSelectedThemes(cb) {
+export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
     let dont_call_right_away = true;
     const call_cb = () => {
         if (dont_call_right_away) {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -122,9 +122,10 @@ for (const k in defaults) {
     data.setDefault(`preferences.${k as ValidPreference}`, defaults[k]);
 }
 
+type PreferencesType = typeof defaults;
 export type ValidPreference = keyof typeof defaults;
 
-export function get<KeyT extends ValidPreference>(key: KeyT): DataSchema[`preferences.${KeyT}`] {
+export function get<KeyT extends ValidPreference>(key: KeyT): PreferencesType[KeyT] {
     if (!(key in defaults)) {
         if ((key as string) === "sound-volume") {
             console.error(
@@ -137,25 +138,30 @@ export function get<KeyT extends ValidPreference>(key: KeyT): DataSchema[`prefer
 
         throw new Error(`Undefined default: ${key}`);
     }
-    return data.get(`preferences.${key}`);
+    // I can't figure out why TypeScript doesn't like this, but I think it's better
+    // to define the type in terms of Preferences instead of DataSchema.
+    return data.get(`preferences.${key}`) as any;
 }
 export function set<KeyT extends ValidPreference>(
     key: KeyT,
-    value: DataSchema[`preferences.${KeyT}`],
+    value: PreferencesType[KeyT],
     replication?: data.Replication,
 ): DataSchema[`preferences.${KeyT}`] {
-    return data.set(`preferences.${key}`, value, replication);
+    return data.set(`preferences.${key}`, value as any, replication);
 }
 export function watch<KeyT extends ValidPreference>(
     key: KeyT,
-    cb: (d: DataSchema[`preferences.${KeyT}`]) => void,
+    cb: (d: PreferencesType[KeyT]) => void,
     call_on_undefined?: boolean,
     dont_call_immediately?: boolean,
 ): void {
-    data.watch(`preferences.${key}`, cb, call_on_undefined, dont_call_immediately);
+    data.watch(`preferences.${key}`, cb as any, call_on_undefined, dont_call_immediately);
 }
-export function unwatch(key: ValidPreference, cb: (d: any) => void): void {
-    data.unwatch(`preferences.${key}`, cb);
+export function unwatch<KeyT extends ValidPreference>(
+    key: KeyT,
+    cb: (d: PreferencesType[KeyT]) => void,
+): void {
+    data.unwatch(`preferences.${key}`, cb as any);
 }
 
 export function dump(): void {

--- a/src/models/puzzles.d.ts
+++ b/src/models/puzzles.d.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022  Ben Jones
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+interface UserT {
+    id: number;
+    username: string;
+    country: string; // Country Code
+    icon: string; // URL
+    ratings: {
+        version: number;
+        overall: {
+            rating: number;
+            deviation: number;
+            volatility: number;
+        };
+    };
+    ranking: number;
+    professional: boolean;
+    ui_class: string;
+}
+
+declare namespace rest_api {
+    interface PuzzleDetail {
+        id: number;
+        order: number;
+        owner: UserT;
+        name: string;
+        created: string; // ISO Date
+        modified: string; // ISO Date
+        puzzle: {
+            mode: string;
+            name: string;
+            puzzle_type: string;
+            width: number;
+            height: number;
+            initial_state: {
+                white: string;
+                black: string;
+            };
+            puzzle_opponent_move_mode: import("goban").PuzzleOpponentMoveMode;
+            puzzle_player_move_mode: import("goban").PuzzlePlayerMoveMode;
+            puzzle_rank: string; // number
+            puzzle_description: string;
+            puzzle_collection: string; // number
+            initial_player: "black" | "white";
+            move_tree: import("goban").MoveTreeJson;
+        };
+        private: boolean;
+        width: number;
+        height: number;
+        type: string;
+        has_solution: boolean;
+        rating: number;
+        rating_count: number;
+        rank: number;
+        collection: {
+            id: number;
+            owner: UserT;
+            name: string;
+            created: string; // ISODate
+            private: boolean;
+            price: string; // Number
+            starting_puzzle: {
+                id: number;
+                initial_state: {
+                    white: string;
+                    black: string;
+                };
+                width: number;
+                height: number;
+            };
+            rating: number;
+            rating_count: number;
+            puzzle_count: number;
+            min_rank: number;
+            max_rank: number;
+            view_count: number;
+            solved_count: number;
+            attempt_count: number;
+            color_transform_enabled: boolean;
+            position_transform_enabled: boolean;
+        };
+        view_count: number;
+        solved_count: number;
+        attempt_count: number;
+
+        zoomable?: boolean;
+    }
+}

--- a/src/models/puzzles.d.ts
+++ b/src/models/puzzles.d.ts
@@ -53,9 +53,9 @@ declare namespace rest_api {
             };
             puzzle_opponent_move_mode: import("goban").PuzzleOpponentMoveMode;
             puzzle_player_move_mode: import("goban").PuzzlePlayerMoveMode;
-            puzzle_rank: string; // number
+            puzzle_rank: number; // this is actually passed as a string, but need consistency with Goban.PuzzleConfig
             puzzle_description: string;
-            puzzle_collection: string; // number
+            puzzle_collection: number; // this is actually passed as a string, but need consistency with Goban.PuzzleConfig
             initial_player: "black" | "white";
             move_tree: import("goban").MoveTreeJson;
         };

--- a/src/views/Puzzle/PuzzleEditing.ts
+++ b/src/views/Puzzle/PuzzleEditing.ts
@@ -151,7 +151,7 @@ export class PuzzleEditor {
             get("puzzles/%%/collection_summary", puzzle_id),
             get("puzzles/%%/rate", puzzle_id),
         ])
-            .then((arr) => {
+            .then((arr: [rest_api.PuzzleDetail, any, any]) => {
                 const rating = arr[2];
                 const puzzle = arr[0].puzzle;
                 const collection = arr[0].collection;
@@ -164,8 +164,8 @@ export class PuzzleEditor {
                         "puzzle.randomize.color",
                     ); /* only randomize when we are getting a new puzzle */
 
-                randomize_transform &= collection.position_transform_enabled;
-                randomize_color &= collection.color_transform_enabled;
+                randomize_transform &&= collection.position_transform_enabled;
+                randomize_color &&= collection.color_transform_enabled;
 
                 this.transform.settings.zoom = preferences.get("puzzle.zoom");
 

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -1324,7 +1324,7 @@ function GeneralPreferences(props: SettingGroupProps): JSX.Element {
             langs = [];
         }
 
-        const new_profanity_settings = {};
+        const new_profanity_settings: { [cc: string]: true } = {};
 
         langs.forEach((lang) => {
             new_profanity_settings[lang.value] = true;

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 import * as preferences from "preferences";
+import { usePreference } from "preferences";
 import * as data from "data";
 import * as moment from "moment";
 
@@ -732,43 +733,21 @@ function GitHubUsername({ uid }: { uid: string }): JSX.Element {
 }
 
 function ChatPreferences(): JSX.Element {
-    const [show_empty_chat_notification, _setEmptyChatNotification]: [
-        boolean,
-        (x: boolean) => void,
-    ] = React.useState(preferences.get("show-empty-chat-notification"));
-    const [group_chat_unread, _setGroupChatUnread]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("chat-subscribe-group-chat-unread"));
-    const [group_chat_mentions, _setGroupChatMentions]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("chat-subscribe-group-mentions"));
-    const [tournament_chat_unread, _setTournamentChatUnread]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("chat-subscribe-tournament-chat-unread"));
-    const [tournament_chat_mentions, _setTournamentChatMentions]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("chat-subscribe-tournament-mentions"));
-
-    function toggleEmptyChatNotification(checked) {
-        preferences.set("show-empty-chat-notification", checked);
-        _setEmptyChatNotification(checked);
-    }
-
-    function toggleGroupChatMentions(checked) {
-        preferences.set("chat-subscribe-group-mentions", checked);
-        _setGroupChatMentions(checked);
-    }
-
-    function toggleGroupChatUnread(checked) {
-        preferences.set("chat-subscribe-group-chat-unread", checked);
-        _setGroupChatUnread(checked);
-    }
-
-    function toggleTournamentChatMentions(checked) {
-        preferences.set("chat-subscribe-tournament-mentions", checked);
-        _setTournamentChatMentions(checked);
-    }
-
-    function toggleTournamentChatUnread(checked) {
-        preferences.set("chat-subscribe-tournament-chat-unread", checked);
-        _setTournamentChatUnread(checked);
-    }
+    const [show_empty_chat_notification, toggleEmptyChatNotification] = usePreference(
+        "show-empty-chat-notification",
+    );
+    const [group_chat_unread, toggleGroupChatUnread] = usePreference(
+        "chat-subscribe-group-chat-unread",
+    );
+    const [group_chat_mentions, toggleGroupChatMentions] = usePreference(
+        "chat-subscribe-group-mentions",
+    );
+    const [tournament_chat_unread, toggleTournamentChatUnread] = usePreference(
+        "chat-subscribe-tournament-chat-unread",
+    );
+    const [tournament_chat_mentions, toggleTournamentChatMentions] = usePreference(
+        "chat-subscribe-tournament-mentions",
+    );
 
     return (
         <div>
@@ -896,20 +875,12 @@ function AnnouncementPreferences(): JSX.Element {
             .catch(errorAlerter);
     }, []);
 
-    const [mute_stream_announcements, _muteStreamAnnouncements]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("mute-stream-announcements"));
-    const [mute_event_announcements, _muteEventAnnouncements]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("mute-event-announcements"));
-
-    function toggleMuteStreamAnnouncements(checked) {
-        preferences.set("mute-stream-announcements", checked);
-        _muteStreamAnnouncements(checked);
-    }
-
-    function toggleMuteEventAnnouncements(checked) {
-        preferences.set("mute-event-announcements", checked);
-        _muteEventAnnouncements(checked);
-    }
+    const [mute_stream_announcements, toggleMuteStreamAnnouncements] = usePreference(
+        "mute-stream-announcements",
+    );
+    const [mute_event_announcements, toggleMuteEventAnnouncements] = usePreference(
+        "mute-event-announcements",
+    );
 
     return (
         <div id="AnnouncementPreferences">
@@ -1006,41 +977,30 @@ function GamePreferences(): JSX.Element {
     const [dock_delay, _setDockDelay]: [number, (x: number) => void] = React.useState(
         preferences.get("dock-delay"),
     );
-    const [ai_review_enabled, _setAiReviewEnabled]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("ai-review-enabled"));
-    const [variations_in_chat, _setVariationsInChat]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("variations-in-chat-enabled"));
+    const [ai_review_enabled, _setAiReviewEnabled] = usePreference("ai-review-enabled");
+    const [variations_in_chat, _setVariationsInChat] = usePreference("variations-in-chat-enabled");
     const [_live_submit_mode, _setLiveSubmitMode]: [string, (x: string) => void] = React.useState(
         getSubmitMode("live"),
     );
     const [_corr_submit_mode, _setCorrSubmitMode]: [string, (x: string) => void] = React.useState(
         getSubmitMode("correspondence"),
     );
-    const [board_labeling, _setBoardLabeling]: [string, (x: string) => void] = React.useState(
-        preferences.get("board-labeling"),
-    );
+    const [board_labeling, setBoardLabeling] = usePreference("board-labeling");
 
-    const [autoadvance, _setAutoAdvance]: [boolean, (x: boolean) => void] = React.useState(
-        preferences.get("auto-advance-after-submit"),
-    );
-    const [always_disable_analysis, _setAlwaysDisableAnalysis]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("always-disable-analysis"));
-    const [dynamic_title, _setDynamicTitle]: [boolean, (x: boolean) => void] = React.useState(
-        preferences.get("dynamic-title"),
-    );
-    const [function_keys_enabled, _setFunctionKeysEnabled]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("function-keys-enabled"));
+    const [autoadvance, setAutoAdvance] = usePreference("auto-advance-after-submit");
+    const [always_disable_analysis, setAlwaysDisableAnalysis] =
+        usePreference("always-disable-analysis");
+    const [dynamic_title, setDynamicTitle] = usePreference("dynamic-title");
+    const [function_keys_enabled, setFunctionKeysEnabled] = usePreference("function-keys-enabled");
     const [autoplay_delay, _setAutoplayDelay]: [number, (x: number) => void] = React.useState(
         preferences.get("autoplay-delay") / 1000,
     );
-    const [variation_stone_transparency, _setVariationStoneTransparency]: [
-        number,
-        (x: number) => void,
-    ] = React.useState(preferences.get("variation-stone-transparency"));
-    const [visual_undo_request_indicator, _setVisualUndoRequestIndicator]: [
-        boolean,
-        (x: boolean) => void,
-    ] = React.useState(preferences.get("visual-undo-request-indicator"));
+    const [variation_stone_transparency, _setVariationStoneTransparency] = usePreference(
+        "variation-stone-transparency",
+    );
+    const [visual_undo_request_indicator, setVisualUndoRequestIndicator] = usePreference(
+        "visual-undo-request-indicator",
+    );
 
     function setDockDelay(ev) {
         const new_delay = parseFloat(ev.target.value);
@@ -1048,29 +1008,10 @@ function GamePreferences(): JSX.Element {
         _setDockDelay(new_delay);
     }
     function toggleAIReview(checked) {
-        preferences.set("ai-review-enabled", !checked);
         _setAiReviewEnabled(!checked);
     }
     function toggleVariationsInChat(checked) {
-        preferences.set("variations-in-chat-enabled", !checked);
         _setVariationsInChat(!checked);
-    }
-
-    function setAutoAdvance(checked) {
-        preferences.set("auto-advance-after-submit", checked),
-            _setAutoAdvance(preferences.get("auto-advance-after-submit"));
-    }
-    function setAlwaysDisableAnalysis(checked) {
-        preferences.set("always-disable-analysis", checked),
-            _setAlwaysDisableAnalysis(preferences.get("always-disable-analysis"));
-    }
-    function setDynamicTitle(checked) {
-        preferences.set("dynamic-title", checked),
-            _setDynamicTitle(preferences.get("dynamic-title"));
-    }
-    function setFunctionKeysEnabled(checked) {
-        preferences.set("function-keys-enabled", checked),
-            _setFunctionKeysEnabled(preferences.get("function-keys-enabled"));
     }
 
     function getSubmitMode(speed) {
@@ -1111,16 +1052,7 @@ function GamePreferences(): JSX.Element {
 
         if (value >= 0.0 && value <= 1.0) {
             _setVariationStoneTransparency(value);
-            preferences.set("variation-stone-transparency", value);
         }
-    }
-    function setVisualUndoRequestIndicator(checked) {
-        preferences.set("visual-undo-request-indicator", checked);
-        _setVisualUndoRequestIndicator(checked);
-    }
-    function setBoardLabeling(value) {
-        preferences.set("board-labeling", value);
-        _setBoardLabeling(value);
     }
     function updateAutoplayDelay(ev) {
         const delay = parseFloat(ev.target.value);
@@ -1280,32 +1212,27 @@ function GamePreferences(): JSX.Element {
 function GeneralPreferences(props: SettingGroupProps): JSX.Element {
     const [profanity_filter, _setProfanityFilter]: [Array<string>, (x: Array<string>) => void] =
         React.useState(Object.keys(preferences.get("profanity-filter")));
+
     const [game_list_threshold, _setGameListThreshold]: [number, (x: number) => void] =
         React.useState(preferences.get("game-list-threshold"));
-    const [_desktop_notifications, _setDesktopNotifications]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("desktop-notifications"));
-    const [show_offline_friends, _setShowOfflineFriends]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("show-offline-friends"));
-    const [unicode_filter_usernames, _setUnicodeFilterUsernames]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("unicode-filter"));
-    const [translation_dialog_never_show, _setTranslationDialogNeverShow]: [
-        boolean,
-        (x: boolean) => void,
-    ] = React.useState(preferences.get("translation-dialog-never-show"));
+    const [_desktop_notifications, setDesktopNotifications] =
+        usePreference("desktop-notifications");
+    const [show_offline_friends, setShowOfflineFriends] = usePreference("show-offline-friends");
+    const [unicode_filter_usernames, setUnicodeFilterUsernames] = usePreference("unicode-filter");
+    const [translation_dialog_never_show, setTranslationDialogNeverShow] = usePreference(
+        "translation-dialog-never-show",
+    );
     const [hide_ui_class, setHideUiClass]: [boolean, (x: boolean) => void] = React.useState(
         props.state.hide_ui_class,
     );
-    const [show_tournament_indicator, _setShowTournamentIndicator]: [
-        boolean,
-        (x: boolean) => void,
-    ] = React.useState(preferences.get("show-tournament-indicator"));
-    const [hide_ranks, _setHideRanks]: [boolean, (x: boolean) => void] = React.useState(
-        preferences.get("hide-ranks"),
+    const [show_tournament_indicator, setShowTournamentIndicator] = usePreference(
+        "show-tournament-indicator",
     );
-    const [rating_graph_always_use, _setAlwaysUse]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("rating-graph-always-use"));
-    const [rating_graph_plot_by_games, _setUseGames]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("rating-graph-plot-by-games"));
+    const [hide_ranks, setHideRanks] = usePreference("hide-ranks");
+    const [rating_graph_always_use, setAlwaysUse] = usePreference("rating-graph-always-use");
+    const [rating_graph_plot_by_games, setPlotByGames] = usePreference(
+        "rating-graph-plot-by-games",
+    );
 
     const user = data.get("user");
     const desktop_notifications_enableable: boolean = typeof Notification !== "undefined";
@@ -1345,29 +1272,13 @@ function GeneralPreferences(props: SettingGroupProps): JSX.Element {
         }
     }
 
-    function setShowOfflineFriends(checked) {
-        preferences.set("show-offline-friends", checked);
-        _setShowOfflineFriends(preferences.get("show-offline-friends"));
-    }
-
-    function setUnicodeFilterUsernames(checked) {
-        preferences.set("unicode-filter", checked);
-        _setUnicodeFilterUsernames(preferences.get("unicode-filter"));
-    }
-
-    function setTranslationDialogNeverShow(checked) {
-        preferences.set("translation-dialog-never-show", checked);
-        _setTranslationDialogNeverShow(preferences.get("translation-dialog-never-show"));
-    }
-
     function updateDesktopNotifications(enabled) {
         if (!enabled) {
             //this.setState({'desktop_notifications_enabled': false});
         }
 
         try {
-            preferences.set("desktop-notifications", enabled);
-            _setDesktopNotifications(enabled);
+            setDesktopNotifications(enabled);
 
             if (enabled) {
                 if ((Notification as any).permission === "denied") {
@@ -1423,25 +1334,6 @@ function GeneralPreferences(props: SettingGroupProps): JSX.Element {
                 hide_ui_class: !checked,
             },
         }).catch(errorAlerter);
-    }
-
-    function setShowTournamentIndicator(checked) {
-        preferences.set("show-tournament-indicator", checked),
-            _setShowTournamentIndicator(preferences.get("show-tournament-indicator"));
-    }
-
-    function setAlwaysUse(checked) {
-        preferences.set("rating-graph-always-use", checked),
-            _setAlwaysUse(preferences.get("rating-graph-always-use"));
-    }
-
-    function setPlotByGames(checked) {
-        preferences.set("rating-graph-plot-by-games", checked),
-            _setUseGames(preferences.get("rating-graph-plot-by-games"));
-    }
-
-    function setHideRanks(checked) {
-        preferences.set("hide-ranks", checked), _setHideRanks(preferences.get("hide-ranks"));
     }
 
     const language_options = Object.entries(languages).map((lang_entry) => ({
@@ -1558,14 +1450,13 @@ function GeneralPreferences(props: SettingGroupProps): JSX.Element {
 }
 
 function ModeratorPreferences(_props: SettingGroupProps): JSX.Element {
-    const [incident_report_notifications, setIncidentReportNotifications]: [
-        boolean,
-        (x: boolean) => void,
-    ] = React.useState(preferences.get("notify-on-incident-report"));
-    const [hide_incident_reports, setHideIncidentReports]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("hide-incident-reports"));
-    const [join_games_anonymously, setJoinGamesAnonymously]: [boolean, (x: boolean) => void] =
-        React.useState(preferences.get("moderator.join-games-anonymously"));
+    const [incident_report_notifications, setIncidentReportNotifications] = usePreference(
+        "notify-on-incident-report",
+    );
+    const [hide_incident_reports, setHideIncidentReports] = usePreference("hide-incident-reports");
+    const [join_games_anonymously, setJoinGamesAnonymously] = usePreference(
+        "moderator.join-games-anonymously",
+    );
 
     const user = data.get("user");
 
@@ -1573,34 +1464,19 @@ function ModeratorPreferences(_props: SettingGroupProps): JSX.Element {
         return null;
     }
 
-    function updateIncidentReportNotifications(checked: boolean) {
-        preferences.set("notify-on-incident-report", checked);
-        setIncidentReportNotifications(checked);
-    }
-
-    function updateHideIncidentReports(checked: boolean) {
-        preferences.set("hide-incident-reports", checked);
-        setHideIncidentReports(checked);
-    }
-
-    function updateJoinGamesAnonymously(checked: boolean) {
-        preferences.set("moderator.join-games-anonymously", checked);
-        setJoinGamesAnonymously(checked);
-    }
-
     return (
         <div>
             <PreferenceLine title={_("Notify me when an incident is submitted for moderation")}>
                 <Toggle
                     checked={incident_report_notifications}
-                    onChange={updateIncidentReportNotifications}
+                    onChange={setIncidentReportNotifications}
                 />
             </PreferenceLine>
             <PreferenceLine title="Hide incident reports">
-                <Toggle checked={hide_incident_reports} onChange={updateHideIncidentReports} />
+                <Toggle checked={hide_incident_reports} onChange={setHideIncidentReports} />
             </PreferenceLine>
             <PreferenceLine title="Join games anonymously">
-                <Toggle checked={join_games_anonymously} onChange={updateJoinGamesAnonymously} />
+                <Toggle checked={join_games_anonymously} onChange={setJoinGamesAnonymously} />
             </PreferenceLine>
         </div>
     );
@@ -1851,18 +1727,18 @@ function AssociationSelect({
 }
 
 function SoundPreferences(): JSX.Element {
-    const [tick_tock_start, __setTickTockStart]: [number, (x: number) => void] = React.useState(
-        preferences.get("sound.countdown.tick-tock.start"),
+    const [tick_tock_start, __setTickTockStart] = usePreference("sound.countdown.tick-tock.start");
+    const [ten_seconds_start, __setTenSecondsStart] = usePreference(
+        "sound.countdown.ten-seconds.start",
     );
-    const [ten_seconds_start, __setTenSecondsStart]: [number, (x: number) => void] = React.useState(
-        preferences.get("sound.countdown.ten-seconds.start"),
+    const [five_seconds_start, __setFiveSecondsStart] = usePreference(
+        "sound.countdown.five-seconds.start",
     );
-    const [five_seconds_start, __setFiveSecondsStart]: [number, (x: number) => void] =
-        React.useState(preferences.get("sound.countdown.five-seconds.start"));
-    const [every_second_start, __setEverySecondStart]: [number, (x: number) => void] =
-        React.useState(preferences.get("sound.countdown.every-second.start"));
-    const [count_direction, __setCountDirection]: [string, (x: string) => void] = React.useState(
-        preferences.get("sound.countdown.byoyomi-direction"),
+    const [every_second_start, __setEverySecondStart] = usePreference(
+        "sound.countdown.every-second.start",
+    );
+    const [count_direction, __setCountDirection] = usePreference(
+        "sound.countdown.byoyomi-direction",
     );
     let count_direction_auto = "down";
 
@@ -1875,23 +1751,18 @@ function SoundPreferences(): JSX.Element {
         count_direction !== "auto" ? count_direction : count_direction_auto;
 
     function setTickTockStart(opt): void {
-        preferences.set("sound.countdown.tick-tock.start", opt.value);
         __setTickTockStart(opt.value);
     }
     function setTenSecondsStart(opt): void {
-        preferences.set("sound.countdown.ten-seconds.start", opt.value);
         __setTenSecondsStart(opt.value);
     }
     function setFiveSecondsStart(opt): void {
-        preferences.set("sound.countdown.five-seconds.start", opt.value);
         __setFiveSecondsStart(opt.value);
     }
     function setEverySecondStart(opt): void {
-        preferences.set("sound.countdown.every-second.start", opt.value);
         __setEverySecondStart(opt.value);
     }
     function setCountDirection(opt): void {
-        preferences.set("sound.countdown.byoyomi-direction", opt.value);
         __setCountDirection(opt.value);
     }
 
@@ -2695,14 +2566,7 @@ function EmailNotificationToggle(props: {
 }
 
 function PreferenceToggle(props: { name: string; preference: ValidPreference }): JSX.Element {
-    const [on, __set]: [boolean, (x: boolean) => void] = React.useState(
-        preferences.get(props.preference),
-    );
-
-    function setPreference(on: boolean): void {
-        preferences.set(props.preference, on);
-        __set(on);
-    }
+    const [on, setPreference] = usePreference(props.preference);
 
     return (
         <div className="PreferenceToggle">


### PR DESCRIPTION
I noticed a common pattern is to create a state variable that is always in sync with preference variables.

```
    const [value, setValue] = React.useState(
        preferences.get("some-key")
    );

   ... later ...

    setValue(new_val);
    preferences.set("some-key", new_val);
```

IMO this is hard to maintain because one always has to remember to set the preference as well as the state variable, and it's a bit verbose.

This PR introduces a custom react hook to wrap the two setters up in one:

```
    const [value, setValue] = usePreference("some-key");

    // sets both preference and state variable
    setValue(new_val);
```

## Proposed Changes

  - Create the `usePreference` hook.
  - Add stricter typing to preferences, and fix type errors.
      - The Puzzle type was part of an investigation into how to approach type fixes.
  - Use `usePreference` in Settings.tsx
