### PR TITLE
PaginatedTable: Refresh on props.source change

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -106,7 +106,7 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
         },
     }));
 
-    React.useEffect(refresh, [order_by, page, page_size, filter, load_again_refresh]);
+    React.useEffect(refresh, [order_by, page, page_size, filter, load_again_refresh, props.source]);
 
     React.useEffect(() => {
         mounted.current = true;
@@ -116,7 +116,7 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
     }, []);
 
     function refresh(force: boolean = false) {
-        const cur = [order_by, page, page_size, filter, load_again_refresh];
+        const cur = [order_by, page, page_size, filter, load_again_refresh, props.source];
         const last = last_loaded.current;
         if (!force && last.length && softEquals(last, cur)) {
             return;


### PR DESCRIPTION
Fixes #1996

`PaginatedTable`s weren't updating when `props.source` changes.  This wasn't a problem in most cases because `source` is often a single endpoint where only the query parameter changes.  But in this case, it was `groups/%%/members`.
