### PR TITLE
Settings for help

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
         "react-datetime": "^3.0.4",
         "react-dom": "^18.0.0",
         "react-dropzone": "^12.0.5",
+        "react-dynamic-help": "^1.0.2",
         "react-linkify": "^1.0.0-alpha",
         "react-number-format": "^3.0.2",
         "react-resize-detector": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
         "react-datetime": "^3.0.4",
         "react-dom": "^18.0.0",
         "react-dropzone": "^12.0.5",
-        "react-dynamic-help": "^1.0.1",
         "react-linkify": "^1.0.0-alpha",
         "react-number-format": "^3.0.2",
         "react-resize-detector": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "react-datetime": "^3.0.4",
         "react-dom": "^18.0.0",
         "react-dropzone": "^12.0.5",
-        "react-dynamic-help": "^0.15.1",
+        "react-dynamic-help": "^1.0.1",
         "react-linkify": "^1.0.0-alpha",
         "react-number-format": "^3.0.2",
         "react-resize-detector": "^7.1.1",

--- a/src/components/NavBar/EXV6NavBar.tsx
+++ b/src/components/NavBar/EXV6NavBar.tsx
@@ -375,8 +375,8 @@ export function EXV6NavBar(): JSX.Element {
                         {_("Profile")}
                     </Link>
 
-                    <Link to="/user/settings" ref={settingsNavLink}>
-                        <i className="fa fa-gear"></i>
+                    <Link to="/user/settings">
+                        <i className="fa fa-gear" ref={settingsNavLink}></i>
                         {_("Settings")}
                     </Link>
                     <span className="fakelink" onClick={logout}>

--- a/src/components/NavBar/EXV6NavBar.tsx
+++ b/src/components/NavBar/EXV6NavBar.tsx
@@ -375,8 +375,8 @@ export function EXV6NavBar(): JSX.Element {
                         {_("Profile")}
                     </Link>
 
-                    <Link to="/user/settings">
-                        <i className="fa fa-gear" ref={settingsNavLink}></i>
+                    <Link to="/user/settings" ref={settingsNavLink}>
+                        <i className="fa fa-gear"></i>
                         {_("Settings")}
                     </Link>
                     <span className="fakelink" onClick={logout}>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { browserHistory } from "ogsHistory";
 
+import * as DynamicHelp from "react-dynamic-help";
+
 import * as data from "data";
 
 import { _ } from "translate";
@@ -97,6 +99,13 @@ function OldNavBar(): JSX.Element {
     const [omnisearch_groups, setOmnisearchGroups] = React.useState([]);
     const [omnisearch_tournaments, setOmnisearchTournaments] = React.useState([]);
 
+    const { registerTargetItem } = React.useContext(DynamicHelp.Api);
+
+    const { ref: toggleLeftNavButton, used: leftNavToggled } =
+        registerTargetItem("toggle-left-nav");
+
+    const { ref: settingsNavLink } = registerTargetItem("settings-nav-link");
+
     const clearOmnisearch = () => {
         abortOmnisearch();
         setOmnisearchString("");
@@ -122,6 +131,7 @@ function OldNavBar(): JSX.Element {
             if (ev && ev.type === "keydown") {
                 omnisearch_input_ref.current.focus();
             }
+            leftNavToggled();
         } else {
             clearOmnisearch();
         }
@@ -243,7 +253,11 @@ function OldNavBar(): JSX.Element {
             <KBShortcut shortcut="shift-`" action={toggleRightNav} />
             <KBShortcut shortcut="escape" action={closeNavbar} />
 
-            <span className="ogs-nav-logo-container" onClick={toggleLeftNav}>
+            <span
+                className="ogs-nav-logo-container"
+                onClick={toggleLeftNav}
+                ref={toggleLeftNavButton}
+            >
                 <i className="fa fa-bars" />
                 <span className="ogs-nav-logo" />
             </span>
@@ -493,7 +507,7 @@ function OldNavBar(): JSX.Element {
                         )}
                         {valid_user && (
                             <li>
-                                <Link to="/user/settings">
+                                <Link to="/user/settings" ref={settingsNavLink}>
                                     <i className="fa fa-gear"></i>
                                     {_("Settings")}
                                 </Link>

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -225,6 +225,8 @@ export interface DataSchema
 
     "preferred-game-settings": rest_api.ChallengeDetails[];
 
+    "debug-dynamic-help": boolean;
+
     // A challenge that the user accepted, but we didn't tell the server yet, because
     // we are busy getting them logged in first.
     pending_accepted_challenge: Challenge;

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -226,6 +226,7 @@ export interface DataSchema
     "preferred-game-settings": rest_api.ChallengeDetails[];
 
     "debug-dynamic-help": boolean;
+    "help-system-enabled": boolean;
 
     // A challenge that the user accepted, but we didn't tell the server yet, because
     // we are busy getting them logged in first.

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -121,6 +121,8 @@ export const defaults = {
 
     "game-history-size-filter": "all",
     "game-history-ranked-filter": "all",
+
+    "help-system-enabled": true,
 };
 
 defaults["profanity-filter"][current_language] = true;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -343,9 +343,11 @@ function ForceReactUpdateWrapper(props): JSX.Element {
 
 const react_root = ReactDOM.createRoot(document.getElementById("main-content"));
 
+const debugDynamicHelp = data.get("debug-dynamic-help", false);
+
 react_root.render(
     <React.StrictMode>
-        <HelpProvider debug={true}>
+        <HelpProvider debug={debugDynamicHelp}>
             <ForceReactUpdateWrapper>{routes}</ForceReactUpdateWrapper>
             <HelpFlows />
         </HelpProvider>

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -141,6 +141,8 @@ light.toast-fg                          = light.bg
 light.link-color                        = #0068F7
 light.link-color-active                 = darken(light.link-color, 20%)
 
+light.help-popup-bg                     = #D471DA
+
 light.default-button                    = #E6E6E0
 light.primary                           = #2480FF
 light.danger                            = #FFA600
@@ -283,6 +285,8 @@ dark.toast-bg                           = dark.fg
 dark.toast-fg                           = dark.bg
 dark.link-color                         = #539bff
 dark.link-color-active                  = darken(dark.link-color, 20%)
+
+dark.help-popup-bg                     = #4E134C
 
 dark.default-button                     = lighten(dark.bg, 10%)
 dark.default-button-color               = dark.fg
@@ -476,4 +480,4 @@ nowrap()
 @require "./views/docs/*.styl";
 
 @require '../node_modules/react-table/react-table.css';
-@require '../node_modules/react-dynamic-help/lib/es5/DynamicHelp.css'; 
+@require '../node_modules/react-dynamic-help/lib/es5/DynamicHelp.css';

--- a/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
+++ b/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
@@ -84,8 +84,11 @@ export function ChallengeLinkLanding(): JSX.Element {
                 .then(() => {
                     alert.close();
                     browserHistory.push(`/game/${challenge.game_id}`);
-                    enableFlow("guest-user-intro-exv6");
-                    enableFlow("guest-user-intro-oldnav");
+                    if (data.get("experiments.v6") === "enabled") {
+                        enableFlow("guest-user-intro-exv6");
+                    } else {
+                        enableFlow("guest-user-intro-old-nav");
+                    }
                 })
                 .catch((err) => {
                     alert.close();

--- a/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
+++ b/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { alert } from "swal_config";
 
+import * as DynamicHelp from "react-dynamic-help";
+
 import * as data from "data";
 import { useUser } from "hooks";
 import { _, pgettext, interpolate } from "translate";
@@ -45,6 +47,8 @@ export function ChallengeLinkLanding(): JSX.Element {
     const [logging_in, set_logging_in] = React.useState<boolean>(false);
 
     const navigate = useNavigate();
+
+    const { enableFlow } = React.useContext(DynamicHelp.Api);
 
     /* Actions */
 
@@ -80,6 +84,8 @@ export function ChallengeLinkLanding(): JSX.Element {
                 .then(() => {
                     alert.close();
                     browserHistory.push(`/game/${challenge.game_id}`);
+                    enableFlow("guest-user-intro-exv6");
+                    enableFlow("guest-user-intro-oldnav");
                 })
                 .catch((err) => {
                     alert.close();

--- a/src/views/HelpFlows/GuestUserIntroEXV6.tsx
+++ b/src/views/HelpFlows/GuestUserIntroEXV6.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import { HelpFlow, HelpItem } from "react-dynamic-help";
+
+import { _ } from "translate";
+
+/**
+ * A help flow intended for guests who arrived on a Challenge Link
+ * (targets components in the EXV6 flow)
+ */
+
+export function GuestUserIntroEXV6(): JSX.Element {
+    return (
+        <HelpFlow id="guest-user-intro-exv6" showInitially={false} debug={false}>
+            <HelpItem target="toggle-right-nav" position={"bottom-left"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="settings-nav-link" position={"center-left"} anchor={"top-right"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="account-settings-button"
+                position={"center-left"}
+                anchor={"top-right"}
+            >
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="password-entry" position={"center-right"}>
+                <div>{_("You can enter your new password here.")} </div>
+            </HelpItem>
+
+            <HelpItem target="profile-edit-link">
+                <div>{_("You can also change your username, here.")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="profile-edit-page"
+                position="center-left"
+                id="help-for-profile-edit-page"
+            >
+                <div>{_("In here you can change your profile appearance, then click 'Save'.")}</div>
+            </HelpItem>
+        </HelpFlow>
+    );
+}

--- a/src/views/HelpFlows/GuestUserIntroEXV6.tsx
+++ b/src/views/HelpFlows/GuestUserIntroEXV6.tsx
@@ -54,7 +54,7 @@ export function GuestUserIntroEXV6(): JSX.Element {
                 <div>{_("You can enter your new password here.")} </div>
             </HelpItem>
 
-            <HelpItem target="profile-edit-link">
+            <HelpItem target="profile-edit-link" position="top-centre" anchor="bottom-left">
                 <div>{_("You can also change your username, here.")} </div>
             </HelpItem>
 

--- a/src/views/HelpFlows/GuestUserIntroEXV6.tsx
+++ b/src/views/HelpFlows/GuestUserIntroEXV6.tsx
@@ -28,7 +28,12 @@ import { _ } from "translate";
 
 export function GuestUserIntroEXV6(): JSX.Element {
     return (
-        <HelpFlow id="guest-user-intro-exv6" showInitially={false} debug={false}>
+        <HelpFlow
+            id="guest-user-intro-exv6"
+            showInitially={false}
+            debug={false}
+            description="Guest user introduction"
+        >
             <HelpItem target="toggle-right-nav" position={"bottom-left"}>
                 <div>{_("To set your password, click here")} </div>
             </HelpItem>
@@ -45,7 +50,7 @@ export function GuestUserIntroEXV6(): JSX.Element {
                 <div>{_("To set your password, click here")} </div>
             </HelpItem>
 
-            <HelpItem target="password-entry" position={"center-right"}>
+            <HelpItem target="password-entry" position={"top-center"}>
                 <div>{_("You can enter your new password here.")} </div>
             </HelpItem>
 

--- a/src/views/HelpFlows/GuestUserIntroEXV6.tsx
+++ b/src/views/HelpFlows/GuestUserIntroEXV6.tsx
@@ -32,7 +32,7 @@ export function GuestUserIntroEXV6(): JSX.Element {
             id="guest-user-intro-exv6"
             showInitially={false}
             debug={false}
-            description="Guest user introduction"
+            description="Guest user introduction (for new Nav)"
         >
             <HelpItem target="toggle-right-nav" position={"bottom-left"}>
                 <div>{_("To set your password, click here")} </div>

--- a/src/views/HelpFlows/GuestUserIntroEXV6.tsx
+++ b/src/views/HelpFlows/GuestUserIntroEXV6.tsx
@@ -44,8 +44,8 @@ export function GuestUserIntroEXV6(): JSX.Element {
 
             <HelpItem
                 target="account-settings-button"
-                position={"center-left"}
-                anchor={"top-right"}
+                position={"center-right"}
+                anchor={"bottom-left"}
             >
                 <div>{_("To set your password, click here")} </div>
             </HelpItem>
@@ -60,8 +60,9 @@ export function GuestUserIntroEXV6(): JSX.Element {
 
             <HelpItem
                 target="profile-edit-page"
-                position="center-left"
-                id="help-for-profile-edit-page"
+                position="bottom-right"
+                anchor="bottom-left"
+                id="help-for-profile-edit-page-exv6"
             >
                 <div>{_("In here you can change your profile appearance, then click 'Save'.")}</div>
             </HelpItem>

--- a/src/views/HelpFlows/GuestUserIntroOldNav.tsx
+++ b/src/views/HelpFlows/GuestUserIntroOldNav.tsx
@@ -28,7 +28,7 @@ import { _ } from "translate";
 
 export function GuestUserIntroOldNav(): JSX.Element {
     return (
-        <HelpFlow id="guest-user-intro-old-nav" showInitially={true} debug={true}>
+        <HelpFlow id="guest-user-intro-old-nav" showInitially={false} debug={false}>
             <HelpItem target="toggle-left-nav" position={"bottom-right"}>
                 <div>{_("To set your password, click here")} </div>
             </HelpItem>

--- a/src/views/HelpFlows/GuestUserIntroOldNav.tsx
+++ b/src/views/HelpFlows/GuestUserIntroOldNav.tsx
@@ -28,7 +28,12 @@ import { _ } from "translate";
 
 export function GuestUserIntroOldNav(): JSX.Element {
     return (
-        <HelpFlow id="guest-user-intro-old-nav" showInitially={false} debug={false}>
+        <HelpFlow
+            id="guest-user-intro-old-nav"
+            showInitially={false}
+            debug={false}
+            description="Guest user introduction (for old Nav)"
+        >
             <HelpItem target="toggle-left-nav" position={"bottom-right"}>
                 <div>{_("To set your password, click here")} </div>
             </HelpItem>

--- a/src/views/HelpFlows/GuestUserIntroOldNav.tsx
+++ b/src/views/HelpFlows/GuestUserIntroOldNav.tsx
@@ -39,23 +39,24 @@ export function GuestUserIntroOldNav(): JSX.Element {
 
             <HelpItem
                 target="account-settings-button"
-                position={"center-left"}
-                anchor={"top-right"}
+                position={"center-right"}
+                anchor={"bottom-left"}
             >
                 <div>{_("To set your password, click here")} </div>
             </HelpItem>
 
-            <HelpItem target="password-entry" position={"center-right"}>
+            <HelpItem target="password-entry" position={"top-center"}>
                 <div>{_("You can enter your new password here.")} </div>
             </HelpItem>
 
-            <HelpItem target="profile-edit-link">
+            <HelpItem target="profile-edit-link" position="top-centre" anchor="bottom-left">
                 <div>{_("You can also change your username, here.")} </div>
             </HelpItem>
 
             <HelpItem
                 target="profile-edit-page"
-                position="center-left"
+                position="bottom-right"
+                anchor="bottom-left"
                 id="help-for-profile-edit-page"
             >
                 <div>{_("In here you can change your profile appearance, then click 'Save'.")}</div>

--- a/src/views/HelpFlows/GuestUserIntroOldNav.tsx
+++ b/src/views/HelpFlows/GuestUserIntroOldNav.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import { HelpFlow, HelpItem } from "react-dynamic-help";
+
+import { _ } from "translate";
+
+/**
+ * A help flow intended for guests who arrived on a Challenge Link
+ * (targets components in the "old" Nav flow)
+ */
+
+export function GuestUserIntroOldNav(): JSX.Element {
+    return (
+        <HelpFlow id="guest-user-intro-old-nav" showInitially={true} debug={true}>
+            <HelpItem target="toggle-left-nav" position={"bottom-right"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="settings-nav-link" position={"top-right"}>
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="account-settings-button"
+                position={"center-left"}
+                anchor={"top-right"}
+            >
+                <div>{_("To set your password, click here")} </div>
+            </HelpItem>
+
+            <HelpItem target="password-entry" position={"center-right"}>
+                <div>{_("You can enter your new password here.")} </div>
+            </HelpItem>
+
+            <HelpItem target="profile-edit-link">
+                <div>{_("You can also change your username, here.")} </div>
+            </HelpItem>
+
+            <HelpItem
+                target="profile-edit-page"
+                position="center-left"
+                id="help-for-profile-edit-page"
+            >
+                <div>{_("In here you can change your profile appearance, then click 'Save'.")}</div>
+            </HelpItem>
+        </HelpFlow>
+    );
+}

--- a/src/views/HelpFlows/HelpFlows.styl
+++ b/src/views/HelpFlows/HelpFlows.styl
@@ -21,6 +21,6 @@
     z-index: z.dynamic-help;
 }
 
-#help-for-profile-edit-page {
+#help-for-profile-edit-page, #help-for-profile-edit-page-exv6 {
     max-width: 15rem;
 }

--- a/src/views/HelpFlows/HelpFlows.styl
+++ b/src/views/HelpFlows/HelpFlows.styl
@@ -19,6 +19,9 @@
 
 .rdh-help-item.rdh-help-item-custom {
     z-index: z.dynamic-help;
+    themed background-color help-popup-bg
+    themed border-color help-popup-bg
+    themed color fg
 }
 
 #help-for-profile-edit-page, #help-for-profile-edit-page-exv6 {

--- a/src/views/HelpFlows/HelpFlows.tsx
+++ b/src/views/HelpFlows/HelpFlows.tsx
@@ -19,43 +19,21 @@ import React from "react";
 
 import { HelpFlow, HelpItem } from "react-dynamic-help";
 
-import { _ } from "translate";
+import { GuestUserIntroEXV6 } from "./GuestUserIntroEXV6";
+import { GuestUserIntroOldNav } from "./GuestUserIntroOldNav";
 
+/**
+ * This component is just a handy wrapper for all the Help Flows
+ * (technically they _can_ be instantiated direct into the HelpProvider, but this encapsulation is tidier!)
+ */
 export function HelpFlows(): JSX.Element {
     return (
         <div id="help-flow-container">
-            <HelpFlow id="guest-user-intro" showInitially={true} debug={true}>
-                <HelpItem target="toggle-right-nav" position={"bottom-left"}>
-                    <div>{_("To set your password, click here")} </div>
-                </HelpItem>
-                <HelpItem target="settings-nav-link" position={"center-left"} anchor={"top-right"}>
-                    <div>{_("To set your password, click here")} </div>
-                </HelpItem>
-                <HelpItem
-                    target="account-settings-button"
-                    position={"center-left"}
-                    anchor={"top-right"}
-                >
-                    <div>{_("To set your password, click here")} </div>
-                </HelpItem>
-                <HelpItem target="password-entry" position={"center-right"}>
-                    <div>{_("You can enter your new password here.")} </div>
-                </HelpItem>
-                <HelpItem target="profile-edit-link">
-                    <div>{_("You can also change your username, here.")} </div>
-                </HelpItem>
-                <HelpItem
-                    target="profile-edit-page"
-                    position="center-left"
-                    id="help-for-profile-edit-page"
-                >
-                    <div>
-                        {_("In here you can change your profile appearance, then click 'Save'.")}{" "}
-                    </div>
-                </HelpItem>
-            </HelpFlow>
+            <GuestUserIntroEXV6 />
 
-            {/* you can register "help-test-flow" anywhere to get this to pop up if needed */}
+            <GuestUserIntroOldNav />
+
+            {/* you can register a "test-help" target anywhere to get this to pop up if needed */}
             <HelpFlow id="help-test-flow" showInitially={true} debug={true}>
                 <HelpItem target="test-help">
                     <div>This is a debug prompt!</div>

--- a/src/views/HelpFlows/HelpFlows.tsx
+++ b/src/views/HelpFlows/HelpFlows.tsx
@@ -17,8 +17,6 @@
 
 import React from "react";
 
-import { HelpFlow, HelpItem } from "react-dynamic-help";
-
 import { GuestUserIntroEXV6 } from "./GuestUserIntroEXV6";
 import { GuestUserIntroOldNav } from "./GuestUserIntroOldNav";
 
@@ -32,13 +30,6 @@ export function HelpFlows(): JSX.Element {
             <GuestUserIntroEXV6 />
 
             <GuestUserIntroOldNav />
-
-            {/* you can register a "test-help" target anywhere to get this to pop up if needed */}
-            <HelpFlow id="help-test-flow" showInitially={true} debug={true}>
-                <HelpItem target="test-help">
-                    <div>This is a debug prompt!</div>
-                </HelpItem>
-            </HelpFlow>
         </>
     );
 }

--- a/src/views/Settings/HelpSettings.tsx
+++ b/src/views/Settings/HelpSettings.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as data from "data";
+
+import { pgettext } from "translate";
+
+import {
+    DEFAULT_DYNAMIC_HELP_CONFIG,
+    DynamicHelpSet,
+    initializeHelpSet,
+    hideHelpSet,
+    allItemsVisible,
+    initialItemsVisible,
+    someItemsVisible,
+} from "dynamic_help_config";
+
+import { PreferenceLine } from "SettingsCommon";
+
+export function HelpSettings(): JSX.Element {
+    const help_sets = Object.keys(DEFAULT_DYNAMIC_HELP_CONFIG) as DynamicHelpSet[];
+
+    // Here, we keep the settings visibility value as state so we rerender when we change it.
+    // We get the initial value for the state by reading it from datam, or using the
+    // default values if it has never been set.
+    const [visibility, setVisibility] = React.useState<{ [help_set: string]: boolean }>(
+        Object.fromEntries(
+            help_sets.map((help_set) => [
+                help_set,
+                data.get(`dynamic-help.${help_set}`, DEFAULT_DYNAMIC_HELP_CONFIG[help_set])
+                    .show_set,
+            ]),
+        ),
+    );
+
+    const show = (help_set: DynamicHelpSet) => {
+        initializeHelpSet(help_set);
+        setVisibility({ ...visibility, [help_set]: true });
+    };
+
+    const hide = (help_set: DynamicHelpSet) => {
+        hideHelpSet(help_set);
+        setVisibility({ ...visibility, [help_set]: false });
+    };
+
+    return (
+        <div>
+            {help_sets.map((help_set) => (
+                <PreferenceLine
+                    key={help_set}
+                    title={DEFAULT_DYNAMIC_HELP_CONFIG[help_set].set_title}
+                >
+                    <button onClick={() => show(help_set)}>
+                        {pgettext("Press this button to show all the initial items", "Reset")}
+                    </button>
+                    <button onClick={() => hide(help_set)}>
+                        {pgettext("Press this button to hide this help set", "Hide set")}
+                    </button>
+                    <span>
+                        {pgettext(
+                            "Following this label is the status of currently visible help items",
+                            "Currently:",
+                        )}
+                    </span>
+                    <span>
+                        {allItemsVisible(help_set)
+                            ? "All"
+                            : initialItemsVisible(help_set)
+                            ? "Initial"
+                            : someItemsVisible(help_set)
+                            ? "Some"
+                            : "None"}
+                    </span>
+                </PreferenceLine>
+            ))}
+        </div>
+    );
+}

--- a/src/views/Settings/HelpSettings.tsx
+++ b/src/views/Settings/HelpSettings.tsx
@@ -19,13 +19,22 @@ import * as React from "react";
 
 import * as DynamicHelp from "react-dynamic-help";
 
-import { pgettext } from "translate";
+import { _, pgettext } from "translate";
 
+import { usePreference } from "preferences";
 import { PreferenceLine } from "SettingsCommon";
+import { Toggle } from "Toggle";
 
 export function HelpSettings(): JSX.Element {
-    const { getFlowInfo, enableFlow } = React.useContext(DynamicHelp.Api);
+    const { getFlowInfo, enableFlow, enableHelp } = React.useContext(DynamicHelp.Api);
     const availableHelp = getFlowInfo() as DynamicHelp.FlowState[];
+
+    const [help_enabled, _toggleHelpEnabled] = usePreference("help-system-enabled");
+
+    const toggleHelpEnabled = (ev) => {
+        enableHelp(!help_enabled);
+        _toggleHelpEnabled(ev);
+    };
 
     // we need a state to trigger re-reander after changing a flow visibility,
     // because DynamicHelp can't trigger a re-render in that circumstance.
@@ -50,27 +59,33 @@ export function HelpSettings(): JSX.Element {
 
     return (
         <div>
-            {availableHelp.map((flow, index) => (
-                <PreferenceLine key={index} title={flow.description}>
-                    <button onClick={() => show(flow)}>
-                        {pgettext("Press this button to show all the initial items", "Reset")}
-                    </button>
-                    <button onClick={() => hide(flow)}>
-                        {pgettext("Press this button to hide this help flow", "Hide")}
-                    </button>
-                    <span>
-                        {pgettext(
-                            "Following this label is the status of currently visible help items",
-                            "Currently:",
-                        )}
-                    </span>
-                    <span>
-                        {flow.visible
-                            ? pgettext("This help flow is showing its help items", "active")
-                            : pgettext("This help flow is not visible", "inactive")}
-                    </span>
-                </PreferenceLine>
-            ))}
+            <PreferenceLine title={_("Show dynamic help.")}>
+                <Toggle checked={help_enabled} onChange={toggleHelpEnabled} />
+            </PreferenceLine>
+
+            <div className={"help-detail-settings" + (help_enabled ? "" : " help-details-greyed")}>
+                {availableHelp.map((flow, index) => (
+                    <PreferenceLine key={index} title={flow.description}>
+                        <button onClick={() => show(flow)}>
+                            {pgettext("Press this button to show all the initial items", "Reset")}
+                        </button>
+                        <button onClick={() => hide(flow)}>
+                            {pgettext("Press this button to hide this help flow", "Hide")}
+                        </button>
+                        <span>
+                            {pgettext(
+                                "Following this label is the status of currently visible help items",
+                                "Currently:",
+                            )}
+                        </span>
+                        <span>
+                            {flow.visible
+                                ? pgettext("This help flow is showing its help items", "active")
+                                : pgettext("This help flow is not visible", "inactive")}
+                        </span>
+                    </PreferenceLine>
+                ))}
+            </div>
         </div>
     );
 }

--- a/src/views/Settings/Settings.styl
+++ b/src/views/Settings/Settings.styl
@@ -380,6 +380,10 @@
 #SelectedSettingsContainer {
     flex: 1;
     display: flex;
+
+    .help-details-greyed {
+        themed color shade4
+    }
 }
 
 // Mobile

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -48,6 +48,7 @@ import { AccountSettings } from "./AccountSettings";
 import { LinkPreferences } from "./LinkPreferences";
 import { AnnouncementPreferences } from "./AnnouncementPreferences";
 import { EmailPreferences } from "./EmailPreferences";
+import { HelpSettings } from "./HelpSettings";
 
 export function Settings(): JSX.Element {
     const { category } = useParams();
@@ -109,6 +110,7 @@ export function Settings(): JSX.Element {
         { key: "announcement", label: _("Announcements Preferences") },
         { key: "blocked_players", label: _("Blocked Players") },
         { key: "account", label: _("Account Settings"), ref: accountSettingsButton },
+        { key: "help", label: _("Help Settings") },
         { key: "link", label: _("Account Linking") },
         /*
         {
@@ -154,6 +156,9 @@ export function Settings(): JSX.Element {
             break;
         case "announcement":
             SelectedPage = AnnouncementPreferences;
+            break;
+        case "help":
+            SelectedPage = HelpSettings;
             break;
         case "link":
             SelectedPage = LinkPreferences;
@@ -257,7 +262,6 @@ type SettingsGroupProps = { selected: boolean; onClick: () => void; children: Re
 
 const SettingsGroup = React.forwardRef<HTMLDivElement, SettingsGroupProps>(
     (props: SettingsGroupProps, ref): JSX.Element => {
-        console.log("SettingsGroup render:", props.children, ref);
         return (
             <div
                 className={"SettingsGroup" + (props.selected ? " selected" : "")}

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,32 +23,32 @@
   integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
 
 "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.7.5":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.9.tgz#805461f967c77ff46c74ca0460ccf4fe933ddd59"
-  integrity sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.10.tgz#39ad504991d77f1f3da91be0b8b949a5bc466fb8"
+  integrity sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.9"
+    "@babel/generator" "^7.18.10"
     "@babel/helper-compilation-targets" "^7.18.9"
     "@babel/helper-module-transforms" "^7.18.9"
     "@babel/helpers" "^7.18.9"
-    "@babel/parser" "^7.18.9"
-    "@babel/template" "^7.18.6"
-    "@babel/traverse" "^7.18.9"
-    "@babel/types" "^7.18.9"
+    "@babel/parser" "^7.18.10"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.18.10"
+    "@babel/types" "^7.18.10"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/generator@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
-  integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
+"@babel/generator@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.10.tgz#794f328bfabdcbaf0ebf9bf91b5b57b61fa77a2a"
+  integrity sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==
   dependencies:
-    "@babel/types" "^7.18.9"
+    "@babel/types" "^7.18.10"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -122,6 +122,11 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-string-parser@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
+  integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
+
 "@babel/helper-validator-identifier@^7.15.7", "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
@@ -150,10 +155,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9", "@babel/parser@^7.5.5":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
-  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.5.5":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.10.tgz#94b5f8522356e69e8277276adf67ed280c90ecc1"
+  integrity sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -246,43 +251,44 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.18.6", "@babel/template@^7.3.3":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.6.tgz#1283f4993e00b929d6e2d3c72fdc9168a2977a31"
-  integrity sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==
+"@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.3.3":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
+  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.18.6"
-    "@babel/types" "^7.18.6"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
-  integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.18.10", "@babel/traverse@^7.18.9":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.10.tgz#37ad97d1cb00efa869b91dd5d1950f8a6cf0cb08"
+  integrity sha512-J7ycxg0/K9XCtLyHf0cz2DqDihonJeIo+z+HEdRe9YuT8TY4A66i+Ab2/xZCEW7Ro60bPCBBfqqboHSamoV3+g==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.9"
+    "@babel/generator" "^7.18.10"
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-function-name" "^7.18.9"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.9"
-    "@babel/types" "^7.18.9"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
-  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
+"@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.10.tgz#4908e81b6b339ca7c6b7a555a5fc29446f26dde6"
+  integrity sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==
   dependencies:
+    "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
@@ -335,17 +341,17 @@
   dependencies:
     tslib "^2.0.0"
 
-"@emotion/babel-plugin@^11.7.1":
-  version "11.9.5"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.9.5.tgz#99cdba190b40b782c276bfbd144df17cc42f765a"
-  integrity sha512-n+9y6TSsvAsOc0hXmdVtqgU6B+ils+zrzTZGg1aV2BkZtBbL7DiasLSpu3fUFwXOkYm63j7+649yb+HhyZxYSA==
+"@emotion/babel-plugin@^11.10.0":
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.0.tgz#ae545b8faa6b42d3a50ec86b70b758296f3c4467"
+  integrity sha512-xVnpDAAbtxL1dsuSelU5A7BnY/lftws0wUexNJZTPsvX/1tM4GZJbclgODhvW4E+NH7E5VFcH0bBn30NvniPJA==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
     "@babel/plugin-syntax-jsx" "^7.17.12"
     "@babel/runtime" "^7.18.3"
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.5"
-    "@emotion/serialize" "^1.0.2"
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/serialize" "^1.1.0"
     babel-plugin-macros "^3.1.0"
     convert-source-map "^1.5.0"
     escape-string-regexp "^4.0.0"
@@ -353,70 +359,70 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^11.4.0", "@emotion/cache@^11.9.3":
-  version "11.9.3"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.9.3.tgz#96638449f6929fd18062cfe04d79b29b44c0d6cb"
-  integrity sha512-0dgkI/JKlCXa+lEXviaMtGBL0ynpx4osh7rjOXE71q9bIF8G+XhJgvi+wDu0B0IdCVx37BffiwXlN9I3UuzFvg==
+"@emotion/cache@^11.10.0", "@emotion/cache@^11.4.0":
+  version "11.10.1"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.1.tgz#75a157c2a6bb9220450f73ebef1df2e1467dc65d"
+  integrity sha512-uZTj3Yz5D69GE25iFZcIQtibnVCFsc/6+XIozyL3ycgWvEdif2uEw9wlUt6umjLr4Keg9K6xRPHmD8LGi+6p1A==
   dependencies:
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/sheet" "^1.1.1"
-    "@emotion/utils" "^1.0.0"
-    "@emotion/weak-memoize" "^0.2.5"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/sheet" "^1.2.0"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
     stylis "4.0.13"
 
-"@emotion/hash@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
-  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+"@emotion/hash@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
+  integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
-"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
-  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+"@emotion/memoize@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
 "@emotion/react@^11.8.1":
-  version "11.9.3"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.9.3.tgz#f4f4f34444f6654a2e550f5dab4f2d360c101df9"
-  integrity sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.0.tgz#53c577f063f26493f68a05188fb87528d912ff2e"
+  integrity sha512-K6z9zlHxxBXwN8TcpwBKcEsBsOw4JWCCmR+BeeOWgqp8GIU1yA2Odd41bwdAAr0ssbQrbJbVnndvv7oiv1bZeQ==
   dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@emotion/babel-plugin" "^11.7.1"
-    "@emotion/cache" "^11.9.3"
-    "@emotion/serialize" "^1.0.4"
-    "@emotion/utils" "^1.1.0"
-    "@emotion/weak-memoize" "^0.2.5"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.0"
+    "@emotion/cache" "^11.10.0"
+    "@emotion/serialize" "^1.1.0"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.4.tgz#ff31fd11bb07999611199c2229e152faadc21a3c"
-  integrity sha512-1JHamSpH8PIfFwAMryO2bNka+y8+KA5yga5Ocf2d7ZEiJjb7xlLW7aknBGZqJLajuLOvJ+72vN+IBSwPlXD1Pg==
+"@emotion/serialize@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.0.tgz#b1f97b1011b09346a40e9796c37a3397b4ea8ea8"
+  integrity sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==
   dependencies:
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/unitless" "^0.7.5"
-    "@emotion/utils" "^1.0.0"
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/unitless" "^0.8.0"
+    "@emotion/utils" "^1.2.0"
     csstype "^3.0.2"
 
-"@emotion/sheet@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.1.tgz#015756e2a9a3c7c5f11d8ec22966a8dbfbfac787"
-  integrity sha512-J3YPccVRMiTZxYAY0IOq3kd+hUP8idY8Kz6B/Cyo+JuXq52Ek+zbPbSQUrVQp95aJ+lsAW7DPL1P2Z+U1jGkKA==
+"@emotion/sheet@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.0.tgz#771b1987855839e214fc1741bde43089397f7be5"
+  integrity sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w==
 
-"@emotion/unitless@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
-  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+"@emotion/unitless@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
+  integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
 
-"@emotion/utils@^1.0.0", "@emotion/utils@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
-  integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
+"@emotion/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
 
-"@emotion/weak-memoize@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
-  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+"@emotion/weak-memoize@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
+  integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@es-joy/jsdoccomment@~0.31.0":
   version "0.31.0"
@@ -461,14 +467,19 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@humanwhocodes/config-array@^0.9.2":
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
-  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+"@humanwhocodes/config-array@^0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
+  integrity sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
     minimatch "^3.0.4"
+
+"@humanwhocodes/gitignore-to-minimatch@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz#316b0a63b91c10e53f242efb4ace5c3b34e8728d"
+  integrity sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
@@ -1226,9 +1237,9 @@
     moment ">=2.14.0"
 
 "@types/node@*":
-  version "18.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.2.tgz#ffc5f0f099d27887c8d9067b54e55090fcd54126"
-  integrity sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==
+  version "18.6.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
+  integrity sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==
 
 "@types/node@^17.0.42":
   version "17.0.45"
@@ -1301,7 +1312,7 @@
     "@types/prop-types" "*"
     "@types/react" "^17"
 
-"@types/react@*", "@types/react@^17", "@types/react@^17.0.14", "@types/react@^18.0.15", "@types/react@^18.0.5":
+"@types/react@*", "@types/react@^17", "@types/react@^17.0.14", "@types/react@^18.0.5":
   version "18.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
   integrity sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==
@@ -1340,21 +1351,21 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin-tslint@^5.26.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.31.0.tgz#e678ecbd0cd87b494aeeffb9f99dee884b6c38b2"
-  integrity sha512-iUwfmHHZ0B8d5H9/rqfpD7rmxWZSl1e9T2yGKL8zr+zW/xpCohsNrWyHc7pkFRWWEoDDC33daoZHERtDZazWtw==
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.32.0.tgz#966a92c89dafe307b736ad6a4ad3672fe89cf1a6"
+  integrity sha512-CXX51UApOdlAkF46ZTg7M7kOjWEfb6Qy5NTNuRhQ3FUD+FCqae1eFlpsC0SFfyhjW/V5c8ctFGiiWezZnKDmVg==
   dependencies:
-    "@typescript-eslint/utils" "5.31.0"
+    "@typescript-eslint/utils" "5.32.0"
     lodash "^4.17.21"
 
 "@typescript-eslint/eslint-plugin@^5.26.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.31.0.tgz#cae1967b1e569e6171bbc6bec2afa4e0c8efccfe"
-  integrity sha512-VKW4JPHzG5yhYQrQ1AzXgVgX8ZAJEvCz0QI6mLRX4tf7rnFfh5D8SKm0Pq6w5PyNfAWJk6sv313+nEt3ohWMBQ==
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz#e27e38cffa4a61226327c874a7be965e9a861624"
+  integrity sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.31.0"
-    "@typescript-eslint/type-utils" "5.31.0"
-    "@typescript-eslint/utils" "5.31.0"
+    "@typescript-eslint/scope-manager" "5.32.0"
+    "@typescript-eslint/type-utils" "5.32.0"
+    "@typescript-eslint/utils" "5.32.0"
     debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
     ignore "^5.2.0"
@@ -1363,68 +1374,68 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.10.0", "@typescript-eslint/parser@^5.26.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.31.0.tgz#7f42d7dcc68a0a6d80a0f3d9a65063aee7bb8d2c"
-  integrity sha512-UStjQiZ9OFTFReTrN+iGrC6O/ko9LVDhreEK5S3edmXgR396JGq7CoX2TWIptqt/ESzU2iRKXAHfSF2WJFcWHw==
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.32.0.tgz#1de243443bc6186fb153b9e395b842e46877ca5d"
+  integrity sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.31.0"
-    "@typescript-eslint/types" "5.31.0"
-    "@typescript-eslint/typescript-estree" "5.31.0"
+    "@typescript-eslint/scope-manager" "5.32.0"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/typescript-estree" "5.32.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.31.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.31.0.tgz#f47a794ba84d9b818ab7f8f44fff55a61016c606"
-  integrity sha512-8jfEzBYDBG88rcXFxajdVavGxb5/XKXyvWgvD8Qix3EEJLCFIdVloJw+r9ww0wbyNLOTYyBsR+4ALNGdlalLLg==
+"@typescript-eslint/scope-manager@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz#763386e963a8def470580cc36cf9228864190b95"
+  integrity sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==
   dependencies:
-    "@typescript-eslint/types" "5.31.0"
-    "@typescript-eslint/visitor-keys" "5.31.0"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/visitor-keys" "5.32.0"
 
-"@typescript-eslint/type-utils@5.31.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.31.0.tgz#70a0b7201360b5adbddb0c36080495aa08f6f3d9"
-  integrity sha512-7ZYqFbvEvYXFn9ax02GsPcEOmuWNg+14HIf4q+oUuLnMbpJ6eHAivCg7tZMVwzrIuzX3QCeAOqKoyMZCv5xe+w==
+"@typescript-eslint/type-utils@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz#45a14506fe3fb908600b4cef2f70778f7b5cdc79"
+  integrity sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==
   dependencies:
-    "@typescript-eslint/utils" "5.31.0"
+    "@typescript-eslint/utils" "5.32.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.31.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.31.0.tgz#7aa389122b64b18e473c1672fb3b8310e5f07a9a"
-  integrity sha512-/f/rMaEseux+I4wmR6mfpM2wvtNZb1p9hAV77hWfuKc3pmaANp5dLAZSiE3/8oXTYTt3uV9KW5yZKJsMievp6g==
+"@typescript-eslint/types@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.32.0.tgz#484273021eeeae87ddb288f39586ef5efeb6dcd8"
+  integrity sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==
 
-"@typescript-eslint/typescript-estree@5.31.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.31.0.tgz#eb92970c9d6e3946690d50c346fb9b1d745ee882"
-  integrity sha512-3S625TMcARX71wBc2qubHaoUwMEn+l9TCsaIzYI/ET31Xm2c9YQ+zhGgpydjorwQO9pLfR/6peTzS/0G3J/hDw==
+"@typescript-eslint/typescript-estree@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz#282943f34babf07a4afa7b0ff347a8e7b6030d12"
+  integrity sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==
   dependencies:
-    "@typescript-eslint/types" "5.31.0"
-    "@typescript-eslint/visitor-keys" "5.31.0"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/visitor-keys" "5.32.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.31.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.31.0.tgz#e146fa00dca948bfe547d665b2138a2dc1b79acd"
-  integrity sha512-kcVPdQS6VIpVTQ7QnGNKMFtdJdvnStkqS5LeALr4rcwx11G6OWb2HB17NMPnlRHvaZP38hL9iK8DdE9Fne7NYg==
+"@typescript-eslint/utils@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.32.0.tgz#eccb6b672b94516f1afc6508d05173c45924840c"
+  integrity sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.31.0"
-    "@typescript-eslint/types" "5.31.0"
-    "@typescript-eslint/typescript-estree" "5.31.0"
+    "@typescript-eslint/scope-manager" "5.32.0"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/typescript-estree" "5.32.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.31.0":
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.31.0.tgz#b0eca264df01ce85dceb76aebff3784629258f54"
-  integrity sha512-ZK0jVxSjS4gnPirpVjXHz7mgdOsZUHzNYSfTw2yPa3agfbt9YfqaBiBZFSSxeBWnpWkzCxTfUpnzA3Vily/CSg==
+"@typescript-eslint/visitor-keys@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz#b9715d0b11fdb5dd10fd0c42ff13987470525394"
+  integrity sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==
   dependencies:
-    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/types" "5.32.0"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
@@ -1646,7 +1657,7 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.4, acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1:
+acorn@^8.0.4, acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
@@ -2004,12 +2015,12 @@ attr-accept@^2.2.2:
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
 autoprefixer@^10.4.2:
-  version "10.4.7"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.7.tgz#1db8d195f41a52ca5069b7593be167618edbbedf"
-  integrity sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==
+  version "10.4.8"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.8.tgz#92c7a0199e1cfb2ad5d9427bd585a3d75895b9e5"
+  integrity sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==
   dependencies:
-    browserslist "^4.20.3"
-    caniuse-lite "^1.0.30001335"
+    browserslist "^4.21.3"
+    caniuse-lite "^1.0.30001373"
     fraction.js "^4.2.0"
     normalize-range "^0.1.2"
     picocolors "^1.0.0"
@@ -2209,7 +2220,7 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.20.2, browserslist@^4.20.3:
+browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.20.2, browserslist@^4.20.3, browserslist@^4.21.3:
   version "4.21.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.3.tgz#5df277694eb3c48bc5c4b05af3e8b7e09c5a6d1a"
   integrity sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==
@@ -2253,7 +2264,7 @@ builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==
 
-builtin-modules@^3.0.0:
+builtin-modules@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
@@ -2334,7 +2345,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001370:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
   version "1.0.30001373"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz#2dc3bc3bfcb5d5a929bec11300883040d7b4b4be"
   integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
@@ -3553,9 +3564,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.202:
-  version "1.4.206"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.206.tgz#580ff85b54d7ec0c05f20b1e37ea0becdd7b0ee4"
-  integrity sha512-h+Fadt1gIaQ06JaIiyqPsBjJ08fV5Q7md+V8bUvQW/9OvXfL2LRICTz2EcnnCP7QzrFTS6/27MRV6Bl9Yn97zA==
+  version "1.4.210"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz#12611fe874b833a3bf3671438b5893aba7858980"
+  integrity sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -3692,9 +3703,9 @@ es-to-primitive@^1.2.1:
     is-symbol "^1.0.2"
 
 es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
-  version "0.10.61"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.61.tgz#311de37949ef86b6b0dcea894d1ffedb909d3269"
-  integrity sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==
+  version "0.10.62"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.62.tgz#5e6adc19a6da524bf3d1e02bbc8960e5eb49a9a5"
+  integrity sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==
   dependencies:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.3"
@@ -3810,9 +3821,9 @@ eslint-plugin-import@^2.26.0:
     tsconfig-paths "^3.14.1"
 
 eslint-plugin-jsdoc@^39.3.1:
-  version "39.3.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.3.tgz#75dd67ce581e7527a69f27800138cc0f9c388236"
-  integrity sha512-K/DAjKRUNaUTf0KQhI9PvsF+Y3mGDx/j0pofXsJCQe/tmRsRweBIXR353c8nAro0lytZYEf7l0PluBpzKDiHxw==
+  version "39.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.4.tgz#6d18c5a071ada5babce9636b02a6c8355e9de2e8"
+  integrity sha512-dYWXhMMHJaq++bY2hyByhgiRzt5qQ7XdfQGiHrU9f3APSSVZ/HuOnXuvUUX7W0jO55Udsu4/7iRlpF/yLFQdSA==
   dependencies:
     "@es-joy/jsdoccomment" "~0.31.0"
     comment-parser "1.3.1"
@@ -3893,12 +3904,13 @@ eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@8, eslint@^8.16.0, eslint@^8.7.0:
-  version "8.20.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.20.0.tgz#048ac56aa18529967da8354a478be4ec0a2bc81b"
-  integrity sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.21.0.tgz#1940a68d7e0573cef6f50037addee295ff9be9ef"
+  integrity sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==
   dependencies:
     "@eslint/eslintrc" "^1.3.0"
-    "@humanwhocodes/config-array" "^0.9.2"
+    "@humanwhocodes/config-array" "^0.10.4"
+    "@humanwhocodes/gitignore-to-minimatch" "^1.0.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -3908,14 +3920,17 @@ eslint@8, eslint@^8.16.0, eslint@^8.7.0:
     eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
     eslint-visitor-keys "^3.3.0"
-    espree "^9.3.2"
+    espree "^9.3.3"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
     functional-red-black-tree "^1.0.1"
     glob-parent "^6.0.1"
     globals "^13.15.0"
+    globby "^11.1.0"
+    grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -3933,12 +3948,12 @@ eslint@8, eslint@^8.16.0, eslint@^8.7.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.0.0, espree@^9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
-  integrity sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==
+espree@^9.0.0, espree@^9.3.2, espree@^9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.3.tgz#2dd37c4162bb05f433ad3c1a52ddf8a49dc08e9d"
+  integrity sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==
   dependencies:
-    acorn "^8.7.1"
+    acorn "^8.8.0"
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
@@ -4237,9 +4252,9 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastest-levenshtein@^1.0.12:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz#9054384e4b7a78c88d01a4432dc18871af0ac859"
-  integrity sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
+  integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -4337,6 +4352,14 @@ find-up@^4.0.0, find-up@^4.1.0:
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 findup-sync@^2.0.0:
@@ -4718,6 +4741,11 @@ graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, gr
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -5241,11 +5269,11 @@ is-buffer@^1.1.5:
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-builtin-module@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.1.0.tgz#6fdb24313b1c03b75f8b9711c0feb8c30b903b00"
-  integrity sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz#bb0310dfe881f144ca83f30100ceb10cf58835e0"
+  integrity sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==
   dependencies:
-    builtin-modules "^3.0.0"
+    builtin-modules "^3.3.0"
 
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
@@ -6313,6 +6341,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash-es@^4.2.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
@@ -7107,6 +7142,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -7120,6 +7162,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map@^4.0.0:
   version "4.0.0"
@@ -7870,14 +7919,6 @@ react-dropzone@^12.0.5:
     file-selector "^0.5.0"
     prop-types "^15.8.1"
 
-react-dynamic-help@^0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-0.15.1.tgz#ab4e01f00af5c49c2c151bd9e273ed145116a725"
-  integrity sha512-B1g8x0+Jha0SnBNdqAnButt1CYPC5yb3WM/ZgOUoJfNV9YjiqacXaZvMwYHMax/a/VCQtsCF/Yxy1Tt6lN7cyA==
-  dependencies:
-    "@types/react" "^18.0.15"
-    react "^18.2.0"
-
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -7975,9 +8016,9 @@ react-themeable@^1.1.0:
     object-assign "^3.0.0"
 
 react-transition-group@^4.3.0:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
-  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"
@@ -7996,7 +8037,7 @@ react-virtualized@^9.22.3:
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
 
-react@^18.0.0, react@^18.2.0:
+react@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -9427,9 +9468,9 @@ type@^1.0.1:
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
 
 type@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f"
-  integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.6.1.tgz#808f389ec777205cc3cd97c1c88ec1a913105aae"
+  integrity sha512-OvgH5rB0XM+iDZGQ1Eg/o7IZn0XYJFVrN/9FQ4OWIYILyJJgVP2s1hLTOFn6UOZoDUI/HctGa0PFlE2n2HW3NQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -10103,3 +10144,8 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,7 +1312,7 @@
     "@types/prop-types" "*"
     "@types/react" "^17"
 
-"@types/react@*", "@types/react@^17", "@types/react@^17.0.14", "@types/react@^18.0.5":
+"@types/react@*", "@types/react@^17", "@types/react@^17.0.14", "@types/react@^18.0.15", "@types/react@^18.0.5":
   version "18.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
   integrity sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==
@@ -7919,6 +7919,14 @@ react-dropzone@^12.0.5:
     file-selector "^0.5.0"
     prop-types "^15.8.1"
 
+react-dynamic-help@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-1.0.2.tgz#33d3c97e6030230be8ea28ccab7dd0f3053c5a44"
+  integrity sha512-5zRTqeHcou+45ZeYFSYpcertQUMZR6jzw5WFAwKDpqcoZHV8lkpmX+gEZc0QUA1EvY8EJJYncig4r2g4V21AgA==
+  dependencies:
+    "@types/react" "^18.0.15"
+    react "^18.2.0"
+
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -8037,7 +8045,7 @@ react-virtualized@^9.22.3:
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
 
-react@^18.0.0:
+react@^18.0.0, react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
Fixes most feedback.

This is on top of PR #1951 .

## Proposed Changes

As per package.json, this needs react-dynamic-help 1.0.2.

 - There's a "Help Settings" settings page.
 - Positioning appears to be mostly acceptable
 - One snag is that in "mobile" layouts there is no popup on the Settings pages to say "click the dropdown and select Account"
    - buy hey,  before there was no help at all :)
    - this is because I haven't figured out how to have branching flows dependent on funky things like display:none
 - Colors are themed and contrasted
    - Drop shadow for popup didn't look that good, I think.
 - The "totally reset help system state" button can be enabled with `data.set("debug-dynamic-help", true)`
    - It might not be needed, because the  HelpSettings page lets you reset each flow.
    - But if you have cruft from old flows then it would be needed
       - Soon DynamicHelp should know how to clean up those

 The help flows can be tested either by arriving at a game as a guest user from a challenge link, or by going to Help settings and pressing "reset".

To properly see the guest's experience, you should then open the "General" page of Settings, before following the popup prompt (otherwise when you arrive back at Settings you'll be on the HelpSettings page, which isn't quite authentic)

      