### PR TITLE
Player cards

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -34,7 +34,6 @@ import {
     GoMath,
     MoveTree,
     AudioClockEvent,
-    Score,
     GoEnginePhase,
     GobanModes,
     GoConditionalMove,
@@ -121,7 +120,6 @@ export function Game(): JSX.Element {
         null,
     );
     const [show_game_timing, set_show_game_timing] = React.useState(false);
-    const [score, set_score] = React.useState<Score>();
 
     const [title, set_title] = React.useState<string>();
 
@@ -1046,10 +1044,6 @@ export function Game(): JSX.Element {
             }
         });
 
-        // We need an initial score for the first display rendering (which is not set in the constructor).
-        // Best to get this from the engine, so we know we have the right structure...
-        set_score(goban.current.engine.computeScore(true));
-
         if (preferences.get("dynamic-title")) {
             /* Title Updates { */
             const last_title = window.document.title;
@@ -1166,10 +1160,7 @@ export function Game(): JSX.Element {
                 goban.current.mode === "play"
             ) {
                 const s = engine.computeScore(false);
-                set_score(s);
                 goban.current.showScores(s);
-            } else {
-                set_score(engine.computeScore(true));
             }
         };
 
@@ -1219,7 +1210,6 @@ export function Game(): JSX.Element {
         goban.current.on("phase", set_phase);
         goban.current.on("phase", () => goban.current.engine.cur_move.clearMarks());
         goban.current.on("title", set_title);
-        goban.current.on("cur_move", () => set_score(goban.current.engine.computeScore(true)));
         goban.current.on("score_estimate", (est) => {
             set_score_estimate_winner(est?.winner || "");
             set_score_estimate_amount(est?.amount);
@@ -1513,7 +1503,6 @@ export function Game(): JSX.Element {
                             review_id={review_id}
                             estimating_score={estimating_score}
                             zen_mode={zen_mode}
-                            score={score}
                             show_title={show_title}
                             title={title}
                         />
@@ -1580,7 +1569,6 @@ export function Game(): JSX.Element {
                                 review_id={review_id}
                                 estimating_score={estimating_score}
                                 zen_mode={zen_mode}
-                                score={score}
                                 show_title={show_title}
                                 title={title}
                             />

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1499,8 +1499,6 @@ export function Game(): JSX.Element {
                             goban={goban.current}
                             historical_black={historical_black}
                             historical_white={historical_white}
-                            game_id={game_id}
-                            review_id={review_id}
                             estimating_score={estimating_score}
                             zen_mode={zen_mode}
                             show_title={show_title}
@@ -1565,8 +1563,6 @@ export function Game(): JSX.Element {
                                 goban={goban.current}
                                 historical_black={historical_black}
                                 historical_white={historical_white}
-                                game_id={game_id}
-                                review_id={review_id}
                                 estimating_score={estimating_score}
                                 zen_mode={zen_mode}
                                 show_title={show_title}

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -66,7 +66,7 @@ import {
 import { CancelButton } from "./PlayButtons";
 import { GameDock } from "./GameDock";
 import swal from "sweetalert2";
-import { useUserIsParticipant } from "./GameHooks";
+import { useShowTitle, useTitle, useUserIsParticipant } from "./GameHooks";
 
 const win = $(window);
 
@@ -121,12 +121,12 @@ export function Game(): JSX.Element {
     );
     const [show_game_timing, set_show_game_timing] = React.useState(false);
 
-    const [title, set_title] = React.useState<string>();
+    const title = useTitle(goban.current);
 
     const [mode, set_mode] = React.useState<GobanModes>("play");
     const [score_estimate_winner, set_score_estimate_winner] = React.useState<string>();
     const [score_estimate_amount, set_score_estimate_amount] = React.useState<number>();
-    const [show_title, set_show_title] = React.useState<boolean>();
+    const show_title = useShowTitle(goban.current);
     const [, set_undo_requested] = React.useState<number | undefined>();
     const [, forceUpdate] = React.useState<number>();
 
@@ -1140,13 +1140,6 @@ export function Game(): JSX.Element {
 
         /* Ensure our state is kept up to date */
 
-        const sync_show_title = () =>
-            set_show_title(
-                !goban.current.submit_move ||
-                    goban.current.engine.playerToMove() !== data.get("user").id ||
-                    null,
-            );
-
         const sync_stone_removal = () => {
             const engine = goban.current.engine;
 
@@ -1168,12 +1161,10 @@ export function Game(): JSX.Element {
             const engine = goban.current.engine;
             set_mode(goban.current.mode);
             set_phase(engine.phase);
-            set_title(goban.current.title);
 
             set_score_estimate_winner(undefined);
             set_undo_requested(engine.undo_requested);
 
-            sync_show_title();
             sync_stone_removal();
 
             // These are only updated on load events
@@ -1209,14 +1200,11 @@ export function Game(): JSX.Element {
         goban.current.on("mode", set_mode);
         goban.current.on("phase", set_phase);
         goban.current.on("phase", () => goban.current.engine.cur_move.clearMarks());
-        goban.current.on("title", set_title);
         goban.current.on("score_estimate", (est) => {
             set_score_estimate_winner(est?.winner || "");
             set_score_estimate_amount(est?.amount);
         });
         goban.current.on("undo_requested", set_undo_requested);
-        goban.current.on("cur_move", sync_show_title);
-        goban.current.on("submit_move", sync_show_title);
 
         goban.current.on("phase", sync_stone_removal);
         goban.current.on("mode", sync_stone_removal);
@@ -1501,8 +1489,6 @@ export function Game(): JSX.Element {
                             historical_white={historical_white}
                             estimating_score={estimating_score}
                             zen_mode={zen_mode}
-                            show_title={show_title}
-                            title={title}
                         />
                     )}
 
@@ -1565,8 +1551,6 @@ export function Game(): JSX.Element {
                                 historical_white={historical_white}
                                 estimating_score={estimating_score}
                                 zen_mode={zen_mode}
-                                show_title={show_title}
-                                title={title}
                             />
                         )}
 

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -110,3 +110,17 @@ export const usePlayerToMove = generateGobanHook(
     (goban: GobanCore | null) => goban?.engine.playerToMove() ?? 0,
     ["cur_move", "last_official_move"],
 );
+
+/** React hook that returns true if the title should be shown. */
+export const useShowTitle = generateGobanHook(
+    (goban: GobanCore | null) => {
+        if (!goban) {
+            return false;
+        }
+        return !goban.submit_move || goban.engine.playerToMove() !== data.get("user")?.id || null;
+    },
+    ["cur_move", "submit_move"],
+);
+
+/** React hook that returns the title text (e.g. "Black to move"). */
+export const useTitle = generateGobanHook((goban: GobanCore | null) => goban?.title, ["title"]);

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -53,7 +53,6 @@ export function PlayerCards({
 
     const [show_score_breakdown, set_show_score_breakdown] = React.useState(false);
 
-    const player_to_move = usePlayerToMove(goban);
     const show_title = useShowTitle(goban);
     const title = useTitle(goban);
 
@@ -83,7 +82,7 @@ export function PlayerCards({
         set_show_score_breakdown(false);
     };
 
-    const onClick = () => (show_score_breakdown ? hideScores() : popupScores());
+    const toggleScorePopup = () => (show_score_breakdown ? hideScores() : popupScores());
 
     return (
         <div className="players">
@@ -92,20 +91,18 @@ export function PlayerCards({
                     historical={historical_black}
                     color="black"
                     goban={goban}
-                    player_to_move={player_to_move}
                     estimating_score={estimating_score}
                     show_score_breakdown={show_score_breakdown}
-                    onClick={onClick}
+                    onScoreClick={toggleScorePopup}
                     zen_mode={zen_mode}
                 />
                 <PlayerCard
                     historical={historical_white}
                     color="white"
                     goban={goban}
-                    player_to_move={player_to_move}
                     estimating_score={estimating_score}
                     show_score_breakdown={show_score_breakdown}
-                    onClick={onClick}
+                    onScoreClick={toggleScorePopup}
                     zen_mode={zen_mode}
                 />
             </div>
@@ -187,10 +184,9 @@ interface PlayerCardProps {
     color: "black" | "white";
     goban: Goban;
     historical: PlayerType;
-    player_to_move: number;
     estimating_score: boolean;
     show_score_breakdown: boolean;
-    onClick: () => void;
+    onScoreClick: () => void;
     zen_mode: boolean;
 }
 
@@ -198,14 +194,14 @@ function PlayerCard({
     color,
     goban,
     historical,
-    player_to_move,
     estimating_score,
     show_score_breakdown,
-    onClick,
+    onScoreClick,
     zen_mode,
 }: PlayerCardProps) {
     const engine = goban.engine;
     const player = engine.players[color];
+    const player_to_move = usePlayerToMove(goban);
 
     const auto_resign_expiration = useAutoResignExpiration(goban, color);
     const score = useScore(goban)[color];
@@ -273,7 +269,7 @@ function PlayerCard({
                 className={
                     "score-container " + (show_score_breakdown ? "show-score-breakdown" : "")
                 }
-                onClick={onClick}
+                onClick={onScoreClick}
             >
                 {show_points && (
                     <div className={"points" + (estimating_score ? " hidden" : "")}>

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -26,7 +26,7 @@ import { Player } from "Player";
 import { lookup, fetch } from "player_cache";
 import { _, interpolate, ngettext } from "translate";
 import * as data from "data";
-import { generateGobanHook, usePlayerToMove } from "./GameHooks";
+import { generateGobanHook, usePlayerToMove, useShowTitle, useTitle } from "./GameHooks";
 import { get_network_latency, get_clock_drift } from "sockets";
 
 type PlayerType = rest_api.games.Player;
@@ -37,8 +37,6 @@ interface PlayerCardsProps {
     historical_white: PlayerType;
     estimating_score: boolean;
     zen_mode: boolean;
-    show_title: boolean;
-    title: string;
 }
 
 export function PlayerCards({
@@ -47,8 +45,6 @@ export function PlayerCards({
     historical_white,
     estimating_score,
     zen_mode,
-    show_title,
-    title,
 }: PlayerCardsProps): JSX.Element {
     const engine = goban.engine;
 
@@ -58,6 +54,8 @@ export function PlayerCards({
     const [show_score_breakdown, set_show_score_breakdown] = React.useState(false);
 
     const player_to_move = usePlayerToMove(goban);
+    const show_title = useShowTitle(goban);
+    const title = useTitle(goban);
 
     const popupScores = () => {
         if (goban.engine.cur_move) {

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -35,8 +35,6 @@ interface PlayerCardsProps {
     goban: Goban;
     historical_black: PlayerType;
     historical_white: PlayerType;
-    game_id: number;
-    review_id: number;
     estimating_score: boolean;
     zen_mode: boolean;
     show_title: boolean;
@@ -47,8 +45,6 @@ export function PlayerCards({
     goban,
     historical_black,
     historical_white,
-    game_id,
-    review_id,
     estimating_score,
     zen_mode,
     show_title,
@@ -150,7 +146,6 @@ export function PlayerCards({
     };
 
     const onClick = () => (show_score_breakdown ? hideScores() : popupScores());
-    const chat_channel = game_id ? `game-${game_id}` : `review-${review_id}`;
 
     return (
         <div className="players">
@@ -163,7 +158,6 @@ export function PlayerCards({
                     estimating_score={estimating_score}
                     show_score_breakdown={show_score_breakdown}
                     onClick={onClick}
-                    chat_channel={chat_channel}
                     zen_mode={zen_mode}
                 />
                 <PlayerCard
@@ -174,7 +168,6 @@ export function PlayerCards({
                     estimating_score={estimating_score}
                     show_score_breakdown={show_score_breakdown}
                     onClick={onClick}
-                    chat_channel={chat_channel}
                     zen_mode={zen_mode}
                 />
             </div>
@@ -187,7 +180,7 @@ export function PlayerCards({
 
                         TODO: move title logic out of this component.
                         */
-                        ((!review_id && show_title && goban?.engine?.rengo) || null) && (
+                        ((!goban.review_id && show_title && goban?.engine?.rengo) || null) && (
                             <div className="game-state">{title}</div>
                         )
                     }
@@ -260,7 +253,6 @@ interface PlayerCardProps {
     estimating_score: boolean;
     show_score_breakdown: boolean;
     onClick: () => void;
-    chat_channel: string;
     zen_mode: boolean;
 }
 
@@ -272,7 +264,6 @@ function PlayerCard({
     estimating_score,
     show_score_breakdown,
     onClick,
-    chat_channel,
     zen_mode,
 }: PlayerCardProps) {
     const engine = goban.engine;
@@ -280,6 +271,8 @@ function PlayerCard({
 
     const auto_resign_expiration = useAutoResignExpiration(goban, color);
     const score = useScore(goban)[color];
+    const { game_id, review_id } = goban;
+    const chat_channel = game_id ? `game-${game_id}` : `review-${review_id}`;
 
     // In rengo we always will have a player icon to show (after initialisation).
     // In other cases, we only have one if `historical` is set

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -65,67 +65,10 @@ export function PlayerCards({
             orig_marks.current = null;
         }
 
-        _popupScores("black");
-        _popupScores("white");
-    };
-    const _popupScores = (color: "black" | "white") => {
-        const only_prisoners = false;
-        const scores = goban.engine.computeScore(only_prisoners);
+        const scores = goban.engine.computeScore(false);
         showing_scores.current = goban.showing_scores;
         goban.showScores(scores);
 
-        const score = scores[color];
-        let html = "";
-        if (!only_prisoners) {
-            html += "<div class='score_breakdown'>";
-            if (score.stones) {
-                html +=
-                    "<div><span>" + _("Stones") + "</span><div>" + score.stones + "</div></div>";
-            }
-            if (score.territory) {
-                html +=
-                    "<div><span>" +
-                    _("Territory") +
-                    "</span><div>" +
-                    score.territory +
-                    "</div></div>";
-            }
-            if (score.prisoners) {
-                html +=
-                    "<div><span>" +
-                    _("Prisoners") +
-                    "</span><div>" +
-                    score.prisoners +
-                    "</div></div>";
-            }
-            if (score.handicap) {
-                html +=
-                    "<div><span>" +
-                    _("Handicap") +
-                    "</span><div>" +
-                    score.handicap +
-                    "</div></div>";
-            }
-            if (score.komi) {
-                html += "<div><span>" + _("Komi") + "</span><div>" + score.komi + "</div></div>";
-            }
-
-            if (!score.stones && !score.territory && !score.prisoners && !score.komi) {
-                html += "<div><span>" + _("No score yet") + "</span>";
-            }
-
-            html += "<div>";
-        } else {
-            html += "<div class='score_breakdown'>";
-            if (score.komi) {
-                html += "<div><span>" + _("Komi") + "</span><div>" + score.komi + "</div></div>";
-            }
-            html +=
-                "<div><span>" + _("Prisoners") + "</span><div>" + score.prisoners + "</div></div>";
-            html += "<div>";
-        }
-
-        $("#" + color + "-score-details").html(html);
         set_show_score_breakdown(true);
     };
     const hideScores = () => {
@@ -136,9 +79,6 @@ export function PlayerCards({
             goban.engine.cur_move.setAllMarks(JSON.parse(orig_marks.current));
         }
         goban.redraw();
-
-        $("#black-score-details").children().remove();
-        $("#white-score-details").children().remove();
 
         set_show_score_breakdown(false);
     };
@@ -352,7 +292,9 @@ function PlayerCard({
                     />
                 )}
                 {!show_points && <div className="komi">{komiString(score.komi)}</div>}
-                <div id={`${color}-score-details`} className="score-details" />
+                <div id={`${color}-score-details`} className="score-details">
+                    <ScorePopup goban={goban} color={color} show={show_score_breakdown} />
+                </div>
             </div>
             {!!(engine.rengo && engine.rengo_teams) && (
                 <div className={"rengo-team-members player-name-container " + color}>
@@ -436,4 +378,59 @@ function useAutoResignExpiration(goban: GobanCore, color: "black" | "white") {
         };
     }, [goban, color]);
     return auto_resign_expiration;
+}
+
+interface ScorePopupProps {
+    show: boolean;
+    goban: GobanCore;
+    color: "black" | "white";
+}
+
+function ScorePopup({ show, goban, color }: ScorePopupProps) {
+    if (!show) {
+        return <React.Fragment />;
+    }
+
+    const scores = goban.engine.computeScore(false);
+    const { stones, prisoners, handicap, komi, territory } = scores[color];
+
+    return (
+        <div className="score_breakdown">
+            {!!stones && (
+                <div>
+                    <span>{_("Stones")}</span>
+                    <div>{stones}</div>
+                </div>
+            )}
+            {!!territory && (
+                <div>
+                    <span>{_("Territory")}</span>
+                    <div>{territory}</div>
+                </div>
+            )}
+            {!!prisoners && (
+                <div>
+                    <span>{_("Prisoners")}</span>
+                    <div>{prisoners}</div>
+                </div>
+            )}
+            {!!handicap && (
+                <div>
+                    <span>{_("Handicap")}</span>
+                    <div>{handicap}</div>
+                </div>
+            )}
+            {!!komi && (
+                <div>
+                    <span>{_("Komi")}</span>
+                    <div>{komi}</div>
+                </div>
+            )}
+            {!stones && !territory && !handicap && !komi && (
+                <div>
+                    <span>{_("No score yet")}</span>
+                </div>
+            )}
+        </div>
+    );
 }


### PR DESCRIPTION
More for the [Goban Centric Components](https://docs.google.com/document/d/1viy_xeQbEZ4_N6SOQll2R4vMRDjxhDz5-wMdG7GtnHI/preview) refactor.

## Proposed Changes

  - Move `*_auto_resign_expiration`, `score`, `title`, and `show_title`, `game_id` and `review_id` into PlayerCard (no longer passed as props)
  - Convert the score popups to React (these were still jquery)
