### PR TITLE
Keep page-controls visible at all times

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -18,19 +18,23 @@
 .PaginatedTable {
     position: relative;
     max-width: 100vw;
-    overflow-x: auto;
-    table {
-        width: 100%;
-        max-width: 100vw;
-        border-collapse: collapse;
-        tr {
-            border-bottom: solid 1px transparent;
-            themed border-bottom-color shade4;
-        }
-        th {
-            text-align: left;
-            color: #919191;
-            font-weight: normal;
+
+    div {
+        overflow-x: auto;
+
+        table {
+            width: 100%;
+            max-width: 100vw;
+            border-collapse: collapse;
+            tr {
+                border-bottom: solid 1px transparent;
+                themed border-bottom-color shade4;
+            }
+            th {
+                text-align: left;
+                color: #919191;
+                font-weight: normal;
+            }
         }
     }
 

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -319,47 +319,49 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
                 />
             )}
             <div className="loading-overlay">{_("Loading")}</div>
-            <table className={extra_classes}>
-                <thead>
-                    <tr>
-                        {columns.map((column, idx) => (
-                            <th
-                                key={idx}
-                                className={cls(null, column)}
-                                {...column.headerProps}
-                                onClick={
-                                    column.orderBy
-                                        ? () => {
-                                              _sort(column.orderBy);
-                                          }
-                                        : null
-                                }
-                            >
-                                {getHeader(column.orderBy, column.header)}
-                            </th>
-                        ))}
-                    </tr>
-                </thead>
-                <tbody>
-                    {rows.map((row) => {
-                        const cols = columns.map((column, idx) => (
-                            <td key={idx} className={cls(row, column)} {...column.cellProps}>
-                                {column_render(column, row)}
-                            </td>
-                        ));
-                        if (props.onRowClick) {
-                            return (
-                                <tr key={row.id} onMouseUp={(ev) => props.onRowClick(row, ev)}>
-                                    {cols}
-                                </tr>
-                            );
-                        } else {
-                            return <tr key={row.id}>{cols}</tr>;
-                        }
-                    })}
-                    {blank_rows}
-                </tbody>
-            </table>
+            <div>
+                <table className={extra_classes}>
+                    <thead>
+                        <tr>
+                            {columns.map((column, idx) => (
+                                <th
+                                    key={idx}
+                                    className={cls(null, column)}
+                                    {...column.headerProps}
+                                    onClick={
+                                        column.orderBy
+                                            ? () => {
+                                                  _sort(column.orderBy);
+                                              }
+                                            : null
+                                    }
+                                >
+                                    {getHeader(column.orderBy, column.header)}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map((row) => {
+                            const cols = columns.map((column, idx) => (
+                                <td key={idx} className={cls(row, column)} {...column.cellProps}>
+                                    {column_render(column, row)}
+                                </td>
+                            ));
+                            if (props.onRowClick) {
+                                return (
+                                    <tr key={row.id} onMouseUp={(ev) => props.onRowClick(row, ev)}>
+                                        {cols}
+                                    </tr>
+                                );
+                            } else {
+                                return <tr key={row.id}>{cols}</tr>;
+                            }
+                        })}
+                        {blank_rows}
+                    </tbody>
+                </table>
+            </div>
             {(!props.hidePageControls || null) && (
                 <div className="page-controls">
                     <div className="left">


### PR DESCRIPTION
## Proposed Changes

Previously, the page controls would move with the PaginatedTable when you scrolled.
Now, only the table entries move so the page controls are always visible.

I added a div around the table and applied the css there, because  `overflow-x: auto` didn't seem to have an effect on tables.

My workaround is based on this: https://stackoverflow.com/q/8706503