### PR TITLE
Add OgsResizeDetector, which does not throw on older browsers.

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -18,7 +18,7 @@
 import * as data from "data";
 import * as player_cache from "player_cache";
 import * as React from "react";
-import ReactResizeDetector from "react-resize-detector";
+import { OgsResizeDetector } from "OgsResizeDetector";
 import { browserHistory } from "ogsHistory";
 import { _, pgettext, interpolate } from "translate";
 import { post, del } from "requests";
@@ -1488,7 +1488,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
     preferredGameSettings = () => {
         return (
             <div style={{ padding: "0.5em" }}>
-                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                <OgsResizeDetector handleWidth handleHeight onResize={this.onResize} />
                 <hr />
                 <div>
                     <span onClick={this.togglePreferredSettings}>

--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import { PersistentElement } from "PersistentElement";
-import ReactResizeDetector from "react-resize-detector";
+import { OgsResizeDetector } from "OgsResizeDetector";
 import { GobanCanvas, GobanCanvasConfig } from "goban";
 // Pull this out its own util
 import { goban_view_mode } from "Game/util";
@@ -120,7 +120,7 @@ export function GobanContainer({
 
     return (
         <div ref={ref_goban_container} className="goban-container">
-            <ReactResizeDetector handleWidth handleHeight onResize={() => onResize()} />
+            <OgsResizeDetector handleWidth handleHeight onResize={() => onResize()} />
             <PersistentElement className="Goban" elt={goban_div} extra_props={extra_props} />
         </div>
     );

--- a/src/components/LadderComponent/LadderComponent.tsx
+++ b/src/components/LadderComponent/LadderComponent.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import ReactResizeDetector from "react-resize-detector";
+import { OgsResizeDetector } from "OgsResizeDetector";
 import { _ } from "translate";
 import { Player } from "Player";
 import { PaginatedTable } from "PaginatedTable";
@@ -33,7 +33,7 @@ export class LadderComponent extends React.PureComponent<LadderComponentProperti
     render() {
         return (
             <div className="LadderComponent">
-                <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
+                <OgsResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
 
                 <PaginatedTable
                     className="ladder"

--- a/src/components/OgsResizeDetector/OgsResizeDetector.tsx
+++ b/src/components/OgsResizeDetector/OgsResizeDetector.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import ReactResizeDetector from "react-resize-detector";
+
+/**
+ * Some OGS users have browsers (mostly Safari <12) that don't support
+ * ResizeObserver.  This class is a wrapper that just does no resize handling
+ * on these older browsers.
+ */
+export function OgsResizeDetector(props: ReactResizeDetector["props"]): JSX.Element {
+    return window.ResizeObserver ? <ReactResizeDetector {...props} /> : <React.Fragment />;
+}

--- a/src/components/OgsResizeDetector/index.ts
+++ b/src/components/OgsResizeDetector/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./OgsResizeDetector";

--- a/src/components/RatingsChart/RatingsChart.tsx
+++ b/src/components/RatingsChart/RatingsChart.tsx
@@ -21,7 +21,7 @@
 import * as d3 from "d3";
 import * as moment from "moment";
 import * as React from "react";
-import ReactResizeDetector from "react-resize-detector";
+import { OgsResizeDetector } from "OgsResizeDetector";
 import { _, pgettext, interpolate } from "translate";
 import { PersistentElement } from "PersistentElement";
 import { RatingEntry, makeRatingEntry } from "./RatingEntry";
@@ -1207,7 +1207,7 @@ export class RatingsChart extends React.Component<RatingsChartProperties, Rating
                     <div className="nodata">{_("No rated games played yet")}</div>
                 ) : (
                     <div className="ratings-graph">
-                        <ReactResizeDetector
+                        <OgsResizeDetector
                             handleWidth
                             handleHeight
                             onResize={() => this.onResize()}

--- a/src/components/RatingsChartByGame/RatingsChartByGame.tsx
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.tsx
@@ -24,7 +24,7 @@
 import * as d3 from "d3";
 import * as moment from "moment";
 import * as React from "react";
-import ReactResizeDetector from "react-resize-detector";
+import { OgsResizeDetector } from "OgsResizeDetector";
 import { _, pgettext, interpolate } from "translate";
 import { PersistentElement } from "PersistentElement";
 import { RatingEntry, makeRatingEntry } from "./RatingEntry";
@@ -931,7 +931,7 @@ export class RatingsChartByGame extends React.Component<RatingsChartProperties, 
                     <div className="nodata">{_("No rated games played yet")}</div>
                 ) : (
                     <div className="ratings-graph">
-                        <ReactResizeDetector
+                        <OgsResizeDetector
                             handleWidth
                             handleHeight
                             onResize={() => this.onResize()}

--- a/src/views/Game/AIReviewChart.tsx
+++ b/src/views/Game/AIReviewChart.tsx
@@ -19,7 +19,7 @@ import * as d3 from "d3";
 import * as React from "react";
 import * as JSNoise from "js-noise";
 import * as data from "data";
-import ReactResizeDetector from "react-resize-detector";
+import { OgsResizeDetector } from "OgsResizeDetector";
 import { AIReviewEntry } from "./AIReview";
 import { PersistentElement } from "PersistentElement";
 import { deepCompare } from "misc";
@@ -621,7 +621,7 @@ export class AIReviewChart extends React.Component<AIReviewChartProperties> {
     render() {
         return (
             <div ref={this.container} className="AIReviewChart">
-                <ReactResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
+                <OgsResizeDetector handleWidth handleHeight onResize={() => this.onResize()} />
                 <PersistentElement elt={this.chart_div} />
             </div>
         );

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import * as data from "data";
 import * as preferences from "preferences";
 import * as player_cache from "player_cache";
-import ReactResizeDetector from "react-resize-detector";
+import { OgsResizeDetector } from "OgsResizeDetector";
 import { browserHistory } from "ogsHistory";
 import { _, pgettext } from "translate";
 import { Card } from "material";
@@ -475,7 +475,7 @@ export class Play extends React.Component<{}, PlayState> {
                                 ref={(el) => (this.ref_container = el)}
                                 className="seek-graph-container"
                             >
-                                <ReactResizeDetector
+                                <OgsResizeDetector
                                     handleWidth
                                     handleHeight
                                     onResize={() => this.onResize()}


### PR DESCRIPTION
Fixes https://forums.online-go.com/t/website-crashing-on-all-of-my-games/43524

## Proposed Changes

  - Create a wrapper that replaces `ReactResizeDetector` with `React.Fragment` if `window.ResizeObserver` is undefined.

This is an imperfect solution, but makes the site usable for folks with older browsers.

## Alternatives considered

- `ErrorBoundary`
- polyfills - this would actually support resizes, but also adds a dependency.
    - react-resize-detector/build/withPolyfill removed in January
    - [resize-observer-polyfill](https://www.npmjs.com/package/resize-observer-polyfill) last updated 4 years ago
    - [@juggle/resize-observer](https://www.npmjs.com/package/@juggle/resize-observer) last updated 10 months ago
