### PR TITLE
Try to clarify which props are for what.

### DIFF
--- a/src/lib/SettingsCommon.tsx
+++ b/src/lib/SettingsCommon.tsx
@@ -25,7 +25,7 @@ import { Toggle } from "Toggle";
 
 export const MAX_DOCK_DELAY = 3.0;
 
-export interface SettingGroupProps {
+export interface SettingGroupPageProps {
     state: SettingsState;
     vacation_base_time: number;
     refresh: () => () => void;

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -27,9 +27,9 @@ import { errorAlerter, errorLogger, ignore } from "misc";
 import { SocialLoginButtons } from "SocialLoginButtons";
 import { alert } from "swal_config";
 
-import { SettingGroupProps } from "SettingsCommon";
+import { SettingGroupPageProps } from "SettingsCommon";
 
-export function AccountSettings(props: SettingGroupProps): JSX.Element {
+export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
     const [password1, setPassword1]: [string, (x: string) => void] = React.useState("");
     const [password2, setPassword2]: [string, (x: string) => void] = React.useState("");
     const [email, __setEmail]: [string, (x: string) => void] = React.useState(

--- a/src/views/Settings/EmailPreferences.tsx
+++ b/src/views/Settings/EmailPreferences.tsx
@@ -24,9 +24,9 @@ import { errorAlerter } from "misc";
 
 import { Toggle } from "Toggle";
 
-import { SettingGroupProps, SettingsState } from "SettingsCommon";
+import { SettingGroupPageProps, SettingsState } from "SettingsCommon";
 
-export function EmailPreferences(props: SettingGroupProps): JSX.Element {
+export function EmailPreferences(props: SettingGroupPageProps): JSX.Element {
     return (
         <div>
             {_("Email me a notification when ...")}

--- a/src/views/Settings/GeneralPreferences.tsx
+++ b/src/views/Settings/GeneralPreferences.tsx
@@ -33,9 +33,9 @@ import { usePreference } from "preferences";
 
 import { Toggle } from "Toggle";
 
-import { SettingGroupProps, PreferenceLine, PreferenceDropdown } from "SettingsCommon";
+import { SettingGroupPageProps, PreferenceLine, PreferenceDropdown } from "SettingsCommon";
 
-export function GeneralPreferences(props: SettingGroupProps): JSX.Element {
+export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
     const [profanity_filter, _setProfanityFilter]: [Array<string>, (x: Array<string>) => void] =
         React.useState(Object.keys(preferences.get("profanity-filter")));
 

--- a/src/views/Settings/LinkPreferences.tsx
+++ b/src/views/Settings/LinkPreferences.tsx
@@ -25,14 +25,14 @@ import { errorAlerter, Timeout } from "misc";
 
 import { Toggle } from "Toggle";
 
-import { SettingGroupProps, PreferenceLine } from "SettingsCommon";
+import { SettingGroupPageProps, PreferenceLine } from "SettingsCommon";
 
 import { IAssociation, associations } from "associations";
 import { allRanks, IRankInfo } from "rank_utils";
 
 let update_link_preferences_debounce: Timeout;
 
-export function LinkPreferences(props: SettingGroupProps): JSX.Element {
+export function LinkPreferences(props: SettingGroupPageProps): JSX.Element {
     const link = props.state.self_reported_account_linkages || {};
 
     function set(key: string): (value: any) => void {

--- a/src/views/Settings/ModeratorPreferences.tsx
+++ b/src/views/Settings/ModeratorPreferences.tsx
@@ -25,9 +25,9 @@ import { usePreference } from "preferences";
 
 import { Toggle } from "Toggle";
 
-import { SettingGroupProps, PreferenceLine } from "SettingsCommon";
+import { SettingGroupPageProps, PreferenceLine } from "SettingsCommon";
 
-export function ModeratorPreferences(_props: SettingGroupProps): JSX.Element {
+export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element {
     const [incident_report_notifications, setIncidentReportNotifications] = usePreference(
         "notify-on-incident-report",
     );

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -33,7 +33,7 @@ import { logout, logoutOtherDevices, logoutAndClearLocalData } from "auth";
 import { LoadingPage } from "Loading";
 import { browserHistory } from "ogsHistory";
 
-import { SettingGroupProps, SettingsState } from "SettingsCommon";
+import { SettingGroupPageProps, SettingsState } from "SettingsCommon";
 
 import { SoundPreferences } from "./SoundPreferences";
 import { GeneralPreferences } from "./GeneralPreferences";
@@ -114,7 +114,7 @@ export function Settings(): JSX.Element {
         { key: "logout", label: _("Logout") },
     ];
 
-    let SelectedPage: (props: SettingGroupProps) => JSX.Element = () => <div>Error</div>;
+    let SelectedPage: (props: SettingGroupPageProps) => JSX.Element = () => <div>Error</div>;
 
     switch (selected) {
         case "general":
@@ -161,7 +161,7 @@ export function Settings(): JSX.Element {
             */
     }
 
-    const props: SettingGroupProps = {
+    const child_props: SettingGroupPageProps = {
         state: settings_state,
         vacation_base_time: vacation_base_time,
         refresh: refresh,
@@ -233,7 +233,7 @@ export function Settings(): JSX.Element {
                 />
 
                 <div id="SelectedSettingsContainer">
-                    {loaded ? <SelectedPage {...props} /> : <LoadingPage />}
+                    {loaded ? <SelectedPage {...child_props} /> : <LoadingPage />}
                 </div>
             </div>
         </div>

--- a/src/views/Settings/VacationSettings.tsx
+++ b/src/views/Settings/VacationSettings.tsx
@@ -23,9 +23,9 @@ import { errorAlerter } from "misc";
 
 import { durationString } from "TimeControl";
 
-import { SettingGroupProps } from "SettingsCommon";
+import { SettingGroupPageProps } from "SettingsCommon";
 
-export function VacationSettings(props: SettingGroupProps): JSX.Element {
+export function VacationSettings(props: SettingGroupPageProps): JSX.Element {
     const [vacation_left, set_vacation_left]: [number, (x: number) => void] = React.useState(
         props.state.profile.vacation_left - (Date.now() - props.vacation_base_time) / 1000,
     );


### PR DESCRIPTION
Fixes reader confusion about what the type `SettingsGroupProps` is for, and the variable `props` in the `<Settings>` component.

## Proposed Changes

props -> child_props

SettingsGroupProps -> SettingsGroupPageProps

(allowing for later creation of the interface `SettingsGroupProps` for the `SettingsGroup` component, which may be needed to add ref forwarding into it)
