### PR TITLE
changing the icon for a ladder game to the ladder icon

### DIFF
--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -332,7 +332,7 @@ export function GameDock({
             )}
             {(ladder_id || null) && (
                 <Link className="plain" to={`/ladder/${ladder_id}`}>
-                    <i className="fa fa-trophy" title={_("This is a ladder game")} /> {_("Ladder")}
+                    <i className="fa fa-list-ol" title={_("This is a ladder game")} /> {_("Ladder")}
                 </Link>
             )}
             {((engine.config as any)["private"] || null) && (


### PR DESCRIPTION
Fixes #

## Proposed Changes

This should fix the game icon to more correctly show which type of game it is.  See here for details:

https://forums.online-go.com/t/fix-icon-for-each-game-type/43223
