### PR TITLE
State the type of the context, matching what RDH says it is.

### DIFF
--- a/src/views/Overview/EXV6Overview.tsx
+++ b/src/views/Overview/EXV6Overview.tsx
@@ -53,7 +53,7 @@ interface OverviewState {
 export class EXV6Overview extends React.Component<{}, OverviewState> {
     private static defaultTitle = "OGS";
 
-    static contextType: ReturnType<typeof React.createContext> = DynamicHelp.Api;
+    static contextType: React.Context<DynamicHelp.AppApi> = DynamicHelp.Api;
     declare context: React.ContextType<typeof DynamicHelp.Api>;
 
     constructor(props: {}) {

--- a/src/views/Overview/Overview.tsx
+++ b/src/views/Overview/Overview.tsx
@@ -72,7 +72,7 @@ interface OverviewState {
 export class OldOverview extends React.Component<{}, OverviewState> {
     private static defaultTitle = "OGS";
 
-    static contextType: ReturnType<typeof React.createContext> = DynamicHelp.Api;
+    static contextType: React.Context<DynamicHelp.AppApi> = DynamicHelp.Api;
     declare context: React.ContextType<typeof DynamicHelp.Api>;
 
     constructor(props: {}) {

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -74,7 +74,7 @@ export class Play extends React.Component<{}, PlayState> {
     seekgraph: SeekGraph;
     resize_check_interval;
 
-    static contextType: ReturnType<typeof React.createContext> = DynamicHelp.Api;
+    static contextType: React.Context<DynamicHelp.AppApi> = DynamicHelp.Api;
     declare context: React.ContextType<typeof DynamicHelp.Api>;
 
     private list_freeze_timeout;


### PR DESCRIPTION
TBD I'm not totally sure this is better, but it _seems_ nicer to use the expicitly stated type of the context, rather than show that we know how surely it must have been created, and rely on that?
