### PR TITLE
Eliminate circular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/parser": "^5.26.0",
         "autoprefixer": "^10.4.2",
         "body-parser": "^1.16.1",
+        "circular-dependency-plugin": "^5.2.2",
         "cssnano": "^5.0.8",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",

--- a/src/components/BanModal/BanModal.styl
+++ b/src/components/BanModal/BanModal.styl
@@ -22,7 +22,7 @@
     max-width: 90vw;
     text-align: center;
 
-    .Player {
+    .player-name {
         font-size: 1.5rem;
         margin: auto;
         padding-bottom: 1rem;

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -21,7 +21,7 @@ import { put } from "requests";
 import { _ } from "translate";
 import { errorAlerter } from "misc";
 import { Modal } from "Modal";
-import { Player } from "Player";
+import * as player_cache from "player_cache";
 
 interface Events {}
 
@@ -42,6 +42,8 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
     }
 
     render() {
+        const player = player_cache.lookup(this.props.player_id);
+
         const ban = () => {
             const player_id = this.props.player_id;
             console.log("Banning player", this.props.player_id);
@@ -65,7 +67,9 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
         return (
             <div className="Modal BanModal">
                 <div className="Modal-content">
-                    <Player user={this.props.player_id} />
+                    <span className="player-name">
+                        {player ? player.username : `Player ${this.props.player_id}`}
+                    </span>
                     <BanDetails onChange={(details) => this.setState({ details: details })} />
                 </div>
                 <div className="buttons">

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -40,7 +40,6 @@ import { sfx } from "sfx";
 import * as preferences from "preferences";
 import { notification_manager } from "Notifications/NotificationManager";
 import { one_bot, bot_count, bots_list } from "bots";
-import { openForkModal } from "./ForkModal";
 import { goban_view_mode } from "Game/util";
 import {
     Goban,
@@ -1717,34 +1716,6 @@ export function createOpenChallenge() {
 }
 export function challengeComputer() {
     return challenge(null, null, true);
-}
-export function challengeFromBoardPosition(goban) {
-    if (!goban) {
-        return;
-    }
-
-    openForkModal(goban);
-
-    /*
-    var game_name = goban.engine.game_name;
-    if ((!game_name || game_name === "") && goban.engine.players) {
-        game_name = goban.engine.players.black.username +" " + _("vs.") + " " +  goban.engine.players.white.username;
-    }
-
-    var state = {
-        "moves": goban.engine.cur_move.getMoveStringToThisPoint(),
-        "initial_state": goban.engine.initial_state,
-        "initial_player": goban.engine.initial_player,
-        "width": goban.engine.width,
-        "height": goban.engine.height,
-        "rules": goban.engine.rules,
-        "handicap": goban.engine.handicap,
-        "move_number": goban.engine.getMoveNumber(),
-        "game_name": game_name,
-    };
-
-    challenge(null, state);
-    */
 }
 export function challengeRematch(
     goban: Goban,

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -41,7 +41,7 @@ import * as preferences from "preferences";
 import { notification_manager } from "Notifications";
 import { one_bot, bot_count, bots_list } from "bots";
 import { openForkModal } from "./ForkModal";
-import { goban_view_mode } from "Game";
+import { goban_view_mode } from "Game/util";
 import {
     Goban,
     GoEngineConfig,

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -38,7 +38,7 @@ import { PlayerIcon } from "PlayerIcon";
 import { timeControlText, shortShortTimeControl, isLiveGame, TimeControlPicker } from "TimeControl";
 import { sfx } from "sfx";
 import * as preferences from "preferences";
-import { notification_manager } from "Notifications";
+import { notification_manager } from "Notifications/NotificationManager";
 import { one_bot, bot_count, bots_list } from "bots";
 import { openForkModal } from "./ForkModal";
 import { goban_view_mode } from "Game/util";

--- a/src/components/ChallengeModal/ForkModal.tsx
+++ b/src/components/ChallengeModal/ForkModal.tsx
@@ -101,3 +101,10 @@ export class ForkModal extends Modal<Events, ForkModalProperties, any> {
 export function openForkModal(goban) {
     return openModal(<ForkModal goban={goban} />);
 }
+export function challengeFromBoardPosition(goban) {
+    if (!goban) {
+        return;
+    }
+
+    openForkModal(goban);
+}

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -27,7 +27,7 @@ import {
     getMentionedChatPreference,
     watchChatSubscriptionChanged,
     unwatchChatSubscriptionChanged,
-} from "Chat";
+} from "./state";
 
 interface ChatDetailsProperties {
     chatChannelId: string;

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -20,7 +20,7 @@ import { browserHistory } from "ogsHistory";
 import { _, pgettext } from "translate";
 import { shouldOpenNewTab } from "misc";
 import { close_all_popovers } from "popover";
-import { close_friend_list } from "FriendList/FriendIndicator";
+import { close_friend_list } from "FriendList/close_friend_list";
 import * as data from "data";
 import {
     getUnreadChatPreference,

--- a/src/components/Chat/ChatIndicator.tsx
+++ b/src/components/Chat/ChatIndicator.tsx
@@ -25,81 +25,15 @@ import {
 } from "chat_manager";
 import * as data from "data";
 import { KBShortcut } from "../KBShortcut";
-import { ChatList } from "Chat";
+import { ChatList } from "./ChatList";
 import * as preferences from "preferences";
-import { TypedEventEmitter } from "TypedEventEmitter";
-
-interface Events {
-    subscription_changed: void;
-}
-const event_emiter = new TypedEventEmitter<Events>();
-
-let chat_subscriptions = {};
-data.watch("chat-indicator.chat-subscriptions", onChatSubscriptionUpdate);
-function onChatSubscriptionUpdate(pref) {
-    chat_subscriptions = pref;
-    event_emiter.emit("subscription_changed");
-}
-let chat_subscribe_new_group_chat_messages = false;
-preferences.watch("chat-subscribe-group-chat-unread", onChatSubscribeGroupMessageChange);
-function onChatSubscribeGroupMessageChange(pref: boolean) {
-    chat_subscribe_new_group_chat_messages = pref;
-    event_emiter.emit("subscription_changed");
-}
-let chat_subscribe_new_group_chat_mentioned = false;
-preferences.watch("chat-subscribe-group-mentions", onChatSubscribeGroupMentionsChange);
-function onChatSubscribeGroupMentionsChange(pref: boolean) {
-    chat_subscribe_new_group_chat_mentioned = pref;
-    event_emiter.emit("subscription_changed");
-}
-let chat_subscribe_new_tournament_chat_messages = false;
-preferences.watch("chat-subscribe-tournament-chat-unread", onChatSubscribeTournamentMessageChange);
-function onChatSubscribeTournamentMessageChange(pref: boolean) {
-    chat_subscribe_new_tournament_chat_messages = pref;
-    event_emiter.emit("subscription_changed");
-}
-let chat_subscribe_new_tournament_chat_mentioned = false;
-preferences.watch("chat-subscribe-tournament-mentions", onChatSubscribeTournamentMentionsChange);
-function onChatSubscribeTournamentMentionsChange(pref: boolean) {
-    chat_subscribe_new_tournament_chat_mentioned = pref;
-    event_emiter.emit("subscription_changed");
-}
-
-export function getUnreadChatPreference(channel: string): boolean {
-    if (channel in chat_subscriptions && "unread" in chat_subscriptions[channel]) {
-        return chat_subscriptions[channel].unread;
-    }
-    if (channel.startsWith("group-")) {
-        return chat_subscribe_new_group_chat_messages;
-    }
-    if (channel.startsWith("tournament-")) {
-        return chat_subscribe_new_tournament_chat_messages;
-    }
-    return false;
-}
-export function getMentionedChatPreference(channel: string): boolean {
-    if (channel in chat_subscriptions && "mentioned" in chat_subscriptions[channel]) {
-        return chat_subscriptions[channel].mentioned;
-    }
-    if (channel.startsWith("group-")) {
-        return chat_subscribe_new_group_chat_mentioned;
-    }
-    if (channel.startsWith("tournament-")) {
-        return chat_subscribe_new_tournament_chat_mentioned;
-    }
-    return false;
-}
-
-export function watchChatSubscriptionChanged(cb: () => void, dont_call_imediately?: boolean): void {
-    // Give a single place to subscribe to setting changes
-    event_emiter.on("subscription_changed", cb);
-    if (!dont_call_imediately) {
-        cb();
-    }
-}
-export function unwatchChatSubscriptionChanged(cb: () => void): void {
-    event_emiter.off("subscription_changed", cb);
-}
+import {
+    chat_subscriptions,
+    getUnreadChatPreference,
+    getMentionedChatPreference,
+    watchChatSubscriptionChanged,
+    unwatchChatSubscriptionChanged,
+} from "./state";
 
 export class ChatIndicator extends React.PureComponent<{}, any> {
     channels: { [channel: string]: ChatChannelProxy } = {};

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -30,12 +30,12 @@ import { shouldOpenNewTab } from "misc";
 import { browserHistory } from "ogsHistory";
 import { popover } from "popover";
 import {
-    ChatDetails,
     getUnreadChatPreference,
     getMentionedChatPreference,
     watchChatSubscriptionChanged,
     unwatchChatSubscriptionChanged,
-} from "Chat";
+} from "./state";
+import { ChatDetails } from "./ChatDetails";
 import { DataSchema } from "data_schema";
 
 interface ChatListProperties {

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -38,12 +38,12 @@ import {
     cachedChannelInformation,
 } from "chat_manager";
 import { ChatLine } from "./ChatLine";
+import { ChatDetails } from "./ChatDetails";
 import { TabCompleteInput } from "TabCompleteInput";
 import { browserHistory } from "ogsHistory";
 import { ObserveGamesComponent } from "ObserveGamesComponent";
 import { profanity_filter } from "profanity_filter";
 import { popover } from "popover";
-import { ChatDetails } from "Chat";
 import swal from "sweetalert2";
 
 interface ChatLogProperties {

--- a/src/components/Chat/state.ts
+++ b/src/components/Chat/state.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as data from "data";
+import * as preferences from "preferences";
+import { TypedEventEmitter } from "TypedEventEmitter";
+
+interface Events {
+    subscription_changed: void;
+}
+const event_emiter = new TypedEventEmitter<Events>();
+
+export let chat_subscriptions = {};
+data.watch("chat-indicator.chat-subscriptions", onChatSubscriptionUpdate);
+function onChatSubscriptionUpdate(pref) {
+    chat_subscriptions = pref;
+    event_emiter.emit("subscription_changed");
+}
+let chat_subscribe_new_group_chat_messages = false;
+preferences.watch("chat-subscribe-group-chat-unread", onChatSubscribeGroupMessageChange);
+function onChatSubscribeGroupMessageChange(pref: boolean) {
+    chat_subscribe_new_group_chat_messages = pref;
+    event_emiter.emit("subscription_changed");
+}
+let chat_subscribe_new_group_chat_mentioned = false;
+preferences.watch("chat-subscribe-group-mentions", onChatSubscribeGroupMentionsChange);
+function onChatSubscribeGroupMentionsChange(pref: boolean) {
+    chat_subscribe_new_group_chat_mentioned = pref;
+    event_emiter.emit("subscription_changed");
+}
+let chat_subscribe_new_tournament_chat_messages = false;
+preferences.watch("chat-subscribe-tournament-chat-unread", onChatSubscribeTournamentMessageChange);
+function onChatSubscribeTournamentMessageChange(pref: boolean) {
+    chat_subscribe_new_tournament_chat_messages = pref;
+    event_emiter.emit("subscription_changed");
+}
+let chat_subscribe_new_tournament_chat_mentioned = false;
+preferences.watch("chat-subscribe-tournament-mentions", onChatSubscribeTournamentMentionsChange);
+function onChatSubscribeTournamentMentionsChange(pref: boolean) {
+    chat_subscribe_new_tournament_chat_mentioned = pref;
+    event_emiter.emit("subscription_changed");
+}
+
+export function getUnreadChatPreference(channel: string): boolean {
+    if (channel in chat_subscriptions && "unread" in chat_subscriptions[channel]) {
+        return chat_subscriptions[channel].unread;
+    }
+    if (channel.startsWith("group-")) {
+        return chat_subscribe_new_group_chat_messages;
+    }
+    if (channel.startsWith("tournament-")) {
+        return chat_subscribe_new_tournament_chat_messages;
+    }
+    return false;
+}
+export function getMentionedChatPreference(channel: string): boolean {
+    if (channel in chat_subscriptions && "mentioned" in chat_subscriptions[channel]) {
+        return chat_subscriptions[channel].mentioned;
+    }
+    if (channel.startsWith("group-")) {
+        return chat_subscribe_new_group_chat_mentioned;
+    }
+    if (channel.startsWith("tournament-")) {
+        return chat_subscribe_new_tournament_chat_mentioned;
+    }
+    return false;
+}
+
+export function watchChatSubscriptionChanged(cb: () => void, dont_call_imediately?: boolean): void {
+    // Give a single place to subscribe to setting changes
+    event_emiter.on("subscription_changed", cb);
+    if (!dont_call_imediately) {
+        cb();
+    }
+}
+export function unwatchChatSubscriptionChanged(cb: () => void): void {
+    event_emiter.off("subscription_changed", cb);
+}

--- a/src/components/FriendList/FriendIndicator.tsx
+++ b/src/components/FriendList/FriendIndicator.tsx
@@ -21,11 +21,9 @@ import * as data from "data";
 import { FriendList } from "./FriendList";
 import { KBShortcut } from "KBShortcut";
 import cached from "cached";
+import { setSetShowFriendList } from "./close_friend_list";
 
 const online_subscriptions = {};
-let ext_setShowFriendList = (_tf: boolean) => {
-    /* noop */
-};
 
 export function FriendIndicator(): JSX.Element {
     const user = data.get("user");
@@ -34,7 +32,7 @@ export function FriendIndicator(): JSX.Element {
     const [, refresh] = React.useState(0);
     const friend_list = React.useRef([]);
 
-    ext_setShowFriendList = setShowFriendList;
+    setSetShowFriendList(setShowFriendList);
 
     React.useEffect(() => {
         if (user.id) {
@@ -91,8 +89,4 @@ export function FriendIndicator(): JSX.Element {
             )}
         </span>
     );
-}
-
-export function close_friend_list() {
-    ext_setShowFriendList(false);
 }

--- a/src/components/FriendList/close_friend_list.ts
+++ b/src/components/FriendList/close_friend_list.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+let ext_setShowFriendList = (_tf: boolean) => {
+    /* noop */
+};
+
+export function setSetShowFriendList(cb: (tf: boolean) => void) {
+    ext_setShowFriendList = cb;
+}
+
+export function close_friend_list() {
+    ext_setShowFriendList(false);
+}

--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -20,7 +20,7 @@ import { PersistentElement } from "PersistentElement";
 import ReactResizeDetector from "react-resize-detector";
 import { GobanCanvas, GobanCanvasConfig } from "goban";
 // Pull this out its own util
-import { goban_view_mode } from "Game";
+import { goban_view_mode } from "Game/util";
 
 interface GobanContainerProps {
     goban?: GobanCanvas;

--- a/src/components/ModNoteModal/ModNoteModal.tsx
+++ b/src/components/ModNoteModal/ModNoteModal.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { browserHistory } from "ogsHistory";
 import { put } from "requests";
 import { errorAlerter } from "misc";
-import { Player } from "Player";
+import * as player_cache from "player_cache";
 import { _ } from "translate";
 
 import { Modal, openModal } from "Modal";
@@ -61,11 +61,12 @@ export class ModNoteModal extends Modal<Events, ModNoteModalProperties, any> {
     };
 
     render() {
+        const player = player_cache.lookup(this.props.player_id);
         return (
             <div className="Modal ModNoteModal">
                 <div className="header">
                     <h2>
-                        {_("Add moderator note for: ")} <Player user={this.props.player_id} />
+                        {_("Add moderator note for: ")} {player?.username}
                     </h2>
                 </div>
                 <textarea

--- a/src/components/Notifications/NotificationManager.tsx
+++ b/src/components/Notifications/NotificationManager.tsx
@@ -522,3 +522,5 @@ export class NotificationManager {
         return true;
     }
 }
+
+export const notification_manager: NotificationManager = new NotificationManager();

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -28,9 +28,7 @@ import { FabX, FabCheck } from "material";
 import { deepEqual } from "misc";
 import { isLiveGame, durationString } from "TimeControl";
 
-import { NotificationManager } from "./NotificationManager";
-
-export const notification_manager: NotificationManager = new NotificationManager();
+import { notification_manager } from "./NotificationManager";
 
 /* TODO: This should be removed once we are happy with the new nav bar style,
  * as we use the NotificationIndicator component for that system */

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -16,7 +16,6 @@
  */
 
 import * as React from "react";
-import { routes } from "routes";
 import { browserHistory } from "ogsHistory";
 import * as data from "data";
 import { shouldOpenNewTab, errorLogger, unicodeFilter } from "misc";
@@ -360,13 +359,7 @@ export function Player(props: PlayerProperties): JSX.Element {
         return (
             // if only we could put {...main_attrs} on the span, we could put the styles in .Player.  But router seems to hate that.
             <span>
-                <a
-                    href={uri}
-                    ref={elt_ref}
-                    {...main_attrs}
-                    onMouseDown={display_details}
-                    router={routes}
-                >
+                <a href={uri} ref={elt_ref} {...main_attrs} onMouseDown={display_details}>
                     {(props.icon || null) && (
                         <PlayerIcon user={combined} size={props.iconSize || 16} />
                     )}

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -21,7 +21,7 @@ import * as data from "data";
 import { shouldOpenNewTab, errorLogger, unicodeFilter } from "misc";
 import { rankString, getUserRating, PROVISIONAL_RATING_CUTOFF } from "rank_utils";
 import { close_all_popovers, popover } from "popover";
-import { close_friend_list } from "FriendList/FriendIndicator";
+import { close_friend_list } from "FriendList/close_friend_list";
 import { PlayerDetails } from "./PlayerDetails";
 import { openPlayerNotesModal } from "PlayerNotesModal";
 import { Flag } from "Flag";

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -28,7 +28,7 @@ import { socket } from "sockets";
 import * as data from "data";
 import { close_all_popovers } from "popover";
 import { Flag } from "Flag";
-import { ban, shadowban, remove_shadowban, remove_ban } from "Moderator";
+import { ban, shadowban, remove_shadowban, remove_ban } from "Moderator/ban_functions";
 import { challenge } from "ChallengeModal";
 import { getPrivateChat } from "PrivateChat";
 import { openBlockPlayerControls } from "BlockPlayer";

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -34,7 +34,7 @@ import { getPrivateChat } from "PrivateChat";
 import { openBlockPlayerControls } from "BlockPlayer";
 import { Player } from "./Player";
 import * as preferences from "preferences";
-import { close_friend_list } from "FriendList/FriendIndicator";
+import { close_friend_list } from "FriendList/close_friend_list";
 import cached from "cached";
 import { openPlayerNotesModal } from "PlayerNotesModal";
 import swal from "sweetalert2";

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -24,7 +24,7 @@ import ITC from "ITC";
 import { splitOnBytes, unicodeFilter } from "misc";
 import { profanity_filter } from "profanity_filter";
 import { player_is_ignored } from "BlockPlayer";
-import { emitNotification } from "Notifications";
+import { emitNotification } from "Notifications/NotificationManager";
 import { PlayerCacheEntry } from "player_cache";
 import * as player_cache from "player_cache";
 import online_status from "online_status";

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -31,7 +31,7 @@ import { kb_bind, kb_unbind } from "KBShortcut";
 import { Player } from "Player";
 import * as player_cache from "player_cache";
 import swal from "sweetalert2";
-import { nominateForRengoChallenge } from "Play";
+import { nominateForRengoChallenge } from "Play/util";
 
 type Challenge = socket_api.seekgraph_global.Challenge;
 

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -16,7 +16,6 @@
  */
 
 import { _, interpolate, pgettext } from "translate";
-import { post } from "requests";
 import { errcodeAlerter } from "ErrcodeModal";
 import { browserHistory } from "ogsHistory";
 import * as preferences from "preferences";
@@ -238,27 +237,6 @@ export function getGameResultText(
     result += winner + "+" + getOutcomeTranslation(outcome);
 
     return result;
-}
-
-export function acceptGroupInvite(invite_id): Promise<any> {
-    return post("me/groups/invitations", { request_id: invite_id }).catch(errorAlerter);
-}
-export function rejectGroupInvite(invite_id): Promise<any> {
-    return post("me/groups/invitations", { delete: true, request_id: invite_id }).catch(
-        errorAlerter,
-    );
-}
-export function acceptFriendRequest(id): Promise<any> {
-    return post("me/friends/invitations", { from_user: id }).catch(errorAlerter);
-}
-export function rejectFriendRequest(id): Promise<any> {
-    return post("me/friends/invitations", { delete: true, from_user: id }).catch(errorAlerter);
-}
-export function acceptTournamentInvite(id): Promise<any> {
-    return post("me/tournaments/invitations", { request_id: id }).catch(errorAlerter);
-}
-export function rejectTournamentInvite(id): Promise<any> {
-    return post("me/tournaments/invitations", { delete: true, request_id: id }).catch(errorAlerter);
 }
 
 function lengthInUtf8Bytes(str) {

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -28,7 +28,7 @@ import { openGameLinkModal } from "./GameLinkModal";
 import { openGameLogModal } from "./GameLogModal";
 import { sfx } from "sfx";
 import swal from "sweetalert2";
-import { challengeFromBoardPosition } from "ChallengeModal";
+import { challengeFromBoardPosition } from "ChallengeModal/ForkModal";
 import { errorAlerter, ignore } from "misc";
 import { openReport } from "Report";
 import { game_control } from "./game_control";

--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -16,19 +16,16 @@
  */
 
 import * as React from "react";
+import * as moment from "moment";
+import * as data from "data";
 import { Link } from "react-router-dom";
 import { _ } from "translate";
-import { post, put } from "requests";
 import { PaginatedTable } from "PaginatedTable";
 import { Card } from "material";
 import { SearchInput } from "misc-ui";
-import { BanModal } from "BanModal";
-import { openModal } from "Modal";
 import { Player } from "Player";
-import * as moment from "moment";
 import { chat_markup } from "Chat";
-import * as data from "data";
-import swal from "sweetalert2";
+import { ban, shadowban } from "./ban_functions";
 
 const whitelist = [
     "aol.com",
@@ -606,68 +603,6 @@ export class ColorTableToggle extends React.Component<{}, any> {
                 </label>
             </div>
         );
-    }
-}
-
-function moderate(player_id, prompt, obj) {
-    return new Promise((resolve, reject) => {
-        swal({
-            text: prompt,
-            input: "text",
-            showCancelButton: true,
-        }).then((reason) => {
-            obj.moderation_note = reason;
-            console.log(obj);
-            put("players/" + player_id + "/moderate", obj)
-                .then(resolve)
-                .catch(reject);
-        }, reject);
-    });
-}
-export function ban(player_id) {
-    if (player_id < 0) {
-        return post("moderation/shadowban_anonymous_user", {
-            ban: 1,
-            user_id: player_id,
-        });
-    } else {
-        /*
-        return moderate(player_id, "Reason for banning? This will be visible to the player now.", {
-            is_banned: 1,
-        });
-        */
-        openModal(<BanModal player_id={player_id} />);
-    }
-    return undefined;
-}
-export function shadowban(player_id) {
-    if (player_id < 0) {
-        return post("moderation/shadowban_anonymous_user", {
-            ban: 1,
-            user_id: player_id,
-        });
-    } else {
-        return moderate(player_id, "Reason for shadow banning?", { is_shadowbanned: 1 });
-    }
-}
-export function remove_ban(player_id) {
-    if (player_id < 0) {
-        return post("moderation/shadowban_anonymous_user", {
-            ban: 0,
-            user_id: player_id,
-        });
-    } else {
-        return moderate(player_id, "Reason for removing ban?", { is_banned: 0 });
-    }
-}
-export function remove_shadowban(player_id) {
-    if (player_id < 0) {
-        return post("moderation/shadowban_anonymous_user", {
-            ban: 0,
-            user_id: player_id,
-        });
-    } else {
-        return moderate(player_id, "Reason for removing the shadow ban?", { is_shadowbanned: 0 });
     }
 }
 

--- a/src/views/Moderator/ban_functions.tsx
+++ b/src/views/Moderator/ban_functions.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { BanModal } from "BanModal";
+import { openModal } from "Modal";
+import { post, put } from "requests";
+import swal from "sweetalert2";
+
+function moderate(player_id, prompt, obj) {
+    return new Promise((resolve, reject) => {
+        swal({
+            text: prompt,
+            input: "text",
+            showCancelButton: true,
+        }).then((reason) => {
+            obj.moderation_note = reason;
+            console.log(obj);
+            put("players/" + player_id + "/moderate", obj)
+                .then(resolve)
+                .catch(reject);
+        }, reject);
+    });
+}
+
+export function ban(player_id) {
+    if (player_id < 0) {
+        return post("moderation/shadowban_anonymous_user", {
+            ban: 1,
+            user_id: player_id,
+        });
+    } else {
+        /*
+        return moderate(player_id, "Reason for banning? This will be visible to the player now.", {
+            is_banned: 1,
+        });
+        */
+        openModal(<BanModal player_id={player_id} />);
+    }
+    return undefined;
+}
+export function shadowban(player_id) {
+    if (player_id < 0) {
+        return post("moderation/shadowban_anonymous_user", {
+            ban: 1,
+            user_id: player_id,
+        });
+    } else {
+        return moderate(player_id, "Reason for shadow banning?", { is_shadowbanned: 1 });
+    }
+}
+export function remove_ban(player_id) {
+    if (player_id < 0) {
+        return post("moderation/shadowban_anonymous_user", {
+            ban: 0,
+            user_id: player_id,
+        });
+    } else {
+        return moderate(player_id, "Reason for removing ban?", { is_banned: 0 });
+    }
+}
+export function remove_shadowban(player_id) {
+    if (player_id < 0) {
+        return post("moderation/shadowban_anonymous_user", {
+            ban: 0,
+            user_id: player_id,
+        });
+    } else {
+        return moderate(player_id, "Reason for removing the shadow ban?", { is_shadowbanned: 0 });
+    }
+}

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -42,9 +42,10 @@ import { Size } from "src/lib/types";
 
 import { RengoManagementPane } from "RengoManagementPane";
 import { RengoTeamManagementPane } from "RengoTeamManagementPane";
+import { nominateForRengoChallenge } from "./util";
 
 const CHALLENGE_LIST_FREEZE_PERIOD = 1000; // Freeze challenge list for this period while they move their mouse on it
-type Challenge = socket_api.seekgraph_global.Challenge;
+export type Challenge = socket_api.seekgraph_global.Challenge;
 
 interface PlayState {
     live_list: Array<Challenge>;
@@ -1402,28 +1403,7 @@ function challenge_sort(A: Challenge, B: Challenge) {
     return A.challenge_id - B.challenge_id;
 }
 
-// This is used by the SeekGraph to perform this function as well as this page...
-
-export function nominateForRengoChallenge(C: Challenge) {
-    swal({
-        text: _("Joining..."), // translator: the server is processing their request to join a rengo game
-        type: "info",
-        showCancelButton: false,
-        showConfirmButton: false,
-        allowEscapeKey: false,
-    }).catch(swal.noop);
-
-    put("challenges/%%/join", C.challenge_id, {})
-        .then(() => {
-            swal.close();
-        })
-        .catch((err) => {
-            swal.close();
-            errorAlerter(err);
-        });
-}
-
-function time_per_move_challenge_sort(A: Challenge, B: Challenge) {
+export function time_per_move_challenge_sort(A: Challenge, B: Challenge) {
     const comparison = Math.sign(A.time_per_move - B.time_per_move);
 
     if (comparison) {

--- a/src/views/Play/util.ts
+++ b/src/views/Play/util.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Challenge } from "./Play";
+import swal from "sweetalert2";
+import { put } from "requests";
+import { errorAlerter } from "misc";
+import { _ } from "translate";
+
+// This is used by the SeekGraph to perform this function as well as this page...
+export function nominateForRengoChallenge(C: Challenge) {
+    swal({
+        text: _("Joining..."), // translator: the server is processing their request to join a rengo game
+        type: "info",
+        showCancelButton: false,
+        showConfirmButton: false,
+        allowEscapeKey: false,
+    }).catch(swal.noop);
+
+    put("challenges/%%/join", C.challenge_id, {})
+        .then(() => {
+            swal.close();
+        })
+        .catch((err: any) => {
+            swal.close();
+            errorAlerter(err);
+        });
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,7 @@ module.exports = (env, argv) => {
 
     plugins.push(
         new CircularDependencyPlugin({
-            exclude: /node_modules/,
+            exclude: /node_modules|LearningHub/,
             failOnError: true,
             allowAsyncCycles: false,
             cwd: process.cwd(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,14 @@
-'use strict';
+"use strict";
 
-var path = require('path');
-let fs = require('fs');
-var webpack = require('webpack');
-const pkg = require('./package.json');
-const TerserPlugin = require('terser-webpack-plugin');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+var path = require("path");
+let fs = require("fs");
+var webpack = require("webpack");
+const pkg = require("./package.json");
+const TerserPlugin = require("terser-webpack-plugin");
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const CircularDependencyPlugin = require("circular-dependency-plugin");
 
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-
+const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 
 let plugins = [];
 
@@ -20,15 +19,15 @@ plugins.push(
                 syntactic: true,
                 semantic: true,
                 declaration: true,
-                global: true
-            }
-        }
-    })
+                global: true,
+            },
+        },
+    }),
 );
 
-
-plugins.push(new webpack.BannerPlugin(
-`Copyright (C) 2012-2022  Online-Go.com
+plugins.push(
+    new webpack.BannerPlugin(
+        `Copyright (C) 2012-2022  Online-Go.com
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -42,35 +41,40 @@ GNU Affero General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
-`));
-
+`,
+    ),
+);
 
 module.exports = (env, argv) => {
-    const production = argv.mode === 'production';
+    const production = argv.mode === "production";
     let alias = {};
 
     if (production) {
         console.log("Production build, enabling react profiling");
         alias = {
-            'react-dom$': 'react-dom/profiling',
-            'scheduler/tracing': 'scheduler/tracing-profiling',
+            "react-dom$": "react-dom/profiling",
+            "scheduler/tracing": "scheduler/tracing-profiling",
         };
     }
 
     plugins.push(
         new CircularDependencyPlugin({
             exclude: /node_modules/,
-            failOnError: false,
+            failOnError: true,
             allowAsyncCycles: false,
             cwd: process.cwd(),
+            onDetected({ module: webpackModuleRecord, paths, compilation }) {
+                compilation.warnings.push(new Error("Circular dependency found:\n    " + paths.join("\n -> ")));
+            },
         }),
     );
 
-
-    plugins.push(new webpack.EnvironmentPlugin({
-        NODE_ENV: production ? 'production' : 'development',
-        DEBUG: false
-    }));
+    plugins.push(
+        new webpack.EnvironmentPlugin({
+            NODE_ENV: production ? "production" : "development",
+            DEBUG: false,
+        }),
+    );
 
     let defines = {
         CLIENT: true,
@@ -79,40 +83,34 @@ module.exports = (env, argv) => {
 
     plugins.push(new webpack.DefinePlugin(defines));
 
-
     if (process.env.ANALYZE) {
-        plugins.push(new BundleAnalyzerPlugin({
-            analyzerPort: 18888,
-        }));
+        plugins.push(
+            new BundleAnalyzerPlugin({
+                analyzerPort: 18888,
+            }),
+        );
     }
 
-
     const config = {
-        mode: production ? 'production' : 'development',
+        mode: production ? "production" : "development",
         entry: {
-            'ogs': './src/main.tsx',
+            ogs: "./src/main.tsx",
         },
         resolve: {
-            modules: [
-                'src/lib',
-                'src/components',
-                'src/views',
-                'src',
-                'node_modules'
-            ],
+            modules: ["src/lib", "src/components", "src/views", "src", "node_modules"],
             alias: alias,
             extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"],
         },
         output: {
-            path: __dirname + '/dist',
-            filename: production ? '[name].min.js' : '[name].js'
+            path: __dirname + "/dist",
+            filename: production ? "[name].min.js" : "[name].js",
         },
         module: {
             rules: [
                 {
                     test: /\.js$/,
                     use: ["source-map-loader"],
-                    enforce: "pre"
+                    enforce: "pre",
                 },
                 // All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
                 {
@@ -124,14 +122,14 @@ module.exports = (env, argv) => {
                         {
                             loader: "ts-loader",
                             options: {
-                                configFile: 'tsconfig.json',
+                                configFile: "tsconfig.json",
                                 transpileOnly: true,
-                                happyPackMode: true
-                            }
-                        }
-                    ]
-                }
-            ]
+                                happyPackMode: true,
+                            },
+                        },
+                    ],
+                },
+            ],
         },
 
         performance: {
@@ -142,37 +140,34 @@ module.exports = (env, argv) => {
         optimization: {
             splitChunks: {
                 cacheGroups: {
-                    "vendor": {
-                        test: /[\\/]node_modules[\\/]/,   // <-- use the test property to specify which deps go here
+                    vendor: {
+                        test: /[\\/]node_modules[\\/]/, // <-- use the test property to specify which deps go here
                         name: "vendor",
                         chunks: "all",
-                        priority: -10
-                    }
-                }
+                        priority: -10,
+                    },
+                },
             },
             minimizer: [
                 new TerserPlugin({
                     parallel: true,
-                    terserOptions: {
-                    },
+                    terserOptions: {},
                 }),
             ],
         },
-
-
 
         plugins: plugins,
 
         //devtool: production ? 'source-map' : 'eval-source-map',
         /* NOTE: The default needs to be source-map for the i18n translation stuff to work. Specifically, using eval-source-map makes it impossible for our xgettext-js parser to parse the embedded source. */
-        devtool: 'source-map',
+        devtool: "source-map",
 
         // When importing a module whose path matches one of the following, just
         // assume a corresponding global variable exists and use that instead.
         // This is important because it allows us to avoid bundling all of our
         // dependencies, which allows browsers to cache those libraries between builds.
         externals: {
-            "goban": "goban",
+            goban: "goban",
         },
 
         devServer: {
@@ -186,7 +181,7 @@ module.exports = (env, argv) => {
                 timings: true,
                 version: true,
                 warnings: true,
-            }
+            },
         },
     };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,12 +59,15 @@ module.exports = (env, argv) => {
 
     plugins.push(
         new CircularDependencyPlugin({
+            // LearningHub is because it's all internal and fixing it would involve globbing a lot of the broken out pages together.
+            // Player is because PlayerDetails has the Player link in it. We should probably make a lighter weight Player
+            // that can be used there instead, but doesn't seem worth the trouble right now as it's an internal thing anyways.
             exclude: /node_modules|LearningHub|Player/,
             failOnError: true,
             allowAsyncCycles: false,
             cwd: process.cwd(),
             onDetected({ module: webpackModuleRecord, paths, compilation }) {
-                compilation.warnings.push(new Error("Circular dependency found:\n    " + paths.join("\n -> ")));
+                compilation.errors.push(new Error("Circular dependency found:\n    " + paths.join("\n -> ")));
             },
         }),
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,7 @@ module.exports = (env, argv) => {
 
     plugins.push(
         new CircularDependencyPlugin({
-            exclude: /node_modules|LearningHub/,
+            exclude: /node_modules|LearningHub|Player/,
             failOnError: true,
             allowAsyncCycles: false,
             cwd: process.cwd(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ var webpack = require('webpack');
 const pkg = require('./package.json');
 const TerserPlugin = require('terser-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const CircularDependencyPlugin = require("circular-dependency-plugin");
 
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
@@ -55,6 +56,15 @@ module.exports = (env, argv) => {
             'scheduler/tracing': 'scheduler/tracing-profiling',
         };
     }
+
+    plugins.push(
+        new CircularDependencyPlugin({
+            exclude: /node_modules/,
+            failOnError: false,
+            allowAsyncCycles: false,
+            cwd: process.cwd(),
+        }),
+    );
 
 
     plugins.push(new webpack.EnvironmentPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,6 +2423,11 @@ ci-info@^3.3.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.1.tgz#58331f6f472a25fe3a50a351ae3052936c2c7f32"
   integrity sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==
 
+circular-dependency-plugin@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz#39e836079db1d3cf2f988dc48c5188a44058b600"
+  integrity sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==
+
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"


### PR DESCRIPTION
This PR adds a circular dependency detector to our webpack process and throws errors if we do things that would result in a circular dependency.

Circular dependencies sometimes work out just fine, but can result in hard to track down things-are-undefined errors as I ran into doing something unrelated, so this PR fixes most of the errors we had and adds a detector that yells at us if we accidentally add a circular dependency in the future.

Most of this is just refactor, however I did remove a `router={routes}` thing from the `<a>` link in `Player`. I have no recollection of why that was there, and I didn't see any reference to it anywhere in the code, so I am hoping it was just some really old react router thing I had to do once upon a time that's now obsolete, everything I've tested so far seems to work just fine without it.