### PR TITLE
Fix for #1240

### DIFF
--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -201,7 +201,8 @@ export function getOutcomeTranslation(outcome: string) {
     }
 
     if (/[0-9.]+/.test(outcome)) {
-        const num = outcome.match(/([0-9.]+)/)[1];
+        const num = Math.round(outcome.match(/([0-9.]+)/)[1]*2)/2;
+
         return interpolate(pgettext("Game outcome", "{{number}} points"), { number: num }); // eslint-disable-line id-denylist
     }
 

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -203,7 +203,7 @@ export function getOutcomeTranslation(outcome: string) {
     if (/[0-9.]+/.test(outcome)) {
         const num: number = +outcome.match(/([0-9.]+)/)[1];
         const rounded_num = Math.round(num * 2) / 2;
-        return interpolate(pgettext("Game outcome", "{{number}} points"), { number: rounded_num }); // eslint-disable-line id-denylist
+        return interpolate(pgettext("Game outcome", "{{score}} points"), { score: rounded_num });
     }
 
     return outcome;

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -203,7 +203,7 @@ export function getOutcomeTranslation(outcome: string) {
     if (/[0-9.]+/.test(outcome)) {
         const num: number = +outcome.match(/([0-9.]+)/)[1];
         const rounded_num = Math.round(num * 2) / 2;
-        return interpolate(pgettext("Game outcome", "{{score}} points"), { score: rounded_num });
+        return interpolate(pgettext("Game outcome", "{{number}} points"), { number: rounded_num }); // eslint-disable-line id-denylist
     }
 
     return outcome;

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -201,7 +201,7 @@ export function getOutcomeTranslation(outcome: string) {
     }
 
     if (/[0-9.]+/.test(outcome)) {
-        const num = Math.round(outcome.match(/([0-9.]+)/)[1]*2)/2;
+        const num = Math.round(outcome.match(/([0-9.]+)/)[1] * 2) / 2;
 
         return interpolate(pgettext("Game outcome", "{{number}} points"), { number: num }); // eslint-disable-line id-denylist
     }

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -201,9 +201,9 @@ export function getOutcomeTranslation(outcome: string) {
     }
 
     if (/[0-9.]+/.test(outcome)) {
-        const num: number = Math.round(outcome.match(/([0-9.]+)/)[1] * 2) / 2;
-
-        return interpolate(pgettext("Game outcome", "{{number}} points"), { number: num }); // eslint-disable-line id-denylist
+        const num: number = outcome.match(/([0-9.]+)/)[1];
+        const rounded_num = Math.round(num * 2) / 2;
+        return interpolate(pgettext("Game outcome", "{{number}} points"), { number: rounded_num }); // eslint-disable-line id-denylist
     }
 
     return outcome;

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -201,7 +201,7 @@ export function getOutcomeTranslation(outcome: string) {
     }
 
     if (/[0-9.]+/.test(outcome)) {
-        const num: number = outcome.match(/([0-9.]+)/)[1];
+        const num: number = +outcome.match(/([0-9.]+)/)[1];
         const rounded_num = Math.round(num * 2) / 2;
         return interpolate(pgettext("Game outcome", "{{number}} points"), { number: rounded_num }); // eslint-disable-line id-denylist
     }

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -201,7 +201,7 @@ export function getOutcomeTranslation(outcome: string) {
     }
 
     if (/[0-9.]+/.test(outcome)) {
-        const num = Math.round(outcome.match(/([0-9.]+)/)[1] * 2) / 2;
+        const num = number(Math.round(outcome.match(/([0-9.]+)/)[1] * 2) / 2);
 
         return interpolate(pgettext("Game outcome", "{{number}} points"), { number: num }); // eslint-disable-line id-denylist
     }

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -201,7 +201,7 @@ export function getOutcomeTranslation(outcome: string) {
     }
 
     if (/[0-9.]+/.test(outcome)) {
-        const num = number(Math.round(outcome.match(/([0-9.]+)/)[1] * 2) / 2);
+        const num: number = Math.round(outcome.match(/([0-9.]+)/)[1] * 2) / 2;
 
         return interpolate(pgettext("Game outcome", "{{number}} points"), { number: num }); // eslint-disable-line id-denylist
     }


### PR DESCRIPTION
Fixes #1240 

## Proposed Changes

  -  Game outcome, when a number is passed, will be rounded to nearest half. 
Solution from: https://stackoverflow.com/questions/6137986/javascript-roundoff-number-to-nearest-0-5

Tested with custom komi of 0.1 and 0.4, which would normally produce a score like 4.999999999999. 
This is my first pull request, so I hope I did everything right
