### PR TITLE
Note in eslintrc that we should investigate our exhaustive-deps warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
         "no-self-assign": "off", // 2 errors
         "no-useless-escape": "off", // 24 errors
         "prefer-spread": "off", // 7 errors
+        "react-hooks/exhaustive-deps": "off", // 41 errors
 
         //==============================================================
 


### PR DESCRIPTION
Fixes wondering whether we have this ommitted on purpose or by ommission.

## Proposed Changes

 - Add the rule into the "off" section of eslintrc for now, because don't want the noise now, but we should investigate