### PR TITLE
Preliminary paste SGF option

### DIFF
--- a/src/components/SGFPasteModal/SGFPasteModal.styl
+++ b/src/components/SGFPasteModal/SGFPasteModal.styl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.SGFPasteModal {
+    width: 30rem;
+    max-width: 100%;
+    height: 55vh
+    max-height: 100%;
+
+    .body {
+        display: flex;
+
+        align-items: stretch;
+        justify-content: stretch;
+        align-content: stretch;
+
+        textarea {
+            flex: 1;
+        }
+    }
+}

--- a/src/components/SGFPasteModal/SGFPasteModal.tsx
+++ b/src/components/SGFPasteModal/SGFPasteModal.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2012-2021  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { _ } from "translate";
+import { Modal, openModal } from "Modal";
+
+interface Events {}
+
+interface SGFPasteModalProperties {
+    onUpload: (rawSGF: string) => void;
+}
+
+export class SGFPasteModal extends Modal<Events, SGFPasteModalProperties, any> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            rawSGF: undefined,
+        };
+    }
+
+    updateData = (ev) => {
+        this.setState({ rawSGF: ev.target.value });
+    };
+
+    uploadSGF = () => {
+        this.props.onUpload(this.state.rawSGF);
+        this.close();
+    };
+
+    render() {
+        return (
+            <div className="Modal SGFPasteModal">
+                <div className="body">
+                    <textarea
+                        placeholder={_("Enter SGF data here")}
+                        value={this.state.rawSGF}
+                        onChange={this.updateData}
+                    />
+                </div>
+                <div className="buttons">
+                    <button onClick={this.close}>{_("Cancel")}</button>
+                    <button className="primary bold" onClick={this.uploadSGF}>
+                        {_("Upload")}
+                    </button>
+                </div>
+            </div>
+        );
+    }
+}
+
+export function openSGFPasteModal(onUpload: (rawSGF: string) => void) {
+    // Note: this modal is deliberately not fastDismiss, because we don't want to accidentally dismiss while drag-selecting a large area of text.
+    return openModal(<SGFPasteModal onUpload={onUpload} />);
+}

--- a/src/components/SGFPasteModal/index.ts
+++ b/src/components/SGFPasteModal/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./SGFPasteModal";

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -29,6 +29,7 @@ import Dropzone from "react-dropzone";
 import { DropzoneRef } from "react-dropzone";
 import * as moment from "moment";
 import { IdType } from "src/lib/types";
+import { openSGFPasteModal } from "SGFPasteModal";
 
 type LibraryPlayerProperties = RouteComponentProps<{
     player_id: string;
@@ -205,6 +206,22 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
             Promise.all(
                 files.map((file) => post("me/games/sgf/%%", this.state.collection_id, file)),
             )
+                .then(() => {
+                    this.refresh(this.props.match.params.player_id).then(ignore).catch(ignore);
+                })
+                .catch(errorAlerter);
+        } else {
+            console.log("Not uploading selected files since we're not on our own library page");
+        }
+    };
+
+    uploadSGFText = (text: string) => {
+        if (parseInt(this.props.match.params.player_id) === data.get("user").id) {
+            const file = new File([text], "pasted.sgf", {
+                type: "application/x-go-sgf",
+                lastModified: new Date().getTime(),
+            });
+            post("me/games/sgf/%%", this.state.collection_id, file)
                 .then(() => {
                     this.refresh(this.props.match.params.player_id).then(ignore).catch(ignore);
                 })
@@ -396,6 +413,14 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
                                                 onClick={() => this.dropzone.open()}
                                             >
                                                 {_("Upload")}
+                                            </button>
+                                            <button
+                                                className="primary"
+                                                onClick={() =>
+                                                    openSGFPasteModal(this.uploadSGFText)
+                                                }
+                                            >
+                                                {_("Paste SGF")}
                                             </button>
                                         </div>
                                     )}


### PR DESCRIPTION
This pull request attempts to address [this feature request](https://forums.online-go.com/t/feature-request-paste-sgf/43876) for the ability to paste raw SGF data.

As I was testing this on the beta server, I noticed that uploaded files are not persisted and do not show up in the SGF library list, even when using the original upload button. The `POST` request from my new feature appears to work properly in that it receives the expected `{"success":"Files uploaded"}` response, but I can't fully test it for this reason. This behavior might be intentional (maybe to avoid storing a bunch of test .sgf files on the beta server?), but any guidance is appreciated.

Let me know if I should change anything else to make this acceptable for production! I think it will need some translation (for the button and placeholder text), but I'm not entirely sure how to start with that.