### PR TITLE
Chat notification settings take 3

### DIFF
--- a/src/components/Chat/ChatDetails.styl
+++ b/src/components/Chat/ChatDetails.styl
@@ -19,10 +19,47 @@
     box-shadow: 0px 1px 1px rgba(0,0,0,0.2);
     border: 1px solid transparent;
     box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.16), 0px 1px 1px 0px rgba(0, 0, 0, 0.15);
-    themed background-color shade4
-    themed border-color shade3
+    themed background-color shade5
+    themed border-color shade4
     themed color fg
-    padding: 0.1rem;
+    padding: 0.3rem;
+
+
+    h6 {
+        margin: 0;
+        padding: 0;
+        margin-top: 0.5rem;
+
+        font-size: 0.8rem;
+
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        a {
+            font-size: 1.0rem;
+        }
+    }
+
+    .notify-option {
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        label {
+            flex: 1;
+        }
+
+        .notify-option-toggle {
+            margin-left: 0.5rem;
+        }
+    }
+
+    .fakelink {
+        float: right;
+    }
 
     .actions {
         margin-top: 0.1rem;
@@ -31,7 +68,7 @@
         justify-content: space-between;
 
         > button {
-            min-width: 15rem;
+            min-width: 12rem;
             text-align: center;
             font-size: 0.8rem;
             .fa, .ogs-goban {

--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -286,7 +286,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
                 />
             ),
             below: event.currentTarget,
-            minWidth: 250,
+            minWidth: 200,
         });
     };
 

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -283,7 +283,7 @@ function ChannelTopic({
                     />
                 ),
                 below: event.currentTarget,
-                minWidth: 250,
+                minWidth: 200,
             });
         },
         [channel, partChannel],


### PR DESCRIPTION
This updates the chat notification settings once again to look more like how discord/slack present their settings. Also reverted the change of terminology from "highlight" to "notification", because we probably do want those to be actual notifications some day, so maybe it's best to just stick with that terminology.

New look:

![image](https://user-images.githubusercontent.com/168460/189430497-8e38b897-2791-452c-a390-c520b2cbc24b.png)

@benjaminpjones 
