### PR TITLE
Use words instead of 'x' to dismiss popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "react-datetime": "^3.0.4",
         "react-dom": "^18.0.0",
         "react-dropzone": "^12.0.5",
-        "react-dynamic-help": "1.1.1",
+        "react-dynamic-help": "1.1.2",
         "react-linkify": "^1.0.0-alpha",
         "react-number-format": "^3.0.2",
         "react-resize-detector": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "react-datetime": "^3.0.4",
         "react-dom": "^18.0.0",
         "react-dropzone": "^12.0.5",
-        "react-dynamic-help": "^1.0.2",
+        "react-dynamic-help": "1.1.1",
         "react-linkify": "^1.0.0-alpha",
         "react-number-format": "^3.0.2",
         "react-resize-detector": "^7.1.1",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,7 @@
 import "whatwg-fetch"; /* polyfills window.fetch */
 import * as Sentry from "@sentry/browser";
 
-import { HelpProvider } from "react-dynamic-help";
+import { HelpProvider, HelpPopupDictionary } from "react-dynamic-help";
 
 import { configure_goban } from "configure-goban";
 import {
@@ -146,7 +146,7 @@ import { routes } from "./routes";
 import { errorAlerter, uuid } from "misc";
 import { close_all_popovers } from "popover";
 import * as sockets from "sockets";
-import { _, setCurrentLanguage } from "translate";
+import { _, setCurrentLanguage, pgettext } from "translate";
 import { init_tabcomplete } from "tabcomplete";
 import * as player_cache from "player_cache";
 import { toast } from "toast";
@@ -345,9 +345,17 @@ const react_root = ReactDOM.createRoot(document.getElementById("main-content"));
 
 const debugDynamicHelp = data.get("debug-dynamic-help", false);
 
+const helpPopupDictionary: HelpPopupDictionary = {
+    "Don't show me these": pgettext(
+        "A button to turn off help popups completely",
+        "Don't show me these",
+    ),
+    Skip: pgettext("A button to dismiss a help popup", "Skip"),
+};
+
 react_root.render(
     <React.StrictMode>
-        <HelpProvider debug={debugDynamicHelp}>
+        <HelpProvider debug={debugDynamicHelp} dictionary={helpPopupDictionary}>
             <ForceReactUpdateWrapper>{routes}</ForceReactUpdateWrapper>
             <HelpFlows />
         </HelpProvider>

--- a/src/views/HelpFlows/HelpFlows.styl
+++ b/src/views/HelpFlows/HelpFlows.styl
@@ -24,6 +24,11 @@
     themed color fg
 }
 
+.rdh-help-item>.rdh-popup-dismissers {
+    themed color shade1
+    cursor: pointer;
+}
+
 #help-for-profile-edit-page, #help-for-profile-edit-page-exv6 {
     max-width: 15rem;
 }

--- a/src/views/HelpFlows/HelpFlows.tsx
+++ b/src/views/HelpFlows/HelpFlows.tsx
@@ -23,7 +23,9 @@ import { GuestUserIntroOldNav } from "./GuestUserIntroOldNav";
 /**
  * This component is just a handy wrapper for all the Help Flows
  * (technically they _can_ be instantiated direct into the HelpProvider, but this encapsulation is tidier!)
+ *
  */
+
 export function HelpFlows(): JSX.Element {
     return (
         <>

--- a/src/views/Settings/HelpSettings.tsx
+++ b/src/views/Settings/HelpSettings.tsx
@@ -21,19 +21,27 @@ import * as DynamicHelp from "react-dynamic-help";
 
 import { _, pgettext } from "translate";
 
-import { usePreference } from "preferences";
 import { PreferenceLine } from "SettingsCommon";
 import { Toggle } from "Toggle";
 
 export function HelpSettings(): JSX.Element {
-    const { getFlowInfo, enableFlow, enableHelp } = React.useContext(DynamicHelp.Api);
+    const {
+        getFlowInfo,
+        enableFlow,
+        enableHelp,
+        getSystemStatus: helpSystemStatus,
+    } = React.useContext(DynamicHelp.Api);
+
     const availableHelp = getFlowInfo() as DynamicHelp.FlowState[];
 
-    const [help_enabled, _toggleHelpEnabled] = usePreference("help-system-enabled");
+    const helpEnabled = helpSystemStatus().enabled;
 
-    const toggleHelpEnabled = (ev) => {
-        enableHelp(!help_enabled);
-        _toggleHelpEnabled(ev);
+    // a local state variable to make sure we re-render when enabled state changes
+    const [__helpEnabled, setRenderNewHelpState] = React.useState(helpEnabled);
+
+    const toggleHelpEnabled = () => {
+        enableHelp(!helpEnabled);
+        setRenderNewHelpState(!helpEnabled);
     };
 
     // we need a state to trigger re-reander after changing a flow visibility,
@@ -60,10 +68,10 @@ export function HelpSettings(): JSX.Element {
     return (
         <div>
             <PreferenceLine title={_("Show dynamic help.")}>
-                <Toggle checked={help_enabled} onChange={toggleHelpEnabled} />
+                <Toggle checked={__helpEnabled} onChange={toggleHelpEnabled} />
             </PreferenceLine>
 
-            <div className={"help-detail-settings" + (help_enabled ? "" : " help-details-greyed")}>
+            <div className={"help-detail-settings" + (__helpEnabled ? "" : " help-details-greyed")}>
                 {availableHelp.map((flow, index) => (
                     <PreferenceLine key={index} title={flow.description}>
                         <button onClick={() => show(flow)}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,10 +7919,10 @@ react-dropzone@^12.0.5:
     file-selector "^0.5.0"
     prop-types "^15.8.1"
 
-react-dynamic-help@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-1.1.1.tgz#be95bac8c11737f93f18f83072ac10fb1949b5e8"
-  integrity sha512-HYteFcMrtn3I+Zhxdh0pDX6JoTLWgeaNnHeX1Q5uPmOhsyoaU6AMctTgzsBDMEJ7p6MS99fQbDcAYoU745/vUg==
+react-dynamic-help@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-1.1.2.tgz#e655d2c729c1ed94c47e003cc614553f522224c2"
+  integrity sha512-3cP/RwdS9UPn7pU8nSWyar0Cvsz6KP4xDaAn3j4OoqfxYnYdIfESVbNN4E4lr6lP+SSspPSmc66n6Okv0UZdoQ==
   dependencies:
     "@types/react" "^18.0.15"
     react "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7919,10 +7919,10 @@ react-dropzone@^12.0.5:
     file-selector "^0.5.0"
     prop-types "^15.8.1"
 
-react-dynamic-help@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-1.0.2.tgz#33d3c97e6030230be8ea28ccab7dd0f3053c5a44"
-  integrity sha512-5zRTqeHcou+45ZeYFSYpcertQUMZR6jzw5WFAwKDpqcoZHV8lkpmX+gEZc0QUA1EvY8EJJYncig4r2g4V21AgA==
+react-dynamic-help@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-1.1.1.tgz#be95bac8c11737f93f18f83072ac10fb1949b5e8"
+  integrity sha512-HYteFcMrtn3I+Zhxdh0pDX6JoTLWgeaNnHeX1Q5uPmOhsyoaU6AMctTgzsBDMEJ7p6MS99fQbDcAYoU745/vUg==
   dependencies:
     "@types/react" "^18.0.15"
     react "^18.2.0"


### PR DESCRIPTION
Fixes #1955, #1956

## Proposed Changes

 - Put "links" into the popup instead of 'x', as per #1955 
 - Allow app to provide translations for the words, via props on HelpProvider
 - Move to react-dynamic-help 1.1.2, to fix #1956

As a consequence of "turning off help" being an event that comes from an RDH popup, the settings page logic for displaying that is updated as well.   The previous implementation was a wrong direction, duplicating the preference in OGS preferences and RDH preference storage.  So that's fixed.

