### PR TITLE
Don't autocapitalize username SignIn field

### DIFF
--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -210,6 +210,7 @@ export class SignIn extends React.PureComponent<{}, any> {
                                 ref={this.ref_username}
                                 name="username"
                                 onKeyPress={this.login}
+                                autoCapitalize="off"
                             />
                             <label htmlFor="password">
                                 {_("Password") /* translators: Provide password to sign in with */}


### PR DESCRIPTION
**Proposed changes**

Turn off autocapitalize on the username field. Chrome Android for example has it on by default.
