### PR TITLE
Don't reset page title unnecessarily.

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -150,6 +150,7 @@ import cached from "cached";
 import * as moment from "moment";
 import swal from "sweetalert2";
 import { ConfigSchema } from "data_schema";
+import * as history from "history";
 
 import "debug";
 
@@ -291,7 +292,7 @@ init_score_estimator()
 /*** Generic error handling from the server ***/
 sockets.socket.on("ERROR", errorAlerter);
 
-browserHistory.listen((/* location */) => {
+browserHistory.listen(({ action /*, location */ }) => {
     try {
         // old google analytics history hook
         /*
@@ -317,7 +318,9 @@ browserHistory.listen((/* location */) => {
         }
         */
 
-        window.document.title = "OGS";
+        if (action !== history.Action.Replace) {
+            window.document.title = "OGS";
+        }
         close_all_popovers();
     } catch (e) {
         console.log(e);


### PR DESCRIPTION
Page title is reset on every history event (as a fallback mechanism for pages which do not have a custom title, I guess?).
This breaks in such cases as:

1. click on “Home” in the navbar;
2. homepage opens and the title shows number of games where it's my move;
3. click “Home” again;
4. title is reset, i.e. it becomes just “OGS”.

## Proposed Changes
  - Reset page title if history event's action is not “Replace”. 