### PR TITLE
Don't display a + sign for negative komi.

### DIFF
--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -345,11 +345,7 @@ function PlayerCard({
                         estimating_score={estimating_score}
                     />
                 )}
-                {!show_points && (
-                    <div className="komi">
-                        {score.komi === 0 ? "" : `+ ${score.komi.toFixed(1)}`}
-                    </div>
-                )}
+                {!show_points && <div className="komi">{komiString(score.komi)}</div>}
                 <div id={`${color}-score-details`} className="score-details" />
             </div>
             {!!(engine.rengo && engine.rengo_teams) && (
@@ -389,4 +385,12 @@ function PlayerFlag({ player_id }: { player_id: number }): JSX.Element {
         return <Flag country={country} />;
     }
     return null;
+}
+
+function komiString(komi: number) {
+    if (!komi) {
+        return "";
+    }
+    const abs_komi = Math.abs(komi).toFixed(1);
+    return komi > 0 ? `+ ${abs_komi}` : `- ${abs_komi}`;
 }


### PR DESCRIPTION
Fixes [Forums: Negative Komi Indicator - @Lys](https://forums.online-go.com/t/negative-komi-indicator/43213/4).

Before:
<img width="229" alt="Screen Shot 2022-05-17 at 2 45 01 PM" src="https://user-images.githubusercontent.com/25233703/169056193-635d78a5-4fb4-453e-8c59-b5abeb7f7dd6.png">
After:
<img width="230" alt="Screen Shot 2022-05-17 at 2 44 44 PM" src="https://user-images.githubusercontent.com/25233703/169056230-4c063b77-ea54-43e8-b43c-b9c0cf689b0b.png">

## Proposed Changes

  - Remove the plus sign when reverse komi.
