### PR TITLE
right-col: use margin+padding instead of just padding

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -416,7 +416,8 @@ goban-view-bar-width=400px
     .right-col {
         flex-basis: 25%;
         padding-left: 0.3rem;
-        padding-right: dock-collapsed-width + 0.3rem;
+        padding-right: 0.3rem;
+        margin-right: dock-collapsed-width;
         min-width: 340px;
     }
 
@@ -437,6 +438,7 @@ goban-view-bar-width=400px
     &.squashed {
         .right-col {
             padding-right: 0;
+            margin-right: 0;
         }
     }
     &.portrait {


### PR DESCRIPTION
Fixes #1807.

When a scrollbar appears (in e.g. rengo games), it is visible instead of behind the right menu.

Before:

![image](https://user-images.githubusercontent.com/466760/169639347-93e8b1ab-0071-4f0b-b831-1d0c6c08ac80.png)

After:
![image](https://user-images.githubusercontent.com/466760/169639449-a6fd97a3-6705-4835-b4aa-23d33bd18f47.png)
