### PR TITLE
Move resize logic into GobanContainer.

### DIFF
--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { PersistentElement } from "PersistentElement";
+import ReactResizeDetector from "react-resize-detector";
+import { GobanCanvas, GobanCanvasConfig } from "goban";
+// Pull this out its own util
+import { goban_view_mode } from "Game";
+
+interface GobanContainerProps {
+    goban?: GobanCanvas;
+    /** callback that is called when the goban detects a resize. */
+    onResize?: () => void;
+    /** Additional props to pass to the PersistentElement that wraps the goban_div */
+    extra_props?: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+}
+
+/**
+ * Takes a GobanCore and its div element, and handles resizes as necessary.
+ */
+export function GobanContainer({
+    goban,
+    onResize: onResizeCb,
+    extra_props,
+}: GobanContainerProps): JSX.Element {
+    const ref_goban_container = React.useRef<HTMLDivElement>(null);
+    const resize_debounce = React.useRef<NodeJS.Timeout | null>(null);
+
+    // Since goban is a GobanCanvas, we know goban.config is a GobanCanvasConfig
+    const goban_div = (goban?.config as GobanCanvasConfig | undefined)?.board_div;
+
+    const recenterGoban = () => {
+        if (!ref_goban_container.current || !goban || !goban_div) {
+            return;
+        }
+        const m = goban.computeMetrics();
+        $(goban_div).css({
+            top: Math.ceil(ref_goban_container.current.offsetHeight - m.height) / 2,
+            left: Math.ceil(ref_goban_container.current.offsetWidth - m.width) / 2,
+        });
+    };
+    const onResize = (no_debounce: boolean = false, do_cb: boolean = true) => {
+        if (!goban || !goban_div) {
+            return;
+        }
+
+        // Allow the consumer of this component to specify additional work
+        // that should be done when the goban container detects a resize.
+        if (do_cb && onResizeCb) {
+            onResizeCb();
+        }
+
+        if (resize_debounce.current) {
+            clearTimeout(resize_debounce.current);
+            resize_debounce.current = null;
+        }
+
+        // this forces a clock refresh, important after a layout when the dom
+        // could have been replaced
+        // TODO: When we are revamping this view we should see if we can either remove this
+        // or move it into a clock component or something.
+        goban.setGameClock(goban.last_clock ?? null);
+
+        if (!ref_goban_container.current) {
+            return;
+        }
+
+        if (goban_view_mode() === "portrait") {
+            const w = $(window).width() + 10;
+            if (ref_goban_container.current.style.minHeight !== `${w}px`) {
+                ref_goban_container.current.style.minHeight = `${w}px`;
+            }
+        } else {
+            if (ref_goban_container.current.style.minHeight !== `initial`) {
+                ref_goban_container.current.style.minHeight = `initial`;
+            }
+            const w = ref_goban_container.current.offsetWidth;
+            if (ref_goban_container.current.style.flexBasis !== `${w}px`) {
+                ref_goban_container.current.style.flexBasis = `${w}px`;
+            }
+        }
+
+        if (no_debounce) {
+            // Debouncing is necessary because setting the square size can be an expensive operation.
+            goban.setSquareSizeBasedOnDisplayWidth(
+                Math.min(
+                    ref_goban_container.current.offsetWidth,
+                    ref_goban_container.current.offsetHeight,
+                ),
+            );
+        } else {
+            resize_debounce.current = setTimeout(() => onResize(true), 10);
+        }
+
+        recenterGoban();
+    };
+
+    React.useEffect(() => {
+        if (!goban) {
+            return;
+        }
+        onResize(/* no_debounce */ true, /* do_cb */ false);
+    }, [goban]);
+
+    if (!goban || !goban_div) {
+        return <React.Fragment />;
+    }
+
+    return (
+        <div ref={ref_goban_container} className="goban-container">
+            <ReactResizeDetector handleWidth handleHeight onResize={() => onResize()} />
+            <PersistentElement className="Goban" elt={goban_div} extra_props={extra_props} />
+        </div>
+    );
+}

--- a/src/components/GobanContainer/index.ts
+++ b/src/components/GobanContainer/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./GobanContainer";

--- a/src/components/PersistentElement/PersistentElement.tsx
+++ b/src/components/PersistentElement/PersistentElement.tsx
@@ -20,7 +20,8 @@ import * as React from "react";
 interface PersistentElementProps {
     elt: HTMLElement | JQuery;
     className?: string;
-    extra_props?: object; // hash of new props to put on the element
+    /** hash of new props to put on the element */
+    extra_props?: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 }
 
 export function PersistentElement(props: PersistentElementProps): JSX.Element {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -16,7 +16,7 @@
  */
 
 import * as data from "data";
-import { GobanSelectedThemes, GoThemes } from "goban";
+import { GobanSelectedThemes, GoThemes, LabelPosition } from "goban";
 import React from "react";
 import { current_language } from "translate";
 import { DataSchema } from "./data_schema";
@@ -47,8 +47,8 @@ export const defaults = {
     "goban-theme-board": null,
     "goban-theme-white": null,
     "hide-ranks": false,
-    "label-positioning": "all",
-    "label-positioning-puzzles": "all",
+    "label-positioning": "all" as LabelPosition,
+    "label-positioning-puzzles": "all" as LabelPosition,
     language: "auto",
     "move-tree-numbering": "move-number" as "none" | "move-coordinates" | "move-number",
     "new-game-board-size": 19,


### PR DESCRIPTION
More for the [Goban Centric Components](https://docs.google.com/document/d/1viy_xeQbEZ4_N6SOQll2R4vMRDjxhDz5-wMdG7GtnHI/preview) refactor.

Goban, Joseki and Puzzles all contain similar logic that handles the resizing of the goban.  My hope is that this class can hide all this away, and make it easier to create Goban-centric views in the future.  While the resize logic was similar, they all differed slightly.  I tried to keep the implementation closest to the `Game` implementation as it seems to be the most mature (specifically it has some de-bounce logic to prevent unnecessary re-renders.)

## Proposed Changes

  - Create a component called `GobanContainer` that handles resize logic for the goban.
  - Move all this logic out of `Game`, `Joseki` and `Puzzle` components.
  - use the `setCoordinates` function to ensure toggling coordinates triggers a recalculation of square size (requires https://github.com/online-go/goban/pull/72).