### PR TITLE
Dynamic help

### DIFF
--- a/src/components/DynamicHelp/NewUserVerifyEmailInSettings/NewUserVerifyEmaiInSettings.styl
+++ b/src/components/DynamicHelp/NewUserVerifyEmailInSettings/NewUserVerifyEmaiInSettings.styl
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.new-user-verify-email-in-settings {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between
+    width: fit-content;
+
+    .fa-window-close {
+        margin: 0.25rem 0px 0.25rem 0.5rem !important;
+    }
+
+    span {
+        max-width: 15rem;
+    }
+
+    // position the help popup to overcome
+    // top margin of the dt below it
+
+    transform-origin: top left;
+    transform: translate(0%, 50%);
+
+    /* deliberately in-line for this help, hence these don't apply...
+
+    position: absolute;
+
+    z-index: z.nav-menu.menu;
+    */
+
+    padding-left: 0.5rem;
+    padding-right: 0.25rem;
+
+    border-width: 2px;
+    border-color: grey;
+    border-style: solid;
+    border-radius: 5px;
+
+    themed background-color dynamic-help-background-color;
+    // opacity: 70%; opacity doesn't look good here.
+
+    //overflow-y: auto;
+    user-select: none;
+
+    box-shadow: 2px -2px 4px 4px rgba(148, 109, 109, 0.75);
+}

--- a/src/components/DynamicHelp/NewUserVerifyEmailInSettings/NewUserVerifyEmailInSettings.tsx
+++ b/src/components/DynamicHelp/NewUserVerifyEmailInSettings/NewUserVerifyEmailInSettings.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as dynamic_help from "dynamic_help_config";
+
+import { _ /*pgettext*/ } from "translate";
+
+const HELP_SET = "new-user-help-set";
+const ITEM = "new-user-verify-email-in-settings";
+
+export function NewUserVerifyEmailInSettings(): JSX.Element {
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+
+    const [show_self, setShowSelf] = React.useState<boolean>(visibility);
+
+    const close = (e) => {
+        dynamic_help.hideHelpSetItem(HELP_SET, ITEM);
+        setShowSelf(false);
+        e.stopPropagation();
+    };
+
+    // we have to allow for the settings changing while we are mounted, yet also be able to
+    // turn ourselves off...
+
+    if (show_self !== visibility) {
+        setShowSelf(visibility);
+    }
+
+    return (
+        <>
+            {(show_self || null) && (
+                <div className={ITEM}>
+                    <span>
+                        {_("Add a valid email address, click the link in the email we send you")}
+                    </span>
+                    <i className="fa fa-window-close" onClick={close} />
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/DynamicHelp/NewUserVerifyEmailInSettings/index.ts
+++ b/src/components/DynamicHelp/NewUserVerifyEmailInSettings/index.ts
@@ -15,10 +15,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export * from "./NewUserWelcome";
 export * from "./NewUserVerifyEmailInSettings";
-export * from "./SettingsButtonHelp";
-export * from "./RightNavHelp";
-export * from "./UsernameChangeHelp";
-export * from "./ProfileButtonUsernameHelp";
-export * from "./ProfilePageUsernameHelp";

--- a/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.styl
+++ b/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.styl
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.new-user-welcome {
+    text-align: right ;
+    display: flex;
+    flex-direction: column;
+    align-items: right;
+    justify-content: right;
+    position: absolute;
+
+    width: fit-content;
+
+    .help-controls {
+        display: flex;
+        justify-content: space-between
+
+        .fa-window-close {
+            margin: 0px !important;
+        }
+    }
+
+    span {
+        width: fit-content;
+        white-space: nowrap;
+    }
+
+    // position the popup
+    transform-origin: top left;
+    transform: translate(-101%, 30%);
+
+    padding: 3px 0.3rem  0 0.3rem;
+
+    border-width: 2px;
+    border-color: grey;
+    border-style: solid;
+    border-radius: 5px;
+
+    themed background-color dynamic-help-background-color;
+    opacity: 70%;
+
+    overflow-y: auto;
+    user-select: none;
+    z-index: z.nav-menu.menu;
+
+    box-shadow: -3px 0px 4px 4px rgba(148, 109, 109, 0.75);
+}

--- a/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.styl
+++ b/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.styl
@@ -15,47 +15,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-.new-user-welcome {
-    text-align: right ;
+.EmailBanner-container {
     display: flex;
-    flex-direction: column;
-    align-items: right;
-    justify-content: right;
-    position: absolute;
+    justify-content: center;
 
-    width: fit-content;
-
-    .help-controls {
-        display: flex;
-        justify-content: space-between
-
-        .fa-window-close {
-            margin: 0px !important;
-        }
+    .fa-times {
+        float: right;
+        padding-left: 1rem;
+        padding-bottom: 1rem;
+        cursor: pointer;
     }
+}
 
-    span {
-        width: fit-content;
-        white-space: nowrap;
+.EmailBanner {
+    width: 40rem;
+    max-width: 100vw;
+    text-align: justify;
+
+    .primary {
+        float: right;
+        margin-left: 1rem;
+        margin-top: 1rem;
     }
-
-    // position the popup
-    transform-origin: top left;
-    transform: translate(-101%, 30%);
-
-    padding: 3px 0.3rem  0 0.3rem;
-
-    border-width: 2px;
-    border-color: grey;
-    border-style: solid;
-    border-radius: 5px;
-
-    themed background-color dynamic-help-background-color;
-    opacity: 70%;
-
-    overflow-y: auto;
-    user-select: none;
-    z-index: z.nav-menu.menu;
-
-    box-shadow: -3px 0px 4px 4px rgba(148, 109, 109, 0.75);
 }

--- a/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
+++ b/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as dynamic_help from "dynamic_help_config";
+
+import { _ } from "translate";
+
+const HELP_SET = "new-user-help-set";
+const ITEM = "new-user-welcome";
+
+export function NewUserWelcome(): JSX.Element {
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+
+    const [show_self, setShowSelf] = React.useState<boolean>(visibility);
+
+    const close = (e) => {
+        dynamic_help.hideHelpSetItem(HELP_SET, ITEM);
+        setShowSelf(false);
+        e.stopPropagation();
+    };
+
+    // we have to allow for the settings changing while we are mounted, yet also be able to
+    // turn ourselves off...
+    if (show_self !== visibility) {
+        setShowSelf(visibility);
+    }
+
+    return (
+        <>
+            {(show_self || null) && (
+                <div className={ITEM}>
+                    <div className="help-controls">
+                        <i className="fa fa-window-close" onClick={close} />
+                        <i className="fa fa-arrow-up" />
+                    </div>
+                    <span>{_("Welcome! You can learn how to play here.")}</span>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
+++ b/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
@@ -22,6 +22,7 @@ import * as dynamic_help from "dynamic_help_config";
 import { _ } from "translate";
 
 import { browserHistory } from "ogsHistory";
+// import { useUser } from "hooks";
 
 import { Card } from "material";
 
@@ -29,7 +30,9 @@ const HELP_SET = "new-user-help-set";
 const ITEM = "new-user-welcome";
 
 export function NewUserWelcome(): JSX.Element {
-    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+    //const user = useUser();
+
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM); // eventually: && !user.email_validated;
 
     const [show_self, setShowSelf] = React.useState<boolean>(visibility);
 

--- a/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
+++ b/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
@@ -21,6 +21,10 @@ import * as dynamic_help from "dynamic_help_config";
 
 import { _ } from "translate";
 
+import { browserHistory } from "ogsHistory";
+
+import { Card } from "material";
+
 const HELP_SET = "new-user-help-set";
 const ITEM = "new-user-welcome";
 
@@ -35,6 +39,12 @@ export function NewUserWelcome(): JSX.Element {
         e.stopPropagation();
     };
 
+    const viewSettings = (e) => {
+        close(e);
+        dynamic_help.showHelpSetItem(HELP_SET, "new-user-verify-email-in-settings");
+        browserHistory.push("/user/settings");
+    };
+
     // we have to allow for the settings changing while we are mounted, yet also be able to
     // turn ourselves off...
     if (show_self !== visibility) {
@@ -44,12 +54,21 @@ export function NewUserWelcome(): JSX.Element {
     return (
         <>
             {(show_self || null) && (
-                <div className={ITEM}>
-                    <div className="help-controls">
-                        <i className="fa fa-window-close" onClick={close} />
-                        <i className="fa fa-arrow-up" />
-                    </div>
-                    <span>{_("Welcome! You can learn how to play here.")}</span>
+                <div className="EmailBanner-container">
+                    <Card className="EmailBanner">
+                        <i className="fa fa-times" onClick={close} />
+                        {_(
+                            "Welcome to OGS! Feel free to start playing games. In an effort to reduce spam and limit trolls, chat is disabled for all users until their email address has been validated. To validate your email address, simply click the activation link that has been sent to you.",
+                        )}
+                        <br />
+                        <br />
+                        {_(
+                            "You can visit the settings page to update your email address or resend the validation email.",
+                        )}
+                        <button className="primary" onClick={viewSettings}>
+                            {_("Go to settings")} &rarr;
+                        </button>
+                    </Card>
                 </div>
             )}
         </>

--- a/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
+++ b/src/components/DynamicHelp/NewUserWelcome/NewUserWelcome.tsx
@@ -42,9 +42,7 @@ export function NewUserWelcome(): JSX.Element {
         e.stopPropagation();
     };
 
-    const viewSettings = (e) => {
-        close(e);
-        dynamic_help.showHelpSetItem(HELP_SET, "new-user-verify-email-in-settings");
+    const viewSettings = () => {
         browserHistory.push("/user/settings");
     };
 

--- a/src/components/DynamicHelp/NewUserWelcome/index.ts
+++ b/src/components/DynamicHelp/NewUserWelcome/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./NewUserWelcome";

--- a/src/components/DynamicHelp/ProfileButtonUsernameHelp/ProfileButtonUsernameHelp.styl
+++ b/src/components/DynamicHelp/ProfileButtonUsernameHelp/ProfileButtonUsernameHelp.styl
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.profile-button-username-help {
+    text-align: right ;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: left;
+    position: absolute;
+
+    width: fit-content;
+
+    .help-controls {
+        display: flex;
+        justify-content: space-between
+        width: 100%
+
+        .fa-window-close {
+            margin-right: 0px !important;
+        }
+    }
+
+    span {
+        width: fit-content;
+        white-space: nowrap;
+    }
+
+    // position the help popup below and slightly displaced
+    // (this is the only position that doesn't appear to risk getting clipped)
+    transform-origin: top left;
+    transform: translate(5%, 90%);
+
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+
+    border-width: 2px;
+    border-color: grey;
+    border-style: solid;
+    border-radius: 5px;
+
+    themed background-color dynamic-help-background-color;
+    // opacity: 70%; opacity doesn't look good here.
+
+    overflow-y: auto;
+    user-select: none;
+    z-index: z.nav-menu.menu;
+
+    box-shadow: 0px 2px 4px 4px rgba(148, 109, 109, 0.75);
+}

--- a/src/components/DynamicHelp/ProfileButtonUsernameHelp/ProfileButtonUsernameHelp.tsx
+++ b/src/components/DynamicHelp/ProfileButtonUsernameHelp/ProfileButtonUsernameHelp.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as dynamic_help from "dynamic_help_config";
+
+import { _ /*pgettext*/ } from "translate";
+
+const HELP_SET = "guest-arrival-help-set";
+const ITEM = "profile-button-username-help";
+
+export function ProfileButtonUsernameHelp(): JSX.Element {
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+
+    const [show_self, setShowSelf] = React.useState<boolean>(visibility);
+
+    const close = (e) => {
+        dynamic_help.hideHelpSetItem(HELP_SET, ITEM);
+        setShowSelf(false);
+        e.stopPropagation();
+    };
+
+    // we have to allow for the settings changing while we are mounted, yet also be able to
+    // turn ourselves off...
+
+    if (show_self !== visibility) {
+        setShowSelf(visibility);
+    }
+
+    return (
+        <>
+            {(show_self || null) && (
+                <div className={ITEM}>
+                    <div className="help-controls">
+                        <i className="fa fa-arrow-up" />
+                        <i className="fa fa-window-close" onClick={close} />
+                    </div>
+                    <span>{_("To change your Username, click here")}</span>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/DynamicHelp/ProfileButtonUsernameHelp/index.ts
+++ b/src/components/DynamicHelp/ProfileButtonUsernameHelp/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./ProfileButtonUsernameHelp";

--- a/src/components/DynamicHelp/ProfilePageUsernameHelp/ProfilePageUsernameHelp.styl
+++ b/src/components/DynamicHelp/ProfilePageUsernameHelp/ProfilePageUsernameHelp.styl
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.profile-page-username-help {
+    text-align: right ;
+    display: flex;
+    flex-direction: column;
+    align-items: right;
+    justify-content: right;
+    position: absolute;
+
+    width: fit-content;
+
+    .help-controls {
+        display: flex;
+        justify-content: space-between
+
+        .fa-window-close {
+            margin: 0px !important;
+        }
+    }
+
+    span {
+        width: fit-content;
+        white-space: nowrap;
+    }
+
+    // position the help popup to the left of the Nav 'button'
+    transform-origin: top left;
+    transform: translate(1%, 30%);
+
+    padding: 3px 0.3rem  0 0.3rem;
+
+    border-width: 2px;
+    border-color: grey;
+    border-style: solid;
+    border-radius: 5px;
+
+    themed background-color dynamic-help-background-color;
+    opacity: 70%;
+
+    overflow-y: auto;
+    user-select: none;
+    z-index: z.nav-menu.menu;
+
+    box-shadow: -3px 0px 4px 4px rgba(148, 109, 109, 0.75);
+}

--- a/src/components/DynamicHelp/ProfilePageUsernameHelp/ProfilePageUsernameHelp.tsx
+++ b/src/components/DynamicHelp/ProfilePageUsernameHelp/ProfilePageUsernameHelp.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as dynamic_help from "dynamic_help_config";
+
+import { _ } from "translate";
+
+const HELP_SET = "guest-arrival-help-set";
+const ITEM = "profile-page-username-help";
+
+export function ProfilePageUsernameHelp(): JSX.Element {
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+
+    const [show_self, setShowSelf] = React.useState<boolean>(visibility);
+
+    const close = (e) => {
+        dynamic_help.hideHelpSetItem(HELP_SET, ITEM);
+        setShowSelf(false);
+        e.stopPropagation();
+    };
+
+    // we have to allow for the settings changing while we are mounted, yet also be able to
+    // turn ourselves off...
+    if (show_self !== visibility) {
+        setShowSelf(visibility);
+    }
+
+    return (
+        <>
+            {(show_self || null) && (
+                <div className={ITEM}>
+                    <div className="help-controls">
+                        <i className="fa fa-arrow-up" />
+                        <i className="fa fa-window-close" onClick={close} />
+                    </div>
+                    <span>{_("To change your username, click here")}</span>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/DynamicHelp/ProfilePageUsernameHelp/index.ts
+++ b/src/components/DynamicHelp/ProfilePageUsernameHelp/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./ProfilePageUsernameHelp";

--- a/src/components/DynamicHelp/RightNavHelp/RightNavHelp.styl
+++ b/src/components/DynamicHelp/RightNavHelp/RightNavHelp.styl
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.right-nav-help {
+    text-align: right ;
+    display: flex;
+    flex-direction: column;
+    align-items: right;
+    justify-content: right;
+    position: absolute;
+
+    width: fit-content;
+
+    .help-controls {
+        display: flex;
+        justify-content: space-between
+
+        .fa-window-close {
+            margin: 0px !important;
+        }
+    }
+
+    span {
+        width: fit-content;
+        white-space: nowrap;
+    }
+
+    // position the help popup to the left of the Nav 'button'
+    transform-origin: top left;
+    transform: translate(-101%, 30%);
+
+    padding: 3px 0.3rem  0 0.3rem;
+
+    border-width: 2px;
+    border-color: grey;
+    border-style: solid;
+    border-radius: 5px;
+
+    themed background-color dynamic-help-background-color;
+    opacity: 70%;
+
+    overflow-y: auto;
+    user-select: none;
+    z-index: z.nav-menu.menu;
+
+    box-shadow: -3px 0px 4px 4px rgba(148, 109, 109, 0.75);
+}

--- a/src/components/DynamicHelp/RightNavHelp/RightNavHelp.tsx
+++ b/src/components/DynamicHelp/RightNavHelp/RightNavHelp.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as dynamic_help from "dynamic_help_config";
+
+import { _ } from "translate";
+
+const HELP_SET = "guest-arrival-help-set";
+const ITEM = "right-nav-help";
+
+export function RightNavHelp(): JSX.Element {
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+
+    const [show_self, setShowSelf] = React.useState<boolean>(visibility);
+
+    const close = (e) => {
+        dynamic_help.hideHelpSetItem(HELP_SET, ITEM);
+        setShowSelf(false);
+        e.stopPropagation();
+    };
+
+    // we have to allow for the settings changing while we are mounted, yet also be able to
+    // turn ourselves off...
+    if (show_self !== visibility) {
+        setShowSelf(visibility);
+    }
+
+    return (
+        <>
+            {(show_self || null) && (
+                <div className={ITEM}>
+                    <div className="help-controls">
+                        <i className="fa fa-window-close" onClick={close} />
+                        <i className="fa fa-arrow-right" />
+                    </div>
+                    <span>{_("To set your password, click here")}</span>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/DynamicHelp/RightNavHelp/index.ts
+++ b/src/components/DynamicHelp/RightNavHelp/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./RightNavHelp";

--- a/src/components/DynamicHelp/SettingsButtonHelp/SettingsButtonHelp.styl
+++ b/src/components/DynamicHelp/SettingsButtonHelp/SettingsButtonHelp.styl
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.settings-button-help {
+    text-align: right ;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: left;
+    position: absolute;
+
+    width: fit-content;
+
+    .help-controls {
+        display: flex;
+        justify-content: space-between
+        width: 100%
+
+        .fa-window-close {
+            margin-right: 0px !important;
+        }
+    }
+
+    span {
+        width: fit-content;
+        white-space: nowrap;
+    }
+
+    // position the help popup below and slightly displaced
+    // (this is the only position that doesn't appear to risk getting clipped)
+    transform-origin: top left;
+    transform: translate(5%, 90%);
+
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+
+    border-width: 2px;
+    border-color: grey;
+    border-style: solid;
+    border-radius: 5px;
+
+    themed background-color dynamic-help-background-color;
+    // opacity: 70%; opacity doesn't look good here.
+
+    overflow-y: auto;
+    user-select: none;
+    z-index: z.nav-menu.menu;
+
+    box-shadow: 0px 2px 4px 4px rgba(148, 109, 109, 0.75);
+}

--- a/src/components/DynamicHelp/SettingsButtonHelp/SettingsButtonHelp.tsx
+++ b/src/components/DynamicHelp/SettingsButtonHelp/SettingsButtonHelp.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as dynamic_help from "dynamic_help_config";
+
+import { _ /*pgettext*/ } from "translate";
+
+const HELP_SET = "guest-arrival-help-set";
+const ITEM = "settings-button-help";
+
+export function SettingsButtonHelp(): JSX.Element {
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+
+    const [show_self, setShowSelf] = React.useState<boolean>(visibility);
+
+    const close = (e) => {
+        dynamic_help.hideHelpSetItem(HELP_SET, ITEM);
+        setShowSelf(false);
+        e.stopPropagation();
+    };
+
+    // we have to allow for the settings changing while we are mounted, yet also be able to
+    // turn ourselves off...
+
+    if (show_self !== visibility) {
+        setShowSelf(visibility);
+    }
+
+    return (
+        <>
+            {(show_self || null) && (
+                <div className={ITEM}>
+                    <div className="help-controls">
+                        <i className="fa fa-arrow-up" />
+                        <i className="fa fa-window-close" onClick={close} />
+                    </div>
+                    <span>{_("To set your password, click here")}</span>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/DynamicHelp/SettingsButtonHelp/index.ts
+++ b/src/components/DynamicHelp/SettingsButtonHelp/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./SettingsButtonHelp";

--- a/src/components/DynamicHelp/UsernameChangeHelp/UsernameChangeHelp.styl
+++ b/src/components/DynamicHelp/UsernameChangeHelp/UsernameChangeHelp.styl
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.username-change-help {
+    text-align: right ;
+    display: flex;
+    flex-direction: column;
+    align-items: right;
+    justify-content: right;
+    position: absolute;
+
+    width: fit-content;
+
+    .help-controls {
+        display: flex;
+        justify-content: space-between
+
+        .fa-window-close {
+            margin: 0px !important;
+        }
+    }
+
+    span {
+        width: fit-content;
+        white-space: nowrap;
+    }
+
+    //
+    transform-origin: top left;
+    transform: translate(-101%, 30%);
+
+    padding: 3px 0.3rem  0 0.3rem;
+
+    border-width: 2px;
+    border-color: grey;
+    border-style: solid;
+    border-radius: 5px;
+
+    themed background-color dynamic-help-background-color;
+    opacity: 70%;
+
+    overflow-y: auto;
+    user-select: none;
+    z-index: z.nav-menu.menu;
+
+    box-shadow: -3px 0px 4px 4px rgba(148, 109, 109, 0.75);
+}

--- a/src/components/DynamicHelp/UsernameChangeHelp/UsernameChangeHelp.tsx
+++ b/src/components/DynamicHelp/UsernameChangeHelp/UsernameChangeHelp.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as dynamic_help from "dynamic_help_config";
+
+import { _ } from "translate";
+
+const HELP_SET = "guest-arrival-help-set";
+const ITEM = "username-change-help";
+
+export function UsernameChangeHelp(): JSX.Element {
+    const visibility = dynamic_help.isVisible(HELP_SET, ITEM);
+
+    const [show_self, setShowSelf] = React.useState<boolean>(visibility);
+
+    const close = (e) => {
+        dynamic_help.hideHelpSetItem(HELP_SET, ITEM);
+        setShowSelf(false);
+        e.stopPropagation();
+    };
+
+    // we have to allow for the settings changing while we are mounted, yet also be able to
+    // turn ourselves off...
+    if (show_self !== visibility) {
+        setShowSelf(visibility);
+    }
+
+    return (
+        <>
+            {(show_self || null) && (
+                <div className={ITEM}>
+                    <div className="help-controls">
+                        <i className="fa fa-window-close" onClick={close} />
+                        <i className="fa fa-arrow-right" />
+                    </div>
+                    <span>{_("You can also change your Username...")}</span>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/DynamicHelp/UsernameChangeHelp/index.ts
+++ b/src/components/DynamicHelp/UsernameChangeHelp/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./UsernameChangeHelp";

--- a/src/components/DynamicHelp/index.ts
+++ b/src/components/DynamicHelp/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2012-2017  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./SettingsButtonHelp";
+export * from "./RightNavHelp";
+export * from "./UsernameChangeHelp";
+export * from "./ProfileButtonUsernameHelp";
+export * from "./ProfilePageUsernameHelp";

--- a/src/components/DynamicHelp/index.ts
+++ b/src/components/DynamicHelp/index.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+export * from "./NewUserWelcome";
 export * from "./SettingsButtonHelp";
 export * from "./RightNavHelp";
 export * from "./UsernameChangeHelp";

--- a/src/components/NavBar/EXV6NavBar.tsx
+++ b/src/components/NavBar/EXV6NavBar.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 import { Link, useLocation } from "react-router-dom";
 
 import * as data from "data";
+import * as preferences from "preferences";
+import * as DynamicHelp from "DynamicHelp";
 
 import { _ } from "translate";
 import { PlayerIcon } from "PlayerIcon";
@@ -32,11 +34,11 @@ import { TurnIndicator } from "TurnIndicator";
 import { NotificationIndicator } from "NotificationIndicator";
 import { TournamentIndicator } from "Announcements";
 import { FriendIndicator } from "FriendList";
-import * as preferences from "preferences";
-//import { ChatIndicator } from "Chat";
+
 import { logout } from "auth";
 import { useUser } from "hooks";
 import { OmniSearch } from "./OmniSearch";
+import { hideHelpSetItem, isVisible, showHelpSetItem } from "dynamic_help_config";
 
 const body = $(document.body);
 
@@ -86,6 +88,15 @@ export function EXV6NavBar(): JSX.Element {
     };
 
     const toggleRightNav = () => {
+        if (!right_nav_active) {
+            if (isVisible("guest-arrival-help-set", "right-nav-help")) {
+                hideHelpSetItem("guest-arrival-help-set", "right-nav-help");
+            }
+            if (isVisible("guest-arrival-help-set", "username-change-help")) {
+                hideHelpSetItem("guest-arrival-help-set", "username-change-help");
+                showHelpSetItem("guest-arrival-help-set", "profile-button-username-help");
+            }
+        }
         setRightNavActive(!right_nav_active);
     };
 
@@ -309,6 +320,8 @@ export function EXV6NavBar(): JSX.Element {
                     <FriendIndicator />
                     <NotificationIndicator onClick={toggleNotifications} />
                     <span className="icon-container" onClick={toggleRightNav}>
+                        <DynamicHelp.RightNavHelp />
+                        <DynamicHelp.UsernameChangeHelp />
                         {user.username}
                     </span>
                 </section>
@@ -328,11 +341,13 @@ export function EXV6NavBar(): JSX.Element {
             {right_nav_active && (
                 <div className="RightNav">
                     <Link to={`/user/view/${user.id}`}>
+                        <DynamicHelp.ProfileButtonUsernameHelp />
                         <PlayerIcon user={user} size={16} />
                         {_("Profile")}
                     </Link>
 
                     <Link to="/user/settings">
+                        <DynamicHelp.SettingsButtonHelp />
                         <i className="fa fa-gear"></i>
                         {_("Settings")}
                     </Link>

--- a/src/components/misc-ui/misc-ui.tsx
+++ b/src/components/misc-ui/misc-ui.tsx
@@ -17,6 +17,10 @@
 
 import * as React from "react";
 
+/* This is intended to create text embedded in a horizontal line like
+ *   --- my text ---
+ * It relies on css for 'left' and 'right' being as expected in context, caveat emptor. */
+
 export const LineText = (props) => (
     <div {...props} className={"LineText " + (props.className || "")}>
         <span className="left" />

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -28,6 +28,8 @@ import { TimeControl, TimeControlTypes } from "src/components/TimeControl";
 import { AutomatchPreferences } from "src/components/AutomatchSettings";
 import { JosekiFilter } from "src/components/JosekiVariationFilter";
 
+import * as dynamic_help from "dynamic_help_config";
+
 interface CachedSchema {
     groups: GroupList;
     active_tournaments: ActiveTournamentList;
@@ -195,7 +197,8 @@ export interface DataSchema
         Prefixed<AutomatchSchema, "automatch">,
         Prefixed<ObservedGamesSchema, "observed-games">,
         Prefixed<AnnouncementsSchema, "announcements">,
-        Prefixed<ChallengeSchema, "challenge"> {
+        Prefixed<ChallengeSchema, "challenge">,
+        Prefixed<dynamic_help.DynamicHelpSchema, "dynamic-help"> {
     user: rest_api.UserConfig;
     bid: string;
     theme: string;

--- a/src/lib/dynamic_help_config.ts
+++ b/src/lib/dynamic_help_config.ts
@@ -20,7 +20,7 @@ import { pgettext } from "./translate";
 
 export type DynamicHelpSet = "new-user-help-set" | "guest-arrival-help-set";
 
-export type NewUserHelpSetItem = "new-user-welcome";
+export type NewUserHelpSetItem = "new-user-welcome" | "new-user-verify-email-in-settings";
 
 export type GuestArrivalHelpSetItem =
     | "right-nav-help"
@@ -61,6 +61,7 @@ export const DEFAULT_DYNAMIC_HELP_CONFIG: DynamicHelpSchema = {
         ),
         items: {
             "new-user-welcome": { show_item: false, set_initially: true },
+            "new-user-verify-email-in-settings": { show_item: false, set_initially: true },
         },
     },
     "guest-arrival-help-set": {

--- a/src/lib/dynamic_help_config.ts
+++ b/src/lib/dynamic_help_config.ts
@@ -49,9 +49,8 @@ export type DynamicHelpSchema = {
     [set_name in DynamicHelpSet]: DynamicHelpSetSchema;
 };
 
-// This could be used to set initial values.  Right now it isn't used for that.
 // This is currently used to define what items are in a help set,
-// so we can make sure we turn them all on in `showHelpSet()`
+// so we can make sure we turn them all on in `showHelpSet()` and related
 export const DEFAULT_DYNAMIC_HELP_CONFIG: DynamicHelpSchema = {
     "new-user-help-set": {
         show_set: false,

--- a/src/lib/dynamic_help_config.ts
+++ b/src/lib/dynamic_help_config.ts
@@ -71,7 +71,7 @@ export const DEFAULT_DYNAMIC_HELP_CONFIG: DynamicHelpSchema = {
         ),
         items: {
             "right-nav-help": { show_item: false, set_initially: true },
-            "settings-button-help": { show_item: false, set_initially: false },
+            "settings-button-help": { show_item: false, set_initially: true },
             "username-change-help": { show_item: false, set_initially: false },
             "profile-button-username-help": { show_item: false, set_initially: false },
             "profile-page-username-help": { show_item: false, set_initially: false },

--- a/src/lib/dynamic_help_config.ts
+++ b/src/lib/dynamic_help_config.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as data from "data";
+import { pgettext } from "./translate";
+
+export type DynamicHelpSet = "new-user-help-set" | "guest-arrival-help-set";
+
+export type NewUserHelpSetItem = "new-user-welcome";
+
+export type GuestArrivalHelpSetItem =
+    | "right-nav-help"
+    | "settings-button-help"
+    | "username-change-help"
+    | "profile-button-username-help"
+    | "profile-page-username-help";
+
+export type HelperSetItem = NewUserHelpSetItem | GuestArrivalHelpSetItem;
+
+export type DynamicHelpSetItemSchema = {
+    show_item: boolean;
+};
+
+export type DynamicHelpSetSchema = {
+    show_set: boolean;
+    set_title: string;
+    items: { [item_name in HelperSetItem]?: DynamicHelpSetItemSchema };
+};
+
+export type DynamicHelpSchema = {
+    [set_name in DynamicHelpSet]: DynamicHelpSetSchema;
+};
+
+// This could be used to set initial values.  Right now it isn't used for that.
+// This is currently used to define what items are in a help set,
+// so we can make sure we turn them all on in `showHelpSet()`
+export const DEFAULT_DYNAMIC_HELP_CONFIG: DynamicHelpSchema = {
+    "new-user-help-set": {
+        show_set: false,
+        set_title: pgettext(
+            "Label for the settings controlling help for newly registered users",
+            "New User Help Set",
+        ),
+        items: {
+            "new-user-welcome": { show_item: false },
+        },
+    },
+    "guest-arrival-help-set": {
+        show_set: false,
+        set_title: pgettext(
+            "Label for the settings controlling help for arriving guests",
+            "Guest Arrival Help Set",
+        ),
+        items: {
+            "right-nav-help": { show_item: false },
+            "settings-button-help": { show_item: false },
+            "username-change-help": { show_item: false },
+            "profile-button-username-help": { show_item: false },
+            "profile-page-username-help": { show_item: false },
+        },
+    },
+};
+
+export function setIsVisible(set_name: DynamicHelpSet): boolean {
+    return data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]).show_set;
+}
+
+export function allItemsVisible(set_name: DynamicHelpSet): boolean {
+    const config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
+
+    return Object.keys(config.items).reduce(
+        (prev, current) => prev && config.items[current].show_item,
+        config.show_set,
+    );
+}
+
+export function someItemsVisible(set_name: DynamicHelpSet): boolean {
+    const config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
+
+    return (
+        config.show_set &&
+        Object.keys(config.items).reduce(
+            (prev, current) => prev || config.items[current].show_item,
+            false,
+        )
+    );
+}
+
+export function isVisible(set_name: DynamicHelpSet, item_name: string): boolean {
+    const set_config = data.get(`dynamic-help.${set_name}`, {
+        show_set: false,
+        items: {},
+        set_title: "",
+    });
+
+    const visible =
+        set_config.show_set &&
+        item_name in set_config.items &&
+        set_config.items[item_name].show_item;
+
+    return visible;
+}
+
+// Turn on "show item" for a help set item...
+export function showHelpSetItem(set_name: DynamicHelpSet, item_name: string): void {
+    setHelpSetItem(true, set_name, item_name);
+}
+
+// Turn off "show item" for a help set item...
+export function hideHelpSetItem(set_name: DynamicHelpSet, item_name: string): void {
+    setHelpSetItem(false, set_name, item_name);
+}
+
+// Set the value of "show_item" for a help set item
+// (with optional parameter of current help set config, to avoid re-reading it a lot)
+// Note: this does not control set show_set for the HelpSet, only show_item for the items
+
+function setHelpSetItem(
+    value: boolean,
+    set_name: DynamicHelpSet,
+    item_name: string,
+    prev_config?,
+): DynamicHelpSetSchema {
+    const set_config =
+        prev_config || data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
+
+    if (!(item_name in set_config["items"])) {
+        set_config["items"][item_name] = { show_item: value };
+    } else {
+        set_config["items"][item_name]["show_item"] = value;
+    }
+
+    data.set(`dynamic-help.${set_name}`, set_config);
+
+    return set_config;
+}
+
+// Turn on "show_set" for a named help set, and turn on all the items.
+export function showHelpSet(set_name: DynamicHelpSet): void {
+    let set_config = data.get(`dynamic-help.${set_name}`);
+
+    set_config = { ...set_config, show_set: true };
+
+    data.set(`dynamic-help.${set_name}`, set_config);
+
+    for (const item in DEFAULT_DYNAMIC_HELP_CONFIG[set_name]["items"]) {
+        set_config = setHelpSetItem(true, set_name, item, set_config);
+    }
+}
+
+// Note: this doesn't change the visibility of the items in the set
+export function hideHelpSet(set_name: DynamicHelpSet): void {
+    const set_config = data.get(`dynamic-help.${set_name}`);
+
+    data.set(`dynamic-help.${set_name}`, { ...set_config, show_set: false });
+}
+
+export function toggleHelpSet(set_name: DynamicHelpSet): boolean {
+    const set_config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
+    const new_value = !set_config.show_set;
+
+    if (new_value) {
+        showHelpSet(set_name);
+    } else {
+        hideHelpSet(set_name);
+    }
+
+    return new_value;
+}

--- a/src/lib/dynamic_help_config.ts
+++ b/src/lib/dynamic_help_config.ts
@@ -32,7 +32,11 @@ export type GuestArrivalHelpSetItem =
 export type HelperSetItem = NewUserHelpSetItem | GuestArrivalHelpSetItem;
 
 export type DynamicHelpSetItemSchema = {
+    // indicates if the item should be visible at the component level.  The set has to be enabled as well.
     show_item: boolean;
+    // indicates if the item should be turned on when the whole set is turned on.
+    // (useful for resetting sets that sequence their messages)
+    set_initially: boolean;
 };
 
 export type DynamicHelpSetSchema = {
@@ -56,7 +60,7 @@ export const DEFAULT_DYNAMIC_HELP_CONFIG: DynamicHelpSchema = {
             "New User Help Set",
         ),
         items: {
-            "new-user-welcome": { show_item: false },
+            "new-user-welcome": { show_item: false, set_initially: true },
         },
     },
     "guest-arrival-help-set": {
@@ -66,11 +70,11 @@ export const DEFAULT_DYNAMIC_HELP_CONFIG: DynamicHelpSchema = {
             "Guest Arrival Help Set",
         ),
         items: {
-            "right-nav-help": { show_item: false },
-            "settings-button-help": { show_item: false },
-            "username-change-help": { show_item: false },
-            "profile-button-username-help": { show_item: false },
-            "profile-page-username-help": { show_item: false },
+            "right-nav-help": { show_item: false, set_initially: true },
+            "settings-button-help": { show_item: false, set_initially: false },
+            "username-change-help": { show_item: false, set_initially: false },
+            "profile-button-username-help": { show_item: false, set_initially: false },
+            "profile-page-username-help": { show_item: false, set_initially: false },
         },
     },
 };
@@ -88,6 +92,16 @@ export function allItemsVisible(set_name: DynamicHelpSet): boolean {
     );
 }
 
+export function initialItemsVisible(set_name: DynamicHelpSet): boolean {
+    const config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
+
+    return Object.keys(config.items).reduce(
+        (prev, current) =>
+            prev && (!config.items[current].set_initially || config.items[current].show_item),
+        config.show_set,
+    );
+}
+
 export function someItemsVisible(set_name: DynamicHelpSet): boolean {
     const config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
 
@@ -101,11 +115,7 @@ export function someItemsVisible(set_name: DynamicHelpSet): boolean {
 }
 
 export function isVisible(set_name: DynamicHelpSet, item_name: string): boolean {
-    const set_config = data.get(`dynamic-help.${set_name}`, {
-        show_set: false,
-        items: {},
-        set_title: "",
-    });
+    const set_config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
 
     const visible =
         set_config.show_set &&
@@ -150,8 +160,8 @@ function setHelpSetItem(
 }
 
 // Turn on "show_set" for a named help set, and turn on all the items.
-export function showHelpSet(set_name: DynamicHelpSet): void {
-    let set_config = data.get(`dynamic-help.${set_name}`);
+export function showAllHelpSetItems(set_name: DynamicHelpSet): void {
+    let set_config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
 
     set_config = { ...set_config, show_set: true };
 
@@ -162,22 +172,28 @@ export function showHelpSet(set_name: DynamicHelpSet): void {
     }
 }
 
+// Turn on "show_set" for a named help set, and turn on all the _initial_ items.
+// (And turn _off_ all the non-initial items)
+export function initializeHelpSet(set_name: DynamicHelpSet): void {
+    let set_config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
+
+    set_config = { ...set_config, show_set: true };
+
+    data.set(`dynamic-help.${set_name}`, set_config);
+
+    for (const item in DEFAULT_DYNAMIC_HELP_CONFIG[set_name]["items"]) {
+        set_config = setHelpSetItem(
+            DEFAULT_DYNAMIC_HELP_CONFIG[set_name]["items"][item].set_initially,
+            set_name,
+            item,
+            set_config,
+        );
+    }
+}
+
 // Note: this doesn't change the visibility of the items in the set
 export function hideHelpSet(set_name: DynamicHelpSet): void {
     const set_config = data.get(`dynamic-help.${set_name}`);
 
     data.set(`dynamic-help.${set_name}`, { ...set_config, show_set: false });
-}
-
-export function toggleHelpSet(set_name: DynamicHelpSet): boolean {
-    const set_config = data.get(`dynamic-help.${set_name}`, DEFAULT_DYNAMIC_HELP_CONFIG[set_name]);
-    const new_value = !set_config.show_set;
-
-    if (new_value) {
-        showHelpSet(set_name);
-    } else {
-        hideHelpSet(set_name);
-    }
-
-    return new_value;
 }

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -74,7 +74,6 @@ z = {
         backdrop       : 300,
         menu           : 310
     },
-    //player-autocomplete: 900, // not sure why this ever existed, if this doesn't cause a problem in a few weeks remove this comment. - anoek 2021-05-20
     nav-menu: {
         backdrop       : 1000,
         menu           : 1010,
@@ -86,6 +85,8 @@ z = {
     popover            : 5000,
     report             : 6000,
     swal               : 10000,
+    challenge-link     : 10010,  // We have to say "Challenge Link Copied" over the top of "Challenge Created"
+
     superchat-modal    : 50005,
     superchat          : 50010,
 }
@@ -233,6 +234,10 @@ light.navbar-highlight-background-color = light.bg;
 light.navbar-background-color           = light.bg;
 light.logo-svg                          = svg-load("../assets/ogs_light.svg")
 
+/** Dynamic Help **/
+
+light.dynamic-help-background-color     = light.bg;  // curiously dark needs differentiation, but light doesn't!
+
 /** Input **/
 
 light.input-bg                          = darken(light.bg, 3%)
@@ -364,6 +369,9 @@ dark.navbar-highlight-background-color  = #333
 dark.navbar-background-color            = lighten(dark.bg, 5%)
 dark.logo-svg                           = svg-load("../assets/ogs_dark.svg")
 
+/** Dynamic Help **/
+
+dark.dynamic-help-background-color     = #00001a;  // stands out boldly
 
 /** Input **/
 
@@ -464,6 +472,7 @@ nowrap()
 
 @require "./components/material/*.styl";
 @require "./components/[A-Z]*/*.styl";
+@require "./components/[A-Z]*/[A-Z]*/*.styl";
 @require "./views/[A-Z]*/*.styl";
 @require "./views/docs/*.styl";
 

--- a/src/views/Overview/EXV6Overview.tsx
+++ b/src/views/Overview/EXV6Overview.tsx
@@ -18,6 +18,9 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import { _ } from "translate";
+
+import * as DynamicHelp from "DynamicHelp";
+
 import { GameList } from "GameList";
 import { post, get, abort_requests_in_flight } from "requests";
 import * as data from "data";
@@ -26,7 +29,7 @@ import * as preferences from "preferences";
 import { errorAlerter, ignore } from "misc";
 import { DismissableNotification } from "DismissableNotification";
 import { ChallengesList } from "./ChallengesList";
-import { EmailBanner } from "EmailBanner";
+
 import { notification_manager } from "Notifications";
 import { ActiveAnnouncements } from "Announcements";
 import { ActiveTournamentList, Group } from "src/lib/types";
@@ -125,7 +128,7 @@ export class EXV6Overview extends React.Component<{}, OverviewState> {
                 <div id="Overview">
                     <div className="left">
                         <DismissableMessages />
-                        <EmailBanner />
+                        <DynamicHelp.NewUserWelcome />
                         <ActiveAnnouncements />
                         <ChallengesList onAccept={() => this.refresh()} />
 

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -18,6 +18,7 @@
 import * as React from "react";
 
 import * as data from "data";
+import * as DynamicHelp from "DynamicHelp";
 
 import { Link } from "react-router-dom";
 import { _ } from "translate";
@@ -175,6 +176,8 @@ export function AccountSettings(props: SettingGroupProps): JSX.Element {
         }
     }
 
+    // Render...
+
     return (
         <div>
             <i>
@@ -183,6 +186,9 @@ export function AccountSettings(props: SettingGroupProps): JSX.Element {
                 </Link>
             </i>
             <dl>
+                <dd>
+                    <DynamicHelp.NewUserVerifyEmailInSettings />
+                </dd>
                 <dt>{_("Email address")}</dt>
                 <dd>
                     <input

--- a/src/views/Settings/GeneralPreferences.tsx
+++ b/src/views/Settings/GeneralPreferences.tsx
@@ -181,6 +181,7 @@ export function GeneralPreferences(props: SettingGroupProps): JSX.Element {
         window.location.reload();
     }
 
+    // Render...
     return (
         <div>
             <PreferenceLine title={_("Language")}>

--- a/src/views/Settings/HelpSettings.tsx
+++ b/src/views/Settings/HelpSettings.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as data from "data";
+
+import { pgettext } from "translate";
+
+import {
+    DEFAULT_DYNAMIC_HELP_CONFIG,
+    DynamicHelpSet,
+    showHelpSet,
+    hideHelpSet,
+    allItemsVisible,
+    someItemsVisible,
+} from "dynamic_help_config";
+
+import { PreferenceLine } from "SettingsCommon";
+
+export function HelpSettings(): JSX.Element {
+    const help_sets = Object.keys(DEFAULT_DYNAMIC_HELP_CONFIG) as DynamicHelpSet[];
+
+    // Here, we keep the settings visibility value as state so we rerender when we change it.
+    // We get the initial value for the state by reading it from datam, or using the
+    // default values if it has never been set.
+    const [visibility, setVisibility] = React.useState<{ [help_set: string]: boolean }>(
+        Object.fromEntries(
+            help_sets.map((help_set) => [
+                help_set,
+                data.get(`dynamic-help.${help_set}`, DEFAULT_DYNAMIC_HELP_CONFIG[help_set])
+                    .show_set,
+            ]),
+        ),
+    );
+
+    const show = (help_set: DynamicHelpSet) => {
+        showHelpSet(help_set);
+        setVisibility({ ...visibility, [help_set]: true });
+    };
+
+    const hide = (help_set: DynamicHelpSet) => {
+        hideHelpSet(help_set);
+        setVisibility({ ...visibility, [help_set]: false });
+    };
+
+    return (
+        <div>
+            {help_sets.map((help_set) => (
+                <PreferenceLine
+                    key={help_set}
+                    title={DEFAULT_DYNAMIC_HELP_CONFIG[help_set].set_title}
+                >
+                    <button onClick={() => show(help_set)}>
+                        {pgettext("Press this button to show all help in the set", "Show all")}
+                    </button>
+                    <button onClick={() => hide(help_set)}>
+                        {pgettext("Press this button to hide this help set", "Hide set")}
+                    </button>
+                    <span>
+                        {pgettext(
+                            "Following this label is the list of currently visible help items",
+                            "Currently:",
+                        )}
+                    </span>
+                    <span>
+                        {allItemsVisible(help_set)
+                            ? "All"
+                            : someItemsVisible(help_set)
+                            ? "Some"
+                            : "None"}
+                    </span>
+                </PreferenceLine>
+            ))}
+        </div>
+    );
+}

--- a/src/views/Settings/HelpSettings.tsx
+++ b/src/views/Settings/HelpSettings.tsx
@@ -24,9 +24,10 @@ import { pgettext } from "translate";
 import {
     DEFAULT_DYNAMIC_HELP_CONFIG,
     DynamicHelpSet,
-    showHelpSet,
+    initializeHelpSet,
     hideHelpSet,
     allItemsVisible,
+    initialItemsVisible,
     someItemsVisible,
 } from "dynamic_help_config";
 
@@ -49,7 +50,7 @@ export function HelpSettings(): JSX.Element {
     );
 
     const show = (help_set: DynamicHelpSet) => {
-        showHelpSet(help_set);
+        initializeHelpSet(help_set);
         setVisibility({ ...visibility, [help_set]: true });
     };
 
@@ -66,20 +67,22 @@ export function HelpSettings(): JSX.Element {
                     title={DEFAULT_DYNAMIC_HELP_CONFIG[help_set].set_title}
                 >
                     <button onClick={() => show(help_set)}>
-                        {pgettext("Press this button to show all help in the set", "Show all")}
+                        {pgettext("Press this button to show all the initial items", "Reset")}
                     </button>
                     <button onClick={() => hide(help_set)}>
                         {pgettext("Press this button to hide this help set", "Hide set")}
                     </button>
                     <span>
                         {pgettext(
-                            "Following this label is the list of currently visible help items",
+                            "Following this label is the status of currently visible help items",
                             "Currently:",
                         )}
                     </span>
                     <span>
                         {allItemsVisible(help_set)
                             ? "All"
+                            : initialItemsVisible(help_set)
+                            ? "Initial"
                             : someItemsVisible(help_set)
                             ? "Some"
                             : "None"}

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -90,15 +90,6 @@ export function Settings(): JSX.Element {
         };
     }
 
-    const selected = category;
-    data.set("settings.page-selected", selected);
-
-    if (dynamic_help.isVisible("guest-arrival-help-set", "settings-button-help")) {
-        dynamic_help.hideHelpSetItem("guest-arrival-help-set", "settings-button-help");
-        dynamic_help.showHelpSetItem("guest-arrival-help-set", "username-change-help");
-        select("account");
-    }
-
     const groups: Array<{ key: string; label: string }> = [
         { key: "general", label: _("General Preferences") },
         { key: "sound", label: _("Sound Preferences") },
@@ -123,6 +114,24 @@ export function Settings(): JSX.Element {
         */
         { key: "logout", label: _("Logout") },
     ];
+
+    const selected = category;
+    data.set("settings.page-selected", selected);
+
+    /* Settings "Dynamic Help Control" ...
+
+     * In normal use, 'guest arrival' and 'new user' are mutually exclusive.
+     * If they are both set (user-choice?), it doesn't really matter, it's arbitrary which one to honour...  */
+
+    if (dynamic_help.isVisible("guest-arrival-help-set", "settings-button-help")) {
+        dynamic_help.hideHelpSetItem("guest-arrival-help-set", "settings-button-help");
+        dynamic_help.showHelpSetItem("guest-arrival-help-set", "username-change-help");
+        select("account");
+    } else if (dynamic_help.isVisible("new-user-help-set", "new-user-welcome")) {
+        dynamic_help.hideHelpSetItem("new-user-help-set", "new-user-welcome");
+        dynamic_help.showHelpSetItem("new-user-help-set", "new-user-verify-email-in-settings");
+        select("account");
+    }
 
     let SelectedPage: (props: SettingGroupProps) => JSX.Element = () => <div>Error</div>;
 

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -23,9 +23,11 @@ import { useParams } from "react-router-dom";
 import * as preferences from "preferences";
 
 import * as data from "data";
+import * as dynamic_help from "dynamic_help_config";
 
 import { _ } from "translate";
 import { get, abort_requests_in_flight } from "requests";
+
 import { errorAlerter, dup } from "misc";
 import { durationString } from "TimeControl";
 
@@ -46,6 +48,7 @@ import { AccountSettings } from "./AccountSettings";
 import { LinkPreferences } from "./LinkPreferences";
 import { AnnouncementPreferences } from "./AnnouncementPreferences";
 import { EmailPreferences } from "./EmailPreferences";
+import { HelpSettings } from "./HelpSettings";
 
 export function Settings(): JSX.Element {
     const { category } = useParams();
@@ -56,9 +59,6 @@ export function Settings(): JSX.Element {
     const [loaded, set_loaded]: [number, (b: number) => void] = React.useState(0);
 
     React.useEffect(refresh, []);
-
-    const selected = category;
-    data.set("settings.page-selected", selected);
 
     function select(s: string): void {
         data.set("settings.page-selected", s);
@@ -90,6 +90,15 @@ export function Settings(): JSX.Element {
         };
     }
 
+    const selected = category;
+    data.set("settings.page-selected", selected);
+
+    if (dynamic_help.isVisible("guest-arrival-help-set", "settings-button-help")) {
+        dynamic_help.hideHelpSetItem("guest-arrival-help-set", "settings-button-help");
+        dynamic_help.showHelpSetItem("guest-arrival-help-set", "username-change-help");
+        select("account");
+    }
+
     const groups: Array<{ key: string; label: string }> = [
         { key: "general", label: _("General Preferences") },
         { key: "sound", label: _("Sound Preferences") },
@@ -102,6 +111,7 @@ export function Settings(): JSX.Element {
         { key: "blocked_players", label: _("Blocked Players") },
         { key: "account", label: _("Account Settings") },
         { key: "link", label: _("Account Linking") },
+        { key: "help", label: _("Help Settings") },
         /*
         {
             key: "experiments",
@@ -149,6 +159,9 @@ export function Settings(): JSX.Element {
             break;
         case "link":
             SelectedPage = LinkPreferences;
+            break;
+        case "help":
+            SelectedPage = HelpSettings;
             break;
         case "logout":
             SelectedPage = LogoutPreferences;

--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -16,6 +16,10 @@
  */
 
 import * as data from "data";
+import * as DynamicHelp from "DynamicHelp";
+
+import { isVisible, hideHelpSetItem } from "dynamic_help_config";
+
 import { Flag } from "Flag";
 import { image_resizer } from "image_resizer";
 import { errorAlerter, ignore } from "misc";
@@ -122,6 +126,9 @@ export function AvatarCard({
             setNewRealNameIsPrivate(user.real_name_is_private);
             setNewCountry(user.country);
             setNewWebsite(user.website);
+            if (isVisible("guest-arrival-help-set", "profile-page-username-help")) {
+                hideHelpSetItem("guest-arrival-help-set", "profile-page-username-help");
+            }
             onEdit();
         }
     };
@@ -318,10 +325,13 @@ export function AvatarCard({
 
             <div className="avatar-buttons">
                 {(global_user.id === user.id || global_user.is_moderator || null) && (
-                    <button onClick={toggleEdit} className="xs edit-button">
-                        <i className={editing ? "fa fa-save" : "fa fa-pencil"} />{" "}
-                        {" " + (editing ? _("Save") : _("Edit"))}
-                    </button>
+                    <>
+                        <button onClick={toggleEdit} className="xs edit-button">
+                            <i className={editing ? "fa fa-save" : "fa fa-pencil"} />{" "}
+                            {" " + (editing ? _("Save") : _("Edit"))}
+                        </button>
+                        <DynamicHelp.ProfilePageUsernameHelp />
+                    </>
                 )}
 
                 {global_user.is_moderator && (

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -22,6 +22,8 @@ import { get, put } from "requests";
 import { parse } from "query-string";
 import * as data from "data";
 import * as moment from "moment";
+import * as dynamic_help from "dynamic_help_config";
+
 import { Card } from "material";
 import { GameList } from "GameList";
 import * as preferences from "preferences";
@@ -301,6 +303,11 @@ export function User(props: { user_id?: number }): JSX.Element {
             setResolved(false);
         };
     }, [user_id]);
+
+    if (dynamic_help.isVisible("guest-arrival-help-set", "profile-button-username-help")) {
+        dynamic_help.hideHelpSetItem("guest-arrival-help-set", "profile-button-username-help");
+        dynamic_help.showHelpSetItem("guest-arrival-help-set", "profile-page-username-help");
+    }
 
     /* Render */
     if (!user) {


### PR DESCRIPTION
Add a "Dynamic Help" capability, with some examples

This completes the prototype that was underway in #1893 (and I intend to merge this into #1893 ASAP, unless it looks like this is "yeah, nah, nice idea, but not the right thing").

I'll write this up properly in a design doc.

Brifely - the idea is that we want to be able to have "dynamic help", which can be popped up when we believe that it will help a user, based on what they have been doing, and dismissed once they have seen it.   Users can turn a flow back on if they want it again (via settings).

The help should be able to come in flows or "sets", so the user can be guided through actions from one page or menu to another.

This prototype has two sets - one for a new user who has just registered, and another for a guest who has just arrived off a challenge link.

The one for a new user is triggered by registering.    It actually replaces the "EmailBanner" with it's first step.   It's currently coded to ignore `user.email_validated` because for some reason all users in dev instances are getting this set before they have actually validated.    If  validation were working properly, this would show a different message depending on whether you have done it or not.

The one for a guest user can't be triggered automatically in this PR because we don't have Challenge Links, but it can be triggered via the new "Help" section of Settings.   To test this, you need to trigger it ("reset" the help set) then click on the Home link, which is where the actual user will encounter it.

An assumption of this implementation is that we'll want and need to be able to create new help items quickly, and their flows BUT each help item will need some individual layout customisation.   It's not "cookie cutter popups", rather it is "bespoke help for each situation, based on a pattern".

## Proposed Changes

 - Dynamic Help utilities
 - Dynamic Help settings in Settings
 - 2 example help sets

