### PR TITLE
Check if review is in sync when review is updated

### DIFF
--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -1038,7 +1038,7 @@ const useReviewOutOfSync = generateGobanHook(
             engine.cur_move.id !== engine.cur_review_move.id
         );
     },
-    ["cur_move"],
+    ["cur_move", "review.updated"],
 );
 
 export function ReviewControls({


### PR DESCRIPTION
## Issue
Sometimes "Sync" button is visible even when I'm in sync with the reviewer:

1. when I'm automatically following review. This happens because `GobanCore` emits `cur_move` event before updating `cur_review_move` ([code](https://github.com/online-go/goban/blob/c59e1d14303020cb9fddc515afd9cb9c8ffbfe98/src/GobanCore.ts#L1536-L1539))
  
2. when I'm out of sync and then reviewer navigates to my current move.

## Proposed Changes
  - Subscribe to `review.updated` event for `useReviewOutOfSync` hook.
  