### PR TITLE
fix: chat notification settings unintuitive

### DIFF
--- a/src/components/Chat/ChatDetails.styl
+++ b/src/components/Chat/ChatDetails.styl
@@ -32,7 +32,7 @@
         justify-content: space-between;
 
         > button {
-            min-width: 98%;
+            min-width: 100%;
             text-align: left;
             .fa, .ogs-goban {
                 padding-right: 0.1rem;

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -171,8 +171,8 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, Chat
                             <i className="fa fa-comment" />
                             {" " +
                                 (this.state.notify_mentioned
-                                    ? _("unfollow mentioned")
-                                    : _("follow mentioned"))}
+                                    ? _("Unfollow Mentioned")
+                                    : _("Follow Mentioned"))}
                         </button>
                     )}
                     {this.state.subscribable && (
@@ -183,8 +183,8 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, Chat
                             <i className="fa fa-comment" />
                             {" " +
                                 (this.state.notify_unread
-                                    ? _("unfollow unread")
-                                    : _("follow unread"))}
+                                    ? _("Unfollow Unread")
+                                    : _("Follow Unread"))}
                         </button>
                     )}
                     {this.props.partFunc ? (

--- a/src/global_styl/global.styl
+++ b/src/global_styl/global.styl
@@ -443,7 +443,7 @@ button, a.btn, .btn {
     padding-top: 0.1em;
     padding-bottom: 0.1em;
     border-radius: 0.3rem;
-    height: 2em;
+    height: fit-content;
     vertical-align: middle;
     box-sizing: border-box;
     line-height: font-size-normal;


### PR DESCRIPTION
Problem: The layout is such that "unfollow mentioned" is not fully visible, so it gets truncated to "unfollow..." (https://github.com/online-go/online-go.com/issues/1971)

Result (Fixed): "Unfollow Mentioned" is visible now.

![onlinego](https://user-images.githubusercontent.com/76787294/188293078-eac00ec0-df53-4074-a931-53ab1d24bc77.png)

