### PR TITLE
Re-try fetching pages after search/filter fails

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -168,6 +168,9 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
             })
             .catch((err) => {
                 console.error(err);
+                if (err.status === 404) {
+                    setPage(1);
+                }
                 setLoading(false);
                 if (load_again.current) {
                     load_again.current = false;


### PR DESCRIPTION
Fixes #1717

## Proposed Changes

  - Resend request, but with `page = 1` after 404 error.