### PR TITLE
popover: remove max-height of 100vh, fixing click events on usernames in tournaments

### DIFF
--- a/src/lib/popover.styl
+++ b/src/lib/popover.styl
@@ -20,7 +20,6 @@
     display: flex;
     //min-height: 100%;
     //height: 100%;
-    max-height: 100vh;
     top: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
Fixes #1604.  BUT mobile users will no longer get to see the green highlight in D. E. tournaments, which they could only see for a fraction of a second before getting redirected.