### PR TITLE
Put a full stop at the end of timing descriptions that have weekend pause

### DIFF
--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -391,7 +391,7 @@ export function timeControlDescription(time_control) {
     }
 
     if (time_control && time_control.pause_on_weekends) {
-        ret += " " + _("Pauses on weekends");
+        ret += " " + _("Pauses on weekends.");
     }
 
     return ret;


### PR DESCRIPTION
Fixes inconsistent use of full stop in timing descriptions.

## Proposed Changes

Put a full stop at the end of timing descriptions that have weekend pause

