### PR TITLE
Connect help to challenge link acceptance

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { browserHistory } from "ogsHistory";
 
+import * as DynamicHelp from "react-dynamic-help";
+
 import * as data from "data";
 
 import { _ } from "translate";
@@ -97,6 +99,13 @@ function OldNavBar(): JSX.Element {
     const [omnisearch_groups, setOmnisearchGroups] = React.useState([]);
     const [omnisearch_tournaments, setOmnisearchTournaments] = React.useState([]);
 
+    const { registerTargetItem } = React.useContext(DynamicHelp.Api);
+
+    const { ref: toggleLeftNavButton, used: leftNavToggled } =
+        registerTargetItem("toggle-left-nav");
+
+    const { ref: settingsNavLink } = registerTargetItem("settings-nav-link");
+
     const clearOmnisearch = () => {
         abortOmnisearch();
         setOmnisearchString("");
@@ -122,6 +131,7 @@ function OldNavBar(): JSX.Element {
             if (ev && ev.type === "keydown") {
                 omnisearch_input_ref.current.focus();
             }
+            leftNavToggled();
         } else {
             clearOmnisearch();
         }
@@ -243,7 +253,11 @@ function OldNavBar(): JSX.Element {
             <KBShortcut shortcut="shift-`" action={toggleRightNav} />
             <KBShortcut shortcut="escape" action={closeNavbar} />
 
-            <span className="ogs-nav-logo-container" onClick={toggleLeftNav}>
+            <span
+                className="ogs-nav-logo-container"
+                onClick={toggleLeftNav}
+                ref={toggleLeftNavButton}
+            >
                 <i className="fa fa-bars" />
                 <span className="ogs-nav-logo" />
             </span>
@@ -493,7 +507,7 @@ function OldNavBar(): JSX.Element {
                         )}
                         {valid_user && (
                             <li>
-                                <Link to="/user/settings">
+                                <Link to="/user/settings" ref={settingsNavLink}>
                                     <i className="fa fa-gear"></i>
                                     {_("Settings")}
                                 </Link>

--- a/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
+++ b/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
@@ -84,8 +84,11 @@ export function ChallengeLinkLanding(): JSX.Element {
                 .then(() => {
                     alert.close();
                     browserHistory.push(`/game/${challenge.game_id}`);
-                    enableFlow("guest-user-intro-exv6");
-                    enableFlow("guest-user-intro-oldnav");
+                    if (data.get("experiments.v6") === "enabled") {
+                        enableFlow("guest-user-intro-exv6");
+                    } else {
+                        enableFlow("guest-user-intro-old-nav");
+                    }
                 })
                 .catch((err) => {
                     alert.close();

--- a/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
+++ b/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { alert } from "swal_config";
 
+import * as DynamicHelp from "react-dynamic-help";
+
 import * as data from "data";
 import { useUser } from "hooks";
 import { _, pgettext, interpolate } from "translate";
@@ -45,6 +47,8 @@ export function ChallengeLinkLanding(): JSX.Element {
     const [logging_in, set_logging_in] = React.useState<boolean>(false);
 
     const navigate = useNavigate();
+
+    const { enableFlow } = React.useContext(DynamicHelp.Api);
 
     /* Actions */
 
@@ -80,6 +84,8 @@ export function ChallengeLinkLanding(): JSX.Element {
                 .then(() => {
                     alert.close();
                     browserHistory.push(`/game/${challenge.game_id}`);
+                    enableFlow("guest-user-intro-exv6");
+                    enableFlow("guest-user-intro-oldnav");
                 })
                 .catch((err) => {
                     alert.close();

--- a/src/views/HelpFlows/GuestUserIntroEXV6.tsx
+++ b/src/views/HelpFlows/GuestUserIntroEXV6.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import { HelpFlow, HelpItem } from "react-dynamic-help";
+
+import { _ } from "translate";
+
+/**
+ * A help flow intended for guests who arrived on a Challenge Link
+ * (targets components in the EXV6 flow)
+ */
+
+export function GuestUserIntroEXV6(): JSX.Element {
+    return (
+        <HelpFlow id="guest-user-intro-exv6" showInitially={false} debug={false}>
+            <HelpItem target="toggle-right-nav" position={"bottom-left"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="settings-nav-link" position={"center-left"} anchor={"top-right"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="account-settings-button"
+                position={"center-left"}
+                anchor={"top-right"}
+            >
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="password-entry" position={"center-right"}>
+                <div>{_("You can enter your new password here.")} </div>
+            </HelpItem>
+
+            <HelpItem target="profile-edit-link">
+                <div>{_("You can also change your username, here.")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="profile-edit-page"
+                position="center-left"
+                id="help-for-profile-edit-page"
+            >
+                <div>{_("In here you can change your profile appearance, then click 'Save'.")}</div>
+            </HelpItem>
+        </HelpFlow>
+    );
+}

--- a/src/views/HelpFlows/GuestUserIntroOldNav.tsx
+++ b/src/views/HelpFlows/GuestUserIntroOldNav.tsx
@@ -28,7 +28,7 @@ import { _ } from "translate";
 
 export function GuestUserIntroOldNav(): JSX.Element {
     return (
-        <HelpFlow id="guest-user-intro-old-nav" showInitially={true} debug={true}>
+        <HelpFlow id="guest-user-intro-old-nav" showInitially={false} debug={false}>
             <HelpItem target="toggle-left-nav" position={"bottom-right"}>
                 <div>{_("To set your password, click here")} </div>
             </HelpItem>

--- a/src/views/HelpFlows/GuestUserIntroOldNav.tsx
+++ b/src/views/HelpFlows/GuestUserIntroOldNav.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import { HelpFlow, HelpItem } from "react-dynamic-help";
+
+import { _ } from "translate";
+
+/**
+ * A help flow intended for guests who arrived on a Challenge Link
+ * (targets components in the "old" Nav flow)
+ */
+
+export function GuestUserIntroOldNav(): JSX.Element {
+    return (
+        <HelpFlow id="guest-user-intro-old-nav" showInitially={true} debug={true}>
+            <HelpItem target="toggle-left-nav" position={"bottom-right"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="settings-nav-link" position={"top-right"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="account-settings-button"
+                position={"center-left"}
+                anchor={"top-right"}
+            >
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="password-entry" position={"center-right"}>
+                <div>{_("You can enter your new password here.")} </div>
+            </HelpItem>
+
+            <HelpItem target="profile-edit-link">
+                <div>{_("You can also change your username, here.")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="profile-edit-page"
+                position="center-left"
+                id="help-for-profile-edit-page"
+            >
+                <div>{_("In here you can change your profile appearance, then click 'Save'.")}</div>
+            </HelpItem>
+        </HelpFlow>
+    );
+}

--- a/src/views/HelpFlows/HelpFlows.tsx
+++ b/src/views/HelpFlows/HelpFlows.tsx
@@ -19,43 +19,21 @@ import React from "react";
 
 import { HelpFlow, HelpItem } from "react-dynamic-help";
 
-import { _ } from "translate";
+import { GuestUserIntroEXV6 } from "./GuestUserIntroEXV6";
+import { GuestUserIntroOldNav } from "./GuestUserIntroOldNav";
 
+/**
+ * This component is just a handy wrapper for all the Help Flows
+ * (technically they _can_ be instantiated direct into the HelpProvider, but this encapsulation is tidier!)
+ */
 export function HelpFlows(): JSX.Element {
     return (
         <div id="help-flow-container">
-            <HelpFlow id="guest-user-intro" showInitially={true} debug={true}>
-                <HelpItem target="toggle-right-nav" position={"bottom-left"}>
-                    <div>{_("To set your password, click here")} </div>
-                </HelpItem>
-                <HelpItem target="settings-nav-link" position={"center-left"} anchor={"top-right"}>
-                    <div>{_("To set your password, click here")} </div>
-                </HelpItem>
-                <HelpItem
-                    target="account-settings-button"
-                    position={"center-left"}
-                    anchor={"top-right"}
-                >
-                    <div>{_("To set your password, click here")} </div>
-                </HelpItem>
-                <HelpItem target="password-entry" position={"center-right"}>
-                    <div>{_("You can enter your new password here.")} </div>
-                </HelpItem>
-                <HelpItem target="profile-edit-link">
-                    <div>{_("You can also change your username, here.")} </div>
-                </HelpItem>
-                <HelpItem
-                    target="profile-edit-page"
-                    position="center-left"
-                    id="help-for-profile-edit-page"
-                >
-                    <div>
-                        {_("In here you can change your profile appearance, then click 'Save'.")}{" "}
-                    </div>
-                </HelpItem>
-            </HelpFlow>
+            <GuestUserIntroEXV6 />
 
-            {/* you can register "help-test-flow" anywhere to get this to pop up if needed */}
+            <GuestUserIntroOldNav />
+
+            {/* you can register a "test-help" target anywhere to get this to pop up if needed */}
             <HelpFlow id="help-test-flow" showInitially={true} debug={true}>
                 <HelpItem target="test-help">
                     <div>This is a debug prompt!</div>


### PR DESCRIPTION
This makes it so that the help flows are off by default, but get activated when a guest arrives on a challenge link.

Goes on top of #1950

Visuals and placement improved, but not quite right yet.

Settings page still coming.