### PR TITLE
Get rid of the  conditional moves button in the dock in rengo games

### DIFF
--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -390,7 +390,7 @@ export function GameDock({
                     <i className="fa fa-sitemap"></i> {_("Analyze game")}
                 </a>
             )}
-            {((!review_id && user_is_player && phase !== "finished") || null) && (
+            {((!review_id && user_is_player && phase !== "finished" && !engine.rengo) || null) && (
                 <a
                     style={{
                         visibility:
@@ -398,11 +398,7 @@ export function GameDock({
                                 ? "visible"
                                 : "hidden",
                     }}
-                    className={
-                        phase !== "finished" && (goban.isAnalysisDisabled() || engine.rengo)
-                            ? "disabled"
-                            : ""
-                    }
+                    className={phase !== "finished" && goban.isAnalysisDisabled() ? "disabled" : ""}
                     onClick={onConditionalMovesClicked}
                 >
                     <i className="fa fa-exchange"></i> {_("Plan conditional moves")}


### PR DESCRIPTION
Fixes [players messing things up by seeing what happens when you click the greyed out conditional moves button](https://forums.online-go.com/t/rengo-status/40415/1120?u=greenasjade)

## Proposed Changes

  Completely remove conditional moves button from Game Dock in rengo games.

(Note: previous implementation (probably by me) assumed that className `disabled` disables the link, but of course it doesn't.   In the nearby cases in the code, the greyed link gets clicked and something down stream checks and decides not to do it.  This is not practical in the case of conditional moves)