### PR TITLE
Joseki: replace fetch with requests functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
         "@typescript-eslint/no-this-alias": "off", // 4 errors
         "@typescript-eslint/triple-slash-reference": "off", // 1 error
 
-        "no-empty-pattern": "off", // 1 error
         "no-misleading-character-class": "off", // 2 errors
         "no-prototype-builtins": "off", // 8 errors
         "no-self-assign": "off", // 2 errors

--- a/src/components/JosekiAdmin/JosekiAdmin.tsx
+++ b/src/components/JosekiAdmin/JosekiAdmin.tsx
@@ -139,7 +139,7 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
         // And if there was one, revert it then move on to the next after the previous is done.
         if (current_selections.get(next_selection)) {
             const target_id = next_selection.substring(7); //  get rid of the wierd "select-" from SelectTable
-            // console.log("Revert requested for ", target_id);
+
             fetch(this.props.server_url + "revert", {
                 method: "post",
                 mode: "cors",
@@ -149,7 +149,6 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
                 .then((res) => res.json())
                 .then((body) => {
                     // Display the result of what happened
-                    // console.log("reversion result", body);
                     const next_selections = new Map(current_selections);
                     next_selections.set(next_selection, false);
                     const next_reversions = new Map(this.state.reversions);
@@ -282,8 +281,6 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
     };
 
     render = () => {
-        // console.log("Joseki Admin render");
-
         // Don't let the user select rows if they can't actually do anything with them.
         const AuditTable = this.props.user_can_administer ? SelectTable : ReactTable;
 

--- a/src/components/JosekiAdmin/JosekiAdmin.tsx
+++ b/src/components/JosekiAdmin/JosekiAdmin.tsx
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 import { _ } from "translate";
+import { get, post, put } from "requests";
 
 import ReactTable from "react-table";
 
@@ -29,7 +30,6 @@ import { JosekiPermissionsPanel } from "JosekiPermissionsPanel";
 import { JosekiPageVisits, JosekiStatsModal } from "JosekiStatsModal";
 
 interface JosekiAdminProps {
-    oje_headers: HeadersInit;
     server_url: string;
     user_can_administer: boolean; // allows them to revert changes, give permissions etc
     user_can_edit: boolean; // allows them to filter
@@ -96,11 +96,7 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
     }
 
     componentDidMount = () => {
-        fetch(this.props.server_url + "appinfo", {
-            mode: "cors",
-            headers: this.props.oje_headers,
-        })
-            .then((res) => res.json())
+        get(this.props.server_url + "appinfo")
             .then((body) => {
                 console.log("App info", body);
                 this.setState({
@@ -140,13 +136,7 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
         if (current_selections.get(next_selection)) {
             const target_id = next_selection.substring(7); //  get rid of the wierd "select-" from SelectTable
 
-            fetch(this.props.server_url + "revert", {
-                method: "post",
-                mode: "cors",
-                headers: this.props.oje_headers,
-                body: JSON.stringify({ audit_id: target_id }),
-            })
-                .then((res) => res.json())
+            post(this.props.server_url + "revert", { audit_id: target_id })
                 .then((body) => {
                     // Display the result of what happened
                     const next_selections = new Map(current_selections);
@@ -194,11 +184,7 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
         //    audits_url += `&type=${this.state.filter_audit_type}`;
         //}
 
-        fetch(audits_url, {
-            mode: "cors",
-            headers: this.props.oje_headers,
-        })
-            .then((res) => res.json())
+        get(audits_url)
             .then((body) => {
                 // initialise selections, so we have the full list of them for select-all operations
                 const selections = new Map();
@@ -267,11 +253,7 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
         const lockdown_url =
             this.props.server_url + "lockdown?lockdown=" + !this.props.db_locked_down;
 
-        fetch(lockdown_url, {
-            method: "put",
-            mode: "cors",
-            headers: this.props.oje_headers,
-        })
+        put(lockdown_url)
             .then(() => {
                 this.props.updateDBLockStatus(!this.props.db_locked_down);
             })
@@ -435,10 +417,7 @@ export class JosekiAdmin extends React.PureComponent<JosekiAdminProps, JosekiAdm
                     <div className="bottom-admin-stuff">
                         <div className="user-admin">
                             <div>{_("Permissions Admin")}</div>
-                            <JosekiPermissionsPanel
-                                oje_headers={this.props.oje_headers}
-                                server_url={this.props.server_url}
-                            />
+                            <JosekiPermissionsPanel server_url={this.props.server_url} />
                         </div>
                         <div className="misc-admin">
                             <button className={"btn"} onClick={this.toggleLockdown}>

--- a/src/components/JosekiPermissionsPanel/JosekiPermissionsPanel.tsx
+++ b/src/components/JosekiPermissionsPanel/JosekiPermissionsPanel.tsx
@@ -64,8 +64,6 @@ export class JosekiPermissionsPanel extends React.PureComponent<
         })
             .then((response) => response.json()) // wait for the body of the response
             .then((body) => {
-                // console.log("Server response:", body);
-
                 this.setState({
                     can_comment: body.can_comment,
                     can_edit: body.can_edit,

--- a/src/components/JosekiPermissionsPanel/JosekiPermissionsPanel.tsx
+++ b/src/components/JosekiPermissionsPanel/JosekiPermissionsPanel.tsx
@@ -18,11 +18,11 @@
 import * as React from "react";
 
 import * as data from "data";
+import { get, put } from "requests";
 
 import { Player } from "Player";
 
 interface JosekiAdminProps {
-    oje_headers: HeadersInit;
     server_url: string;
 }
 
@@ -58,11 +58,7 @@ export class JosekiPermissionsPanel extends React.PureComponent<
         }
 
         this.setState({ throb: true });
-        fetch(this.props.server_url + "permissions?id=" + e.target.value, {
-            mode: "cors",
-            headers: this.props.oje_headers,
-        })
-            .then((response) => response.json()) // wait for the body of the response
+        get(this.props.server_url + "permissions?id=" + e.target.value)
             .then((body) => {
                 this.setState({
                     can_comment: body.can_comment,
@@ -102,13 +98,7 @@ export class JosekiPermissionsPanel extends React.PureComponent<
 
         new_permissions[permission] = value;
 
-        fetch(this.props.server_url + "permissions?id=" + this.state.userid, {
-            method: "put",
-            mode: "cors",
-            headers: this.props.oje_headers,
-            body: JSON.stringify(new_permissions),
-        })
-            .then((res) => res.json())
+        put(this.props.server_url + "permissions?id=" + this.state.userid, new_permissions)
             .then((body) => {
                 // Display the result of what happened
                 console.log("permissions result", body);

--- a/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
+++ b/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
@@ -103,7 +103,6 @@ export function JosekiVariationFilter(props: JosekiVariationFilterProps) {
         //const tags = (e === null || e.length === 0) ? null : e.map(t => typeof(t) === 'number' ? t : t.value);
         const new_filter = { ...props.current_filter, tags };
 
-        // console.log("new tag filter", new_filter);
         props.set_variation_filter(new_filter); // tell parent the fiter changed, so the view needs to change
     };
 

--- a/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
+++ b/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
@@ -21,11 +21,11 @@ import { _ } from "translate";
 import * as player_cache from "player_cache";
 import { JosekiTagSelector, JosekiTag } from "../JosekiTagSelector";
 import { PlayerCacheEntry } from "player_cache";
+import { get } from "requests";
 
 export type JosekiFilter = { contributor: number; tags: JosekiTag[]; source: number };
 
 interface JosekiVariationFilterProps {
-    oje_headers: HeadersInit;
     contributor_list_url: string;
     source_list_url: string;
     set_variation_filter: any;
@@ -43,11 +43,7 @@ export function JosekiVariationFilter(props: JosekiVariationFilterProps) {
 
     React.useEffect(() => {
         // Get the list of contributors to chose from
-        fetch(props.contributor_list_url, {
-            mode: "cors",
-            headers: props.oje_headers,
-        })
-            .then((res) => res.json())
+        get(props.contributor_list_url)
             .then((body) => {
                 //console.log("Server response to contributors GET:", body);
                 const new_contributor_list: ContributorList = [];
@@ -79,16 +75,9 @@ export function JosekiVariationFilter(props: JosekiVariationFilterProps) {
                 console.log("Contributors GET failed:", r);
             });
 
-        fetch(props.source_list_url, {
-            mode: "cors",
-            headers: props.oje_headers,
-        })
-            .then((res) => res.json())
+        get(props.source_list_url)
             .then((body) => {
-                // This can possibly be changed to !== undefined or != null,
-                // But I don't want to touch this right now -BPJ
-                // eslint-disable-next-line eqeqeq
-                if (body.sources != undefined) {
+                if (body.sources != null) {
                     // Sentry reports that we somehow receive a body with undefined source_list!?
                     setSourceList(body.sources);
                 }

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -18,7 +18,12 @@
 import { deepCompare } from "misc";
 import { IdType } from "./types";
 
-export function api1ify(path) {
+/**
+ * If a non-absolute path is provided, appends "/api/v1/" to the input.
+ *
+ * @param path a path or a URL
+ */
+export function api1ify(path: string) {
     if (path.indexOf("/api/v") === 0) {
         return path;
     }
@@ -32,6 +37,7 @@ export function api1ify(path) {
     return `/api/v1/${path}`;
 }
 
+/** alias for api1ify */
 export const api1 = api1ify;
 
 let initialized = false;
@@ -68,16 +74,16 @@ type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
 interface RequestFunction {
     (url: string): Promise<any>;
-    (url: string, id_or_data: number | any): Promise<any>;
-    (url: string, id: IdType, data: any): Promise<any>;
+    (url: string, id_or_data: IdType | object): Promise<any>;
+    (url: string, id: IdType, data: object): Promise<any>;
 }
 
-export function request(method: Method): RequestFunction {
-    return (url, ...rest) => {
+function request(method: Method): RequestFunction {
+    return (url: string, ...rest: [] | [number | string | object] | [number | string, object]) => {
         initialize();
 
         let id: IdType | undefined;
-        let data: any;
+        let data: object;
         switch (typeof rest[0]) {
             case "number":
             case "string":
@@ -182,7 +188,8 @@ export function request(method: Method): RequestFunction {
     };
 }
 
-export function getCookie(name) {
+/** Returns the cookie value for a given key */
+export function getCookie(name: string) {
     let cookieValue = null;
     if (document.cookie && document.cookie !== "") {
         const cookies = document.cookie.split(";");
@@ -197,13 +204,69 @@ export function getCookie(name) {
     return cookieValue;
 }
 
+/**
+ * Fetches data using the GET method.
+ * @param url the URL for the request. If a relative path is passed, /api/vi/
+ *     will be appended.
+ * @param [id] providing an id is optional.  It will be interpolated into the
+ *     URL where "%%" appears.
+ * @param [data] providing data is optional. This is used as the request payload
+ *     in JSON format.
+ * @returns a Promise that resolves with the response payload.
+ */
 export const get = request("GET");
+/**
+ * Fetches data using the POST method.
+ * @param url the URL for the request. If a relative path is passed, /api/vi/
+ *     will be appended.
+ * @param [id] providing an id is optional.  It will be interpolated into the
+ *     URL where "%%" appears.
+ * @param [data] providing data is optional. This is used as the request payload
+ *     in JSON format.
+ * @returns a Promise that resolves with the response payload.
+ */
 export const post = request("POST");
+/**
+ * Fetches data using the PUT method.
+ * @param url the URL for the request. If a relative path is passed, /api/vi/
+ *     will be appended.
+ * @param [id] providing an id is optional.  It will be interpolated into the
+ *     URL where "%%" appears.
+ * @param [data] providing data is optional. This is used as the request payload
+ *     in JSON format.
+ * @returns a Promise that resolves with the response payload.
+ */
 export const put = request("PUT");
+/**
+ * Fetches data using the PATCH method.
+ * @param url the URL for the request. If a relative path is passed, /api/vi/
+ *     will be appended.
+ * @param [id] providing an id is optional.  It will be interpolated into the
+ *     URL where "%%" appears.
+ * @param [data] providing data is optional. This is used as the request payload
+ *     in JSON format.
+ * @returns a Promise that resolves with the response payload.
+ */
 export const patch = request("PATCH");
+/**
+ * Fetches data using the DELETE method.
+ * @param url the URL for the request. If a relative path is passed, /api/vi/
+ *     will be appended.
+ * @param [id] providing an id is optional.  It will be interpolated into the
+ *     URL where "%%" appears.
+ * @param [data] providing data is optional. This is used as the request payload
+ *     in JSON format.
+ * @returns a Promise that resolves with the response payload.
+ */
 export const del = request("DELETE");
 
-export function abort_requests_in_flight(url, method?: Method) {
+/**
+ * Cancels any requests using the specified URL and method.
+ * @param url the URL for the request.
+ * @param [method] providing a method is optional.  If no method is provided,
+ *     all requests to the URL will be cancelled.
+ */
+export function abort_requests_in_flight(url: string, method?: Method): void {
     for (const id in requests_in_flight) {
         const req = requests_in_flight[id];
         if (req.url === url && (!method || method === req.type)) {

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -43,7 +43,7 @@ import { JosekiTagSelector, JosekiTag } from "JosekiTagSelector";
 import { Throbber } from "Throbber";
 import { IdType } from "src/lib/types";
 
-const server_url = "/oje/";
+const server_url = data.get("oje-url", "/oje/");
 
 const prefetch_url = (node_id: string, variation_filter?: JosekiFilter, mode?: string) => {
     let prefetch_url = server_url + "positions?id=" + node_id;

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -198,7 +198,7 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
     last_server_position = ""; // the most recent position that the server returned to us, used in backstepping
     last_placement = "";
     next_moves: Array<any> = []; // these are the moves that the server has told us are available as joseki moves from the current board position
-    current_marks: []; // the marks on the board - from the server, or from editing
+    current_marks: Array<{ label: string; position: string }>; // the marks on the board - from the server, or from editing
     load_sequence_to_board = false; // True if we need to load the stones from the whole sequence received from the server onto the board
     show_comments_requested = false; //  If there is a "show_comments" parameter in the URL
     previous_position = {} as any; // Saving the information of the node we have moved from, so we can get back to it
@@ -1018,7 +1018,7 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
         this.fetchNextFilteredMovesFor(this.state.current_node_id, filter);
     };
 
-    updateMarks = (marks) => {
+    updateMarks = (marks: Array<{ label: string; position: string }>) => {
         this.current_marks = marks;
         this.renderCurrentJosekiPosition();
     };
@@ -1978,7 +1978,7 @@ interface EditProps {
     tags: Array<any>; // TBD yuk what is this `any`
     contributor: number;
     save_new_info: (move_type, variation_label, tags, description, joseki_source, marks) => void;
-    update_marks: ({}) => void;
+    update_marks: (marks: Array<{ label: string; position: string }>) => void;
 }
 
 interface EditState {


### PR DESCRIPTION
Now that OJE is part of the Django API, it doesn't seem to need custom headers. Using the requests.ts functions seems to simplify the code quite a bit because we are no longer manually passing headers and pulling json from the response.

## Proposed Changes

  - JSDoc for requests.ts
      - I considered adding tests too, but mocking `$.ajax` was tricky.  At some point I think we will want to switch to the `fetch` API there instead any way.
  - Replace all `fetch` calls with the equivalent requests.ts function.
  - Fix the `no-empty-pattern` error in `Joseki.tsx`
