### PR TITLE
Replace react-sortable-hoc with dnd-kit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,11 @@
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.2",
         "xgettext-js": "^3.0.0",
-        "yarn": "^1.22.18"
+        "yarn": "^1.22.19"
     },
     "dependencies": {
+        "@dnd-kit/core": "^6.0.3",
+        "@dnd-kit/sortable": "^7.0.0",
         "@sentry/browser": "^6.16.1",
         "@types/d3": "^5.7.2",
         "@types/howler": "^2.2.2",
@@ -115,7 +117,6 @@
         "react-resize-detector": "^7.1.1",
         "react-router-dom": "^6.3.0",
         "react-select": "^5.0.1",
-        "react-sortable-hoc": "^2.0.0",
         "react-split": "^2.0.9",
         "react-switch": "^5.0.1",
         "react-table": "^6.10.0",

--- a/src/views/PuzzleCollection/SortablePuzzleList.tsx
+++ b/src/views/PuzzleCollection/SortablePuzzleList.tsx
@@ -21,8 +21,21 @@ import { errorAlerter, navigateTo } from "misc";
 import { get, put } from "requests";
 import { longRankString } from "rank_utils";
 import { MiniGoban } from "MiniGoban";
-import { SortableContainer, SortableElement } from "react-sortable-hoc";
-import arrayMove from "array-move";
+import {
+    DndContext,
+    DragEndEvent,
+    useSensors,
+    MouseSensor,
+    useSensor,
+    TouchSensor,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import {
+    arrayMove,
+    SortableContext,
+    useSortable,
+    verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { IdType } from "src/lib/types";
 
 interface PuzzleEntryInterface {
@@ -66,71 +79,112 @@ export class SortablePuzzleList extends React.Component<
             .catch(errorAlerter);
     }
 
-    onSortEnd = ({ oldIndex, newIndex }) => {
-        if (oldIndex === newIndex) {
+    handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+
+        if (over == null) {
             return;
         }
+
+        if (active.id === over.id) {
+            return;
+        }
+
+        const oldIndex = this.state.entries.findIndex((entry) => active.id === entry.id);
+        const newIndex = this.state.entries.findIndex((entry) => over.id === entry.id);
 
         const after = oldIndex < newIndex ? newIndex : newIndex - 1;
 
         put(`puzzles/${this.state.entries[oldIndex].id}/order`, {
             after: newIndex ? this.state.entries[after].id : 0,
-        })
-            .then((asdf) => {
-                console.log(asdf);
-            })
-            .catch(errorAlerter);
+        }).catch(errorAlerter);
 
-        this.setState(({ entries }) => ({
-            entries: arrayMove(entries, oldIndex, newIndex),
-        }));
+        this.setState(({ entries }) => {
+            return { entries: arrayMove(entries, oldIndex, newIndex) };
+        });
     };
 
     render() {
         return (
-            <SortablePuzzleListContainer entries={this.state.entries} onSortEnd={this.onSortEnd} />
+            <SortablePuzzleListContainer
+                entries={this.state.entries}
+                onDragEnd={this.handleDragEnd}
+            />
         );
     }
 }
 
-const PuzzleEntry: any = SortableElement(({ puzzle }: { puzzle: PuzzleEntryInterface }) => (
-    <li className="SortablePuzzleListEntry">
-        <span className="minigoban">
-            <MiniGoban
-                noLink
-                id={null}
-                json={puzzle.puzzle}
-                displayWidth={64}
-                white={null}
-                black={null}
-            />
-        </span>
-        <span className="name">{puzzle.name}</span>
-        <span className="difficulty">{longRankString(puzzle.rank)}</span>
-        <button
-            className="edit"
-            onClick={(ev) => {
-                ev.stopPropagation();
-                ev.preventDefault();
-                navigateTo(`/puzzle/${puzzle.id}`, ev);
-            }}
-            onAuxClick={(ev) => {
-                ev.stopPropagation();
-                ev.preventDefault();
-                navigateTo(`/puzzle/${puzzle.id}`, ev);
-            }}
-        >
-            {_("Edit")}
-        </button>
-    </li>
-));
+function PuzzleEntry({ puzzle }: { puzzle: PuzzleEntryInterface }) {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+        id: puzzle.id,
+    });
 
-const SortablePuzzleListContainer: any = SortableContainer(
-    ({ entries }: { entries: Array<PuzzleEntryInterface> }) => (
-        <ul className="SortablePuzzleList">
-            {entries.map((entry, index) => (
-                <PuzzleEntry key={entry.id} index={index} puzzle={entry} />
-            ))}
-        </ul>
-    ),
-);
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <li
+            className="SortablePuzzleListEntry"
+            ref={setNodeRef}
+            {...attributes}
+            {...listeners}
+            style={style}
+        >
+            <span className="minigoban">
+                <MiniGoban
+                    noLink
+                    id={null}
+                    json={puzzle.puzzle}
+                    displayWidth={64}
+                    white={null}
+                    black={null}
+                />
+            </span>
+            <span className="name">{puzzle.name}</span>
+            <span className="difficulty">{longRankString(puzzle.rank)}</span>
+            <button
+                className="edit"
+                onClick={(ev) => {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                    navigateTo(`/puzzle/${puzzle.id}`, ev);
+                }}
+                onAuxClick={(ev) => {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                    navigateTo(`/puzzle/${puzzle.id}`, ev);
+                }}
+            >
+                {_("Edit")}
+            </button>
+        </li>
+    );
+}
+
+function SortablePuzzleListContainer({
+    entries,
+    onDragEnd,
+}: {
+    entries: Array<PuzzleEntryInterface>;
+    onDragEnd: (event: DragEndEvent) => void;
+}) {
+    const sensors = useSensors(
+        // Without this activation constraint, the "Edit" button doesn't work
+        // because dnd swallows click events.
+        useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+        useSensor(TouchSensor),
+    );
+    return (
+        <DndContext onDragEnd={onDragEnd} sensors={sensors}>
+            <SortableContext items={entries} strategy={verticalListSortingStrategy}>
+                <ul className="SortablePuzzleList">
+                    {entries.map((entry) => (
+                        <PuzzleEntry key={entry.id} puzzle={entry} />
+                    ))}
+                </ul>
+            </SortableContext>
+        </DndContext>
+    );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,7 +247,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.2.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -304,6 +304,37 @@
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+
+"@dnd-kit/accessibility@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz#3ccbefdfca595b0a23a5dc57d3de96bc6935641c"
+  integrity sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.0.3.tgz#f99ce312e2d75a1245a99709bfce0d84434bebcc"
+  integrity sha512-8u/yer6W1uvDfAq7EmWWDYpOJzzx1Okylcy9STKzSmEJLXqyO3WiEdhSfW50WJUKjMl2TfvUi6DHZuYCuyAD7g==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.0.0"
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-7.0.0.tgz#b094b288a8bd37cb74af0ed347b5ca4cfe6ce795"
+  integrity sha512-Em6d1n18lMmpRnNB9mmBWN/X7wNDnIw26tab+c7H0jCjW9UQ0+lRV+vatB1lLzFZlgQgIas/A/TXZDY16RQA5Q==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.0.tgz#b3e956ea63a1347c9d0e1316b037ddcc6140acda"
+  integrity sha512-h65/pn2IPCCIWwdlR2BMLqRkDxpTEONA+HQW3n765HBijLYGyrnTCLa2YQt8VVjjSQD6EfFlTE6aS2Q/b6nb2g==
+  dependencies:
+    tslib "^2.0.0"
 
 "@emotion/babel-plugin@^11.7.1":
   version "11.9.2"
@@ -5146,13 +5177,6 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
-
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
@@ -6499,7 +6523,7 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7942,15 +7966,6 @@ react-select@^5.0.1:
     prop-types "^15.6.0"
     react-transition-group "^4.3.0"
 
-react-sortable-hoc@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz#f6780d8aa4b922a21f3e754af542f032677078b7"
-  integrity sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    invariant "^2.2.4"
-    prop-types "^15.5.7"
-
 react-split@^2.0.9:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/react-split/-/react-split-2.0.14.tgz#ef198259bf43264d605f792fb3384f15f5b34432"
@@ -9337,6 +9352,11 @@ tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^2.0.3, tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
@@ -10087,10 +10107,10 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn@^1.22.18:
-  version "1.22.18"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.18.tgz#05b822ade8c672987bab8858635145da0850f78a"
-  integrity sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==
+yarn@^1.22.19:
+  version "1.22.19"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Fixes #1845 

## Proposed Changes

  - Replace `react-sortable-hoc` with `dnd-kit`

It's a little unfortunate - `dnd-kit/sortable` is harder to use IMO, but I think the change is necessary since  `react-sortable-hoc` relies heavily on `findDOMNode` (deprecated).
