### PR TITLE
Ladder position error wording 2

### DIFF
--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -645,7 +645,7 @@ function canChallengeTooltip(obj: any): string {
             case 0x002:
                 return pgettext(
                     "Can't challenge player in ladder because: ",
-                    "Player is a lower rank than you",
+                    "Their ladder position is lower than yours",
                 );
             case 0x003:
                 return pgettext(
@@ -655,7 +655,7 @@ function canChallengeTooltip(obj: any): string {
             case 0x004:
                 return pgettext(
                     "Can't challenge player in ladder because: ",
-                    "Your ladder position is too high",
+                    "Their ladder position is too high",
                 );
             case 0x005:
                 return interpolate(


### PR DESCRIPTION
Fixes #1738
Fixes #2036 

Changes both instances of "rank" and corrects "player" referring to challenge target not self.