### PR TITLE
Make language-picker stay on one line

### DIFF
--- a/src/components/LanguagePicker/LanguagePicker.styl
+++ b/src/components/LanguagePicker/LanguagePicker.styl
@@ -17,6 +17,7 @@
 
 
 .LanguagePicker {
+    white-space: nowrap; // keep the icon in line with the language label
     themed color text-color
     padding-right: 1.0rem;
     i {


### PR DESCRIPTION
Fixes # language picker getting split into two lines

## Proposed Changes

use `white-space: nowrap` to stop it being split.