### PR TITLE
Fix ChatList links

### DIFF
--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -219,7 +219,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
     };
 
     goToChannel = (ev) => {
-        setActiveChannel($(ev.target).attr("data-channel"));
+        setActiveChannel(ev.currentTarget.getAttribute("data-channel"));
         if (ev && shouldOpenNewTab(ev)) {
             window.open("/chat");
         } else {
@@ -437,7 +437,7 @@ export class ChatList extends React.PureComponent<ChatListProperties, ChatListSt
                                     ? "channel active"
                                     : "channel") + chan_class("tournament-" + chan.id)
                             }
-                            data-channel={"tournaments-" + chan.id}
+                            data-channel={"tournament-" + chan.id}
                             onClick={this.goToChannel}
                         >
                             <span className="channel-name" data-channel={"tournament-" + chan.id}>


### PR DESCRIPTION
Links in the ChatList are slightly broken:
* clicking on icon doesn't work
* for tournaments clicking inside `div` padding takes me to wrong URL

## Proposed Changes
* use `event.currentTarget` instead of `event.target`
* fix tournamets' `data-channel` attribute
