### PR TITLE
PlayButtons: Shorten props list and derive state from goban

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -58,7 +58,6 @@ import { goban_view_mode, goban_view_squashed, ViewMode, shared_ip_with_player_m
 import { game_control } from "./game_control";
 import { PlayerCards } from "./PlayerCards";
 import {
-    CancelButton,
     EstimateScore,
     PlayControls,
     AnalyzeButtonBar,
@@ -67,6 +66,7 @@ import {
     deleteBranch,
     ReviewControls,
 } from "./PlayControls";
+import { CancelButton } from "./PlayButtons";
 import { GameDock } from "./GameDock";
 import swal from "sweetalert2";
 

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -131,8 +131,6 @@ export function Game(): JSX.Element {
     const [title, set_title] = React.useState<string>();
 
     const [mode, set_mode] = React.useState<GobanModes>("play");
-    const [resign_mode, set_resign_mode] = React.useState<"cancel" | "resign">();
-    const [resign_text, set_resign_text] = React.useState<string>();
     const [score_estimate_winner, set_score_estimate_winner] = React.useState<string>();
     const [score_estimate_amount, set_score_estimate_amount] = React.useState<number>();
     const [show_title, set_show_title] = React.useState<boolean>();
@@ -755,42 +753,6 @@ export function Game(): JSX.Element {
         return ret;
     };
 
-    const cancelOrResign = () => {
-        let dropping_from_casual_rengo = false;
-
-        if (goban.current.engine.rengo && goban.current.engine.rengo_casual_mode) {
-            const team = goban.current.engine.rengo_teams.black.find(
-                (p) => p.id === data.get("user").id,
-            )
-                ? "black"
-                : "white";
-            dropping_from_casual_rengo = goban.current.engine.rengo_teams[team].length > 1;
-        }
-
-        if (resign_mode === "cancel") {
-            swal({
-                text: _("Are you sure you wish to cancel this game?"),
-                confirmButtonText: _("Yes"),
-                cancelButtonText: _("No"),
-                showCancelButton: true,
-                focusCancel: true,
-            })
-                .then(() => goban.current.cancelGame())
-                .catch(() => 0);
-        } else {
-            swal({
-                text: dropping_from_casual_rengo
-                    ? _("Are you sure you want to abandon your team?")
-                    : _("Are you sure you wish to resign this game?"),
-                confirmButtonText: _("Yes"),
-                cancelButtonText: _("No"),
-                showCancelButton: true,
-                focusCancel: true,
-            })
-                .then(() => goban.current.resign())
-                .catch(() => 0);
-        }
-    };
     const goban_setModeDeferredPlay = () => {
         goban.current.setModeDeferred("play");
     };
@@ -847,9 +809,6 @@ export function Game(): JSX.Element {
             goban={goban.current}
             show_cancel={show_cancel}
             player_to_move={player_to_move}
-            onCancel={cancelOrResign}
-            resign_text={resign_text}
-            view_mode={view_mode}
             user_is_player={user_is_player}
             review_list={review_list}
             stashed_conditional_moves={stashed_conditional_moves.current}
@@ -1208,16 +1167,6 @@ export function Game(): JSX.Element {
 
         /* Ensure our state is kept up to date */
 
-        const sync_resign_text = () => {
-            if (goban.current.engine.gameCanBeCanceled()) {
-                set_resign_text(_("Cancel game"));
-                set_resign_mode("cancel");
-            } else {
-                set_resign_text(_("Resign"));
-                set_resign_mode("resign");
-            }
-        };
-
         const sync_show_title = () =>
             set_show_title(
                 !goban.current.submit_move ||
@@ -1258,7 +1207,6 @@ export function Game(): JSX.Element {
             set_score_estimate_winner(undefined);
             set_undo_requested(engine.undo_requested);
 
-            sync_resign_text();
             sync_show_title();
             sync_move_info();
             sync_stone_removal();
@@ -1304,7 +1252,6 @@ export function Game(): JSX.Element {
             set_score_estimate_amount(est?.amount);
         });
         goban.current.on("undo_requested", set_undo_requested);
-        goban.current.on("cur_move", sync_resign_text);
         goban.current.on("cur_move", sync_show_title);
         goban.current.on("submit_move", sync_show_title);
         goban.current.on("cur_move", sync_move_info);
@@ -1643,11 +1590,7 @@ export function Game(): JSX.Element {
                         !zen_mode &&
                         user_is_player &&
                         phase !== "finished") ||
-                        null) && (
-                        <CancelButton view_mode={view_mode} onClick={cancelOrResign}>
-                            {resign_text}
-                        </CancelButton>
-                    )}
+                        null) && <CancelButton goban={goban.current} className="bold reject" />}
 
                     {((view_mode === "portrait" && !zen_mode) || null) && (
                         <GameDock

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -135,7 +135,6 @@ export function Game(): JSX.Element {
     const [score_estimate_winner, set_score_estimate_winner] = React.useState<string>();
     const [score_estimate_amount, set_score_estimate_amount] = React.useState<number>();
     const [show_title, set_show_title] = React.useState<boolean>();
-    const [player_to_move, set_player_to_move] = React.useState<number>();
     const [, set_undo_requested] = React.useState<number | undefined>();
     const [, forceUpdate] = React.useState<number>();
 
@@ -809,7 +808,6 @@ export function Game(): JSX.Element {
         <PlayControls
             goban={goban.current}
             show_cancel={show_cancel}
-            player_to_move={player_to_move}
             review_list={review_list}
             stashed_conditional_moves={stashed_conditional_moves.current}
             mode={mode}
@@ -1174,10 +1172,6 @@ export function Game(): JSX.Element {
                     null,
             );
 
-        const sync_move_info = () => {
-            set_player_to_move(goban.current.engine.playerToMove());
-        };
-
         const sync_stone_removal = () => {
             const engine = goban.current.engine;
 
@@ -1208,7 +1202,6 @@ export function Game(): JSX.Element {
             set_undo_requested(engine.undo_requested);
 
             sync_show_title();
-            sync_move_info();
             sync_stone_removal();
 
             // These are only updated on load events
@@ -1253,8 +1246,6 @@ export function Game(): JSX.Element {
         goban.current.on("undo_requested", set_undo_requested);
         goban.current.on("cur_move", sync_show_title);
         goban.current.on("submit_move", sync_show_title);
-        goban.current.on("cur_move", sync_move_info);
-        goban.current.on("last_official_move", sync_move_info);
 
         goban.current.on("phase", sync_stone_removal);
         goban.current.on("mode", sync_stone_removal);
@@ -1557,7 +1548,6 @@ export function Game(): JSX.Element {
                             historical_white={historical_white}
                             black_auto_resign_expiration={black_auto_resign_expiration}
                             white_auto_resign_expiration={white_auto_resign_expiration}
-                            player_to_move={player_to_move}
                             game_id={game_id}
                             review_id={review_id}
                             estimating_score={estimating_score}
@@ -1627,7 +1617,6 @@ export function Game(): JSX.Element {
                                 historical_white={historical_white}
                                 black_auto_resign_expiration={black_auto_resign_expiration}
                                 white_auto_resign_expiration={white_auto_resign_expiration}
-                                player_to_move={player_to_move}
                                 game_id={game_id}
                                 review_id={review_id}
                                 estimating_score={estimating_score}

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -69,6 +69,7 @@ import {
 import { CancelButton } from "./PlayButtons";
 import { GameDock } from "./GameDock";
 import swal from "sweetalert2";
+import { useUserIsParticipant } from "./GameHooks";
 
 const win = $(window);
 
@@ -101,7 +102,7 @@ export function Game(): JSX.Element {
     const [squashed, set_squashed] = React.useState<boolean>(goban_view_squashed());
     const [estimating_score, set_estimating_score] = React.useState<boolean>(false);
     const [analyze_pencil_color, set_analyze_pencil_color] = React.useState<string>("#004cff");
-    const [user_is_player, set_user_is_player] = React.useState(false);
+    const user_is_player = useUserIsParticipant(goban.current);
     const [zen_mode, set_zen_mode] = React.useState(false);
     const [autoplaying, set_autoplaying] = React.useState(false);
     const [review_list, set_review_list] = React.useState([]);
@@ -809,7 +810,6 @@ export function Game(): JSX.Element {
             goban={goban.current}
             show_cancel={show_cancel}
             player_to_move={player_to_move}
-            user_is_player={user_is_player}
             review_list={review_list}
             stashed_conditional_moves={stashed_conditional_moves.current}
             mode={mode}
@@ -1212,7 +1212,6 @@ export function Game(): JSX.Element {
             sync_stone_removal();
 
             // These are only updated on load events
-            set_user_is_player(engine.isParticipant(data.get("user").id));
 
             // I have no recollection of this code and why I thought it was necessary. If you find
             // this code after 2022-06-01, feel free to remove it. - anoek 2022-04-19
@@ -1526,7 +1525,6 @@ export function Game(): JSX.Element {
             selected_chat_log={selected_chat_log}
             onSelectedChatModeChange={set_selected_chat_log}
             goban={goban.current}
-            userIsPlayer={user_is_player}
             channel={game_id ? `game-${game_id}` : `review-${review_id}`}
             game_id={game_id}
             review_id={review_id}

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -31,11 +31,11 @@ import { chat_markup } from "components/Chat";
 import { inGameModChannel } from "chat_manager";
 import { MoveTree } from "goban";
 import { game_control } from "./game_control";
+import { useUserIsParticipant } from "./GameHooks";
 
 export type ChatMode = "main" | "malkovich" | "moderator" | "hidden" | "personal";
 interface GameChatProperties {
     goban: Goban;
-    userIsPlayer: boolean;
     selected_chat_log: ChatMode;
     onSelectedChatModeChange: (c: ChatMode) => void;
     channel: string;
@@ -77,6 +77,7 @@ export function GameChat(props: GameChatProperties): JSX.Element {
     const chat_log_hash = React.useRef<{ [k: string]: boolean }>({});
     const chat_lines = React.useRef<ChatLine[]>([]);
     const [, refresh] = React.useState<number>();
+    const userIsPlayer = useUserIsParticipant(props.goban);
 
     React.useEffect(() => {
         if (!props.goban) {
@@ -253,14 +254,14 @@ export function GameChat(props: GameChatProperties): JSX.Element {
                 />
             )}
             <div className="chat-input-container input-group">
-                {((props.userIsPlayer && data.get("user").email_validated) || null) && (
+                {((userIsPlayer && data.get("user").email_validated) || null) && (
                     <ChatLogToggleButton
                         selected_chat_log={selected_chat_log}
                         toggleChatLog={toggleChatLog}
                         isUserModerator={false}
                     />
                 )}
-                {((!props.userIsPlayer && data.get("user").is_moderator) || null) && (
+                {((!userIsPlayer && data.get("user").is_moderator) || null) && (
                     <ChatLogToggleButton
                         selected_chat_log={selected_chat_log}
                         toggleChatLog={toggleChatLog}
@@ -295,7 +296,7 @@ export function GameChat(props: GameChatProperties): JSX.Element {
                     onKeyPress={onKeyPress}
                     onFocus={() => setShowQuickChat(false)}
                 />
-                {props.userIsPlayer &&
+                {userIsPlayer &&
                 user.email_validated &&
                 props.game_id &&
                 selected_chat_log === "main" ? (

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -33,6 +33,7 @@ import { errorAlerter, ignore } from "misc";
 import { openReport } from "Report";
 import { game_control } from "./game_control";
 import { openGameInfoModal } from "./GameInfoModal";
+import { useUserIsParticipant } from "./GameHooks";
 
 interface DockProps {
     goban: Goban;
@@ -90,7 +91,7 @@ export function GameDock({
     let annul = user?.is_moderator && phase === "finished";
     const annulable = !annulled && engine.config.ranked;
     const unannulable = annulled && engine.config.ranked;
-    const user_is_player = engine.isParticipant(user?.id || 0);
+    const user_is_player = useUserIsParticipant(goban);
 
     const review = !!review_id;
     const game = !!game_id;

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -61,3 +61,15 @@ export function useUserIsParticipant(goban?: GobanCore) {
     }, [goban]);
     return user_is_participant;
 }
+
+/** React hook that returns the current move number from goban */
+export function useCurrentMoveNumber(goban: GobanCore): number {
+    const [cur_move_number, setCurMoveNumber] = React.useState(
+        goban.engine.cur_move?.move_number || -1,
+    );
+    React.useEffect(() => {
+        goban.on("load", () => setCurMoveNumber(goban.engine.cur_move?.move_number || -1));
+        goban.on("cur_move", (move) => setCurMoveNumber(move.move_number));
+    }, [goban]);
+    return cur_move_number;
+}

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -18,6 +18,7 @@
 import * as React from "react";
 import { GobanCore } from "goban";
 import { game_control } from "./game_control";
+import * as data from "data";
 
 /** React hook that returns true if an undo was requested on the current move */
 export function useUndoRequested(goban: GobanCore): boolean {
@@ -40,7 +41,23 @@ export function useUndoRequested(goban: GobanCore): boolean {
         goban.on("load", syncShowUndoRequested);
         goban.on("undo_requested", syncShowUndoRequested);
         goban.on("last_official_move", syncShowUndoRequested);
-    });
+    }, [goban, game_control.in_pushed_analysis]);
 
     return show_undo_requested;
+}
+
+/** React hook that returns true if user is a participant in this game */
+export function useUserIsParticipant(goban?: GobanCore) {
+    const [user_is_participant, setUserIsParticipant] = React.useState(false);
+    React.useEffect(() => {
+        if (!goban) {
+            return;
+        }
+
+        setUserIsParticipant(goban.engine.isParticipant(data.get("user").id));
+        goban.on("load", () =>
+            setUserIsParticipant(goban.engine.isParticipant(data.get("user").id)),
+        );
+    }, [goban]);
+    return user_is_participant;
 }

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { GobanCore } from "goban";
+import { game_control } from "./game_control";
+
+/** React hook that returns true if an undo was requested on the current move */
+export function useUndoRequested(goban: GobanCore): boolean {
+    const [show_undo_requested, setShowUndoRequested] = React.useState(
+        goban.engine.undo_requested === goban.engine.last_official_move.move_number,
+    );
+    React.useEffect(() => {
+        const syncShowUndoRequested = () => {
+            if (game_control.in_pushed_analysis) {
+                return;
+            }
+
+            setShowUndoRequested(
+                goban.engine.undo_requested === goban.engine.last_official_move.move_number &&
+                    goban.engine.undo_requested === goban.engine.cur_move.move_number,
+            );
+        };
+        syncShowUndoRequested();
+
+        goban.on("load", syncShowUndoRequested);
+        goban.on("undo_requested", syncShowUndoRequested);
+        goban.on("last_official_move", syncShowUndoRequested);
+    });
+
+    return show_undo_requested;
+}

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -21,9 +21,10 @@ import { game_control } from "./game_control";
 import * as data from "data";
 
 /** React hook that returns true if an undo was requested on the current move */
-export function useUndoRequested(goban: GobanCore): boolean {
+export function useShowUndoRequested(goban: GobanCore): boolean {
     const [show_undo_requested, setShowUndoRequested] = React.useState(
-        goban.engine.undo_requested === goban.engine.last_official_move.move_number,
+        goban.engine.undo_requested === goban.engine.last_official_move.move_number &&
+            goban.engine.undo_requested === goban.engine.cur_move.move_number,
     );
     React.useEffect(() => {
         const syncShowUndoRequested = () => {
@@ -41,6 +42,7 @@ export function useUndoRequested(goban: GobanCore): boolean {
         goban.on("load", syncShowUndoRequested);
         goban.on("undo_requested", syncShowUndoRequested);
         goban.on("last_official_move", syncShowUndoRequested);
+        goban.on("cur_move", syncShowUndoRequested);
     }, [goban, game_control.in_pushed_analysis]);
 
     return show_undo_requested;

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -73,3 +73,26 @@ export function useCurrentMoveNumber(goban: GobanCore): number {
     }, [goban]);
     return cur_move_number;
 }
+
+/** React hook that returns the current player whose move it is.
+ *
+ * @returns the player ID of the player whose turn it is.
+ */
+export function usePlayerToMove(goban?: GobanCore): number {
+    const [player_to_move, set_player_to_move] = React.useState<number>();
+    React.useEffect(() => {
+        if (!goban) {
+            set_player_to_move(0);
+            return;
+        }
+        const sync_move_info = () => {
+            set_player_to_move(goban.engine.playerToMove());
+        };
+        sync_move_info();
+        goban.on("load", sync_move_info);
+        goban.on("cur_move", sync_move_info);
+        goban.on("last_official_move", sync_move_info);
+    }, [goban]);
+
+    return player_to_move;
+}

--- a/src/views/Game/PlayButtons.test.tsx
+++ b/src/views/Game/PlayButtons.test.tsx
@@ -1,0 +1,348 @@
+import { AdHocPackedMove, Goban } from "goban";
+import { CancelButton, PlayButtons } from "./PlayButtons";
+import { act, cleanup, fireEvent, render, screen /* waitFor */ } from "@testing-library/react";
+import * as React from "react";
+import * as data from "data";
+
+const LOGGED_IN_USER = {
+    anonymous: false,
+    id: 123,
+    username: "test_user",
+    registration_date: "2022-05-10 11:03:24.299562+00:00",
+    ratings: {
+        version: 5,
+        overall: { rating: 1500, deviation: 350, volatility: 0.06 },
+    },
+    country: "un",
+    professional: false,
+    ranking: 23,
+    provisional: 0,
+    can_create_tournaments: true,
+    is_moderator: false,
+    is_superuser: false,
+    is_tournament_moderator: false,
+    supporter: true,
+    supporter_level: 4,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "https://secure.gravatar.com/avatar/8d809ecc50408afc399a4cb7c8fd4510?s=32&d=retro",
+    email: "",
+    email_validated: false,
+    is_announcer: false,
+} as const;
+
+const LESS_THAN_SIX_MOVES = {
+    moves: [
+        [16, 3, 9136],
+        [3, 2, 18978.5],
+        [15, 16, 4274.5],
+    ] as AdHocPackedMove[],
+} as const;
+const MORE_THAN_SIX_MOVES = {
+    moves: [
+        [16, 3, 9136],
+        [3, 2, 18978.5],
+        [15, 16, 4274.5],
+        [14, 2, 3816],
+        [2, 15, 6869],
+        [16, 14, 6241.5],
+        [15, 4, 4485],
+    ] as AdHocPackedMove[],
+} as const;
+
+beforeEach(() => {
+    data.set("user", LOGGED_IN_USER);
+});
+
+afterEach(() => {
+    data.remove("user");
+    cleanup();
+});
+
+describe("CancelButton", () => {
+    test('says "Cancel game" in the first 6 moves.', () => {
+        const goban = new Goban(LESS_THAN_SIX_MOVES);
+
+        render(<CancelButton goban={goban} />);
+
+        expect(screen.getByText("Cancel game")).toBeDefined();
+        expect(screen.queryByText("Resign")).toBeNull();
+    });
+
+    test('says "Resign" after 6 moves', () => {
+        const goban = new Goban(MORE_THAN_SIX_MOVES);
+
+        render(<CancelButton goban={goban} />);
+
+        expect(screen.getByText("Resign")).toBeDefined();
+        expect(screen.queryByText("Cancel game")).toBeNull();
+    });
+
+    /*
+    Most of these tests pass, but for some reason, the swal modal never closes.
+    I found this issue: https://github.com/sweetalert2/sweetalert2/issues/1426
+    which shows that sweetalert wasn't resolving in tests
+    Seems like the issue was fixed in swal2 v8.3.0, so maybe I try to
+    uncomment this test after upgrading...
+
+    test("allows user to cancel before 6 moves.", async () => {
+        const goban = new Goban(LESS_THAN_SIX_MOVES);
+        const cancel_spy = spyOn(goban, "cancelGame");
+
+        render(<CancelButton goban={goban} />);
+        fireEvent.click(screen.getByText("Cancel game"));
+
+        expect(screen.getByText(/Are you sure.*cancel.*?/)).toBeDefined();
+
+        fireEvent.click(screen.getByText("Yes"));
+
+        // Wait for the sweetalert to close (not sure why this isn't synchronous)
+        await waitFor(() => expect(cancel_spy).toHaveBeenCalledTimes(1));
+    });
+
+    test("allows user to resign after 6 moves.", async () => {
+        const goban = new Goban(MORE_THAN_SIX_MOVES);
+        const resign_spy = spyOn(goban, "resign");
+
+        render(<CancelButton goban={goban} />);
+        fireEvent.click(screen.getByText("Resign"));
+
+        expect(screen.getByText(/Are you sure.*resign.*?/)).toBeDefined();
+
+        fireEvent.click(screen.getByText("Yes"));
+
+        // Wait for the sweetalert to close (not sure why this isn't synchronous)
+        await waitFor(() => expect(resign_spy).toHaveBeenCalledTimes(1));
+    });
+
+    test("allows user to abandon in casual rengo.", async () => {
+        const goban = new Goban({
+            ...MORE_THAN_SIX_MOVES,
+            rengo: true,
+            rengo_teams: {
+                black: [
+                    { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                    { id: 234, username: "user2" },
+                ],
+                white: [
+                    { id: 345, username: "user3" },
+                    { id: 456, username: "user4" },
+                ],
+            },
+            rengo_casual_mode: true,
+        });
+        const resign_spy = spyOn(goban, "resign");
+        render(<CancelButton goban={goban} />);
+        fireEvent.click(screen.getByText("Resign"));
+        expect(screen.getByText(/Are you sure.*abandon.*?/)).toBeDefined();
+        fireEvent.click(screen.getByText("Yes"));
+        // Wait for the sweetalert to close (not sure why this isn't synchronous)
+        await waitFor(() => expect(resign_spy).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(resign_spy).toHaveBeenCalledTimes(1));
+    });
+
+    test("allows user to change their mind", async () => {
+        const goban = new Goban(MORE_THAN_SIX_MOVES);
+        const resign_spy = spyOn(goban, "resign");
+
+        render(<CancelButton goban={goban} />);
+        fireEvent.click(screen.getByText("Resign"));
+
+        expect(screen.getByText(/Are you sure.*resign.*?/)).toBeDefined();
+
+        fireEvent.click(screen.getByText("No"));
+
+        await waitForElementToBeRemoved(screen.getByRole("dialog"));
+
+        expect(resign_spy).not.toHaveBeenCalled();
+    });
+    */
+});
+
+describe("PlayButtons", () => {
+    test("normal game when it's my opponent's turn.", () => {
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // Black went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+
+        render(<PlayButtons goban={goban} />);
+
+        // Present
+        expect(screen.getByText("Cancel game")).toBeDefined();
+        expect(screen.getByText("Undo")).toBeDefined();
+
+        // Absent
+        expect(screen.queryByText("Accept Undo")).toBeNull();
+        expect(screen.queryByText("Submit Move")).toBeNull();
+        expect(screen.queryByText("Pass")).toBeNull();
+    });
+
+    test("normal game when it's my turn.", () => {
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // B
+                [14, 2, 3816], // White went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+
+        render(<PlayButtons goban={goban} />);
+
+        // Present
+        expect(screen.getByText("Cancel game")).toBeDefined();
+        expect(screen.getByText("Pass")).toBeDefined();
+
+        // Absent
+        expect(screen.queryByText("Undo")).toBeNull();
+        expect(screen.queryByText("Accept Undo")).toBeNull();
+        expect(screen.queryByText("Submit Move")).toBeNull();
+    });
+
+    test('shows "Accept Undo" when opponent requested an undo.', () => {
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // B
+                [14, 2, 3816], // White went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+        goban.engine.undo_requested = 4;
+        render(<PlayButtons goban={goban} />);
+
+        // Present
+        expect(screen.getByText("Cancel game")).toBeDefined();
+        expect(screen.getByText("Pass")).toBeDefined();
+        expect(screen.queryByText("Accept Undo")).toBeDefined();
+
+        // Absent
+        expect(screen.queryByText("Undo")).toBeNull();
+        expect(screen.queryByText("Submit Move")).toBeNull();
+    });
+
+    test('shows "Accept undo" if undo was requested after initial render', () => {
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // B
+                [14, 2, 3816], // White went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+        render(<PlayButtons goban={goban} />);
+
+        //
+        act(() => {
+            goban.engine.undo_requested = 4;
+        });
+
+        // Present
+        expect(screen.getByText("Cancel game")).toBeDefined();
+        expect(screen.getByText("Pass")).toBeDefined();
+        expect(screen.queryByText("Accept Undo")).toBeDefined();
+
+        // Absent
+        expect(screen.queryByText("Undo")).toBeNull();
+        expect(screen.queryByText("Submit Move")).toBeNull();
+    });
+
+    test('shows "Submit Move" when user staged a move.', () => {
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // B
+                [14, 2, 3816], // White went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+        goban.engine.place(10, 10);
+        // usually this is set by a tap event, but I don't really
+        // want to mess with GobanCanvas in these tests.
+        goban.submit_move = jest.fn();
+        render(<PlayButtons goban={goban} />);
+
+        // Present
+        expect(screen.getByText("Cancel game")).toBeDefined();
+        expect(screen.getByText("Submit Move")).toBeDefined();
+
+        // Absent
+        expect(screen.queryByText("Undo")).toBeNull();
+        expect(screen.queryByText("Accept Undo")).toBeNull();
+        expect(screen.queryByText("Pass")).toBeNull();
+
+        // Check that submit button actually triggers a submit
+        fireEvent.click(screen.getByText("Submit Move"));
+        expect(goban.submit_move).toHaveBeenCalledTimes(1);
+    });
+
+    test("Don't show undo for rengo", () => {
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // Black went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+            rengo: true,
+        });
+
+        render(<PlayButtons goban={goban} />);
+
+        // Present
+        expect(screen.getByText("Cancel game")).toBeDefined();
+
+        // Absent
+        expect(screen.queryByText("Accept Undo")).toBeNull();
+        expect(screen.queryByText("Submit Move")).toBeNull();
+        expect(screen.queryByText("Pass")).toBeNull();
+        expect(screen.queryByText("Undo")).toBeNull();
+    });
+
+    test("Don't show undo on the first move", () => {
+        const goban = new Goban({
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+
+        render(<PlayButtons goban={goban} />);
+
+        // Present
+        expect(screen.getByText("Cancel game")).toBeDefined();
+        expect(screen.getByText("Pass")).toBeDefined();
+
+        // Absent
+        expect(screen.queryByText("Accept Undo")).toBeNull();
+        expect(screen.queryByText("Submit Move")).toBeNull();
+        expect(screen.queryByText("Undo")).toBeNull();
+    });
+});

--- a/src/views/Game/PlayButtons.test.tsx
+++ b/src/views/Game/PlayButtons.test.tsx
@@ -78,6 +78,32 @@ describe("CancelButton", () => {
         expect(screen.queryByText("Cancel game")).toBeNull();
     });
 
+    test('changes to "Resign" on the 6th move.', () => {
+        const goban = new Goban({
+            // 5 moves
+            moves: [
+                [16, 3, 9136.12],
+                [3, 2, 1897.853],
+                [15, 16, 4274.0],
+                [14, 2, 3816],
+                [2, 15, 6869],
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+
+        render(<CancelButton goban={goban} />);
+
+        act(() => {
+            goban.engine.place(10, 10);
+        });
+
+        expect(screen.getByText("Resign")).toBeDefined();
+        expect(screen.queryByText("Cancel game")).toBeNull();
+    });
+
     /*
     Most of these tests pass, but for some reason, the swal modal never closes.
     I found this issue: https://github.com/sweetalert2/sweetalert2/issues/1426
@@ -252,7 +278,6 @@ describe("PlayButtons", () => {
         });
         render(<PlayButtons goban={goban} />);
 
-        //
         act(() => {
             goban.engine.undo_requested = 4;
         });

--- a/src/views/Game/PlayButtons.test.tsx
+++ b/src/views/Game/PlayButtons.test.tsx
@@ -370,4 +370,57 @@ describe("PlayButtons", () => {
         expect(screen.queryByText("Submit Move")).toBeNull();
         expect(screen.queryByText("Undo")).toBeNull();
     });
+
+    test("Don't show undo if analyzing the game", () => {
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // Black went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+
+        render(<PlayButtons goban={goban} />);
+
+        // go back two moves
+        act(() => {
+            goban.engine.showPrevious();
+            goban.engine.showPrevious();
+        });
+
+        expect(screen.queryByText("Undo")).toBeNull();
+    });
+
+    test("Don't show accept undo if analyzing the game", () => {
+        console.log("test started");
+        const goban = new Goban({
+            moves: [
+                [16, 3, 9136.12], // B
+                [3, 2, 1897.853], // W
+                [15, 16, 4274.0], // B
+                [14, 2, 3816], // White went last
+            ],
+            players: {
+                black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
+                white: { id: 456, username: "test_user2" },
+            },
+        });
+
+        render(<PlayButtons goban={goban} />);
+        // opponent requests undo
+        act(() => {
+            goban.engine.undo_requested = 4;
+        });
+        // go back two moves
+        act(() => {
+            goban.engine.showPrevious();
+            goban.engine.showPrevious();
+        });
+
+        expect(screen.queryByText("Accept Undo")).toBeNull();
+    });
 });

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -23,18 +23,17 @@ import * as preferences from "preferences";
 import * as data from "data";
 import { game_control } from "./game_control";
 import swal from "sweetalert2";
-import { useCurrentMoveNumber, useUndoRequested } from "./GameHooks";
+import { useCurrentMoveNumber, usePlayerToMove, useUndoRequested } from "./GameHooks";
 
 interface PlayButtonsProps {
     goban: Goban;
-    player_to_move: number;
 
     // This option exists because Cancel Button is placed below
     // chat on mobile layouts.
     show_cancel: boolean;
 }
 
-export function PlayButtons({ goban, player_to_move, show_cancel }: PlayButtonsProps): JSX.Element {
+export function PlayButtons({ goban, show_cancel }: PlayButtonsProps): JSX.Element {
     const engine = goban.engine;
     const phase = engine.phase;
 
@@ -44,6 +43,7 @@ export function PlayButtons({ goban, player_to_move, show_cancel }: PlayButtonsP
             : engine.players.black.id;
     const is_my_move = real_player_to_move === data.get("user").id;
     const cur_move_number = useCurrentMoveNumber(goban);
+    const player_to_move = usePlayerToMove(goban);
 
     const [show_submit, setShowSubmit] = React.useState(false);
     React.useEffect(() => {

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -30,10 +30,10 @@ interface PlayButtonsProps {
 
     // This option exists because Cancel Button is placed below
     // chat on mobile layouts.
-    show_cancel: boolean;
+    show_cancel?: boolean;
 }
 
-export function PlayButtons({ goban, show_cancel }: PlayButtonsProps): JSX.Element {
+export function PlayButtons({ goban, show_cancel = true }: PlayButtonsProps): JSX.Element {
     const engine = goban.engine;
     const phase = engine.phase;
 
@@ -161,10 +161,10 @@ export function PlayButtons({ goban, show_cancel }: PlayButtonsProps): JSX.Eleme
 }
 
 interface CancelButtonProps {
-    className: string;
+    className?: string;
     goban: GobanCore;
 }
-export function CancelButton({ className, goban }: CancelButtonProps) {
+export function CancelButton({ className = "", goban }: CancelButtonProps) {
     const [resign_mode, set_resign_mode] = React.useState<"cancel" | "resign">();
     React.useEffect(() => {
         const sync_resign_mode = () => {
@@ -210,7 +210,7 @@ export function CancelButton({ className, goban }: CancelButtonProps) {
 
     return (
         <button className={`cancel-button ${className}`} onClick={cancelOrResign}>
-            {resign_mode === "cancel" ? _("Cancel Game") : _("Resign")}
+            {resign_mode === "cancel" ? _("Cancel game") : _("Resign")}
         </button>
     );
 }

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -23,7 +23,7 @@ import * as preferences from "preferences";
 import * as data from "data";
 import { game_control } from "./game_control";
 import swal from "sweetalert2";
-import { useCurrentMoveNumber, usePlayerToMove, useUndoRequested } from "./GameHooks";
+import { useCurrentMoveNumber, usePlayerToMove, useShowUndoRequested } from "./GameHooks";
 
 interface PlayButtonsProps {
     goban: Goban;
@@ -82,7 +82,7 @@ export function PlayButtons({ goban, show_cancel = true }: PlayButtonsProps): JS
         goban.on("cur_move", syncShowAcceptUndo);
         goban.on("submit_move", syncShowAcceptUndo);
     }, [goban]);
-    const show_undo_requested = useUndoRequested(goban);
+    const show_undo_requested = useShowUndoRequested(goban);
 
     const onUndo = () => {
         if (
@@ -111,27 +111,31 @@ export function PlayButtons({ goban, show_cancel = true }: PlayButtonsProps): JS
     return (
         <span className="play-buttons">
             <span>
-                {((cur_move_number >= 1 &&
-                    !engine.rengo &&
-                    player_to_move !== data.get("user").id &&
-                    !(engine.undo_requested >= engine.getMoveNumber()) &&
-                    goban.submit_move == null) ||
-                    null) && (
-                    <button className="bold undo-button xs" onClick={onUndo}>
-                        {_("Undo")}
-                    </button>
-                )}
-                {show_undo_requested && (
-                    <span>
-                        {show_accept_undo && (
-                            <button
-                                className="sm primary bold accept-undo-button"
-                                onClick={() => goban.acceptUndo()}
-                            >
-                                {_("Accept Undo")}
+                {cur_move_number === goban.engine.last_official_move.move_number && (
+                    <>
+                        {((cur_move_number >= 1 &&
+                            !engine.rengo &&
+                            player_to_move !== data.get("user").id &&
+                            !(engine.undo_requested >= engine.getMoveNumber()) &&
+                            goban.submit_move == null) ||
+                            null) && (
+                            <button className="bold undo-button xs" onClick={onUndo}>
+                                {_("Undo")}
                             </button>
                         )}
-                    </span>
+                        {show_undo_requested && (
+                            <span>
+                                {show_accept_undo && (
+                                    <button
+                                        className="sm primary bold accept-undo-button"
+                                        onClick={() => goban.acceptUndo()}
+                                    >
+                                        {_("Accept Undo")}
+                                    </button>
+                                )}
+                            </span>
+                        )}
+                    </>
                 )}
             </span>
             <span>

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -23,13 +23,12 @@ import * as preferences from "preferences";
 import * as data from "data";
 import { game_control } from "./game_control";
 import swal from "sweetalert2";
+import { useUndoRequested } from "./GameHooks";
 
 interface PlayButtonsProps {
     cur_move_number: number;
     goban: Goban;
     player_to_move: number;
-    // Is this variable any different from show_accept_undo? -BPJ
-    show_undo_requested: boolean;
 
     // This option exists because Cancel Button is placed below
     // chat on mobile layouts.
@@ -40,7 +39,6 @@ export function PlayButtons({
     cur_move_number,
     goban,
     player_to_move,
-    show_undo_requested,
     show_cancel,
 }: PlayButtonsProps): JSX.Element {
     const engine = goban.engine;
@@ -89,6 +87,7 @@ export function PlayButtons({
         goban.on("cur_move", syncShowAcceptUndo);
         goban.on("submit_move", syncShowAcceptUndo);
     }, [goban]);
+    const show_undo_requested = useUndoRequested(goban);
 
     const onUndo = () => {
         if (

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -195,34 +195,26 @@ export function CancelButton({ className, goban }: CancelButtonProps) {
             dropping_from_casual_rengo = goban.engine.rengo_teams[team].length > 1;
         }
 
-        if (resign_mode === "cancel") {
-            swal({
-                text: _("Are you sure you wish to cancel this game?"),
-                confirmButtonText: _("Yes"),
-                cancelButtonText: _("No"),
-                showCancelButton: true,
-                focusCancel: true,
-            })
-                .then(() => goban.cancelGame())
-                .catch(() => 0);
-        } else {
-            swal({
-                text: dropping_from_casual_rengo
-                    ? _("Are you sure you want to abandon your team?")
-                    : _("Are you sure you wish to resign this game?"),
-                confirmButtonText: _("Yes"),
-                cancelButtonText: _("No"),
-                showCancelButton: true,
-                focusCancel: true,
-            })
-                .then(() => goban.resign())
-                .catch(() => 0);
-        }
+        const text =
+            resign_mode === "cancel"
+                ? _("Are you sure you wish to cancel this game?")
+                : dropping_from_casual_rengo
+                ? _("Are you sure you want to abandon your team?")
+                : _("Are you sure you wish to resign this game?");
+        const cb = resign_mode === "cancel" ? () => goban.cancelGame() : () => goban.resign();
+
+        swal({
+            text: text,
+            confirmButtonText: _("Yes"),
+            cancelButtonText: _("No"),
+            showCancelButton: true,
+            focusCancel: true,
+        })
+            .then(cb)
+            .catch(swal.noop);
     };
 
     return (
-        // portrait: bold reject
-        // otherwise: bold xs
         <button className={`cancel-button ${className}`} onClick={cancelOrResign}>
             {resign_mode === "cancel" ? _("Cancel Game") : _("Resign")}
         </button>

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -176,7 +176,7 @@ export function CancelButton({ className = "", goban }: CancelButtonProps) {
         };
         sync_resign_mode();
         goban.on("load", sync_resign_mode);
-        goban.on("mode", sync_resign_mode);
+        goban.on("cur_move", sync_resign_mode);
     }, [goban]);
 
     const cancelOrResign = () => {

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -23,10 +23,9 @@ import * as preferences from "preferences";
 import * as data from "data";
 import { game_control } from "./game_control";
 import swal from "sweetalert2";
-import { useUndoRequested } from "./GameHooks";
+import { useCurrentMoveNumber, useUndoRequested } from "./GameHooks";
 
 interface PlayButtonsProps {
-    cur_move_number: number;
     goban: Goban;
     player_to_move: number;
 
@@ -35,12 +34,7 @@ interface PlayButtonsProps {
     show_cancel: boolean;
 }
 
-export function PlayButtons({
-    cur_move_number,
-    goban,
-    player_to_move,
-    show_cancel,
-}: PlayButtonsProps): JSX.Element {
+export function PlayButtons({ goban, player_to_move, show_cancel }: PlayButtonsProps): JSX.Element {
     const engine = goban.engine;
     const phase = engine.phase;
 
@@ -49,6 +43,7 @@ export function PlayButtons({
             ? engine.players.white.id
             : engine.players.black.id;
     const is_my_move = real_player_to_move === data.get("user").id;
+    const cur_move_number = useCurrentMoveNumber(goban);
 
     const [show_submit, setShowSubmit] = React.useState(false);
     React.useEffect(() => {

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { _ } from "translate";
+import { Goban, JGOFNumericPlayerColor } from "goban";
+import { ViewMode } from "./util";
+import { isLiveGame } from "TimeControl";
+import * as preferences from "preferences";
+import * as data from "data";
+import { game_control } from "./game_control";
+import swal from "sweetalert2";
+
+interface PlayButtonsProps {
+    cur_move_number: number;
+    goban: Goban;
+    player_to_move: number;
+    // Is this variable any different from show_accept_undo? -BPJ
+    show_undo_requested: boolean;
+
+    // Cancel buttons are in props because the Cancel Button is placed below
+    // chat on mobile.
+    show_cancel: boolean;
+    onCancel: () => void;
+
+    view_mode: ViewMode;
+    resign_text: string;
+}
+
+export function PlayButtons({
+    cur_move_number,
+    goban,
+    player_to_move,
+    show_undo_requested,
+    show_cancel,
+    onCancel,
+    view_mode,
+    resign_text,
+}: PlayButtonsProps): JSX.Element {
+    const engine = goban.engine;
+    const phase = engine.phase;
+
+    const real_player_to_move =
+        engine.last_official_move?.player === JGOFNumericPlayerColor.BLACK
+            ? engine.players.white.id
+            : engine.players.black.id;
+    const is_my_move = real_player_to_move === data.get("user").id;
+
+    const [show_submit, setShowSubmit] = React.useState(false);
+    React.useEffect(() => {
+        const syncShowSubmit = () => {
+            setShowSubmit(
+                !!goban.submit_move &&
+                    goban.engine.cur_move &&
+                    goban.engine.cur_move.parent &&
+                    goban.engine.last_official_move &&
+                    goban.engine.cur_move.parent.id === goban.engine.last_official_move.id,
+            );
+        };
+        syncShowSubmit();
+
+        goban.on("submit_move", syncShowSubmit);
+        goban.on("last_official_move", syncShowSubmit);
+        goban.on("cur_move", syncShowSubmit);
+    }, [goban]);
+
+    const [show_accept_undo, setShowAcceptUndo] = React.useState<boolean>(false);
+    React.useEffect(() => {
+        const syncShowAcceptUndo = () => {
+            if (game_control.in_pushed_analysis) {
+                return;
+            }
+
+            setShowAcceptUndo(
+                goban.engine.playerToMove() === data.get("user").id ||
+                    (goban.submit_move != null &&
+                        goban.engine.playerNotToMove() === data.get("user").id) ||
+                    null,
+            );
+        };
+        syncShowAcceptUndo();
+
+        goban.on("cur_move", syncShowAcceptUndo);
+        goban.on("submit_move", syncShowAcceptUndo);
+    }, [goban]);
+
+    const onUndo = () => {
+        if (
+            data.get("user").id === goban.engine.playerNotToMove() &&
+            goban.engine.undo_requested !== goban.engine.getMoveNumber()
+        ) {
+            goban.requestUndo();
+        }
+    };
+
+    const pass = () => {
+        if (!isLiveGame(goban.engine.time_control) || !preferences.get("one-click-submit-live")) {
+            swal({ text: _("Are you sure you want to pass?"), showCancelButton: true })
+                .then(() => goban.pass())
+                .catch(() => 0);
+        } else {
+            goban.pass();
+        }
+    };
+
+    const [submitting_move, setSubmittingMove] = React.useState(false);
+    React.useEffect(() => {
+        goban.on("submitting-move", setSubmittingMove);
+    }, [goban]);
+
+    return (
+        <span className="play-buttons">
+            <span>
+                {((cur_move_number >= 1 &&
+                    !engine.rengo &&
+                    player_to_move !== data.get("user").id &&
+                    !(engine.undo_requested >= engine.getMoveNumber()) &&
+                    goban.submit_move == null) ||
+                    null) && (
+                    <button className="bold undo-button xs" onClick={onUndo}>
+                        {_("Undo")}
+                    </button>
+                )}
+                {show_undo_requested && (
+                    <span>
+                        {show_accept_undo && (
+                            <button
+                                className="sm primary bold accept-undo-button"
+                                onClick={() => goban.acceptUndo()}
+                            >
+                                {_("Accept Undo")}
+                            </button>
+                        )}
+                    </span>
+                )}
+            </span>
+            <span>
+                {((!show_submit && is_my_move && engine.handicapMovesLeft() === 0) || null) && (
+                    <button className="sm primary bold pass-button" onClick={pass}>
+                        {_("Pass")}
+                    </button>
+                )}
+                {((show_submit && engine.undo_requested !== engine.getMoveNumber()) || null) && (
+                    <button
+                        className="sm primary bold submit-button"
+                        id="game-submit-move"
+                        disabled={submitting_move}
+                        onClick={() => goban.submit_move()}
+                    >
+                        {_("Submit Move")}
+                    </button>
+                )}
+            </span>
+            <span>
+                {show_cancel && phase !== "finished" && (
+                    <CancelButton view_mode={view_mode} onClick={onCancel}>
+                        {resign_text}
+                    </CancelButton>
+                )}
+            </span>
+        </span>
+    );
+}
+
+interface CancelButtonProps {
+    view_mode: ViewMode;
+    onClick: React.MouseEventHandler<HTMLButtonElement>;
+    children: string;
+}
+export function CancelButton({ view_mode, onClick, children }: CancelButtonProps) {
+    if (view_mode === "portrait") {
+        return (
+            <button className="bold cancel-button reject" onClick={onClick}>
+                {children}
+            </button>
+        );
+    } else {
+        return (
+            <button className="xs bold cancel-button" onClick={onClick}>
+                {children}
+            </button>
+        );
+    }
+}

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -83,7 +83,7 @@ test("No moves have been played", () => {
 
     render(<PlayControls goban={goban} {...PLAY_CONTROLS_DEFAULTS} />);
 
-    expect(screen.getByText("Cancel Game")).toBeDefined();
+    expect(screen.getByText("Cancel game")).toBeDefined();
     expect(screen.queryByText("Undo")).toBeNull();
     expect(screen.queryByText("Accept Undo")).toBeNull();
     expect(screen.queryByText("Submit")).toBeNull();

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -79,7 +79,7 @@ test("Show only cancel if no moves have been played", () => {
     });
     data.set("user", TEST_USER);
 
-    render(<PlayControls goban={goban} {...PLAY_CONTROLS_DEFAULTS} resign_text="Cancel Game" />);
+    render(<PlayControls goban={goban} {...PLAY_CONTROLS_DEFAULTS} />);
 
     expect(screen.getByText("Cancel Game")).toBeDefined();
     expect(screen.queryByText("Undo")).toBeNull();

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -37,9 +37,6 @@ const PLAY_CONTROLS_DEFAULTS = {
     onCancel: () => {
         return;
     },
-    resign_text: "Resign",
-    view_mode: "wide",
-    user_is_player: true,
     review_list: [] as any,
     stashed_conditional_moves: null,
     mode: "play",
@@ -73,9 +70,14 @@ const PLAY_CONTROLS_DEFAULTS = {
     },
 } as const;
 
-test("Show only cancel if no moves have been played", () => {
+test("No moves have been played", () => {
     const goban = new Goban({
         game_id: 1234,
+        // TEST_USER must be a member of the game in order for cancel to show up.
+        players: {
+            black: { id: 123, username: "test_user" },
+            white: { id: 456, username: "test_user2" },
+        },
     });
     data.set("user", TEST_USER);
 
@@ -85,14 +87,14 @@ test("Show only cancel if no moves have been played", () => {
     expect(screen.queryByText("Undo")).toBeNull();
     expect(screen.queryByText("Accept Undo")).toBeNull();
     expect(screen.queryByText("Submit")).toBeNull();
-    expect(screen.queryByText("Pass")).toBeNull();
+    expect(screen.getByText("Pass")).toBeDefined();
 });
 
 test("Don't render play buttons if user is not a player", () => {
     const goban = new Goban({ game_id: 1234 });
     data.set("user", TEST_USER);
 
-    render(<PlayControls goban={goban} {...PLAY_CONTROLS_DEFAULTS} user_is_player={false} />);
+    render(<PlayControls goban={goban} {...PLAY_CONTROLS_DEFAULTS} />);
 
     expect(screen.queryByText("Resign")).toBeNull();
     expect(screen.queryByText("Undo")).toBeNull();
@@ -110,6 +112,12 @@ test("Renders undo if it is not the players turn", () => {
             [2, 2, 68110],
             [16, 2, 53287],
         ],
+        // Since three moves have been played, black must have had the last move
+        // That is one of the requirements for "undo" to show up.
+        players: {
+            black: { id: 123, username: "test_user" },
+            white: { id: 456, username: "test_user2" },
+        },
     });
     data.set("user", TEST_USER);
 

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -41,7 +41,7 @@ import { errorAlerter } from "misc";
 import { close_all_popovers } from "popover";
 import { setExtraActionCallback, Player } from "Player";
 import { PlayButtons } from "./PlayButtons";
-import { useUndoRequested } from "./GameHooks";
+import { useUndoRequested, useUserIsParticipant } from "./GameHooks";
 
 interface PlayControlsProps {
     goban: Goban;
@@ -50,8 +50,6 @@ interface PlayControlsProps {
     // Cancel buttons are in props because the Cancel Button is placed below
     // chat on mobile.
     show_cancel: boolean;
-
-    user_is_player: boolean;
 
     readonly review_list: Array<{ owner: PlayerCacheEntry; id: number }>;
 
@@ -95,7 +93,6 @@ export function PlayControls({
     show_title,
     renderEstimateScore,
     annulled,
-    user_is_player,
     renderAnalyzeButtonBar,
     setMoveTreeContainer,
     zen_mode,
@@ -288,6 +285,8 @@ export function PlayControls({
         goban.autoScore();
         return false;
     };
+
+    const user_is_player = useUserIsParticipant(goban);
 
     return (
         <div className="play-controls">

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -26,7 +26,6 @@ import {
     MoveTree,
     PlayerColor,
 } from "goban";
-import { game_control } from "./game_control";
 import device from "device";
 import swal from "sweetalert2";
 import { challengeRematch } from "ChallengeModal";
@@ -42,6 +41,7 @@ import { errorAlerter } from "misc";
 import { close_all_popovers } from "popover";
 import { setExtraActionCallback, Player } from "Player";
 import { PlayButtons } from "./PlayButtons";
+import { useUndoRequested } from "./GameHooks";
 
 interface PlayControlsProps {
     goban: Goban;
@@ -183,26 +183,7 @@ export function PlayControls({
         goban.on("cur_move", (move) => setCurMoveNumber(move.move_number));
     }, [goban]);
 
-    const [show_undo_requested, setShowUndoRequested] = React.useState(
-        goban.engine.undo_requested === goban.engine.last_official_move.move_number,
-    );
-    React.useEffect(() => {
-        const syncShowUndoRequested = () => {
-            if (game_control.in_pushed_analysis) {
-                return;
-            }
-
-            setShowUndoRequested(
-                goban.engine.undo_requested === goban.engine.last_official_move.move_number &&
-                    goban.engine.undo_requested === goban.engine.cur_move.move_number,
-            );
-        };
-        syncShowUndoRequested();
-
-        goban.on("load", syncShowUndoRequested);
-        goban.on("undo_requested", syncShowUndoRequested);
-        goban.on("last_official_move", syncShowUndoRequested);
-    });
+    const show_undo_requested = useUndoRequested(goban);
 
     const [winner, set_winner] = React.useState(goban.engine.winner);
     React.useEffect(() => {
@@ -313,7 +294,6 @@ export function PlayControls({
             <div className="game-action-buttons">
                 {mode === "play" && phase === "play" && user_is_player && (
                     <PlayButtons
-                        show_undo_requested={show_undo_requested}
                         cur_move_number={cur_move_number}
                         player_to_move={player_to_move}
                         goban={goban}

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import * as React from "react";
-import { ViewMode } from "./util";
 import { _, interpolate, pgettext } from "translate";
 import * as data from "data";
 import {
@@ -51,10 +50,7 @@ interface PlayControlsProps {
     // Cancel buttons are in props because the Cancel Button is placed below
     // chat on mobile.
     show_cancel: boolean;
-    onCancel: () => void;
-    resign_text: string;
 
-    view_mode: ViewMode;
     user_is_player: boolean;
 
     readonly review_list: Array<{ owner: PlayerCacheEntry; id: number }>;
@@ -95,9 +91,6 @@ export function PlayControls({
     stashed_conditional_moves,
     mode,
     phase,
-    resign_text,
-    onCancel,
-    view_mode,
     title,
     show_title,
     renderEstimateScore,
@@ -320,14 +313,11 @@ export function PlayControls({
             <div className="game-action-buttons">
                 {mode === "play" && phase === "play" && user_is_player && (
                     <PlayButtons
-                        resign_text={resign_text}
                         show_undo_requested={show_undo_requested}
                         cur_move_number={cur_move_number}
                         player_to_move={player_to_move}
-                        onCancel={onCancel}
                         goban={goban}
                         show_cancel={show_cancel}
-                        view_mode={view_mode}
                     />
                 )}
             </div>

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -20,7 +20,6 @@ import { _, interpolate, pgettext } from "translate";
 import * as data from "data";
 import {
     Goban,
-    JGOFNumericPlayerColor,
     GoConditionalMove,
     GobanModes,
     GoEnginePhase,
@@ -29,8 +28,6 @@ import {
     PlayerColor,
 } from "goban";
 import { game_control } from "./game_control";
-import { isLiveGame } from "TimeControl";
-import * as preferences from "preferences";
 import device from "device";
 import swal from "sweetalert2";
 import { challengeRematch } from "ChallengeModal";
@@ -45,6 +42,7 @@ import { toast } from "toast";
 import { errorAlerter } from "misc";
 import { close_all_popovers } from "popover";
 import { setExtraActionCallback, Player } from "Player";
+import { PlayButtons } from "./PlayButtons";
 
 interface PlayControlsProps {
     goban: Goban;
@@ -649,178 +647,6 @@ export function PlayControls({
             )}
         </div>
     );
-}
-
-interface PlayButtonsProps {
-    cur_move_number: number;
-    goban: Goban;
-    player_to_move: number;
-    // Is this variable any different from show_accept_undo? -BPJ
-    show_undo_requested: boolean;
-
-    // Cancel buttons are in props because the Cancel Button is placed below
-    // chat on mobile.
-    show_cancel: boolean;
-    onCancel: () => void;
-
-    view_mode: ViewMode;
-    resign_text: string;
-}
-
-function PlayButtons({
-    cur_move_number,
-    goban,
-    player_to_move,
-    show_undo_requested,
-    show_cancel,
-    onCancel,
-    view_mode,
-    resign_text,
-}: PlayButtonsProps) {
-    const engine = goban.engine;
-    const phase = engine.phase;
-
-    const real_player_to_move =
-        engine.last_official_move?.player === JGOFNumericPlayerColor.BLACK
-            ? engine.players.white.id
-            : engine.players.black.id;
-    const is_my_move = real_player_to_move === data.get("user").id;
-
-    const [show_submit, setShowSubmit] = React.useState(false);
-    React.useEffect(() => {
-        const syncShowSubmit = () => {
-            setShowSubmit(
-                !!goban.submit_move &&
-                    goban.engine.cur_move &&
-                    goban.engine.cur_move.parent &&
-                    goban.engine.last_official_move &&
-                    goban.engine.cur_move.parent.id === goban.engine.last_official_move.id,
-            );
-        };
-        syncShowSubmit();
-
-        goban.on("submit_move", syncShowSubmit);
-        goban.on("last_official_move", syncShowSubmit);
-        goban.on("cur_move", syncShowSubmit);
-    }, [goban]);
-
-    const [show_accept_undo, setShowAcceptUndo] = React.useState<boolean>(false);
-    React.useEffect(() => {
-        const syncShowAcceptUndo = () => {
-            if (game_control.in_pushed_analysis) {
-                return;
-            }
-
-            setShowAcceptUndo(
-                goban.engine.playerToMove() === data.get("user").id ||
-                    (goban.submit_move != null &&
-                        goban.engine.playerNotToMove() === data.get("user").id) ||
-                    null,
-            );
-        };
-        syncShowAcceptUndo();
-
-        goban.on("cur_move", syncShowAcceptUndo);
-        goban.on("submit_move", syncShowAcceptUndo);
-    }, [goban]);
-
-    const onUndo = () => {
-        if (
-            data.get("user").id === goban.engine.playerNotToMove() &&
-            goban.engine.undo_requested !== goban.engine.getMoveNumber()
-        ) {
-            goban.requestUndo();
-        }
-    };
-
-    const pass = () => {
-        if (!isLiveGame(goban.engine.time_control) || !preferences.get("one-click-submit-live")) {
-            swal({ text: _("Are you sure you want to pass?"), showCancelButton: true })
-                .then(() => goban.pass())
-                .catch(() => 0);
-        } else {
-            goban.pass();
-        }
-    };
-
-    const [submitting_move, setSubmittingMove] = React.useState(false);
-    React.useEffect(() => {
-        goban.on("submitting-move", setSubmittingMove);
-    }, [goban]);
-
-    return (
-        <span className="play-buttons">
-            <span>
-                {((cur_move_number >= 1 &&
-                    !engine.rengo &&
-                    player_to_move !== data.get("user").id &&
-                    !(engine.undo_requested >= engine.getMoveNumber()) &&
-                    goban.submit_move == null) ||
-                    null) && (
-                    <button className="bold undo-button xs" onClick={onUndo}>
-                        {_("Undo")}
-                    </button>
-                )}
-                {show_undo_requested && (
-                    <span>
-                        {show_accept_undo && (
-                            <button
-                                className="sm primary bold accept-undo-button"
-                                onClick={() => goban.acceptUndo()}
-                            >
-                                {_("Accept Undo")}
-                            </button>
-                        )}
-                    </span>
-                )}
-            </span>
-            <span>
-                {((!show_submit && is_my_move && engine.handicapMovesLeft() === 0) || null) && (
-                    <button className="sm primary bold pass-button" onClick={pass}>
-                        {_("Pass")}
-                    </button>
-                )}
-                {((show_submit && engine.undo_requested !== engine.getMoveNumber()) || null) && (
-                    <button
-                        className="sm primary bold submit-button"
-                        id="game-submit-move"
-                        disabled={submitting_move}
-                        onClick={() => goban.submit_move()}
-                    >
-                        {_("Submit Move")}
-                    </button>
-                )}
-            </span>
-            <span>
-                {show_cancel && phase !== "finished" && (
-                    <CancelButton view_mode={view_mode} onClick={onCancel}>
-                        {resign_text}
-                    </CancelButton>
-                )}
-            </span>
-        </span>
-    );
-}
-
-interface CancelButtonProps {
-    view_mode: ViewMode;
-    onClick: React.MouseEventHandler<HTMLButtonElement>;
-    children: string;
-}
-export function CancelButton({ view_mode, onClick, children }: CancelButtonProps) {
-    if (view_mode === "portrait") {
-        return (
-            <button className="bold cancel-button reject" onClick={onClick}>
-                {children}
-            </button>
-        );
-    } else {
-        return (
-            <button className="xs bold cancel-button" onClick={onClick}>
-                {children}
-            </button>
-        );
-    }
 }
 
 function createConditionalMoveTreeDisplay(

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -41,7 +41,7 @@ import { errorAlerter } from "misc";
 import { close_all_popovers } from "popover";
 import { setExtraActionCallback, Player } from "Player";
 import { PlayButtons } from "./PlayButtons";
-import { useCurrentMoveNumber, useUndoRequested, useUserIsParticipant } from "./GameHooks";
+import { useCurrentMoveNumber, useShowUndoRequested, useUserIsParticipant } from "./GameHooks";
 
 interface PlayControlsProps {
     goban: Goban;
@@ -170,7 +170,7 @@ export function PlayControls({
         goban.on("paused", setPaused);
     }, [goban]);
 
-    const show_undo_requested = useUndoRequested(goban);
+    const show_undo_requested = useShowUndoRequested(goban);
 
     const [winner, set_winner] = React.useState(goban.engine.winner);
     React.useEffect(() => {

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -41,7 +41,7 @@ import { errorAlerter } from "misc";
 import { close_all_popovers } from "popover";
 import { setExtraActionCallback, Player } from "Player";
 import { PlayButtons } from "./PlayButtons";
-import { useUndoRequested, useUserIsParticipant } from "./GameHooks";
+import { useCurrentMoveNumber, useUndoRequested, useUserIsParticipant } from "./GameHooks";
 
 interface PlayControlsProps {
     goban: Goban;
@@ -172,14 +172,6 @@ export function PlayControls({
         goban.on("paused", setPaused);
     }, [goban]);
 
-    const [cur_move_number, setCurMoveNumber] = React.useState(
-        goban.engine.cur_move?.move_number || -1,
-    );
-    React.useEffect(() => {
-        goban.on("load", () => setCurMoveNumber(goban.engine.cur_move?.move_number || -1));
-        goban.on("cur_move", (move) => setCurMoveNumber(move.move_number));
-    }, [goban]);
-
     const show_undo_requested = useUndoRequested(goban);
 
     const [winner, set_winner] = React.useState(goban.engine.winner);
@@ -287,13 +279,13 @@ export function PlayControls({
     };
 
     const user_is_player = useUserIsParticipant(goban);
+    const cur_move_number = useCurrentMoveNumber(goban);
 
     return (
         <div className="play-controls">
             <div className="game-action-buttons">
                 {mode === "play" && phase === "play" && user_is_player && (
                     <PlayButtons
-                        cur_move_number={cur_move_number}
                         player_to_move={player_to_move}
                         goban={goban}
                         show_cancel={show_cancel}

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -45,7 +45,6 @@ import { useCurrentMoveNumber, useUndoRequested, useUserIsParticipant } from "./
 
 interface PlayControlsProps {
     goban: Goban;
-    player_to_move: number;
 
     // Cancel buttons are in props because the Cancel Button is placed below
     // chat on mobile.
@@ -98,7 +97,6 @@ export function PlayControls({
     zen_mode,
     selected_chat_log,
     onShareAnalysis,
-    player_to_move,
     variation_name,
     updateVariationName,
     variationKeyPress,
@@ -285,11 +283,7 @@ export function PlayControls({
         <div className="play-controls">
             <div className="game-action-buttons">
                 {mode === "play" && phase === "play" && user_is_player && (
-                    <PlayButtons
-                        player_to_move={player_to_move}
-                        goban={goban}
-                        show_cancel={show_cancel}
-                    />
+                    <PlayButtons goban={goban} show_cancel={show_cancel} />
                 )}
             </div>
             <div className="game-state">

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -26,6 +26,7 @@ import { Player } from "Player";
 import { lookup, fetch } from "player_cache";
 import { _, interpolate, ngettext } from "translate";
 import * as data from "data";
+import { usePlayerToMove } from "./GameHooks";
 
 type PlayerType = rest_api.games.Player;
 
@@ -35,7 +36,6 @@ interface PlayerCardsProps {
     historical_white: PlayerType;
     black_auto_resign_expiration: Date;
     white_auto_resign_expiration: Date;
-    player_to_move: number;
     game_id: number;
     review_id: number;
     estimating_score: boolean;
@@ -51,7 +51,6 @@ export function PlayerCards({
     historical_white,
     black_auto_resign_expiration,
     white_auto_resign_expiration,
-    player_to_move,
     game_id,
     review_id,
     estimating_score,
@@ -66,6 +65,8 @@ export function PlayerCards({
     const showing_scores = React.useRef<boolean>(false);
 
     const [show_score_breakdown, set_show_score_breakdown] = React.useState(false);
+
+    const player_to_move = usePlayerToMove(goban);
 
     const popupScores = () => {
         if (goban.engine.cur_move) {


### PR DESCRIPTION
Following along with the strategy described in [Goban Centric Components](https://docs.google.com/document/d/1viy_xeQbEZ4_N6SOQll2R4vMRDjxhDz5-wMdG7GtnHI/preview), I have replaced most props for `PlayButtons` (and its subcomponent `CancelButton`) with custom hooks:

Before:
```
<PlayButtons
    resign_text={resign_text}
    show_undo_requested={show_undo_requested}
    cur_move_number={cur_move_number}
    player_to_move={player_to_move}
    onCancel={onCancel}
    goban={goban}
    show_cancel={show_cancel}
    view_mode={view_mode}
/>
```
After:
```
<PlayButtons goban={goban} show_cancel={show_cancel} />
```

## Proposed Changes

  - Add GameHooks.ts (a collection of hooks that subscribe to goban events).
  - Reduce PlayButtons and CancelButton to 1.5 props each.
  - Write tests.
