### PR TITLE
generateGobanHook

### DIFF
--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -98,7 +98,7 @@ export const useUserIsParticipant = generateGobanHook((goban: GobanCore | null) 
 
 /** React hook that returns the current move number from goban */
 export const useCurrentMoveNumber = generateGobanHook(
-    (goban: GobanCore) => goban.engine.cur_move?.move_number || -1,
+    (goban: GobanCore | null) => goban?.engine.cur_move?.move_number || -1,
     ["cur_move"],
 );
 

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -25,21 +25,25 @@ import * as data from "data";
  * Generates a custom react hook that can return a prop that is derived from a
  * goban object.  It trigger an update on any of the specified events, in
  * addition to the first time it is called and when the goban first loads.
- * @param deriveProp a function that takes in a GobanCore object and returns a value.
+ * @param deriveProp a function that takes in a Goban-like object and returns a value.
  * @param events a list of events that should trigger a recalculation of this value.
  * @returns a React Hook.
  */
-export function generateGobanHook<T>(
-    deriveProp: (goban: GobanCore) => T,
-    events: Array<keyof GobanEvents>,
-): (goban: GobanCore) => T {
-    return (goban: GobanCore) => {
+export function generateGobanHook<T, G extends GobanCore | undefined>(
+    deriveProp: (goban: G) => T,
+    events: Array<keyof Omit<GobanEvents, "load">> = [],
+): (goban: G) => T {
+    return (goban: G) => {
         const [prop, setProp] = React.useState(deriveProp(goban));
         React.useEffect(() => {
             const syncProp = () => {
                 setProp(deriveProp(goban));
             };
             syncProp();
+
+            if (!goban) {
+                return;
+            }
 
             const events_with_load: Array<keyof GobanEvents> = ["load", ...events];
             for (const e of events_with_load) {

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -19,6 +19,7 @@ import { _, interpolate, pgettext } from "translate";
 import * as data from "data";
 import {
     Goban,
+    GobanCore,
     GoConditionalMove,
     GobanModes,
     GoEnginePhase,
@@ -41,7 +42,12 @@ import { errorAlerter } from "misc";
 import { close_all_popovers } from "popover";
 import { setExtraActionCallback, Player } from "Player";
 import { PlayButtons } from "./PlayButtons";
-import { useCurrentMoveNumber, useShowUndoRequested, useUserIsParticipant } from "./GameHooks";
+import {
+    generateGobanHook,
+    useCurrentMoveNumber,
+    useShowUndoRequested,
+    useUserIsParticipant,
+} from "./GameHooks";
 
 interface PlayControlsProps {
     goban: Goban;
@@ -1036,7 +1042,7 @@ export function deleteBranch(goban: Goban, mode: GobanModes) {
 
 interface ReviewControlsProps {
     mode: GobanModes;
-    goban: Goban;
+    goban: GobanCore;
     review_id: number;
     renderEstimateScore: () => JSX.Element;
     renderAnalyzeButtonBar: () => JSX.Element;
@@ -1054,6 +1060,26 @@ interface ReviewControlsProps {
     selected_chat_log: ChatMode;
 }
 
+const useReviewOwnerId = generateGobanHook(
+    (goban: GobanCore) => goban.review_owner_id,
+    ["review_owner_id"],
+);
+const useReviewControllerId = generateGobanHook(
+    (goban: GobanCore) => goban.review_controller_id,
+    ["review_controller_id"],
+);
+const useReviewOutOfSync = generateGobanHook(
+    (goban: GobanCore) => {
+        const engine = goban.engine;
+        return (
+            engine.cur_move &&
+            engine.cur_review_move &&
+            engine.cur_move.id !== engine.cur_review_move.id
+        );
+    },
+    ["cur_move"],
+);
+
 export function ReviewControls({
     goban,
     mode,
@@ -1070,9 +1096,9 @@ export function ReviewControls({
 }: ReviewControlsProps) {
     const user = data.get("user");
 
-    const [review_owner_id, set_review_owner_id] = React.useState<number>();
-    const [review_controller_id, set_review_controller_id] = React.useState<number>();
-    const [review_out_of_sync, set_review_out_of_sync] = React.useState<boolean>();
+    const review_owner_id = useReviewOwnerId(goban);
+    const review_controller_id = useReviewControllerId(goban);
+    const review_out_of_sync = useReviewOutOfSync(goban);
     React.useEffect(() => {
         const renderExtraPlayerActions = (player_id: number) => {
             const user = data.get("user");
@@ -1135,23 +1161,6 @@ export function ReviewControls({
             return null;
         };
         setExtraActionCallback(renderExtraPlayerActions);
-        const sync_review_out_of_sync = () => {
-            const engine = goban.engine;
-            set_review_out_of_sync(
-                engine.cur_move &&
-                    engine.cur_review_move &&
-                    engine.cur_move.id !== engine.cur_review_move.id,
-            );
-        };
-
-        goban.on("load", () => {
-            set_review_owner_id(goban.review_owner_id);
-            set_review_controller_id(goban.review_controller_id);
-            sync_review_out_of_sync();
-        });
-        goban.on("review_owner_id", set_review_owner_id);
-        goban.on("review_controller_id", set_review_controller_id);
-        goban.on("cur_move", sync_review_out_of_sync);
     }, [goban]);
 
     const [move_text, set_move_text] = React.useState<string>();


### PR DESCRIPTION
Fixes #1855

## Proposed Changes

  - Create higher-order function `generateGobanHook` that takes care of a lot of the things that need to happen when handling Goban state (getting initial state, subscribing to events, canceling said subscriptions)
  - Replace function implementations that seem to fit this pattern in GameHooks.
  - Use`generateGobanHook` in review controls to fix the issue with initial values being unset.

## Additional Context

https://github.com/online-go/online-go.com/pull/1856