### PR TITLE
Fix #1738: Ladder position error wording

### DIFF
--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -655,7 +655,7 @@ function canChallengeTooltip(obj: any): string {
             case 0x004:
                 return pgettext(
                     "Can't challenge player in ladder because: ",
-                    "Player's rank is too high",
+                    "Your ladder position is too high",
                 );
             case 0x005:
                 return interpolate(


### PR DESCRIPTION
Fixes #1738

## Proposed Changes

Changes error wording to say, "Your ladder position is too high" instead of using the word "rank"
