### PR TITLE
Disable touch actions when pen tool is selected

### DIFF
--- a/src/global_styl/global.styl
+++ b/src/global_styl/global.styl
@@ -632,6 +632,5 @@ display: inline-block;
 }
 
 .noscroll {
-    height: 100%;
-    overflow: hidden;
+    touch-action: none;
 }

--- a/src/global_styl/global.styl
+++ b/src/global_styl/global.styl
@@ -630,3 +630,8 @@ display: inline-block;
 .invisible {
     visibility: hidden;
 }
+
+.noscroll {
+    height: 100%;
+    overflow: hidden;
+}

--- a/src/global_styl/global.styl
+++ b/src/global_styl/global.styl
@@ -631,6 +631,6 @@ display: inline-block;
     visibility: hidden;
 }
 
-.noscroll {
+.no-touch-action {
     touch-action: none;
 }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -68,6 +68,7 @@ import { useCurrentMove, useShowTitle, useTitle, useUserIsParticipant } from "./
 import { GobanContainer } from "GobanContainer";
 import { GobanContext } from "./goban_context";
 import { is_valid_url } from "url_validation";
+import { disableScrolling, enableScrolling } from "./scrolling";
 
 export function Game(): JSX.Element {
     const params = useParams<"game_id" | "review_id" | "move_number">();
@@ -339,8 +340,13 @@ export function Game(): JSX.Element {
         if (checkAndEnterAnalysis()) {
             $("#game-analyze-button-bar .active").removeClass("active");
             $("#game-analyze-" + tool + "-tool").addClass("active");
+            enableScrolling();
             switch (tool) {
                 case "draw":
+                    if ("ontouchstart" in window) {
+                        void alert.fire(_("Scrolling is disabled while the pen tool is selected."));
+                        disableScrolling();
+                    }
                     goban.current.setAnalyzeTool(tool, analyze_pencil_color);
                     break;
                 case "erase":

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -68,7 +68,7 @@ import { useCurrentMove, useShowTitle, useTitle, useUserIsParticipant } from "./
 import { GobanContainer } from "GobanContainer";
 import { GobanContext } from "./goban_context";
 import { is_valid_url } from "url_validation";
-import { disableScrolling, enableScrolling } from "./scrolling";
+import { disableTouchAction, enableTouchAction } from "./touch_actions";
 
 export function Game(): JSX.Element {
     const params = useParams<"game_id" | "review_id" | "move_number">();
@@ -340,12 +340,12 @@ export function Game(): JSX.Element {
         if (checkAndEnterAnalysis()) {
             $("#game-analyze-button-bar .active").removeClass("active");
             $("#game-analyze-" + tool + "-tool").addClass("active");
-            enableScrolling();
+            enableTouchAction();
             switch (tool) {
                 case "draw":
                     if ("ontouchstart" in window) {
                         void alert.fire(_("Scrolling is disabled while the pen tool is selected."));
-                        disableScrolling();
+                        disableTouchAction();
                     }
                     goban.current.setAnalyzeTool(tool, analyze_pencil_color);
                     break;

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -51,7 +51,7 @@ import {
 } from "./GameHooks";
 import { useGoban } from "./goban_context";
 import { is_valid_url } from "url_validation";
-import { enableScrolling } from "./scrolling";
+import { enableTouchAction } from "./touch_actions";
 
 interface PlayControlsProps {
     // Cancel buttons are in props because the Cancel Button is placed below
@@ -551,7 +551,7 @@ export function PlayControls({
                         <button
                             className="sm primary bold"
                             onClick={() => {
-                                enableScrolling();
+                                enableTouchAction();
                                 goban.setModeDeferred("play");
                             }}
                         >
@@ -739,7 +739,7 @@ export function AnalyzeButtonBar({
     };
 
     const goban_setModeDeferredPlay = () => {
-        enableScrolling();
+        enableTouchAction();
         goban.setModeDeferred("play");
     };
 

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -51,6 +51,7 @@ import {
 } from "./GameHooks";
 import { useGoban } from "./goban_context";
 import { is_valid_url } from "url_validation";
+import { enableScrolling } from "./scrolling";
 
 interface PlayControlsProps {
     // Cancel buttons are in props because the Cancel Button is placed below
@@ -549,7 +550,10 @@ export function PlayControls({
                     <span>
                         <button
                             className="sm primary bold"
-                            onClick={() => goban.setModeDeferred("play")}
+                            onClick={() => {
+                                enableScrolling();
+                                goban.setModeDeferred("play");
+                            }}
                         >
                             {_("Back to Game")}
                         </button>
@@ -735,6 +739,7 @@ export function AnalyzeButtonBar({
     };
 
     const goban_setModeDeferredPlay = () => {
+        enableScrolling();
         goban.setModeDeferred("play");
     };
 

--- a/src/views/Game/scrolling.ts
+++ b/src/views/Game/scrolling.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export function disableScrolling() {
+    document.documentElement.classList.add("noscroll");
+    document.body.classList.add("noscroll");
+}
+
+export function enableScrolling() {
+    document.documentElement.classList.remove("noscroll");
+    document.body.classList.remove("noscroll");
+}

--- a/src/views/Game/scrolling.ts
+++ b/src/views/Game/scrolling.ts
@@ -17,10 +17,8 @@
 
 export function disableScrolling() {
     document.documentElement.classList.add("noscroll");
-    document.body.classList.add("noscroll");
 }
 
 export function enableScrolling() {
     document.documentElement.classList.remove("noscroll");
-    document.body.classList.remove("noscroll");
 }

--- a/src/views/Game/touch_actions.ts
+++ b/src/views/Game/touch_actions.ts
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function disableScrolling() {
-    document.documentElement.classList.add("noscroll");
+export function disableTouchAction() {
+    document.documentElement.classList.add("no-touch-action");
 }
 
-export function enableScrolling() {
-    document.documentElement.classList.remove("noscroll");
+export function enableTouchAction() {
+    document.documentElement.classList.remove("no-touch-action");
 }


### PR DESCRIPTION
Fixes #1913

## Proposed Changes

  - Sets `touch-action: none` when pen tool is selected
  - Fires an alert when user selects pen tool on a touch device