### PR TITLE
Chat notification / highlight settings update to us checkmarks instead of buttons

### DIFF
--- a/src/components/Chat/ChatDetails.styl
+++ b/src/components/Chat/ChatDetails.styl
@@ -22,21 +22,25 @@
     themed background-color shade4
     themed border-color shade3
     themed color fg
-    max-width: 130px;
     padding: 0.1rem;
 
     .actions {
         margin-top: 0.1rem;
-        display: flex;
-        flex-wrap: wrap;
+        display: inline-flex;
+        flex-direction: column;
         justify-content: space-between;
 
         > button {
-            min-width: 98%;
-            text-align: left;
+            min-width: 15rem;
+            text-align: center;
+            font-size: 0.8rem;
             .fa, .ogs-goban {
                 padding-right: 0.1rem;
             }
+        }
+
+        .view-group {
+            text-align: right;
         }
     }
 }

--- a/src/components/Chat/ChatDetails.tsx
+++ b/src/components/Chat/ChatDetails.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import { browserHistory } from "ogsHistory";
-import { _, pgettext } from "translate";
+import { pgettext } from "translate";
 import { shouldOpenNewTab } from "misc";
 import { close_all_popovers } from "popover";
 import { close_friend_list } from "FriendList/close_friend_list";
@@ -135,24 +135,23 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, Chat
     };
 
     render() {
-        const group_text = pgettext("Go to the main page for this group.", "Group Page");
         const tournament_text = pgettext(
             "Go to the main page for this tournament.",
             "Tournament Page",
         );
-        const leave_text = pgettext("Leave the selected channel.", "Leave Channel");
+        const leave_text = pgettext("Leave the selected channel.", "Leave channel");
+
+        const group_url =
+            (this.state.channelId.startsWith("group-") || null) &&
+            "/group/" + this.state.channelId.slice(6);
 
         return (
             <div className="ChatDetails">
                 <div className="actions">
-                    {this.state.channelId.startsWith("group") && (
-                        <button
-                            className="xs noshadow"
-                            onAuxClick={this.goToGroup}
-                            onClick={this.goToGroup}
-                        >
-                            <i className="fa fa-users" /> {group_text}
-                        </button>
+                    {group_url && (
+                        <div className="fakelink view-group" onClick={this.goToGroup}>
+                            {pgettext("Generic link text to go to a group page", "View group")}
+                        </div>
                     )}
                     {this.state.channelId.startsWith("tournament") && (
                         <button
@@ -163,30 +162,40 @@ export class ChatDetails extends React.PureComponent<ChatDetailsProperties, Chat
                             <i className="fa fa-trophy" /> {tournament_text}
                         </button>
                     )}
+                    <hr />
                     {this.state.subscribable && (
-                        <button
-                            className={"xs noshadow "} // + this.state.notify_mentioned ? "active" : "inactive"}
-                            onClick={this.toggleMentionNotification}
-                        >
-                            <i className="fa fa-comment" />
-                            {" " +
-                                (this.state.notify_mentioned
-                                    ? _("unfollow mentioned")
-                                    : _("follow mentioned"))}
-                        </button>
+                        <div>
+                            <input
+                                type="checkbox"
+                                id="notify_mentioned"
+                                checked={this.state.notify_mentioned}
+                                onChange={this.toggleMentionNotification}
+                            />
+                            <label htmlFor="notify_mentioned">
+                                {pgettext(
+                                    "Don't notify on unread @user mentions in a chat channel",
+                                    "Highlight when mentioned",
+                                )}
+                            </label>
+                        </div>
                     )}
                     {this.state.subscribable && (
-                        <button
-                            className={"xs noshadow "} // + this.state.notify_unread ? "active" : "inactive"}
-                            onClick={this.toggleNewMessageNotification}
-                        >
-                            <i className="fa fa-comment" />
-                            {" " +
-                                (this.state.notify_unread
-                                    ? _("unfollow unread")
-                                    : _("follow unread"))}
-                        </button>
+                        <div>
+                            <input
+                                type="checkbox"
+                                id="notify_unread"
+                                checked={this.state.notify_unread}
+                                onChange={this.toggleNewMessageNotification}
+                            />
+                            <label htmlFor="notify_unread">
+                                {pgettext(
+                                    "Don't notify on unread messages in a chat channel",
+                                    "Highlight on unread messages",
+                                )}
+                            </label>
+                        </div>
                     )}
+                    <hr />
                     {this.props.partFunc ? (
                         <button className="xs noshadow reject" onClick={this.leave}>
                             <i className="fa fa-times" /> {leave_text}

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -286,7 +286,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
                 />
             ),
             below: event.currentTarget,
-            minWidth: 130,
+            minWidth: 250,
         });
     };
 

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -283,7 +283,7 @@ function ChannelTopic({
                     />
                 ),
                 below: event.currentTarget,
-                minWidth: 130,
+                minWidth: 250,
             });
         },
         [channel, partChannel],

--- a/src/lib/popover.tsx
+++ b/src/lib/popover.tsx
@@ -119,6 +119,7 @@ export function popover(config: PopoverConfig): PopOver {
         const rectangle = config.below.getBoundingClientRect();
         x = rectangle.left + window.scrollX;
         x = Math.min(x, bounds.x - minWidth);
+        console.log(bounds.x, x, minWidth);
 
         y = rectangle.bottom + window.scrollY;
 


### PR DESCRIPTION
This PR adjusts the look of the chat notification settings. The original issue was brought to light in #1986, this PR revisits the look of the component entirely,

This PR makes the component look something like this:

![image](https://user-images.githubusercontent.com/168460/189215565-060b687f-5b63-40bb-98ba-0ea7d8370347.png)

