### PR TITLE
Modify iframe embed code to play nicely with Discourse

### DIFF
--- a/src/views/Game/GameLinkModal.tsx
+++ b/src/views/Game/GameLinkModal.tsx
@@ -42,7 +42,7 @@ export class GameLinkModal extends Modal<Events, GameLinkModalProperties, {}> {
             sgf_url = `${window.location.protocol}//${window.location.hostname}/api/v1/games/${goban.game_id}/sgf/${goban.game_id}.sgf`;
             png_url = `${window.location.protocol}//${window.location.hostname}/api/v1/games/${goban.game_id}/png/${goban.game_id}.png`;
             const embed_url = `${window.location.protocol}//${window.location.hostname}/game/${goban.game_id}/embed`;
-            embed_html = `<iframe src="${embed_url}" style="width: 400px; height: 444px;" allowtransparency="true" scrolling="no" frameborder="0"></iframe>`;
+            embed_html = `<iframe src="${embed_url}" width="345px" height="345px" allowtransparency="true" scrolling="no" frameborder="0"></iframe>`;
         } else {
             sgf_url = `${window.location.protocol}//${window.location.hostname}/api/v1/reviews/${goban.review_id}/sgf/${goban.review_id}.sgf`;
             png_url = `${window.location.protocol}//${window.location.hostname}/api/v1/reviews/${goban.review_id}/png/${goban.review_id}.png`;


### PR DESCRIPTION
Discourse doesn't respect certain iframe attributes such as style. Therefore,
style="width: ..; height: .." was replaced with width=".." and height="..".

<img width="885" alt="Screen Shot 2022-06-16 at 8 09 42 PM" src="https://user-images.githubusercontent.com/25233703/174218253-8e3a1236-188d-46dd-b404-f01485c999e6.png">

Note: I also took width and height down to 345px as that is closer to the native elements on the [Observe Games](https://online-go.com/observe-games) page.