### PR TITLE
Make `GameAcceptModal` pass the right type `user` to `Player`

### DIFF
--- a/src/components/GameAcceptModal/GameAcceptModal.tsx
+++ b/src/components/GameAcceptModal/GameAcceptModal.tsx
@@ -76,9 +76,10 @@ export class GameAcceptModal extends Modal<Events, GameAcceptModalProperties, {}
         }
 
         const challenger_details: PlayerObjectType = {
+            id: challenge.user_id,
+            username: challenge.username,
             pro: challenge.pro,
             rank: challenge.rank,
-            username: challenge.username,
         };
 
         return (

--- a/src/components/GameAcceptModal/GameAcceptModal.tsx
+++ b/src/components/GameAcceptModal/GameAcceptModal.tsx
@@ -20,7 +20,7 @@ import { _ } from "translate";
 import { post } from "requests";
 import { openModal, Modal } from "Modal";
 import { timeControlDescription, usedForCheating } from "TimeControl";
-import { Player } from "Player";
+import { Player, PlayerObjectType } from "Player";
 import { errorAlerter, yesno } from "misc";
 import swal from "sweetalert2";
 
@@ -75,12 +75,18 @@ export class GameAcceptModal extends Modal<Events, GameAcceptModalProperties, {}
             player_color = _("Random");
         }
 
+        const challenger_details: PlayerObjectType = {
+            pro: challenge.pro,
+            rank: challenge.rank,
+            username: challenge.username,
+        };
+
         return (
             <div className="Modal GameAcceptModal">
                 <div className="header">
                     <div>
                         <h2>
-                            <Player icon iconSize={32} user={challenge} />
+                            <Player icon iconSize={32} user={challenger_details} />
                         </h2>
                         <h4>{challenge.name}</h4>
                     </div>

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -35,7 +35,7 @@ import online_status from "online_status";
  * should probably start warning about remaining uses of these fields and then
  * clean/remove them when they pop up. */
 
-interface PlayerObjectType {
+export interface PlayerObjectType {
     id?: number;
     player_id?: number; // alias for id, should be removed but here for backwards compatibility
 
@@ -54,7 +54,7 @@ interface PlayerObjectType {
     ui_class?: string;
 }
 
-interface PlayerProperties {
+export interface PlayerProperties {
     icon?: boolean;
     iconSize?: number;
     user: number | PlayerObjectType;


### PR DESCRIPTION
Fixes confusion when reading a `challenge` being passed as a `user` to a `Player`

## Proposed Changes

Create the correctly typed object for the props of `Player` and pass that in.