### PR TITLE
Clean up changing user: we have to reload when this happens.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "react-datetime": "^3.0.4",
         "react-dom": "^18.0.0",
         "react-dropzone": "^12.0.5",
-        "react-dynamic-help": "^2.1.7",
+        "react-dynamic-help": "2.2.0",
         "react-linkify": "^1.0.0-alpha",
         "react-number-format": "^3.0.2",
         "react-resize-detector": "^7.1.1",

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -204,14 +204,6 @@ data.watch("user", (user) => {
     }
 });
 
-/*
-data.watch("config.ogs", (settings) => {
-    if (settings && settings.channels) {
-        global_channels = settings.channels;
-    }
-});
-*/
-
 export function resolveChannelDisplayName(channel: string): string {
     if (channel === "shadowban") {
         return global_channels[channel];

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -113,7 +113,8 @@ export enum Replication {
 
 const defaults: Partial<DataSchema> = {};
 const store: Partial<DataSchema> = {};
-const event_emitter = new TypedEventEmitter<Events>();
+
+export const event_emitter = new TypedEventEmitter<Events>();
 
 //  Note that as well as "without emit", this is "without remote storage" as well.
 // (you cant set-remote-storage-without-emit)
@@ -688,10 +689,15 @@ function load_from_local_storage_and_sync() {
 }
 
 // Here we load from local storage but don't actually sync because we're not connected yet
-load_from_local_storage_and_sync();
 
-// The immediate call to load_from_local_storage_and_sync doesn't appear to do anything, because
-//  1) loaded_user_id is set from the previous call (directly above), so the call bails immediately
-//  2) the socket isn't connected yet
-// There may be some subtle reason why it's needed again here though...
-watch("config.user", load_from_local_storage_and_sync);
+// The sync comes later when the socket connects.
+
+// We don't call immediately, because we need to wait till main.tsx has loaded the correct config from cached.config
+// (until that happens, the `config` values in local storage are for the prior user)
+
+watch(
+    "user",
+    load_from_local_storage_and_sync,
+    /* call on undefined */ false,
+    /* don't call immediately */ true,
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -111,24 +111,25 @@ try {
 } catch (e) {
     data.setDefault("theme", "light");
 }
-data.setDefault("config", {
-    user: {
-        anonymous: true,
-        id: 0,
-        username: "Guest",
-        ranking: -100,
-        country: "un",
-        pro: 0,
-    },
-});
-data.setDefault("config.user", {
+
+const default_user = {
     anonymous: true,
     id: 0,
     username: "Guest",
     ranking: -100,
     country: "un",
     pro: 0,
-});
+    supporter: false,
+    is_moderator: false,
+    is_superuser: false,
+    is_tournament_moderator: false,
+    can_create_tournaments: false,
+    tournament_admin: false,
+};
+
+data.setDefault("config", { user: default_user });
+
+data.setDefault("config.user", default_user);
 
 data.setDefault("config.cdn", window["cdn_service"]);
 data.setDefault(
@@ -171,42 +172,41 @@ moment.locale(getPreferredLanguage());
 setCurrentLanguage(getPreferredLanguage());
 
 /*** Load our config ***/
-data.watch(cached.config, (config) => {
+
+/* cached.config is supplied by the server and stored with `data.set()` in response to a login action (login, register),
+   after which a page-reload occurs (due to navigation to logged-in page) and that's where this is executed */
+
+const cached_config = data.get(cached.config);
+
+// If cached_config doesn't exist, then the user-defaults set further above (anonymous) will apply...
+
+if (cached_config) {
     /* We do a pass where we set everything, and then we 'set' everything
      * again to do the emits that we are expecting. Otherwise triggers
      * that are depending on other parts of the config will fire without
      * having up to date information (in particular user / auth stuff) */
-    for (const key in config) {
-        data.setWithoutEmit(`config.${key as keyof ConfigSchema}`, config[key]);
+    for (const key in cached_config) {
+        data.setWithoutEmit(`config.${key as keyof ConfigSchema}`, cached_config[key]);
     }
-    for (const key in config) {
-        data.set(`config.${key as keyof ConfigSchema}`, config[key]);
+    for (const key in cached_config) {
+        data.set(`config.${key as keyof ConfigSchema}`, cached_config[key]);
     }
-});
+}
 
-let last_username: string | null = null;
-data.watch("config.user", (user) => {
-    try {
-        Sentry.setUser({
-            id: user.id,
-            username: user.username,
-        });
-    } catch (e) {
-        console.error(e);
-    }
+const user = data.get("config.user"); // guaranteed to return anonymous by the defaults, unless they are logged in
 
-    player_cache.update(user);
-    data.set("user", user);
-    window["user"] = user;
+try {
+    Sentry.setUser({
+        id: user.id,
+        username: user.username,
+    });
+} catch (e) {
+    console.error(e);
+}
 
-    if (last_username && last_username !== user.username) {
-        last_username = user.username;
-        if (forceReactUpdate) {
-            forceReactUpdate();
-        }
-    }
-    last_username = user.username;
-});
+player_cache.update(user);
+data.set("user", user);
+window["user"] = user;
 
 /***
  * Setup a device UUID so we can logout other *devices* and not all other
@@ -235,42 +235,42 @@ try {
 let auth_connect_fn = () => {
     return;
 };
-data.watch("config.user", (user) => {
-    if (!user.anonymous) {
-        auth_connect_fn = (): void => {
-            sockets.socket.send("authenticate", {
-                auth: data.get("config.chat_auth"),
-                player_id: user.id,
-                username: user.username,
-                jwt: data.get("config.user_jwt"),
-                bid: get_bid(),
-                useragent: navigator.userAgent,
-                language: ogs_current_language,
-                language_version: ogs_language_version,
-                client_version: ogs_version,
-            });
-            sockets.socket.send("chat/connect", {
-                auth: data.get("config.chat_auth"),
-                player_id: user.id,
-                ranking: user.ranking,
-                username: user.username,
-                ui_class: user.ui_class,
-            });
-        };
-    } else if (user.id < 0) {
-        auth_connect_fn = (): void => {
-            sockets.socket.send("chat/connect", {
-                player_id: user.id,
-                ranking: user.ranking,
-                username: user.username,
-                ui_class: user.ui_class,
-            });
-        };
-    }
-    if (sockets.socket.connected) {
-        auth_connect_fn();
-    }
-});
+
+if (!user.anonymous) {
+    auth_connect_fn = (): void => {
+        sockets.socket.send("authenticate", {
+            auth: data.get("config.chat_auth"),
+            player_id: user.id,
+            username: user.username,
+            jwt: data.get("config.user_jwt"),
+            bid: get_bid(),
+            useragent: navigator.userAgent,
+            language: ogs_current_language,
+            language_version: ogs_language_version,
+            client_version: ogs_version,
+        });
+        sockets.socket.send("chat/connect", {
+            auth: data.get("config.chat_auth"),
+            player_id: user.id,
+            ranking: user.ranking,
+            username: user.username,
+            ui_class: user.ui_class,
+        });
+    };
+} else if (user.id < 0) {
+    auth_connect_fn = (): void => {
+        sockets.socket.send("chat/connect", {
+            player_id: user.id,
+            ranking: user.ranking,
+            username: user.username,
+            ui_class: user.ui_class,
+        });
+    };
+}
+if (sockets.socket.connected) {
+    auth_connect_fn();
+}
+
 sockets.socket.on("connect", () => {
     auth_connect_fn();
 });
@@ -294,30 +294,6 @@ sockets.socket.on("ERROR", errorAlerter);
 
 browserHistory.listen(({ action /*, location */ }) => {
     try {
-        // old google analytics history hook
-        /*
-        const cleaned_path = location.pathname.replace(/\/[0-9]+(\/.*)?/, "/ID");
-        let user_type = "error";
-        const user = data.get("user");
-
-        if (!user || user.anonymous) {
-            user_type = "anonymous";
-        } else if (user.supporter) {
-            user_type = "supporter";
-        } else {
-            user_type = "non-supporter";
-        }
-
-        if (gtag) {
-            window["gtag"]("config", "UA-37743954-2", {
-                page_path: cleaned_path,
-                custom_map: {
-                    dimension1: user_type,
-                },
-            });
-        }
-        */
-
         if (action !== history.Action.Replace) {
             window.document.title = "OGS";
         }
@@ -342,12 +318,33 @@ const helpPopupDictionary: HelpPopupDictionary = {
 };
 
 // Make help system use our server-based storage, to achieve logged-in-user-specific help state.
+
+// Note: possibly data.ts should take care of "whether REMOTE_OVERRIDES_LOCAL is ready"
+//  wait till remote data is loaded
+let storage_loaded = false;
+
+data.event_emitter.on("remote_data_sync_complete", () => {
+    storage_loaded = true;
+});
+
+//  don't inherit old values
+if (user.anonymous) {
+    data.remove("rdh-system-state");
+}
+
 const dynamicHelpStorage: DynamicHelp.DynamicHelpStorageAPI = {
     saveState: (rdhState: string) => {
-        return data.set("rdh-system-state", rdhState, data.Replication.REMOTE_OVERWRITES_LOCAL);
+        if (storage_loaded) {
+            debugDynamicHelp && console.log("Writing rdhState", user.username, user.id, rdhState);
+            return data.set("rdh-system-state", rdhState, data.Replication.REMOTE_OVERWRITES_LOCAL);
+        } else {
+            debugDynamicHelp && console.log("NOT writing rdhState");
+            return "{}";
+        }
     },
     getState: (defaultValue?: string) => {
         const newstate = data.get("rdh-system-state", defaultValue);
+        debugDynamicHelp && console.log("Read rdhState", user.username, user.id, newstate);
         return newstate;
     },
 };
@@ -355,16 +352,6 @@ const dynamicHelpStorage: DynamicHelp.DynamicHelpStorageAPI = {
 /* Initialization done, render!! */
 const svg_loader = document.getElementById("loading-svg-container");
 svg_loader.parentNode.removeChild(svg_loader);
-
-let forceReactUpdate: () => void;
-
-function ForceReactUpdateWrapper(props): JSX.Element {
-    const [update, setUpdate] = React.useState(1);
-    forceReactUpdate = () => {
-        setUpdate(update + 1);
-    };
-    return <React.Fragment key={update}>{props.children}</React.Fragment>;
-}
 
 const react_root = ReactDOM.createRoot(document.getElementById("main-content"));
 
@@ -375,7 +362,7 @@ react_root.render(
             dictionary={helpPopupDictionary}
             storageApi={dynamicHelpStorage}
         >
-            <ForceReactUpdateWrapper>{routes}</ForceReactUpdateWrapper>
+            {routes}
             <HelpFlows />
         </HelpProvider>
     </React.StrictMode>,

--- a/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
+++ b/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
@@ -19,8 +19,6 @@ import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { alert } from "swal_config";
 
-import * as DynamicHelp from "react-dynamic-help";
-
 import * as data from "data";
 import { useUser } from "hooks";
 import { _, pgettext, interpolate } from "translate";
@@ -47,8 +45,6 @@ export function ChallengeLinkLanding(): JSX.Element {
     const [logging_in, set_logging_in] = React.useState<boolean>(false);
 
     const navigate = useNavigate();
-
-    const { triggerFlow } = React.useContext(DynamicHelp.Api);
 
     /* Actions */
 
@@ -83,12 +79,7 @@ export function ChallengeLinkLanding(): JSX.Element {
             post("challenges/%%/accept", challenge.challenge_id, {})
                 .then(() => {
                     alert.close();
-                    browserHistory.push(`/game/${challenge.game_id}`);
-                    if (data.get("experiments.v6") === "enabled") {
-                        triggerFlow("guest-user-intro-exv6");
-                    } else {
-                        triggerFlow("guest-user-intro-old-nav");
-                    }
+                    navigate(`/game/${challenge.game_id}#challenge-link`, { replace: true });
                 })
                 .catch((err) => {
                     alert.close();
@@ -105,6 +96,7 @@ export function ChallengeLinkLanding(): JSX.Element {
             set_logging_in(true);
             // We need to save the challenge info in this way for when we come back after logging in.
             data.set("pending_accepted_challenge", linked_challenge);
+            // Go to sign in, and come back to this page ("welcome") after signing in
             navigate("/sign-in#/welcome/accepted", { replace: true });
         }
     };
@@ -127,9 +119,11 @@ export function ChallengeLinkLanding(): JSX.Element {
         })
             .then((config) => {
                 data.set(cached.config, config);
-
-                doAcceptance(linked_challenge);
+                // This is the page reload required for a new registration
+                data.set("pending_accepted_challenge", linked_challenge);
+                window.location.assign("/welcome/accepted");
             })
+
             // note - no handling at the moment for the hopefully madly-unlikely duplicate username,
             // we just crash and burn here in that case, like any other error.
 

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -16,6 +16,7 @@
  */
 
 import * as data from "data";
+import * as DynamicHelp from "react-dynamic-help";
 import * as preferences from "preferences";
 import * as React from "react";
 import { useParams, useLocation, useSearchParams } from "react-router-dom";
@@ -78,6 +79,8 @@ export function Game(): JSX.Element {
     const game_id = params.game_id ? parseInt(params.game_id) : 0;
     const review_id = params.review_id ? parseInt(params.review_id) : 0;
     const return_url = is_valid_url(searchParams.get("return")) ? searchParams.get("return") : null;
+
+    const { triggerFlow } = React.useContext(DynamicHelp.Api);
 
     /* Refs */
     const ref_move_tree_container = React.useRef<HTMLElement>();
@@ -1298,6 +1301,7 @@ export function Game(): JSX.Element {
                 })
                 .catch(ignore);
         }
+
         /*** END initialize ***/
 
         return () => {
@@ -1372,6 +1376,16 @@ export function Game(): JSX.Element {
         console.log(last_phase.current);
         last_phase.current = phase;
     }, [phase, return_url]);
+
+    React.useEffect(() => {
+        if (window.location.hash.includes("challenge-link")) {
+            if (data.get("experiments.v6") === "enabled") {
+                triggerFlow("guest-user-intro-exv6");
+            } else {
+                triggerFlow("guest-user-intro-old-nav");
+            }
+        }
+    });
 
     /**********/
     /* RENDER */

--- a/src/views/HelpFlows/HelpFlows.tsx
+++ b/src/views/HelpFlows/HelpFlows.tsx
@@ -20,12 +20,8 @@ import * as DynamicHelp from "react-dynamic-help";
 
 import * as data from "data";
 
-import { TypedEventEmitter } from "TypedEventEmitter";
-
 import { GuestUserIntroEXV6 } from "./GuestUserIntroEXV6";
 import { GuestUserIntroOldNav } from "./GuestUserIntroOldNav";
-
-const events = new TypedEventEmitter<any>();
 
 /**
  * This component is a handy wrapper for all the Help Flows, and reset on login/logout
@@ -34,22 +30,22 @@ const events = new TypedEventEmitter<any>();
  */
 
 export function HelpFlows(): JSX.Element {
-    const { enableHelp } = React.useContext(DynamicHelp.Api);
+    const { enableHelp, reloadUserState: reloadUserHelpState } = React.useContext(DynamicHelp.Api);
 
     React.useEffect(() => {
         const updateHelpState = () => {
             const user = data.get("config.user");
             if (!user?.anonymous) {
-                enableHelp(true);
+                reloadUserHelpState();
             } else {
                 enableHelp(false);
             }
         };
 
-        events.on("remote_data_sync_complete", updateHelpState);
+        data.event_emitter.on("remote_data_sync_complete", updateHelpState);
 
         return () => {
-            events.off("remote_data_sync_complete", updateHelpState);
+            data.event_emitter.off("remote_data_sync_complete", updateHelpState);
         };
     }, [enableHelp]);
 

--- a/src/views/Register/Register.tsx
+++ b/src/views/Register/Register.tsx
@@ -52,6 +52,7 @@ export function Register(): JSX.Element {
                 .then((config) => {
                     data.set(cached.config, config);
 
+                    // Note: this causes a page reload, and the new user is set up from scratch in the process
                     if (window.location.hash && window.location.hash[1] === "/") {
                         window.location.pathname = window.location.hash.substring(1);
                     } else {

--- a/src/views/Settings/HelpSettings.tsx
+++ b/src/views/Settings/HelpSettings.tsx
@@ -40,8 +40,9 @@ export function HelpSettings(): JSX.Element {
     const [__helpEnabled, setRenderNewHelpState] = React.useState(helpEnabled);
 
     const toggleHelpEnabled = () => {
-        enableHelp(!__helpEnabled);
-        setRenderNewHelpState(!__helpEnabled);
+        const toggle_to = !__helpEnabled;
+        enableHelp(toggle_to);
+        setRenderNewHelpState(toggle_to);
     };
 
     // we need a state to trigger re-reander after changing a flow visibility,

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -110,9 +110,9 @@ export function SignIn(): JSX.Element {
                         window.location.pathname = config.redirect + (window.location.hash || "");
                         return;
                     }
-
                     data.set(cached.config, config);
 
+                    // Note: this causes a page reload, and the new user is set up from scratch in the process
                     if (window.location.hash && window.location.hash[1] === "/") {
                         const next_page = window.location.hash.substring(1);
                         window.location.pathname = next_page;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7900,10 +7900,10 @@ react-dropzone@^12.0.5:
     file-selector "^0.5.0"
     prop-types "^15.8.1"
 
-react-dynamic-help@^2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-2.1.7.tgz#31c1931a2804749c626d52427737c383ac3b1d53"
-  integrity sha512-Tq4Xv8WPvre1Iswime5jqLbyZbGgfktNhWWenByY7MIHyYmbW2Wzf720SxvxqcXGxq0vHb1huldPKNlVYAq2fQ==
+react-dynamic-help@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-dynamic-help/-/react-dynamic-help-2.2.0.tgz#5777cf217ab7f8e064b84cc9777df5cd114b5b7c"
+  integrity sha512-7NFD8o5Tn3kHGlSJxP07PH0GnZXvRx2hFlQpXLCYJkQ3+fn/1V8kA9n4vN6iniIFNCQXGgSOiqVJ8ztyG+EKww==
   dependencies:
     "@types/react" "^18.0.15"
 


### PR DESCRIPTION
Fixes confusion around how changing user actions (login, logout, register) happens.

## Proposed Changes

This innocuous sounding PR is a bit ambitious actually.

It gets rid of code that tries to watch `config.user` and deal with change-of-user on the fly, and instead runs those things once on page load.

There are some things that watch `user`, this is different: that change is triggered after `cached.config` is loaded, and it seems legitimate to wait till that happens, so these remain.

In addition, this change takes care of notifying RDH what's going on in a less buggy way, and protects RDH from writing back any nonsense that it might receive as "state" before remote-sync has happened.
