### PR TITLE
Make target language "debug" a special case for autotranslate

### DIFF
--- a/src/components/AutoTranslate/AutoTranslate.tsx
+++ b/src/components/AutoTranslate/AutoTranslate.tsx
@@ -91,7 +91,6 @@ export function AutoTranslate({
 async function auto_translate(text: string): Promise<Translation> {
     let res: Promise<Translation>;
 
-    console.log(current_language);
     if (current_language === "debug") {
         res = Promise.resolve({
             source_language: null,

--- a/src/components/AutoTranslate/AutoTranslate.tsx
+++ b/src/components/AutoTranslate/AutoTranslate.tsx
@@ -89,9 +89,21 @@ export function AutoTranslate({
 }
 
 async function auto_translate(text: string): Promise<Translation> {
-    const res = await post("/termination-api/translate", {
-        source: text,
-        language: current_language,
-    });
+    let res: Promise<Translation>;
+
+    console.log(current_language);
+    if (current_language === "debug") {
+        res = Promise.resolve({
+            source_language: null,
+            source_text: text,
+            target_language: "debug",
+            target_text: `[${text}]`,
+        });
+    } else {
+        res = await post("/termination-api/translate", {
+            source: text,
+            language: current_language,
+        });
+    }
     return res;
 }


### PR DESCRIPTION
that does not got out to get translated, but behaves as if it did.

Fixes hitting external translation service with retries for "debug" language

## Proposed Changes

Interept at the point we go to request the translation and supply a "debug" translation instead, if debug is the target.