### PR TITLE
Provide an ObserveGamesComponent filter for Malkovich games.

### DIFF
--- a/src/components/ObserveGamesComponent/ObserveGamesComponent.tsx
+++ b/src/components/ObserveGamesComponent/ObserveGamesComponent.tsx
@@ -446,6 +446,10 @@ export class ObserveGamesComponent extends React.PureComponent<
                         "friend_games_only",
                         pgettext("Filter games list", "Friend games only"),
                     )}
+                    {this.filterOption(
+                        "malk_only",
+                        pgettext("Filter games list", "Malkovich games only"),
+                    )}
                 </div>
 
                 <div className="filter-group">


### PR DESCRIPTION
Fixes limited discoverability of Malkovich function

## Proposed Changes

 Provide a "malkovich only" filter on the Watch page

** note: requires https://github.com/online-go/ogs-node/pull/20 in order to actually work.