### PR TITLE
Game.tsx: Replace useScore with useCurrentMove

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -64,7 +64,7 @@ import {
 import { CancelButton } from "./PlayButtons";
 import { GameDock } from "./GameDock";
 import swal from "sweetalert2";
-import { useScore, useShowTitle, useTitle, useUserIsParticipant } from "./GameHooks";
+import { useCurrentMove, useShowTitle, useTitle, useUserIsParticipant } from "./GameHooks";
 import { GobanContainer } from "GobanContainer";
 import { GobanContext } from "./goban_context";
 
@@ -119,7 +119,7 @@ export function Game(): JSX.Element {
     const [show_game_timing, set_show_game_timing] = React.useState(false);
 
     const title = useTitle(goban.current);
-    useScore(goban.current);
+    const cur_move = useCurrentMove(goban.current);
 
     const [mode, set_mode] = React.useState<GobanModes>("play");
     const [score_estimate_winner, set_score_estimate_winner] = React.useState<string>();
@@ -745,7 +745,7 @@ export function Game(): JSX.Element {
                 <AIReview
                     onAIReviewSelected={(r) => set_selected_ai_review_uuid(r?.uuid)}
                     game_id={game_id}
-                    move={goban.current.engine.cur_move}
+                    move={cur_move}
                     hidden={!ai_review_enabled}
                 />
             );

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -102,6 +102,12 @@ export const useCurrentMoveNumber = generateGobanHook(
     ["cur_move"],
 );
 
+/** React hook that returns the current move tree from goban */
+export const useCurrentMove = generateGobanHook(
+    (goban: GobanCore | null) => goban?.engine.cur_move,
+    ["cur_move"],
+);
+
 /** React hook that returns the current player whose move it is.
  *
  * @returns the player ID of the player whose turn it is.
@@ -124,14 +130,3 @@ export const useShowTitle = generateGobanHook(
 
 /** React hook that returns the title text (e.g. "Black to move"). */
 export const useTitle = generateGobanHook((goban: GobanCore | null) => goban?.title, ["title"]);
-
-export const useScore = generateGobanHook(
-    (goban: GobanCore) => {
-        if (!goban) {
-            return;
-        }
-        const engine = goban.engine;
-        return engine.computeScore(true);
-    },
-    ["cur_move"],
-);


### PR DESCRIPTION
Though there is no functional change, I think this makes it more clear why the hook is necessary: "cur_move" events trigger a rerender of `AIReview`, which depends on the value of `goban.engine.cur_move`.

Related: #1877

## Proposed Changes

  - Replace `useScore` with `useCurrentMove`
  - Pass the result in as `props.move`

Note: I considered moving `move` from `AIReview.props` into `AIReview.state` because it can be derived from `goban`, but that ended up being way more verbose because we can't make use of the custom hook inside a class component. See https://github.com/online-go/online-go.com/commit/0200d664c601735aa7c162480499cafaed221b0b.
