### PR TITLE
Made is so that the auto-translated text appears as the primary text

### DIFF
--- a/src/components/AutoTranslate/AutoTranslate.styl
+++ b/src/components/AutoTranslate/AutoTranslate.styl
@@ -1,10 +1,14 @@
 .AutoTranslate {
-    .translation {
+    .translation-original {
         font-style: italic;
+        font-size: smaller;
         themed background-color shade5
         padding: 0.5em;
     }
     .language-map {
+        font-style: italic;
+        font-size: smaller;
         text-align: right;
+        themed background-color shade5
     }
 }


### PR DESCRIPTION
… with the original as the "FYI" afterwards.

Fixes?   Well, it's a proposal intended to fix the feeling of the translation being an afterthought, and move in the direction of the site feeling more "natural" for a non-English visitor.

## Proposed Changes

If there's a translation, then display it in the primary formatting, with the original text as an FYI.

This commit also changes the way that the "Debug" language is displayed in translated form, so that it doesn't break Markdown.   If this isn't merged, I'll resubmit that bit :D
