### PR TITLE
Move to rdh 1.2.0 for rdh-target-highlight class

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "react-datetime": "^3.0.4",
         "react-dom": "^18.0.0",
         "react-dropzone": "^12.0.5",
-        "react-dynamic-help": "1.1.3",
+        "react-dynamic-help": "^1.2.0",
         "react-linkify": "^1.0.0-alpha",
         "react-number-format": "^3.0.2",
         "react-resize-detector": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7940,10 +7940,10 @@ react-dropzone@^12.0.5:
     file-selector "^0.5.0"
     prop-types "^15.8.1"
 
-react-dynamic-help@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-1.1.3.tgz#3bfebf9c82bc1793f4b0ca67d6c60999c478f1ea"
-  integrity sha512-5FX4K6QMTl3r5snKbEZ/15hrSoFBK/s0DLIFt+vBldfLWAOn3pGEGLk/rK9zDOm5vZsVj4M+yeKtuYRkLG0uyw==
+react-dynamic-help@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-1.2.0.tgz#07a886fbe29db0bdac271792e9602d7c70f143dc"
+  integrity sha512-9ute9o9gLzuvEmqHMRduewt2LRszoi9QkmnHt94X+LuyeVc+O8sj+lzvnrVF/v1RN6xitTjK2nFiwyQ6tZ4hJw==
   dependencies:
     "@types/react" "^18.0.15"
 


### PR DESCRIPTION
Fixes inability to customise dynamic help target highlighting

## Proposed Changes

Added css classes instead of box shadow to rdh targets.

`rdh-target-highlight`
