### PR TITLE
Upgrade to sweetalert2 v11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "redux": "^3.7.2",
         "sanitize-html": "^2.3.2",
         "socket.io-client": "4.3.2",
-        "sweetalert2": "^6.11.5",
+        "sweetalert2": "^11.4.17",
         "ts-md5": "^1.2.7",
         "valid-url": "^1.0.9",
         "whatwg-fetch": "^3.0.0"

--- a/src/components/Announcements/ActiveAnnouncements.tsx
+++ b/src/components/Announcements/ActiveAnnouncements.tsx
@@ -31,7 +31,7 @@ import { getBlocks, setAnnouncementBlock } from "../BlockPlayer";
 import * as data from "data";
 import * as preferences from "preferences";
 
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 // Holds the expirations dates of cleared announcements
 const hard_cleared_announcements: { [id: number]: number } = data.get(
@@ -115,20 +115,23 @@ export class ActiveAnnouncements extends React.PureComponent {
                                 username: announcement.creator.username,
                             }),
                             onClick: () => {
-                                swal({
-                                    text: interpolate(
-                                        _(
-                                            "Are you sure you want to hide all announcements from {{name}}?",
+                                alert
+                                    .fire({
+                                        text: interpolate(
+                                            _(
+                                                "Are you sure you want to hide all announcements from {{name}}?",
+                                            ),
+                                            { name: announcement.creator.username },
                                         ),
-                                        { name: announcement.creator.username },
-                                    ),
-                                    showCancelButton: true,
-                                    confirmButtonText: _("Yes"),
-                                    cancelButtonText: _("Cancel"),
-                                })
-                                    .then(() => {
-                                        setAnnouncementBlock(announcement.creator.id, true);
-                                        this.forceUpdate();
+                                        showCancelButton: true,
+                                        confirmButtonText: _("Yes"),
+                                        cancelButtonText: _("Cancel"),
+                                    })
+                                    .then(({ value: yes }) => {
+                                        if (yes) {
+                                            setAnnouncementBlock(announcement.creator.id, true);
+                                            this.forceUpdate();
+                                        }
                                     })
                                     .catch(() => 0);
                                 return;
@@ -140,17 +143,20 @@ export class ActiveAnnouncements extends React.PureComponent {
                         announcement_actions.push({
                             title: _("Hide stream announcements"),
                             onClick: () => {
-                                swal({
-                                    text: _(
-                                        "Are you sure you want to hide all announcements for streamers?",
-                                    ),
-                                    showCancelButton: true,
-                                    confirmButtonText: _("Yes"),
-                                    cancelButtonText: _("Cancel"),
-                                })
-                                    .then(() => {
-                                        preferences.set("mute-stream-announcements", true);
-                                        this.forceUpdate();
+                                alert
+                                    .fire({
+                                        text: _(
+                                            "Are you sure you want to hide all announcements for streamers?",
+                                        ),
+                                        showCancelButton: true,
+                                        confirmButtonText: _("Yes"),
+                                        cancelButtonText: _("Cancel"),
+                                    })
+                                    .then(({ value: yes }) => {
+                                        if (yes) {
+                                            preferences.set("mute-stream-announcements", true);
+                                            this.forceUpdate();
+                                        }
                                     })
                                     .catch(() => 0);
                                 return;
@@ -162,17 +168,20 @@ export class ActiveAnnouncements extends React.PureComponent {
                         announcement_actions.push({
                             title: _("Hide event announcements"),
                             onClick: () => {
-                                swal({
-                                    text: _(
-                                        "Are you sure you want to hide all event announcements?",
-                                    ),
-                                    showCancelButton: true,
-                                    confirmButtonText: _("Yes"),
-                                    cancelButtonText: _("Cancel"),
-                                })
-                                    .then(() => {
-                                        preferences.set("mute-event-announcements", true);
-                                        this.forceUpdate();
+                                alert
+                                    .fire({
+                                        text: _(
+                                            "Are you sure you want to hide all event announcements?",
+                                        ),
+                                        showCancelButton: true,
+                                        confirmButtonText: _("Yes"),
+                                        cancelButtonText: _("Cancel"),
+                                    })
+                                    .then(({ value: yes }) => {
+                                        if (yes) {
+                                            preferences.set("mute-event-announcements", true);
+                                            this.forceUpdate();
+                                        }
                                     })
                                     .catch(() => 0);
                                 return;
@@ -184,17 +193,20 @@ export class ActiveAnnouncements extends React.PureComponent {
                         announcement_actions.push({
                             title: _("Hide go service advertisements"),
                             onClick: () => {
-                                swal({
-                                    text: _(
-                                        "Are you sure you want to hide all go related advertisements?",
-                                    ),
-                                    showCancelButton: true,
-                                    confirmButtonText: _("Yes"),
-                                    cancelButtonText: _("Cancel"),
-                                })
-                                    .then(() => {
-                                        preferences.set("mute-event-announcements", true);
-                                        this.forceUpdate();
+                                alert
+                                    .fire({
+                                        text: _(
+                                            "Are you sure you want to hide all go related advertisements?",
+                                        ),
+                                        showCancelButton: true,
+                                        confirmButtonText: _("Yes"),
+                                        cancelButtonText: _("Cancel"),
+                                    })
+                                    .then(({ value: yes }) => {
+                                        if (yes) {
+                                            preferences.set("mute-event-announcements", true);
+                                            this.forceUpdate();
+                                        }
                                     })
                                     .catch(() => 0);
                                 return;

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -44,7 +44,7 @@ import { browserHistory } from "ogsHistory";
 import { ObserveGamesComponent } from "ObserveGamesComponent";
 import { profanity_filter } from "profanity_filter";
 import { popover } from "popover";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 interface ChatLogProperties {
     channel: string;
@@ -519,7 +519,7 @@ function ChatInput({ channel, autoFocus }: InternalChatLogProperties): JSX.Eleme
             if (event.charCode === 13) {
                 const input = event.target as HTMLInputElement;
                 if (!socket.connected) {
-                    void swal(_("Connection to server lost"));
+                    void alert.fire(_("Connection to server lost"));
                     return false;
                 }
 

--- a/src/components/GameAcceptModal/GameAcceptModal.tsx
+++ b/src/components/GameAcceptModal/GameAcceptModal.tsx
@@ -21,7 +21,7 @@ import { post } from "requests";
 import { openModal, Modal } from "Modal";
 import { Player, PlayerObjectType } from "Player";
 import { errorAlerter } from "misc";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { ChallengeDetailsReviewPane } from "../ChallengeDetailsReviewPane";
 
 interface Events {}
@@ -40,22 +40,22 @@ export class GameAcceptModal extends Modal<Events, GameAcceptModalProperties, {}
     }
 
     accept = () => {
-        swal({
+        void alert.fire({
             text: "Accepting...",
-            type: "info",
+            icon: "info",
             showCancelButton: false,
             showConfirmButton: false,
             allowEscapeKey: false,
-        }).catch(swal.noop);
+        });
 
         post("challenges/%%/accept", this.props.challenge.challenge_id, {})
             .then(() => {
-                swal.close();
+                alert.close();
                 this.close();
                 this.props.onAccept(this.props.challenge);
             })
             .catch((err) => {
-                swal.close();
+                alert.close();
                 errorAlerter(err);
             });
     };

--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -31,7 +31,7 @@ import { openReportedConversationModal } from "ReportedConversationModal";
 import { ReportedConversation, report_categories } from "Report";
 import { AutoTranslate } from "AutoTranslate";
 import { PlayerCacheEntry } from "player_cache";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 export interface Report {
     id: number;
@@ -130,7 +130,7 @@ export function IncidentReportTracker(): JSX.Element {
                     post("moderation/incident/%%", report.id, { id: report.id, action: "claim" })
                         .then((res) => {
                             if (res.vanished) {
-                                swal("Report was removed").catch(swal.noop);
+                                void alert.fire("Report was removed");
                             }
                         })
                         .catch(errorAlerter);
@@ -142,12 +142,13 @@ export function IncidentReportTracker(): JSX.Element {
                 };
 
                 report.set_note = () => {
-                    swal({
-                        input: "text",
-                        inputValue: report.moderator_note,
-                        showCancelButton: true,
-                    })
-                        .then((txt) => {
+                    void alert
+                        .fire({
+                            input: "text",
+                            inputValue: report.moderator_note,
+                            showCancelButton: true,
+                        })
+                        .then(({ value: txt }) => {
                             post("moderation/incident/%%", report.id, {
                                 id: report.id,
                                 action: "note",
@@ -155,8 +156,7 @@ export function IncidentReportTracker(): JSX.Element {
                             })
                                 .then(ignore)
                                 .catch(errorAlerter);
-                        })
-                        .catch(ignore);
+                        });
                 };
 
                 if (!(report.id in active_incident_reports_ref.current)) {

--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import * as data from "data";
 import { _ } from "translate";
 import { put, get, del } from "requests";
-import { errorAlerter, ignore } from "misc";
+import { errorAlerter } from "misc";
 import { proRankList } from "rank_utils";
 import { Modal, openModal } from "Modal";
 import { lookup } from "player_cache";
@@ -30,7 +30,7 @@ interface ModerateUserProperties {
     playerId?: number;
 }
 
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 const pro_ranks = proRankList(false);
 
@@ -57,12 +57,13 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
     }
 
     save = () => {
-        swal({
-            text: _("Moderator note"),
-            input: "text",
-            showCancelButton: true,
-        })
-            .then((reason) => {
+        void alert
+            .fire({
+                text: _("Moderator note"),
+                input: "text",
+                showCancelButton: true,
+            })
+            .then(({ value: reason }) => {
                 if (!reason) {
                     return;
                 }
@@ -98,8 +99,7 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                         this.close();
                     })
                     .catch(errorAlerter);
-            })
-            .catch(ignore);
+            });
     };
     setLockedUsername = (ev) => this.setState({ locked_username: ev.target.checked });
     setSupporter = (ev) => this.setState({ supporter: ev.target.checked });
@@ -120,18 +120,18 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
         const user_id = this.props.playerId;
         const username = lookup(user_id)?.username || "";
 
-        swal({
-            text: `Are you sure you want to delete the account "${username}" (${user_id})? This cannot be undone.`,
-            showCancelButton: true,
-        })
+        void alert
+            .fire({
+                text: `Are you sure you want to delete the account "${username}" (${user_id})? This cannot be undone.`,
+                showCancelButton: true,
+            })
             .then(() => {
                 del(`players/${user_id}`, {})
                     .then(() => {
-                        swal("Done").catch(swal.noop);
+                        void alert.fire("Done");
                     })
                     .catch(errorAlerter);
-            })
-            .catch(ignore);
+            });
     };
 
     render() {

--- a/src/components/NewGameModal/NewGameModal.tsx
+++ b/src/components/NewGameModal/NewGameModal.tsx
@@ -31,7 +31,7 @@ import {
 import { shortShortTimeControl } from "TimeControl";
 import * as preferences from "preferences";
 import { bot_count } from "bots";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 interface Events {}
 
@@ -75,7 +75,7 @@ export class NewGameModal extends Modal<Events, NewGameModalProperties, any> {
     };
     newComputer = () => {
         if (bot_count() === 0) {
-            swal(_("Sorry, all bots seem to be offline, please try again later.")).catch(swal.noop);
+            void alert.fire(_("Sorry, all bots seem to be offline, please try again later."));
             return;
         }
         challengeComputer();

--- a/src/components/Player/PlayerDetails.tsx
+++ b/src/components/Player/PlayerDetails.tsx
@@ -37,7 +37,7 @@ import * as preferences from "preferences";
 import { close_friend_list } from "FriendList/close_friend_list";
 import cached from "cached";
 import { openPlayerNotesModal } from "PlayerNotesModal";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { PlayerCacheEntry } from "player_cache";
 import { openReport } from "Report";
 
@@ -250,21 +250,27 @@ export class PlayerDetails extends React.PureComponent<
 
         this.close_all_modals_and_popovers();
     };
+
     removeAllChats = () => {
         this.close_all_modals_and_popovers();
 
-        swal({
-            text: _(
-                `Are you sure you wish to remove all non-game chats made by user ${this.props.playerId}? This is not reversible.`,
-            ),
-            confirmButtonText: _("Yes"),
-            cancelButtonText: _("No"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => socket.send("chat/remove_all", { player_id: this.props.playerId }))
-            .catch(() => 0);
+        void alert
+            .fire({
+                text: _(
+                    `Are you sure you wish to remove all non-game chats made by user ${this.props.playerId}? This is not reversible.`,
+                ),
+                confirmButtonText: _("Yes"),
+                cancelButtonText: _("No"),
+                showCancelButton: true,
+                focusCancel: true,
+            })
+            .then(({ value: yes }) => {
+                if (yes) {
+                    socket.send("chat/remove_all", { player_id: this.props.playerId });
+                }
+            });
     };
+
     render() {
         const user = data.get("user");
 

--- a/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
+++ b/src/components/RengoTeamManagementPane/RengoTeamManagementPane.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 import { balanceTeams, unassignPlayers } from "rengo_balancer";
 import { _, pgettext } from "translate";
@@ -62,18 +62,20 @@ export class RengoTeamManagementPane extends React.PureComponent<
     };
 
     _kickRengoUser = (player_id: number) => {
-        swal({
-            text: pgettext(
-                "Confirmation text to remove the selected player from all rengo challenges",
-                "This will kick the person from all rengo challenges, are you sure you want to do this?",
-            ),
-            showCancelButton: true,
-        })
-            .then(() => {
-                this.setState({ assignment_pending: true });
-                this.props.kickRengoUser(player_id, this.done.bind(self));
+        void alert
+            .fire({
+                text: pgettext(
+                    "Confirmation text to remove the selected player from all rengo challenges",
+                    "This will kick the person from all rengo challenges, are you sure you want to do this?",
+                ),
+                showCancelButton: true,
             })
-            .catch(() => 0);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    this.setState({ assignment_pending: true });
+                    this.props.kickRengoUser(player_id, this.done.bind(self));
+                }
+            });
     };
 
     render = () => {

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -22,7 +22,7 @@ import { Card } from "material";
 import { _, pgettext } from "translate";
 import { PlayerIcon } from "PlayerIcon";
 import { post } from "requests";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 type ReportType =
     | "stalling"
@@ -215,12 +215,12 @@ export function Report(props: ReportProperties): JSX.Element {
             .then(() => {
                 set_submitting(false);
                 onClose();
-                swal({ text: _("Thanks for the report!") }).catch(swal.noop);
+                void alert.fire({ text: _("Thanks for the report!") });
             })
             .catch(() => {
                 set_submitting(false);
                 onClose();
-                swal({ text: _("There was an error submitting your report") }).catch(swal.noop);
+                void alert.fire({ text: _("There was an error submitting your report") });
             });
     }
 

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -30,7 +30,7 @@ import { rankString, bounded_rank } from "rank_utils";
 import { kb_bind, kb_unbind } from "KBShortcut";
 import { Player } from "Player";
 import * as player_cache from "player_cache";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { nominateForRengoChallenge } from "Play/util";
 
 type Challenge = socket_api.seekgraph_global.Challenge;
@@ -754,7 +754,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
                             //console.log("Remove");
                             del("challenges/%%", C.challenge_id)
                                 .then(() => e.html(_("Challenge removed")))
-                                .catch(() => swal(_("Error removing challenge")));
+                                .catch(() => alert.fire(_("Error removing challenge")));
                         }),
                 );
             } else {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,13 +18,13 @@
 import * as data from "data";
 import cached from "cached";
 import { get } from "requests";
-import { errorLogger, ignore } from "misc";
+import { errorLogger } from "misc";
 import ITC from "ITC";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 ITC.register("logout", (device_uuid: string) => {
     if (device_uuid !== data.get("device.uuid", "")) {
-        swal("This device has been logged out remotely").then(logout).catch(logout);
+        alert.fire("This device has been logged out remotely").then(logout).catch(logout);
     }
 });
 
@@ -38,16 +38,17 @@ export function logout() {
 }
 
 export function logoutOtherDevices() {
-    swal({
-        text: "Logout of other devices you are logged in to?",
-        showCancelButton: true,
-    })
-        .then(() => {
-            ITC.send("logout", data.get("device.uuid"));
-            swal("Other devices have been logged out").then(ignore).catch(ignore);
+    void alert
+        .fire({
+            text: "Logout of other devices you are logged in to?",
+            showCancelButton: true,
         })
-        .catch(ignore);
-    //get("/api/v0/logout?everywhere=1").then(console.log).catch(errorAlerter);
+        .then(({ value: accept }) => {
+            if (accept) {
+                ITC.send("logout", data.get("device.uuid"));
+                void alert.fire("Other devices have been logged out");
+            }
+        });
 }
 
 export function logoutAndClearLocalData() {

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -19,7 +19,7 @@ import { _, interpolate, pgettext } from "translate";
 import { errcodeAlerter } from "ErrcodeModal";
 import { browserHistory } from "ogsHistory";
 import * as preferences from "preferences";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 import { Goban } from "goban";
 import { isLiveGame } from "TimeControl";
@@ -370,10 +370,10 @@ export function errorAlerter(...args) {
         }
         errcodeAlerter(errobj);
     } else {
-        swal({
+        void alert.fire({
             title: _(err.substring(0, 128)),
-            type: "error",
-        }).catch(swal.noop);
+            icon: "error",
+        });
     }
     console.error(err);
 }

--- a/src/lib/swal_config.ts
+++ b/src/lib/swal_config.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { _ } from "translate";
+import Swal from "sweetalert2";
+
+/*** SweetAlert setup ***/
+
+export const alert = Swal.mixin({
+    customClass: {
+        confirmButton: "primary",
+        cancelButton: "reject",
+    },
+    buttonsStyling: false,
+    reverseButtons: true,
+    confirmButtonText: _("OK"),
+    cancelButtonText: _("Cancel"),
+    allowEscapeKey: true,
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -148,7 +148,7 @@ import * as player_cache from "player_cache";
 import { toast } from "toast";
 import cached from "cached";
 import * as moment from "moment";
-import swal from "sweetalert2";
+
 import { ConfigSchema } from "data_schema";
 import * as history from "history";
 import "debug";
@@ -206,18 +206,6 @@ data.watch("config.user", (user) => {
  * tabs with our new logout-other-devices button
  */
 data.set("device.uuid", data.get("device.uuid", uuid()));
-
-/*** SweetAlert setup ***/
-swal.setDefaults({
-    confirmButtonClass: "primary",
-    cancelButtonClass: "reject",
-    buttonsStyling: false,
-    reverseButtons: true,
-    confirmButtonText: _("OK"),
-    cancelButtonText: _("Cancel"),
-    allowEscapeKey: true,
-    //focusCancel: true,
-});
 
 /***
  * Test if local storage is disabled for some reason (Either because the user

--- a/src/views/Admin/Admin.tsx
+++ b/src/views/Admin/Admin.tsx
@@ -20,7 +20,7 @@ import { Link } from "react-router-dom";
 import { post, get } from "requests";
 import { socket } from "sockets";
 import { ignore, getPrintableError } from "misc";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 declare let ogs_release;
 declare let ogs_version;
@@ -114,11 +114,11 @@ export class Admin extends React.PureComponent<{}, AdminState> {
         };
 
         if (txt) {
-            swal({ text: txt, showCancelButton: true })
-                .then(() => {
+            void alert.fire({ text: txt, showCancelButton: true }).then(({ value: accept }) => {
+                if (accept) {
                     doPost();
-                })
-                .catch(ignore);
+                }
+            });
         } else {
             doPost();
         }

--- a/src/views/AppealsCenter/AppealsCenter.tsx
+++ b/src/views/AppealsCenter/AppealsCenter.tsx
@@ -22,7 +22,7 @@ import { _ } from "translate";
 import * as moment from "moment";
 import { PaginatedTable } from "PaginatedTable";
 import * as data from "data";
-//import swal from "sweetalert2";
+//import { alert } from "swal_config";
 
 export function AppealsCenter(): JSX.Element {
     const user = data.get("user");

--- a/src/views/BlockedVPN/BlockedVPN.tsx
+++ b/src/views/BlockedVPN/BlockedVPN.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { post } from "requests";
 import { errorAlerter } from "misc";
 
@@ -26,10 +26,10 @@ export function BlockedVPN(): JSX.Element {
     function submit() {
         post("/firewall/report_vpn", { vpn_name: vpn })
             .then(() =>
-                swal(
+                alert.fire(
                     "Thank you",
-                    `Thank you for letting us know! You can sign up by disabling your VPN. Once you've signed up, you can turn your VPN back on to play on the site.`,
-                ).catch(swal.noop),
+                    "Thank you for letting us know! You can sign up by disabling your VPN. Once you've signed up, you can turn your VPN back on to play on the site.",
+                ),
             )
             .catch(errorAlerter);
     }

--- a/src/views/Firewall/Firewall.tsx
+++ b/src/views/Firewall/Firewall.tsx
@@ -22,7 +22,7 @@ import { post, put, del } from "requests";
 import { deepCompare, errorAlerter } from "misc";
 import { PaginatedTable } from "PaginatedTable";
 import { Player } from "Player";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 /*
 import { Card } from "material";
 import { SearchInput } from "misc-ui";
@@ -215,9 +215,7 @@ function FirewallRuleRow({
         put(`/firewall/rule/${firewall_rule.id}`, firewall_rule)
             .then(() => {
                 table_refresh();
-                swal("Saved")
-                    .then(() => 0)
-                    .catch(() => 0);
+                void alert.fire("Saved");
                 setMessage(null);
             })
             .catch((err: any) => {
@@ -232,19 +230,18 @@ function FirewallRuleRow({
     }
 
     function del_row() {
-        swal({
-            text: "Are you sure you want to delete this row?",
-            showCancelButton: true,
-            confirmButtonText: "Yes",
-            cancelButtonText: "Cancel",
-        })
+        alert
+            .fire({
+                text: "Are you sure you want to delete this row?",
+                showCancelButton: true,
+                confirmButtonText: "Yes",
+                cancelButtonText: "Cancel",
+            })
             .then(() => {
                 del(`/firewall/rule/${firewall_rule.id}`)
                     .then(() => {
                         table_refresh();
-                        swal("Deleted")
-                            .then(() => 0)
-                            .catch(() => 0);
+                        void alert.fire("Deleted");
                     })
                     .catch(errorAlerter);
             })

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -43,7 +43,7 @@ import {
     GobanCore,
 } from "goban";
 import { game_control } from "./game_control";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { GobanContext } from "./goban_context";
 
 export interface AIReviewEntry {
@@ -277,7 +277,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
         const user = data.get("user");
 
         if (user.anonymous) {
-            swal(_("Please sign in first")).catch(swal.noop);
+            void alert.fire(_("Please sign in first"));
         } else {
             if (user.supporter || user.professional || user.is_moderator) {
                 post(`games/${this.getGameId()}/ai_reviews`, {
@@ -286,7 +286,7 @@ export class AIReview extends React.Component<AIReviewProperties, AIReviewState>
                 })
                     .then((res) => {
                         sanityCheck(res);
-                        swal("Analysis started").catch(swal.noop);
+                        void alert.fire(_("Analysis started"));
                     })
                     .catch(errorAlerter);
             } else {

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -63,7 +63,7 @@ import {
 } from "./PlayControls";
 import { CancelButton } from "./PlayButtons";
 import { GameDock } from "./GameDock";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { useCurrentMove, useShowTitle, useTitle, useUserIsParticipant } from "./GameHooks";
 import { GobanContainer } from "GobanContainer";
 import { GobanContext } from "./goban_context";
@@ -439,7 +439,7 @@ export function Game(): JSX.Element {
     };
     const gameAnalyze = () => {
         if (goban.current.isAnalysisDisabled() && goban.current.engine.phase !== "finished") {
-            //swal(_("Analysis mode has been disabled for this game"));
+            //alert.fire(_("Analysis mode has been disabled for this game"));
         } else {
             const last_estimate_move = stopEstimatingScore();
 
@@ -590,7 +590,7 @@ export function Game(): JSX.Element {
     };
     const enterConditionalMovePlanner = () => {
         if (goban.current.isAnalysisDisabled() && goban.current.engine.phase !== "finished") {
-            //swal(_("Conditional moves have been disabled for this game."));
+            //alert.fire(_("Conditional moves have been disabled for this game."));
         } else {
             stashed_conditional_moves.current = goban.current.conditional_tree.duplicate();
             goban.current.setMode("conditional");
@@ -610,16 +610,19 @@ export function Game(): JSX.Element {
             goban.current.engine.phase !== "finished" &&
             is_player
         ) {
-            //swal(_("Analysis mode has been disabled for this game, you can start a review after the game has concluded."));
+            //alert.fire(_("Analysis mode has been disabled for this game, you can start a review after the game has concluded."));
         } else {
-            swal({
-                text: _("Start a review of this game?"),
-                showCancelButton: true,
-            })
-                .then(() => {
-                    post("games/%%/reviews", game_id, {})
-                        .then((res) => browserHistory.push(`/review/${res.id}`))
-                        .catch(errorAlerter);
+            alert
+                .fire({
+                    text: _("Start a review of this game?"),
+                    showCancelButton: true,
+                })
+                .then(({ value: accept }) => {
+                    if (accept) {
+                        post("games/%%/reviews", game_id, {})
+                            .then((res) => browserHistory.push(`/review/${res.id}`))
+                            .catch(errorAlerter);
+                    }
                 })
                 .catch(ignore);
         }

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -26,9 +26,9 @@ import { openACLModal } from "ACLModal";
 import { openGameLinkModal } from "./GameLinkModal";
 import { openGameLogModal } from "./GameLogModal";
 import { sfx } from "sfx";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { challengeFromBoardPosition } from "ChallengeModal/ForkModal";
-import { errorAlerter, ignore } from "misc";
+import { errorAlerter } from "misc";
 import { openReport } from "Report";
 import { game_control } from "./game_control";
 import { openGameInfoModal } from "./GameInfoModal";
@@ -194,11 +194,11 @@ export function GameDock({
         }
 
         if (!obj.reported_user_id) {
-            swal(
+            void alert.fire(
                 _(
                     'Please report the player that is a problem by clicking on their name and selecting "Report".',
                 ),
-            ).catch(swal.noop);
+            );
         } else {
             openReport(obj);
         }
@@ -207,7 +207,7 @@ export function GameDock({
     // Mod Functions
     const decide = (winner: string): void => {
         if (!game_id) {
-            swal(_("Game ID missing")).catch(swal.noop);
+            void alert.fire(_("Game ID missing"));
             return;
         }
 
@@ -230,7 +230,7 @@ export function GameDock({
     const decide_tie = () => decide("tie");
     const force_autoscore = () => {
         if (!game_id) {
-            swal(_("Game ID missing")).catch(swal.noop);
+            void alert.fire(_("Game ID missing"));
             return;
         }
 
@@ -250,7 +250,7 @@ export function GameDock({
     };
     const do_annul = (tf: boolean): void => {
         if (!game_id) {
-            swal(_("Game ID missing")).catch(swal.noop);
+            void alert.fire(_("Game ID missing"));
             return;
         }
 
@@ -274,9 +274,9 @@ export function GameDock({
         })
             .then(() => {
                 if (tf) {
-                    swal({ text: _("Game has been annulled") }).catch(swal.noop);
+                    void alert.fire({ text: _("Game has been annulled") });
                 } else {
-                    swal({ text: _("Game ranking has been restored") }).catch(swal.noop);
+                    void alert.fire({ text: _("Game ranking has been restored") });
                 }
                 onGameAnnulled(tf);
             })
@@ -301,24 +301,26 @@ export function GameDock({
         );
     };
     const delete_ai_reviews = () => {
-        swal({
-            text: _("Really clear ALL AI reviews for this game?"),
-            showCancelButton: true,
-        })
-            .then(() => {
-                console.info(`Clearing AI reviews for ${game_id}`);
-                del(`games/${game_id}/ai_reviews`, {})
-                    .then(() => console.info("AI Reviews cleared"))
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Really clear ALL AI reviews for this game?"),
+                showCancelButton: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    console.info(`Clearing AI reviews for ${game_id}`);
+                    del(`games/${game_id}/ai_reviews`, {})
+                        .then(() => console.info("AI Reviews cleared"))
+                        .catch(errorAlerter);
+                }
+            });
     };
     const force_ai_review = (analysis_type: "fast" | "full") => {
         post(`games/${game_id}/ai_reviews`, {
             engine: "katago",
             type: analysis_type,
         })
-            .then(() => swal(_("Analysis started")))
+            .then(() => void alert.fire(_("Analysis started")))
             .catch(errorAlerter);
     };
 
@@ -448,7 +450,7 @@ export function GameDock({
                 <a
                     className="disabled"
                     onClick={() =>
-                        swal(
+                        void alert.fire(
                             _(
                                 "SGF downloading for this game is disabled until the game is complete.",
                             ),

--- a/src/views/Game/GameInfoModal.tsx
+++ b/src/views/Game/GameInfoModal.tsx
@@ -24,10 +24,10 @@ import { openModal, Modal, ModalConstructorInput } from "Modal";
 import { timeControlDescription } from "TimeControl";
 import { Player } from "Player";
 import { handicapText } from "GameAcceptModal";
-import { errorAlerter, ignore, rulesText, yesno, getGameResultText } from "misc";
+import { errorAlerter, rulesText, yesno, getGameResultText } from "misc";
 import { rankString } from "rank_utils";
 import { browserHistory } from "ogsHistory";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { GobanConfig, GoEnginePlayerEntry } from "goban";
 
 interface Events {}
@@ -90,21 +90,23 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, {}> {
         const review_id = this.props.config.review_id;
 
         if (review_id) {
-            swal({
-                text: _("Are you sure you wish to delete this board?"),
-                showCancelButton: true,
-            })
-                .then(() => {
-                    console.log("Should be deleting");
-
-                    del(`reviews/${review_id}`)
-                        .then(() => {
-                            this.close();
-                            console.log(browserHistory.back());
-                        })
-                        .catch(errorAlerter);
+            void alert
+                .fire({
+                    text: _("Are you sure you wish to delete this board?"),
+                    showCancelButton: true,
                 })
-                .catch(ignore);
+                .then(({ value: accept }) => {
+                    if (accept) {
+                        console.log("Should be deleting");
+
+                        del(`reviews/${review_id}`)
+                            .then(() => {
+                                this.close();
+                                console.log(browserHistory.back());
+                            })
+                            .catch(errorAlerter);
+                    }
+                });
         }
     };
 

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -22,7 +22,7 @@ import { isLiveGame } from "TimeControl";
 import * as preferences from "preferences";
 import * as data from "data";
 import { game_control } from "./game_control";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { useCurrentMoveNumber, usePlayerToMove, useShowUndoRequested } from "./GameHooks";
 import { useGoban } from "./goban_context";
 
@@ -95,9 +95,13 @@ export function PlayButtons({ show_cancel = true }: PlayButtonsProps): JSX.Eleme
 
     const pass = () => {
         if (!isLiveGame(goban.engine.time_control) || !preferences.get("one-click-submit-live")) {
-            swal({ text: _("Are you sure you want to pass?"), showCancelButton: true })
-                .then(() => goban.pass())
-                .catch(() => 0);
+            void alert
+                .fire({ text: _("Are you sure you want to pass?"), showCancelButton: true })
+                .then(({ value: accept }) => {
+                    if (accept) {
+                        goban.pass();
+                    }
+                });
         } else {
             goban.pass();
         }
@@ -199,15 +203,19 @@ export function CancelButton({ className = "" }: CancelButtonProps) {
                 : _("Are you sure you wish to resign this game?");
         const cb = resign_mode === "cancel" ? () => goban.cancelGame() : () => goban.resign();
 
-        swal({
-            text: text,
-            confirmButtonText: _("Yes"),
-            cancelButtonText: _("No"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(cb)
-            .catch(swal.noop);
+        void alert
+            .fire({
+                text: text,
+                confirmButtonText: _("Yes"),
+                cancelButtonText: _("No"),
+                showCancelButton: true,
+                focusCancel: true,
+            })
+            .then(({ value: accept }) => {
+                if (accept) {
+                    cb();
+                }
+            });
     };
 
     return (

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -29,7 +29,7 @@ import {
     PlayerColor,
 } from "goban";
 import device from "device";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { challengeRematch } from "ChallengeModal";
 import { Clock } from "Clock";
 import { getOutcomeTranslation } from "misc";
@@ -249,9 +249,16 @@ export function PlayControls({
         );
     };
     const onStoneRemovalCancel = () => {
-        swal({ text: _("Are you sure you want to resume the game?"), showCancelButton: true })
-            .then(() => goban.rejectRemovedStones())
-            .catch(() => 0);
+        void alert
+            .fire({
+                text: _("Are you sure you want to resume the game?"),
+                showCancelButton: true,
+            })
+            .then(({ value: accept }) => {
+                if (accept) {
+                    goban.rejectRemovedStones();
+                }
+            });
         return false;
     };
     const onStoneRemovalAccept = () => {
@@ -975,21 +982,23 @@ export function deleteBranch(goban: Goban, mode: GobanModes) {
     }
 
     if (goban.engine.cur_move.trunk) {
-        swal({
+        void alert.fire({
             text: _(
                 "The current position is not an explored branch, so there is nothing to delete",
             ),
-        }).catch(swal.noop);
+        });
     } else {
-        swal({
-            text: _("Are you sure you wish to remove this move branch?"),
-            showCancelButton: true,
-        })
-            .then(() => {
-                goban.deleteBranch();
-                goban.syncReviewMove();
+        void alert
+            .fire({
+                text: _("Are you sure you wish to remove this move branch?"),
+                showCancelButton: true,
             })
-            .catch(() => 0);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    goban.deleteBranch();
+                    goban.syncReviewMove();
+                }
+            });
     }
 }
 

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -37,7 +37,7 @@ import * as moment from "moment";
 import { PlayerAutocomplete } from "PlayerAutocomplete";
 import { EmbeddedChatCard } from "Chat";
 import { localize_time_strings } from "localize-time";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { PlayerCacheEntry } from "player_cache";
 import { is_valid_url } from "url_validation";
 
@@ -270,12 +270,13 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
         browserHistory.push(`/tournament/new/${this.state.group_id}`);
     };
     createTournamentRecord = () => {
-        swal({
-            text: _("Tournament Name"),
-            input: "text",
-            showCancelButton: true,
-        })
-            .then((name) => {
+        alert
+            .fire({
+                text: _("Tournament Name"),
+                input: "text",
+                showCancelButton: true,
+            })
+            .then(({ value: name }) => {
                 if (!name) {
                     return;
                 }
@@ -340,14 +341,16 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
     };
     postNewNews = () => {
         if (this.state.new_news_title.trim().length < 5) {
-            swal({ title: _("Please provide a title") })
+            alert
+                .fire({ title: _("Please provide a title") })
                 .then(() => this.ref_new_news_title.current.focus())
                 .catch(errorAlerter);
             this.ref_new_news_title.current.focus();
             return;
         }
         if (this.state.new_news_body.trim().length < 16) {
-            swal({ title: _("Please provide more content for your news") })
+            alert
+                .fire({ title: _("Please provide more content for your news") })
                 .then(() => this.ref_new_news_body.current.focus())
                 .catch(errorAlerter);
             this.ref_new_news_body.current.focus();
@@ -380,29 +383,31 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
         }, 1);
     };
     deleteNewsPost(entry) {
-        swal({
-            text: _("Delete this news post?"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                post("group/%%/news/", this.state.group_id, {
-                    id: entry.id,
-                    delete: true,
-                })
-                    .then(() => {
-                        this.news_ref.current?.refresh();
-                        /* Since the removal of the refs I don't think we need to worry about this? - anoek 2021-12-23
-                if (this.refs.news) {
-                    this.setState({news_refresh: Date.now()});
-                } else {
-                    this.resolve(this.state.group_id);
-                }
-                */
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Delete this news post?"),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    post("group/%%/news/", this.state.group_id, {
+                        id: entry.id,
+                        delete: true,
+                    })
+                        .then(() => {
+                            this.news_ref.current?.refresh();
+                            /* Since the removal of the refs I don't think we need to worry about this? - anoek 2021-12-23
+                    if (this.refs.news) {
+                        this.setState({news_refresh: Date.now()});
+                    } else {
+                        this.resolve(this.state.group_id);
+                    }
+                    */
+                        })
+                        .catch(errorAlerter);
+                }
+            });
     }
     editNewsPost(entry) {
         this.setState({ editing_news: entry });
@@ -1133,72 +1138,80 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
     };
 
     deleteGroup = () => {
-        swal({
-            text: _("Are you SURE you want to delete this group? This action is irreversible."),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                del("groups/%%", this.state.group.id)
-                    .then(() => {
-                        browserHistory.push("/groups/");
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Are you SURE you want to delete this group? This action is irreversible."),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    del("groups/%%", this.state.group.id)
+                        .then(() => {
+                            browserHistory.push("/groups/");
+                        })
+                        .catch(errorAlerter);
+                }
+            });
     };
 
     makeAdmin(player_id: number) {
-        swal({
-            text: _("Are you sure you wish to make this user an administrator of the group?"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                put("groups/%%/members", this.state.group_id, {
-                    player_id: player_id,
-                    is_admin: true,
-                })
-                    .then(() => this.resolve(this.state.group_id))
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Are you sure you wish to make this user an administrator of the group?"),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(() => 0);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    put("groups/%%/members", this.state.group_id, {
+                        player_id: player_id,
+                        is_admin: true,
+                    })
+                        .then(() => this.resolve(this.state.group_id))
+                        .catch(errorAlerter);
+                }
+            });
         close_all_popovers();
     }
     unAdmin(player_id: number) {
-        swal({
-            text: _("Are you sure you wish to remove administrator privileges from this user?"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                put("groups/%%/members", this.state.group_id, {
-                    player_id: player_id,
-                    is_admin: false,
-                })
-                    .then(() => this.resolve(this.state.group_id))
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Are you sure you wish to remove administrator privileges from this user?"),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(() => 0);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    put("groups/%%/members", this.state.group_id, {
+                        player_id: player_id,
+                        is_admin: false,
+                    })
+                        .then(() => this.resolve(this.state.group_id))
+                        .catch(errorAlerter);
+                }
+            });
         close_all_popovers();
     }
     kick(player_id: number) {
-        swal({
-            text: _("Are you sure you wish to remove this user from the group?"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                post("groups/%%/members", this.state.group_id, {
-                    delete: true,
-                    player_id: player_id,
-                })
-                    .then(() => {
-                        this.resolve(this.state.group_id);
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Are you sure you wish to remove this user from the group?"),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(() => 0);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    post("groups/%%/members", this.state.group_id, {
+                        delete: true,
+                        player_id: player_id,
+                    })
+                        .then(() => {
+                            this.resolve(this.state.group_id);
+                        })
+                        .catch(errorAlerter);
+                }
+            });
         close_all_popovers();
     }
 }

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -27,7 +27,7 @@ import { shouldOpenNewTab } from "misc";
 import { PlayerAutocomplete } from "PlayerAutocomplete";
 import { close_all_popovers, popover } from "popover";
 import { browserHistory } from "ogsHistory";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { RouteComponentProps, rr6ClassShim } from "ogs-rr6-shims";
 import { IdType } from "src/lib/types";
 
@@ -100,15 +100,16 @@ class _Ladder extends React.PureComponent<LadderProperties, LadderState> {
     };
 
     leave = () => {
-        swal({
-            text: _(
-                "Are you sure you want to withdraw from the ladder? If you decide to rejoin the ladder in the future you will have to start from the bottom!",
-            ),
-            showCancelButton: true,
-            confirmButtonText: _("Yes"),
-            cancelButtonText: _("No"),
-            focusCancel: true,
-        })
+        alert
+            .fire({
+                text: _(
+                    "Are you sure you want to withdraw from the ladder? If you decide to rejoin the ladder in the future you will have to start from the bottom!",
+                ),
+                showCancelButton: true,
+                confirmButtonText: _("Yes"),
+                cancelButtonText: _("No"),
+                focusCancel: true,
+            })
             .then(() => {
                 del("ladders/%%/players", this.props.match.params.ladder_id)
                     .then(() => {
@@ -461,11 +462,12 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
     adjustLadderPosition(player) {
         console.log(player);
 
-        swal({
-            text: "New ladder position for player " + player.username,
-            input: "number",
-            showCancelButton: true,
-        })
+        alert
+            .fire({
+                text: "New ladder position for player " + player.username,
+                input: "number",
+                showCancelButton: true,
+            })
             .then((new_rank) => {
                 put("ladders/%%/players/moderate", this.props.ladder.props.match.params.ladder_id, {
                     moderation_note: "Adjusting ladder position",
@@ -596,17 +598,18 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
     };
 
     challenge(ladder_player) {
-        swal({
-            text: interpolate(
-                _(
-                    "Are you ready to start your game with {{player_name}}?",
-                ) /* translators: ladder challenge */,
-                { player_name: ladder_player.player.username },
-            ),
-            showCancelButton: true,
-            confirmButtonText: _("Yes!"),
-            cancelButtonText: _("No"),
-        })
+        alert
+            .fire({
+                text: interpolate(
+                    _(
+                        "Are you ready to start your game with {{player_name}}?",
+                    ) /* translators: ladder challenge */,
+                    { player_name: ladder_player.player.username },
+                ),
+                showCancelButton: true,
+                confirmButtonText: _("Yes!"),
+                cancelButtonText: _("No"),
+            })
             .then(() => {
                 post(
                     "ladders/%%/players/challenge",

--- a/src/views/LearningHub/LearningHub.tsx
+++ b/src/views/LearningHub/LearningHub.tsx
@@ -26,7 +26,7 @@ import { getSectionCompletion, getSectionByName } from "./util";
 import { ignore } from "misc";
 import { browserHistory } from "ogsHistory";
 import { MiniGoban } from "MiniGoban";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 interface LearningHubParams {
     section: string;
@@ -259,10 +259,11 @@ class SectionNav extends React.Component<{}, any> {
     }
 
     resetProgress = () => {
-        swal({
-            text: _("Are you sure you wish to reset your tutorial progress?"),
-            showCancelButton: true,
-        })
+        alert
+            .fire({
+                text: _("Are you sure you wish to reset your tutorial progress?"),
+                showCancelButton: true,
+            })
             .then(() => {
                 data.removePrefix("learning-hub.");
                 browserHistory.push("/learn-to-play-go");

--- a/src/views/Moderator/ban_functions.tsx
+++ b/src/views/Moderator/ban_functions.tsx
@@ -19,21 +19,23 @@ import * as React from "react";
 import { BanModal } from "BanModal";
 import { openModal } from "Modal";
 import { post, put } from "requests";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 function moderate(player_id, prompt, obj) {
     return new Promise((resolve, reject) => {
-        swal({
-            text: prompt,
-            input: "text",
-            showCancelButton: true,
-        }).then((reason) => {
-            obj.moderation_note = reason;
-            console.log(obj);
-            put("players/" + player_id + "/moderate", obj)
-                .then(resolve)
-                .catch(reject);
-        }, reject);
+        alert
+            .fire({
+                text: prompt,
+                input: "text",
+                showCancelButton: true,
+            })
+            .then((reason) => {
+                obj.moderation_note = reason;
+                console.log(obj);
+                put("players/" + player_id + "/moderate", obj)
+                    .then(resolve)
+                    .catch(reject);
+            }, reject);
     });
 }
 

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -37,7 +37,7 @@ import { bot_count } from "bots";
 import { SupporterGoals } from "SupporterGoals";
 import { CreatedChallengeInfo } from "types";
 
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { Size } from "src/lib/types";
 
 import { RengoManagementPane } from "RengoManagementPane";
@@ -309,7 +309,7 @@ export class Play extends React.Component<{}, PlayState> {
 
     newComputerGame = () => {
         if (bot_count() === 0) {
-            swal(_("Sorry, all bots seem to be offline, please try again later.")).catch(swal.noop);
+            void alert.fire(_("Sorry, all bots seem to be offline, please try again later."));
             return;
         }
         challengeComputer();
@@ -412,20 +412,20 @@ export class Play extends React.Component<{}, PlayState> {
     };
 
     startOwnRengoChallenge = (the_challenge: Challenge) => {
-        swal({
+        void alert.fire({
             text: "Starting...",
-            type: "info",
+            icon: "info",
             showCancelButton: false,
             showConfirmButton: false,
             allowEscapeKey: false,
-        }).catch(swal.noop);
+        });
 
         post("challenges/%%/start", the_challenge.challenge_id, {})
             .then(() => {
-                swal.close();
+                alert.close();
             })
             .catch((err) => {
-                swal.close();
+                alert.close();
                 errorAlerter(err);
             });
     };
@@ -1040,22 +1040,22 @@ export class Play extends React.Component<{}, PlayState> {
     }
 
     unNominateForRengoChallenge = (C: Challenge) => {
-        swal({
+        void alert.fire({
             text: _("Withdrawing..."), // translator: the server is processing their request to withdraw from a rengo challenge
-            type: "info",
+            icon: "info",
             showCancelButton: false,
             showConfirmButton: false,
             allowEscapeKey: false,
-        }).catch(swal.noop);
+        });
 
         this.closeChallengeManagementPane(C.challenge_id);
 
         del("challenges/%%/join", C.challenge_id, {})
             .then(() => {
-                swal.close();
+                alert.close();
             })
             .catch((err) => {
-                swal.close();
+                alert.close();
                 errorAlerter(err);
             });
     };

--- a/src/views/Play/util.ts
+++ b/src/views/Play/util.ts
@@ -16,27 +16,27 @@
  */
 
 import type { Challenge } from "./Play";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { put } from "requests";
 import { errorAlerter } from "misc";
 import { _ } from "translate";
 
 // This is used by the SeekGraph to perform this function as well as this page...
 export function nominateForRengoChallenge(C: Challenge) {
-    swal({
+    void alert.fire({
         text: _("Joining..."), // translator: the server is processing their request to join a rengo game
-        type: "info",
+        icon: "info",
         showCancelButton: false,
         showConfirmButton: false,
         allowEscapeKey: false,
-    }).catch(swal.noop);
+    });
 
     put("challenges/%%/join", C.challenge_id, {})
         .then(() => {
-            swal.close();
+            alert.close();
         })
         .catch((err: any) => {
-            swal.close();
+            alert.close();
             errorAlerter(err);
         });
 }

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -36,7 +36,7 @@ import { TransformSettings, PuzzleTransform } from "./PuzzleTransform";
 import { PuzzleNavigation } from "./PuzzleNavigation";
 import { PuzzleEditor } from "./PuzzleEditing";
 import { GobanContainer } from "GobanContainer";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 type PuzzleProperties = RouteComponentProps<{ puzzle_id: string }>;
 
@@ -478,18 +478,17 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                 }),
             });
         } else if (ev.target.value === "new") {
-            swal({
-                text: _("Collection name"),
-                input: "text",
-                showCancelButton: true,
-            })
-                .then((name) => {
+            void alert
+                .fire({
+                    text: _("Collection name"),
+                    input: "text",
+                    showCancelButton: true,
+                })
+                .then(({ value: name }) => {
                     if (!name || name.length < 5) {
-                        swal({
+                        void alert.fire({
                             text: _("Please provide a longer name for your new puzzle collection"),
-                        })
-                            .then(ignore)
-                            .catch(ignore);
+                        });
                         return;
                     }
 
@@ -497,8 +496,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                         .createPuzzleCollection(this.state.puzzle, name)
                         .then((state) => this.setState(state))
                         .catch(errorAlerter);
-                })
-                .catch(ignore);
+                });
         }
     };
     setSetupStep = () => {
@@ -611,20 +609,22 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
         this.forceUpdate();
     };
     deletePuzzle = () => {
-        swal({
-            text: _("Are you sure you want to delete this puzzle?"),
-            showCancelButton: true,
-        })
-            .then(() => {
-                del("puzzles/%%", +this.props.match.params.puzzle_id)
-                    .then(() =>
-                        browserHistory.push(
-                            `/puzzle-collection/${this.state.puzzle.puzzle_collection}`,
-                        ),
-                    )
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Are you sure you want to delete this puzzle?"),
+                showCancelButton: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    del("puzzles/%%", +this.props.match.params.puzzle_id)
+                        .then(() =>
+                            browserHistory.push(
+                                `/puzzle-collection/${this.state.puzzle.puzzle_collection}`,
+                            ),
+                        )
+                        .catch(errorAlerter);
+                }
+            });
     };
 
     showHint = () => {

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -18,11 +18,11 @@
 import * as React from "react";
 import * as data from "data";
 import { _, pgettext } from "translate";
-import { ignore, errorAlerter, navigateTo } from "misc";
+import { errorAlerter, navigateTo } from "misc";
 import { get, del, put, abort_requests_in_flight } from "requests";
 import { SortablePuzzleList } from "./SortablePuzzleList";
 import { openACLModal } from "ACLModal";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { useParams } from "react-router-dom";
 
 export function PuzzleCollection(): JSX.Element {
@@ -167,23 +167,25 @@ export function PuzzleCollection(): JSX.Element {
             position_transform_enabled: position_transform_enabled,
         })
             .then(() => {
-                swal("Changes saved").then(ignore).catch(ignore);
+                void alert.fire("Changes saved");
             })
             .catch(errorAlerter);
     }
 
     function remove() {
-        swal({
-            text: _("Are you sure you wish to remove this puzzle collection?"),
-            showCancelButton: true,
-        })
-            .then(() => {
-                del(`puzzles/collections/${collection_id}`)
-                    .then(() => {
-                        window.location.pathname = "/puzzle-collections/" + data.get("user").id;
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Are you sure you wish to remove this puzzle collection?"),
+                showCancelButton: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    del(`puzzles/collections/${collection_id}`)
+                        .then(() => {
+                            window.location.pathname = "/puzzle-collections/" + data.get("user").id;
+                        })
+                        .catch(errorAlerter);
+                }
+            });
     }
 }

--- a/src/views/PuzzleCollection/PuzzleCollectionList.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollectionList.tsx
@@ -19,13 +19,13 @@ import * as React from "react";
 import * as moment from "moment";
 import { _ } from "translate";
 import { post } from "requests";
-import { ignore, errorAlerter, navigateTo, unitify } from "misc";
+import { errorAlerter, navigateTo, unitify } from "misc";
 import { PaginatedTable } from "PaginatedTable";
 import { longRankString, rankString } from "rank_utils";
 import { StarRating } from "StarRating";
 import { Player } from "Player";
 import { MiniGoban } from "MiniGoban";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { useParams } from "react-router";
 
 export function PuzzleCollectionList(): JSX.Element {
@@ -151,16 +151,18 @@ export function PuzzleCollectionList(): JSX.Element {
     );
 
     function newPuzzleCollection() {
-        swal({
-            text: _("Collection name"),
-            input: "text",
-            showCancelButton: true,
-        })
-            .then((name) => {
+        void alert
+            .fire({
+                text: _("Collection name"),
+                input: "text",
+                showCancelButton: true,
+            })
+            .then((res) => {
+                const name = res.value;
                 if (!name || name.length < 5) {
-                    swal({ text: _("Please provide a longer name for your new puzzle collection") })
-                        .then(ignore)
-                        .catch(ignore);
+                    void alert.fire({
+                        text: _("Please provide a longer name for your new puzzle collection"),
+                    });
                     return;
                 }
 
@@ -173,7 +175,6 @@ export function PuzzleCollectionList(): JSX.Element {
                         navigateTo(`/puzzle-collection/${res.id}`);
                     })
                     .catch(errorAlerter);
-            })
-            .catch(ignore);
+            });
     }
 }

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -25,7 +25,7 @@ import { post, get, put, del, getCookie } from "requests";
 import { errorAlerter, errorLogger, ignore } from "misc";
 
 import { SocialLoginButtons } from "SocialLoginButtons";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 import { SettingGroupProps } from "SettingsCommon";
 
@@ -89,23 +89,26 @@ export function AccountSettings(props: SettingGroupProps): JSX.Element {
                 .then(() => {
                     props.refresh();
                     refreshAccountSettings();
-                    swal(_("Password updated successfully!")).catch(swal.noop);
+                    void alert.fire(_("Password updated successfully!"));
                 })
                 .catch(errorAlerter);
         } else {
-            swal({
-                text: _("Enter your current password"),
-                input: "password",
-            })
-                .then((password) => {
-                    post("/api/v0/changePassword", {
-                        old_password: password,
-                        new_password: password1,
-                    })
-                        .then(() => {
-                            swal(_("Password updated successfully!")).catch(swal.noop);
+            alert
+                .fire({
+                    text: _("Enter your current password"),
+                    input: "password",
+                })
+                .then(({ value: password }) => {
+                    if (password) {
+                        post("/api/v0/changePassword", {
+                            old_password: password,
+                            new_password: password1,
                         })
-                        .catch(errorAlerter);
+                            .then(() => {
+                                void alert.fire(_("Password updated successfully!"));
+                            })
+                            .catch(errorAlerter);
+                    }
                 })
                 .catch(errorAlerter);
         }
@@ -114,9 +117,9 @@ export function AccountSettings(props: SettingGroupProps): JSX.Element {
     function resendValidationEmail() {
         post("me/validateEmail", {})
             .then(() => {
-                swal(
+                void alert.fire(
                     "Validation email sent! Please check your email and click the validation link.",
-                ).catch(swal.noop);
+                );
             })
             .catch(errorAlerter);
     }
@@ -154,21 +157,28 @@ export function AccountSettings(props: SettingGroupProps): JSX.Element {
         if (user && user.id) {
             if (!settings.password_is_set) {
                 // social auth account
-                swal({
-                    text: _("Are you sure you want to delete this account? This cannot be undone."),
-                    showCancelButton: true,
-                })
-                    .then(() => {
-                        doDel(null);
+                void alert
+                    .fire({
+                        text: _(
+                            "Are you sure you want to delete this account? This cannot be undone.",
+                        ),
+                        showCancelButton: true,
                     })
-                    .catch(ignore);
+                    .then(({ value: accept }) => {
+                        if (accept) {
+                            doDel(null);
+                        }
+                    });
             } else {
-                swal({
-                    text: _("Enter your current password"),
-                    input: "password",
-                })
-                    .then((password) => {
-                        doDel(password);
+                alert
+                    .fire({
+                        text: _("Enter your current password"),
+                        input: "password",
+                    })
+                    .then(({ value: password }) => {
+                        if (password) {
+                            doDel(password);
+                        }
                     })
                     .catch(errorAlerter);
             }

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -29,7 +29,7 @@ import { Md5 } from "ts-md5/dist/md5";
 import { SocialLoginButtons } from "SocialLoginButtons";
 
 window["Md5"] = Md5;
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 export function get_bid() {
     const bid = data.get("bid") || `${Math.random()}`.split(".")[1];
@@ -159,18 +159,19 @@ export class SignIn extends React.PureComponent<{}, any> {
     }
 
     resetPassword = () => {
-        swal({
-            text: _("What is your username?"),
-            input: "text",
-            showCancelButton: true,
-        })
+        alert
+            .fire({
+                text: _("What is your username?"),
+                input: "text",
+                showCancelButton: true,
+            })
             .then((username) => {
                 post("/api/v0/reset", { username: username })
                     .then((res) => {
                         if (res.success) {
-                            swal(
+                            void alert.fire(
                                 _("An email with your new password has been emailed to you."),
-                            ).catch(swal.noop);
+                            );
                         } else {
                             console.error(res);
                             errorAlerter(res);

--- a/src/views/Styling/Styling.tsx
+++ b/src/views/Styling/Styling.tsx
@@ -30,7 +30,7 @@ import { Markdown } from "Markdown";
 import { Steps } from "Steps";
 import { errcodeAlerter } from "ErrcodeModal";
 import * as moment from "moment";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 export class Styling extends React.PureComponent<{}, any> {
     ccinput = null;
@@ -532,17 +532,17 @@ function bigtoast() {
         <div>
             <h1>Big stuff</h1>
             is comming to a place near you!
-            <button onClick={() => swal("HI")}> Click me </button>
+            <button onClick={() => alert.fire("HI")}> Click me </button>
         </div>,
     ).on("close", () => {
         console.log("Toast closed");
     });
 }
 function swal_popup() {
-    swal({
+    void alert.fire({
         title: "Title here",
         text: "Some text here",
         input: "text",
         showCancelButton: true,
-    }).catch(swal.noop);
+    });
 }

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -46,7 +46,7 @@ import { computeAverageMoveTime, GoEngineRules } from "goban";
 import { openMergeReportModal } from "MergeReportModal";
 import * as d3 from "d3";
 import Dropzone from "react-dropzone";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 let logspam_debounce: any;
 
@@ -438,47 +438,53 @@ class _Tournament extends React.PureComponent<TournamentProperties, TournamentSt
     };
 
     startTournament = () => {
-        swal({
-            text: _("Start this tournament now?"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                post("tournaments/%%/start", this.state.tournament.id, {})
-                    .then(ignore)
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Start this tournament now?"),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    post("tournaments/%%/start", this.state.tournament.id, {})
+                        .then(ignore)
+                        .catch(errorAlerter);
+                }
+            });
     };
     deleteTournament = () => {
-        swal({
-            text: _("Delete this tournament?"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                del("tournaments/%%", this.state.tournament.id)
-                    .then(() => {
-                        browserHistory.push("/");
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("Delete this tournament?"),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    del("tournaments/%%", this.state.tournament.id)
+                        .then(() => {
+                            browserHistory.push("/");
+                        })
+                        .catch(errorAlerter);
+                }
+            });
     };
     endTournament = () => {
-        swal({
-            text: _("End this tournament?"),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                post("tournaments/%%/end", this.state.tournament.id, {})
-                    .then(() => {
-                        this.reloadTournament();
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: _("End this tournament?"),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    post("tournaments/%%/end", this.state.tournament.id, {})
+                        .then(() => {
+                            this.reloadTournament();
+                        })
+                        .catch(errorAlerter);
+                }
+            });
     };
     setUserToInvite = (user) => {
         this.setState({ user_to_invite: user });
@@ -518,14 +524,19 @@ class _Tournament extends React.PureComponent<TournamentProperties, TournamentSt
             .catch(errorAlerter);
     };
     resign = () => {
-        swal({
-            text: _(
-                "Are you sure you want to resign from the tournament? This will also resign you from all games you are playing in this tournament.",
-            ),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(this.partTournament)
+        alert
+            .fire({
+                text: _(
+                    "Are you sure you want to resign from the tournament? This will also resign you from all games you are playing in this tournament.",
+                ),
+                showCancelButton: true,
+                focusCancel: true,
+            })
+            .then(({ value: accept }) => {
+                if (accept) {
+                    this.partTournament;
+                }
+            })
             .catch(errorAlerter);
     };
     updateEliminationTrees() {
@@ -936,7 +947,7 @@ class _Tournament extends React.PureComponent<TournamentProperties, TournamentSt
                 }
             }
             if (not_laid_out) {
-                swal("Warning: " + not_laid_out + " matches not laid out").catch(swal.noop);
+                void alert.fire("Warning: " + not_laid_out + " matches not laid out");
             }
 
             const svg = d3.select(elimination_tree);
@@ -1211,27 +1222,25 @@ class _Tournament extends React.PureComponent<TournamentProperties, TournamentSt
 
         if (tournament.name.length < 5) {
             this.ref_tournament_name.current.focus();
-            swal(_("Please provide a name for the tournament")).catch(swal.noop);
+            void alert.fire(_("Please provide a name for the tournament"));
             return;
         }
 
         if (tournament.description.length < 5) {
             this.ref_description.current.focus();
-            swal(_("Please provide a description for the tournament")).catch(swal.noop);
+            void alert.fire(_("Please provide a description for the tournament"));
             return;
         }
 
         const max_players = parseInt(tournament.settings.maximum_players);
         if (max_players > 10 && tournament.tournament_type === "roundrobin") {
             this.ref_max_players.current.focus();
-            swal(_("Round Robin tournaments are limited to a maximum of 10 players")).catch(
-                swal.noop,
-            );
+            void alert.fire(_("Round Robin tournaments are limited to a maximum of 10 players"));
             return;
         }
         if (max_players < 2) {
             this.ref_max_players.current.focus();
-            swal(_("You need at least two players in a tournament")).catch(swal.noop);
+            void alert.fire(_("You need at least two players in a tournament"));
             return;
         }
 
@@ -3126,39 +3135,42 @@ class _Tournament extends React.PureComponent<TournamentProperties, TournamentSt
     kick(player_id: number) {
         const user = player_cache.lookup(player_id);
 
-        swal({
-            text: interpolate(_("Really kick {{user}} from the tournament?"), {
-                user: user.username,
-            }),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                post("tournaments/%%/players", this.state.tournament.id, {
-                    delete: true,
-                    player_id: user.id,
-                })
-                    .then(ignore)
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: interpolate(_("Really kick {{user}} from the tournament?"), {
+                    user: user.username,
+                }),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    post("tournaments/%%/players", this.state.tournament.id, {
+                        delete: true,
+                        player_id: user.id,
+                    })
+                        .then(ignore)
+                        .catch(errorAlerter);
+                }
+            });
 
         close_all_popovers();
     }
     adjustPoints(player_id: number) {
         const user = player_cache.lookup(player_id);
 
-        swal({
-            input: "number",
-            text: interpolate(
-                pgettext("How may tournament points to adjust a user by", "Adjustment for %s"),
-                [user.username],
-            ),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then((val) => {
-                const v = parseInt(val);
+        alert
+            .fire({
+                input: "number",
+                text: interpolate(
+                    pgettext("How may tournament points to adjust a user by", "Adjustment for %s"),
+                    [user.username],
+                ),
+                showCancelButton: true,
+                focusCancel: true,
+            })
+            .then(({ value }) => {
+                const v = parseInt(value);
                 if (!v) {
                     return;
                 }
@@ -3178,19 +3190,21 @@ class _Tournament extends React.PureComponent<TournamentProperties, TournamentSt
     disqualify(player_id: number) {
         const user = player_cache.lookup(player_id);
 
-        swal({
-            text: interpolate(_("Really disqualify {{user}}?"), { user: user.username }),
-            showCancelButton: true,
-            focusCancel: true,
-        })
-            .then(() => {
-                put("tournaments/%%/players", this.state.tournament.id, {
-                    disqualify: user.id,
-                })
-                    .then(ignore)
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                text: interpolate(_("Really disqualify {{user}}?"), { user: user.username }),
+                showCancelButton: true,
+                focusCancel: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    put("tournaments/%%/players", this.state.tournament.id, {
+                        disqualify: user.id,
+                    })
+                        .then(ignore)
+                        .catch(errorAlerter);
+                }
+            });
 
         close_all_popovers();
     }
@@ -3296,23 +3310,25 @@ function OpenGothaTournamentRound({
 
     function startRound() {
         console.log("ok");
-        swal({
-            text: interpolate(
-                pgettext(
-                    "Start the tournament round now? Leave {{num}} as it is, it is a placeholder for the round number.",
-                    "Start round {{num}} now?",
+        void alert
+            .fire({
+                text: interpolate(
+                    pgettext(
+                        "Start the tournament round now? Leave {{num}} as it is, it is a placeholder for the round number.",
+                        "Start round {{num}} now?",
+                    ),
+                    { num: selectedRound },
                 ),
-                { num: selectedRound },
-            ),
-            showCancelButton: true,
-            //focusCancel: true
-        })
-            .then(() => {
-                post(`tournaments/${tournament.id}/rounds/${selectedRound}/start`)
-                    .then(ignore)
-                    .catch(errorAlerter);
+                showCancelButton: true,
+                //focusCancel: true
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    post(`tournaments/${tournament.id}/rounds/${selectedRound}/start`)
+                        .then(ignore)
+                        .catch(errorAlerter);
+                }
+            });
     }
 
     const selected_round = rounds[selectedRound - 1];

--- a/src/views/TournamentRecord/TournamentRecord.tsx
+++ b/src/views/TournamentRecord/TournamentRecord.tsx
@@ -28,7 +28,7 @@ import { RouteComponentProps, rr6ClassShim } from "ogs-rr6-shims";
 
 window["dup"] = dup;
 
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 const ranks = allRanks();
 
 type TournamentRecordProperties = RouteComponentProps<{ tournament_record_id: string }>;
@@ -195,73 +195,83 @@ class _TournamentRecord extends React.PureComponent<
     };
 
     removePlayer(player: any) {
-        swal({
-            title: "Really remove player?",
-            text: player.name + " [" + rankString(player.rank) + "]",
-            showCancelButton: true,
-        })
-            .then(() => {
-                del(`tournament_records/${this.state.tournament_record_id}/players/${player.id}`)
-                    .then(() => {
-                        this.player_table_ref.current?.refresh();
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                title: "Really remove player?",
+                text: player.name + " [" + rankString(player.rank) + "]",
+                showCancelButton: true,
             })
-            .catch(ignore);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    del(
+                        `tournament_records/${this.state.tournament_record_id}/players/${player.id}`,
+                    )
+                        .then(() => {
+                            this.player_table_ref.current?.refresh();
+                        })
+                        .catch(errorAlerter);
+                }
+            });
     }
 
     deleteEntry(round, entry) {
-        swal({
-            text: "Are you sure you wish to delete this entry? The original game or review content will not be affected, but the entry will be removed from this list of game in this round.",
-            showCancelButton: true,
-        })
-            .then(() => {
-                for (let i = 0; i < round.entries.length; ++i) {
-                    if (round.entries[i].id === entry.id) {
-                        round.entries.splice(i, 1);
-                        break;
+        alert
+            .fire({
+                text: "Are you sure you wish to delete this entry? The original game or review content will not be affected, but the entry will be removed from this list of game in this round.",
+                showCancelButton: true,
+            })
+            .then(({ value: accept }) => {
+                if (accept) {
+                    for (let i = 0; i < round.entries.length; ++i) {
+                        if (round.entries[i].id === entry.id) {
+                            round.entries.splice(i, 1);
+                            break;
+                        }
                     }
-                }
-                this.forceUpdate();
+                    this.forceUpdate();
 
-                del(
-                    `tournament_records/${this.state.tournament_record_id}/rounds/${round.id}/${entry.id}`,
-                )
-                    .then(ignore)
-                    .catch(errorAlerter);
+                    del(
+                        `tournament_records/${this.state.tournament_record_id}/rounds/${round.id}/${entry.id}`,
+                    )
+                        .then(ignore)
+                        .catch(errorAlerter);
+                }
             })
             .catch(errorAlerter);
     }
 
     deleteRound(round: Round) {
-        swal({
-            title: _("Are you sure you wish to delete this round?"),
-            text: round.name,
-            showCancelButton: true,
-        })
-            .then(() => {
-                del(`tournament_records/${this.state.tournament_record_id}/round/${round.id}/`)
-                    .then(() => {
-                        for (let i = 0; i < this.state.rounds.length; ++i) {
-                            if (this.state.rounds[i].id === round.id) {
-                                this.state.rounds.splice(i, 1);
-                                break;
-                            }
-                        }
-                        this.forceUpdate();
-                    })
-                    .catch(errorAlerter);
+        void alert
+            .fire({
+                title: _("Are you sure you wish to delete this round?"),
+                text: round.name,
+                showCancelButton: true,
             })
-            .catch(swal.noop);
+            .then(({ value: accept }) => {
+                if (accept) {
+                    del(`tournament_records/${this.state.tournament_record_id}/round/${round.id}/`)
+                        .then(() => {
+                            for (let i = 0; i < this.state.rounds.length; ++i) {
+                                if (this.state.rounds[i].id === round.id) {
+                                    this.state.rounds.splice(i, 1);
+                                    break;
+                                }
+                            }
+                            this.forceUpdate();
+                        })
+                        .catch(errorAlerter);
+                }
+            });
     }
 
     linkGame(round: Round) {
-        swal({
-            text: _("Please provide the link to the game, review, or demo board"),
-            input: "text",
-            showCancelButton: true,
-        })
-            .then((url) => {
+        void alert
+            .fire({
+                text: _("Please provide the link to the game, review, or demo board"),
+                input: "text",
+                showCancelButton: true,
+            })
+            .then(({ value: url }) => {
                 if (!url) {
                     return;
                 }
@@ -275,8 +285,7 @@ class _TournamentRecord extends React.PureComponent<
                         this.forceUpdate();
                     })
                     .catch(errorAlerter);
-            })
-            .catch(ignore);
+            });
     }
 
     recordGame(round: Round) {

--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -25,7 +25,7 @@ import * as player_cache from "player_cache";
 import * as React from "react";
 import Dropzone from "react-dropzone";
 import { del, put } from "requests";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 import { durationString } from "TimeControl";
 import { cc_to_country_name, pgettext, sorted_locale_countries, _ } from "translate";
 import { is_valid_url } from "url_validation";
@@ -92,27 +92,29 @@ export function AvatarCard({
 
     const toggleEdit = () => {
         if (editing) {
-            let promise: Promise<void>;
+            let promise: Promise<any>;
             if (!data.get("user")?.is_moderator && user.username !== new_username) {
-                promise = swal({
+                promise = alert.fire({
                     text: _(
                         "You can only change your name once every 30 days. Are you sure you wish to change your username at this time?",
                     ),
                     showCancelButton: true,
                 });
             } else {
-                promise = Promise.resolve();
+                promise = Promise.resolve({ value: true }); // pretend to be an accepted alert
             }
             promise
-                .then(() => {
-                    onSave({
-                        username: new_username,
-                        first_name: new_first_name,
-                        last_name: new_last_name,
-                        real_name_is_private: new_real_name_is_private,
-                        country: new_country,
-                        website: new_website,
-                    });
+                .then(({ value }) => {
+                    if (value) {
+                        onSave({
+                            username: new_username,
+                            first_name: new_first_name,
+                            last_name: new_last_name,
+                            real_name_is_private: new_real_name_is_private,
+                            country: new_country,
+                            website: new_website,
+                        });
+                    }
                 })
                 .catch(ignore);
         } else {

--- a/src/views/User/BotControls.tsx
+++ b/src/views/User/BotControls.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { _ } from "translate";
 import { put, post } from "requests";
 import { errorAlerter } from "misc";
-import swal from "sweetalert2";
+import { alert } from "swal_config";
 
 interface BotControlsProperties {
     bot_id: number;
@@ -52,7 +52,7 @@ export function BotControls({
     const saveBot = () => {
         put("ui/bot/saveBotInfo", { bot_id: bot_id, bot_ai: bot_ai })
             .then(() => {
-                swal("Bot Engine updated").catch(swal.noop);
+                void alert.fire("Bot Engine updated");
             })
             .catch(errorAlerter);
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9069,10 +9069,10 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
-sweetalert2@^6.11.5:
-  version "6.11.5"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-6.11.5.tgz#a1ede34089225eb864898f4b613db4fec5dbe334"
-  integrity sha512-8Otu1SlWGS/u3e31cOg+uqrwyoQbByEScKp7UupmCfwEZE9St3coO1e6CXv83YzZtzdDgowdK1hBPKPW7SRp4Q==
+sweetalert2@^11.4.17:
+  version "11.4.17"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.4.17.tgz#d51a67d034c97b8a9854ce0c161ee21fdd681c4a"
+  integrity sha512-z0iQW5fDdvtoDNle3iHTKunsuNWgPaMifVu0GPtdguR0uVPrvg9gg9bnSQeJ4tx3C7FwJOEnRshxrs6fFItRvw==
 
 symbol-observable@^1.0.3:
   version "1.2.0"


### PR DESCRIPTION
Fixes out of date dependency.

## Proposed Changes

 - Change version of sweetalert2 from 6.x to 11.x
 - Factor out configuration from main.tsx into separate file
 - Convert from no-longer-supported `default` to `mixin`
 - Convert all uses of `swal` to use the newly defined `alert`  with  the mixed-in defaults
 - Handle alert-dismissal the new way (alert acceptance and dismissal both happen inside promise-accept - it's necessary to test the promise payload to see what happened).
    - https://github.com/sweetalert2/sweetalert2/releases/tag/v7.0.0 
 -  Use `void` to indicate where we are ignoring promise-reject results from the alert, instead of various forms of "do nothing" in the `catch`.
 
