### PR TITLE
Initialize our state if we start off with an existing goban that's already been loaded

### DIFF
--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -1070,9 +1070,15 @@ export function ReviewControls({
 }: ReviewControlsProps) {
     const user = data.get("user");
 
-    const [review_owner_id, set_review_owner_id] = React.useState<number>();
-    const [review_controller_id, set_review_controller_id] = React.useState<number>();
-    const [review_out_of_sync, set_review_out_of_sync] = React.useState<boolean>();
+    const [review_owner_id, set_review_owner_id] = React.useState<number>(goban?.review_owner_id);
+    const [review_controller_id, set_review_controller_id] = React.useState<number>(
+        goban?.review_controller_id,
+    );
+    const [review_out_of_sync, set_review_out_of_sync] = React.useState<boolean>(
+        goban?.engine.cur_move &&
+            goban?.engine.cur_review_move &&
+            goban?.engine.cur_move.id !== goban?.engine.cur_review_move.id,
+    );
     React.useEffect(() => {
         const renderExtraPlayerActions = (player_id: number) => {
             const user = data.get("user");


### PR DESCRIPTION
Without initializaing we were counting on the `load` event firing to set
these correctly, which doesn't happen if the goban is already loaded.
(Though maybe it should?)

Fixes #1855

Ping @benjaminpjones to see if you have any better ideas on how to
reduce code duplication.
