### PR TITLE
Add profile fields to Account Settings page

### DIFF
--- a/src/components/InfoBall/InfoBall.styl
+++ b/src/components/InfoBall/InfoBall.styl
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ .InfoBall {
+     padding-left: 0.5rem;
+     padding-right: 0.5rem;
+     position: relative;
+
+     i {
+         cursor: pointer;
+     }
+
+     .details {
+         display: none;
+     }
+
+     &.force-show-details, &:hover {
+         .details {
+             display: inline-block;
+             max-width: 20rem;
+             width: 20rem;
+             position: absolute;
+             themed background-color primary
+             themed color colored-background-fg
+             border-radius: 0.5rem;
+             padding: 0.5rem;
+             z-index: z.infoball;
+         }
+     }
+
+     .backdrop {
+         display: inline-block;
+         position: fixed;
+         top: 0;
+         left: 0;
+         right: 0;
+         bottom: 0;
+         z-index: z.modal.backdrop;
+     }
+
+ }

--- a/src/components/InfoBall/InfoBall.styl
+++ b/src/components/InfoBall/InfoBall.styl
@@ -52,4 +52,10 @@
          z-index: z.modal.backdrop;
      }
 
+
+     &.force-hide-details {
+         .details {
+             display: none !important;
+         }
+     }
  }

--- a/src/components/InfoBall/InfoBall.styl
+++ b/src/components/InfoBall/InfoBall.styl
@@ -39,6 +39,8 @@
              border-radius: 0.5rem;
              padding: 0.5rem;
              z-index: z.infoball;
+             top: 1.5rem;
+             left: 0;
          }
      }
 

--- a/src/components/InfoBall/InfoBall.tsx
+++ b/src/components/InfoBall/InfoBall.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* From https://loading.io/css/ */
+
+import * as React from "react";
+
+interface InfoBallProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+export function InfoBall({ children, className }: InfoBallProps): JSX.Element {
+    const [show, setShow] = React.useState(false);
+
+    if (!className) {
+        className = "fa fa-info-circle";
+    }
+    return (
+        <span
+            className={"InfoBall" + (show ? " force-show-details" : "")}
+            onClick={() => {
+                setShow(!show);
+            }}
+        >
+            <i className={className} />
+            <div className="details">{children}</div>
+            {show ? <div className="backdrop" onClick={() => setShow(false)} /> : null}
+        </span>
+    );
+}

--- a/src/components/InfoBall/InfoBall.tsx
+++ b/src/components/InfoBall/InfoBall.tsx
@@ -25,21 +25,54 @@ interface InfoBallProps {
 }
 
 export function InfoBall({ children, className }: InfoBallProps): JSX.Element {
+    /* The force hide system is to prevent the info box being held open on a
+     * mobile device when the details popup is clicked. The expected behavior
+     * is to close, and while show does set to close, because the users input
+     * focus is now over the details box, the :hover takes over and keeps it
+     * open. */
     const [show, setShow] = React.useState(false);
+    const [forceHide, setForceHide] = React.useState(false);
 
     if (!className) {
         className = "fa fa-info-circle";
     }
     return (
         <span
-            className={"InfoBall" + (show ? " force-show-details" : "")}
+            className={
+                "InfoBall" +
+                (show ? " force-show-details" : "") +
+                (forceHide ? " force-hide-details" : "")
+            }
             onClick={() => {
                 setShow(!show);
             }}
         >
-            <i className={className} />
-            <div className="details">{children}</div>
-            {show ? <div className="backdrop" onClick={() => setShow(false)} /> : null}
+            <i
+                className={className}
+                onMouseEnter={() => {
+                    setForceHide(false);
+                }}
+            />
+            <div
+                className="details"
+                onClick={(event) => {
+                    setShow(false);
+                    setForceHide(true);
+                    event.stopPropagation();
+                    return false;
+                }}
+            >
+                {children}
+            </div>
+            {show ? (
+                <div
+                    className="backdrop"
+                    onClick={(event) => {
+                        setShow(false);
+                        event.stopPropagation();
+                    }}
+                />
+            ) : null}
         </span>
     );
 }

--- a/src/components/InfoBall/index.ts
+++ b/src/components/InfoBall/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./InfoBall";

--- a/src/components/NavBar/EXV6NavBar.styl
+++ b/src/components/NavBar/EXV6NavBar.styl
@@ -44,6 +44,10 @@ header.NavBar {
         flex-shrink: 0;
     }
 
+    .mobile-only {
+        display: none !important;
+    }
+
     /* desktop / wide screens */
     @media (min-width: (hamburger-cutoff + 1px)) {
 
@@ -114,6 +118,14 @@ header.NavBar {
     @media only screen and (max-width: hamburger-cutoff) {
         .left {
             display: none !important;
+        }
+
+        .Menu.mobile-only {
+            display: flex !important;
+
+            img.PlayerIcon {
+                margin-left: 0.5rem;
+            }
         }
 
         .icon-container {

--- a/src/components/NavBar/EXV6NavBar.tsx
+++ b/src/components/NavBar/EXV6NavBar.tsx
@@ -268,6 +268,22 @@ export function EXV6NavBar(): JSX.Element {
                         </Link>
                     )}
                 </Menu>
+
+                <Menu title={_("Settings")} to="/settings" className="mobile-only">
+                    <Link to={`/user/view/${user.id}`}>
+                        <PlayerIcon user={user} size={16} />
+                        {_("Profile")}
+                    </Link>
+
+                    <Link to="/user/settings" ref={settingsNavLink}>
+                        <i className="fa fa-gear"></i>
+                        {_("Settings")}
+                    </Link>
+                    <span className="fakelink" onClick={logout}>
+                        <i className="fa fa-power-off"></i>
+                        {_("Sign out")}
+                    </span>
+                </Menu>
             </nav>
 
             <section className="center OmniSearch-container">
@@ -386,11 +402,12 @@ interface MenuProps {
     title: string;
     to?: string;
     children: React.ReactNode;
+    className?: string;
 }
 
-function Menu({ title, to, children }: MenuProps): JSX.Element {
+function Menu({ title, to, children, className }: MenuProps): JSX.Element {
     return (
-        <section className="Menu">
+        <section className={"Menu " + (className || "")}>
             {to ? (
                 <Link to={to} className="Menu-title">
                     {title}

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -84,6 +84,7 @@ z = {
         container      : 2010,
     },
     popover            : 5000,
+    infoball           : 5010,
     report             : 6000,
     swal               : 10000,
     challenge-link     : 10010,  // We have to say "Challenge Link Copied" over the top of "Challenge Created"

--- a/src/views/Settings/AccountSettings.styl
+++ b/src/views/Settings/AccountSettings.styl
@@ -1,0 +1,49 @@
+.AccountSettings {
+    display: flex;
+    flex-direction: column;
+
+
+    .explanation {
+        margin-top: 0.5rem;
+    }
+
+    .fa-info-circle {
+        margin-right: 0.5rem;
+    }
+
+    .row {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
+        flex-wrap: wrap;
+    }
+
+    .left, .right {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        flex: 1;
+        width: 45%;
+        min-width: 20rem;
+        padding-right: 1rem;
+    }
+
+    .bottom {
+
+    }
+
+    .password-update {
+        padding: 0.5rem;
+    }
+
+    .save-button-container {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+        margin-top: 1rem;
+    }
+}

--- a/src/views/Settings/AccountSettings.styl
+++ b/src/views/Settings/AccountSettings.styl
@@ -2,15 +2,6 @@
     display: flex;
     flex-direction: column;
 
-
-    .explanation {
-        margin-top: 0.5rem;
-    }
-
-    .fa-info-circle {
-        margin-right: 0.5rem;
-    }
-
     .row {
         display: flex;
         flex-direction: row;

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -303,7 +303,7 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
                                     <i>
                                         {pgettext(
                                             "This is an explanation for what 'Username' is",
-                                            "This is what other players will know you as.",
+                                            "This is what other players will know you as. You may change your username once every 30 days.",
                                         )}
                                     </i>
                                 </div>

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -30,6 +30,7 @@ import { useUser } from "hooks";
 import { image_resizer } from "image_resizer";
 import { Flag } from "Flag";
 import { toast } from "toast";
+import { InfoBall } from "InfoBall";
 import { pgettext, sorted_locale_countries, _ } from "translate";
 
 export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
@@ -290,27 +291,48 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
             <div className="row">
                 <div className="left">
                     <dl>
-                        <dt>{_("Username")}</dt>
+                        <dt>
+                            {_("Username")}
+                            <InfoBall>
+                                {pgettext(
+                                    "This is an explanation for what 'Username' is",
+                                    "This is what other players will know you as. You may change your username once every 30 days.",
+                                )}
+                            </InfoBall>
+                        </dt>
                         <dd>
                             <div>
                                 <input
                                     value={username}
                                     onChange={(ev) => setUsername(ev.target.value)}
                                 />
-
-                                <div className="explanation">
-                                    <i className="fa fa-info-circle" />
-                                    <i>
-                                        {pgettext(
-                                            "This is an explanation for what 'Username' is",
-                                            "This is what other players will know you as. You may change your username once every 30 days.",
-                                        )}
-                                    </i>
-                                </div>
                             </div>
                         </dd>
 
-                        <dt>{_("Name")}</dt>
+                        <dt>{_("Password")}</dt>
+                        <dd className="password-update" ref={passwordEntry}>
+                            <div>
+                                <input
+                                    type="password"
+                                    placeholder={_("Enter a new password")}
+                                    value={password1}
+                                    onChange={(ev) => setPassword1(ev.target.value)}
+                                />
+                            </div>
+                            <div>
+                                <input
+                                    placeholder={_("(again)")}
+                                    type="password"
+                                    value={password2}
+                                    onChange={(ev) => setPassword2(ev.target.value)}
+                                />
+                            </div>
+                        </dd>
+
+                        <dt>
+                            {_("Name")}
+                            <InfoBall>{_("Providing your real name is optional.")}</InfoBall>
+                        </dt>
                         <dd>
                             <div>
                                 <input
@@ -336,33 +358,16 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
                                 />{" "}
                                 <label htmlFor="real-name-is-private">{_("Hide real name")}</label>
                             </div>
-
-                            <div className="explanation">
-                                <i className="fa fa-info-circle" />
-                                <i>{_("Providing your real name is optional.")}</i>
-                            </div>
                         </dd>
 
-                        <dt>{_("Password")}</dt>
-                        <dd className="password-update" ref={passwordEntry}>
-                            <div>
-                                <input
-                                    type="password"
-                                    value={password1}
-                                    onChange={(ev) => setPassword1(ev.target.value)}
-                                />
-                            </div>
-                            <div>
-                                <input
-                                    placeholder={_("(again)")}
-                                    type="password"
-                                    value={password2}
-                                    onChange={(ev) => setPassword2(ev.target.value)}
-                                />
-                            </div>
-                        </dd>
-
-                        <dt>{_("Email address")}</dt>
+                        <dt>
+                            {_("Email address")}
+                            <InfoBall>
+                                {_(
+                                    'Providing your email address is optional. Your email address is used for sending things like password reset requests and turn notifications. Notification emails may be turned off under "Email Notifications".',
+                                )}
+                            </InfoBall>
+                        </dt>
                         <dd>
                             <input
                                 type="email"
@@ -370,13 +375,8 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
                                 value={email}
                                 onChange={(ev) => setEmail(ev.target.value)}
                             />
-                            <div className="explanation">
-                                <i className="fa fa-info-circle" />
-                                <i>
-                                    {_(
-                                        'Providing your email address is optional. We will never sell your email address to third parties. Your email address is used for sending things like password reset requests and turn notifications. Notification emails may be turned off under "Email Notifications".',
-                                    )}
-                                </i>
+                            <div style={{ marginTop: "0.5rem" }}>
+                                <i>We will never sell your email address.</i>
                             </div>
 
                             {email && !email_changed && !email_validated && (


### PR DESCRIPTION
This patch finally adds the username, icon, country, website, name fields to the "Account Settings" page.

The fields are still editable on the profile pages as well, at least for the time being.

---

@GreenAsJade I removed a line

```
const { ref: profileLink } = registerTargetItem("profile-edit-link"); // cleared on Profile page
```
that was related to the help stuff you've been working on. I *think* this was not being used anymore, and would be obviated anyways, but I wanted to let you know in case I missed something.
