### PR TITLE
Bugfixes needed to make the move tree variation saver take the correc…

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -24,6 +24,18 @@
     bottom: env(safe-area-inset-bottom);
     right: 0;
     left: 0;
+
+    .hidden, .hidden.active, .hidden:focus, .hidden:hover {
+        themed background-color hidden-bg
+    }
+
+    .malkovich, .malkovich.active, .malkovich:focus, .malkovich:hover {
+        themed background-color malkovich-bg
+    }
+
+    .personal, .personal.active, .personal:focus, .personal:hover {
+        themed background-color personal-bg
+    }
 }
 
 .Game.portrait.squashed {
@@ -35,6 +47,8 @@
     top: 0;
 }
 
+// Is this really intended as a global scope css directive?
+// I don't dare scope it for now, but it looks odd: if it's global, it should probably be in ogs.styl?
 .submit-button {
     white-space: nowrap;
 }

--- a/src/views/Game/GameChat.styl
+++ b/src/views/Game/GameChat.styl
@@ -247,16 +247,4 @@ game-chat-user-list-width=10rem;
             right: 0px;
         }
     }
-
-    .hidden, .hidden.active, .hidden:focus, .hidden:hover {
-        themed background-color hidden-bg
-    }
-
-    .malkovich, .malkovich.active, .malkovich:focus, .malkovich:hover {
-        themed background-color malkovich-bg
-    }
-
-    .personal, .personal.active, .personal:focus, .personal:hover {
-        themed background-color personal-bg
-    }
 }

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -1130,7 +1130,7 @@ function ShareAnalysisButton(props: ShareAnalysisButtonProperties): JSX.Element 
         case "personal":
             return (
                 <button
-                    className="sm {selected_chat_log}"
+                    className={`sm ${selected_chat_log}`}
                     type="button"
                     disabled={isUserAnonymous}
                     onClick={shareAnalysis}


### PR DESCRIPTION
Fixes it not being clear that the move-tree variation-saver will honour the "chat type" selection.

## Proposed Changes

 - Move related css 'up' out of `GameChat` and into `Game` scope.
 - Fix interpolation of chat-type into variation-tree-saver class name
 
