### PR TITLE
Trigger resize/recenter on goban "load" events.

### DIFF
--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -21,6 +21,7 @@ import ReactResizeDetector from "react-resize-detector";
 import { GobanCanvas, GobanCanvasConfig } from "goban";
 // Pull this out its own util
 import { goban_view_mode } from "Game/util";
+import { generateGobanHook } from "Game/GameHooks";
 
 interface GobanContainerProps {
     goban?: GobanCanvas;
@@ -110,12 +111,8 @@ export function GobanContainer({
         recenterGoban();
     };
 
-    React.useEffect(() => {
-        if (!goban) {
-            return;
-        }
-        onResize(/* no_debounce */ true, /* do_cb */ false);
-    }, [goban]);
+    // Trigger resize on new Goban and subsequent "load" events
+    generateGobanHook(() => onResize(/* no_debounce */ true, /* do_cb */ false))(goban);
 
     if (!goban || !goban_div) {
         return <React.Fragment />;


### PR DESCRIPTION
Fixes #1889 

## Proposed Changes

  - A resize should triggered on Goban "load" events

## Screenshots
![Screen Shot 2022-05-29 at 21 39 23](https://user-images.githubusercontent.com/25233703/170919985-71392dcb-8df5-4581-b0e2-cad64c922944.png) ![Screen Shot 2022-05-29 at 21 39 29](https://user-images.githubusercontent.com/25233703/170919992-b96c0c06-2d95-43ac-ae30-091571faa615.png)

(previously odd-size boards were not centered on page load)


