### PR TITLE
Fix capitalize function in GameHistoryTable.tsx

### DIFF
--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -358,7 +358,7 @@ function getGameResultRichText(game: rest_api.Game) {
 }
 
 function capitalize<T extends string>(s: T): Capitalize<T> {
-    return (s.toUpperCase() + s.slice(1)) as Capitalize<T>;
+    return (s.charAt(0).toUpperCase() + s.slice(1)) as Capitalize<T>;
 }
 
 function getResultClass(game: rest_api.Game, user_id: number): ResultClass {


### PR DESCRIPTION
It was broken and the game history looked like this.

![CORRESPONDENCEorrespondence](https://user-images.githubusercontent.com/99894371/178097065-0307ee1b-e715-47b6-a3f7-7054f76f9381.png)
