### PR TITLE
Fix URL validator regex

### DIFF
--- a/src/lib/url_validation.ts
+++ b/src/lib/url_validation.ts
@@ -19,5 +19,5 @@ export function is_valid_url(url: string): boolean {
     if (!url || typeof url !== "string") {
         return false;
     }
-    return /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/.test(url.toLowerCase());
+    return /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)\/?$/.test(url.toLowerCase());
 }


### PR DESCRIPTION
URL validator regex has a superfluous `*` character, which makes the regex engine go completely bananas for certain invalid inputs.

For example with `https://en.wikipedia.org/wiki/Colonoscopy@`:
```
$ time node test.js
node test.js  41.91s user 0.34s system 99% cpu 42.387 total
```

