### PR TITLE
potential fix for sort issue on game library page

### DIFF
--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -177,8 +177,8 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
 
                 for (const collection_id in collections) {
                     const collection = collections[collection_id];
-                    collection.collections.sort((a, b) => a.name.localeCompare(b));
-                    collection.games.sort((a, b) => a.name.localeCompare(b));
+                    collection.collections.sort((a, b) => a.name.localeCompare(b.name));
+                    collection.games.sort((a, b) => a.name.localeCompare(b.name));
                 }
 
                 const ct = (collection) => {


### PR DESCRIPTION
## Fixes

Game libraries are intermittently sorted in random order, and sometimes sorted correctly. See the below thread for some context and that other folks have noticed this.

https://forums.online-go.com/t/sgf-library-sort/42511/2

## Proposed Changes

I'm not a typescript expert, but looking through the code this is the only area where localeCompare is used without specifying the compare string, here we're passing just the b object to be sorted. It seems possible that this is the source of the issue, and if not it will at least make the code consistent on this point.

I'm a first time contributor, so please let me know if I should be doing anything differently in this process!