### PR TITLE
Move side effects from translate.ts to main.tsx.

### DIFF
--- a/src/lib/rank_utils.test.ts
+++ b/src/lib/rank_utils.test.ts
@@ -34,12 +34,6 @@ import {
     effective_outcome,
 } from "./rank_utils";
 
-// workaround for setGobanTranslations not found error
-// This can probably be fixed by removing sideeffects from translate.ts
-jest.mock("goban", () => ({
-    setGobanTranslations: jest.fn(),
-}));
-
 test("rank_to_rating", () => {
     // 30k
     expect(rank_to_rating(0)).toBeCloseTo(525);

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -140,7 +140,6 @@ function setPluralIdx() {
             pluralidx = (count: number) => (count === 1 ? 0 : 1);
     }
 }
-setPluralIdx();
 
 const debug_wrap = current_language === "debug" ? (s: string) => `[${s}]` : (s: string) => s;
 
@@ -526,7 +525,6 @@ export function setCurrentLanguage(language_code: string) {
     });
     setPluralIdx();
 }
-setCurrentLanguage(current_language);
 
 export default {
     gettext: gettext,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -142,7 +142,7 @@ import { routes } from "./routes";
 import { errorAlerter, uuid } from "misc";
 import { close_all_popovers } from "popover";
 import * as sockets from "sockets";
-import { _ } from "translate";
+import { _, setCurrentLanguage } from "translate";
 import { init_tabcomplete } from "tabcomplete";
 import * as player_cache from "player_cache";
 import { toast } from "toast";
@@ -151,12 +151,17 @@ import * as moment from "moment";
 import swal from "sweetalert2";
 import { ConfigSchema } from "data_schema";
 import * as history from "history";
-
 import "debug";
 
-/*** Initialize moment in our current language ***/
-declare function getPreferredLanguage();
+/**
+ * getPreferredLanguage() is defined in index.html. It gets the user's chosen
+ * language from preferences.
+ */
+declare function getPreferredLanguage(): string;
+
+// Initialize moment in our current language
 moment.locale(getPreferredLanguage());
+setCurrentLanguage(getPreferredLanguage());
 
 /*** Load our config ***/
 data.watch(cached.config, (config) => {

--- a/src/views/User/UserByName.test.tsx
+++ b/src/views/User/UserByName.test.tsx
@@ -6,12 +6,6 @@ import * as React from "react";
 //import * as requests from "../../lib/requests";
 import { User } from "./User";
 
-// workaround for setGobanTranslations not found error
-// This can probably be fixed by removing sideeffects from translate.ts
-jest.mock("goban", () => ({
-    setGobanTranslations: jest.fn(),
-}));
-
 let container: HTMLDivElement = null;
 beforeEach(() => {
     // setup a DOM element as a render target


### PR DESCRIPTION
For some reason, the tests don't play nicely with Goban, especially when functions are called in a module.  One of the hacks I had in every test suite was this:

```
// workaround for setGobanTranslations not found error
// This can probably be fixed by removing sideeffects from translate.ts
jest.mock("goban", () => ({
    setGobanTranslations: jest.fn(),
}));
```

By removing the side effects from translate.ts (and putting them in main.tsx), I was able to remove these mocks from the tests.

At some point, I need to figure out how to actually deal with goban code in tests, but this makes writing tests just a tiny bit easier.

## Proposed Changes

  - Call `setCurrentLanguage` in main.tsx, not translate.tsx.
  - Remove goban mock from tests that didn't have anything to do with Goban.
