### PR TITLE
announcements: show tournament announcement up to 35 minutes in advance, so clock skew does not hide it

### DIFF
--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -128,7 +128,9 @@ export class Announcements extends React.PureComponent<{}, AnnouncementsState> {
             }, moment(announcement.expiration).toDate().getTime() - Date.now());
         } else {
             const t = moment(announcement.expiration).toDate().getTime() - Date.now();
-            if (t > 0 && t < 30 * 60 * 1000) {
+            // Tournaments are announced 30 minutes prior, but allow
+            // up to 5 minutes of clock skew.
+            if (t > 0 && t < 35 * 60 * 1000) {
                 data.set("active-tournament", announcement);
             }
         }


### PR DESCRIPTION
Fixes #1399.

You will now see a trophy indicator every time instead of with 50% probability depending on the direction of your device's clock skew.  Allowing up to 5 minutes of skew since I don't think there's any downside, but I have not tested this much.