### PR TITLE
Hide Announcements (and PMs etc.) for embeds

### DIFF
--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -175,13 +175,6 @@ export class Announcements extends React.PureComponent<{}, AnnouncementsState> {
                     return (
                         <div className="announcement" key={idx}>
                             <i className="fa fa-times-circle" onClick={announcement.clear} />
-                            {/*
-                    {(announcement.type === 'tournament' || null) &&
-                        <span className='expiration'>
-                            {moment(announcement.expiration).fromNow(true)}:
-                        </span>
-                    }
-                    */}
                             {announcement.link ? (
                                 announcement.link.indexOf("://") > 0 ? (
                                     <a href={announcement.link} target="_blank">

--- a/src/components/NavBar/NavBar.styl
+++ b/src/components/NavBar/NavBar.styl
@@ -343,6 +343,10 @@ body.dark #NavBar button.theme-button.dark {
     }
 }
 
+body.zen #NavBar & {
+    display: none;
+}
+
 // do for accessible what we do for dark...
 body.accessible #NavBar button.theme-button.accessible {
     background-color: accessible.primary

--- a/src/views/GameEmbed/GameEmbed.tsx
+++ b/src/views/GameEmbed/GameEmbed.tsx
@@ -36,20 +36,13 @@ export function GameEmbed(): JSX.Element {
 
     const game_id = params.game_id ? parseInt(params.game_id) : 0;
 
-    // Hide NavBar
+    // Hide NavBar, announcements, PMs etc.
     React.useEffect(() => {
-        const v6_nav_bar = document.getElementsByClassName("NavBar")[0] as HTMLElement;
-        const old_nav_bar = document.getElementById("NavBar");
-        const nav_bar = v6_nav_bar || old_nav_bar;
-
-        if (nav_bar) {
-            nav_bar.style.display = "none";
-        }
+        const body = document.getElementsByTagName("body")[0];
+        body.classList.add("zen");
 
         return () => {
-            if (nav_bar) {
-                delete nav_bar.style.display;
-            }
+            body.classList.remove("zen");
         };
     }, []);
 


### PR DESCRIPTION
Fixes

>Site notifications show up inside the embed :smile: 

https://forums.online-go.com/t/embed-live-game/42216/10

## Proposed Changes

  - Just tell OGS we are in zen mode in embed panes
  - Remove NavBar hiding logic since it respects zen mode.

This feels like a bit of a hack since this isn't technically zen mode, but zen mode does so much, and embeds needs it all so why re-invent the wheel? :)
