### PR TITLE
Add "4x4" option in puzzle

### DIFF
--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -1062,6 +1062,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                                         <option value={9}>{_("9x9")}</option>
                                         <option value={7}>{_("7x7")}</option>
                                         <option value={5}>{_("5x5")}</option>
+                                        <option value={4}>{_("4x4")}</option>
                                     </select>
 
                                     <select


### PR DESCRIPTION
Fixes #

## Proposed Changes
.
  - 張 栩 made puzzles of 4x4 board in https://www.amazon.co.jp/dp/B07CKY1VK5 . I want to solve it in the OGS puzzle.
