### PR TITLE
Double the resolution of nation flags in games.

### DIFF
--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -346,7 +346,7 @@ function PlayerFlag({ player_id }: { player_id: number }): JSX.Element {
     }, [player_id]);
 
     if (country) {
-        return <Flag country={country} />;
+        return <Flag country={country} big />;
     }
     return null;
 }

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -152,6 +152,7 @@
             .player-flag {
                 top: 1rem;
                 left: 1rem;
+                transform-origin: 6px 10px;
             }
         }
     }
@@ -211,6 +212,8 @@
         display: inline-block;
         left: 3rem;
         top: 3rem;
+        transform: scale(0.5);
+        transform-origin: 4px 12px;
 
         .flag {
             vertical-align: bottom;
@@ -360,6 +363,7 @@
             top: unset;
             right: 0.1rem;
             bottom: -0.2rem;
+            transform-origin: 40px bottom;
         }
         .auto-resign-overlay {
             flex-direction: row;


### PR DESCRIPTION
This is done by using the 32px asset, scaled down by 50%.

Fixes #1824 

Note: There's probably room for improvement further down the stack.  In other words, I have only "fixed" this for games (where these flags are seen most often).  However, the flag is still blurry in, for example, the popover for the `Player` component.  But if we want to fix blurry flags everywhere, it might mean updating world-flags to contain 64px assets (or even vector graphics).  Just a thought.

Tested: This is difficult, but I tried all layouts that have their own css - desktop, portrait, and squashed views, as well as odd shaped flags (Swiss, Nepal, LGBTQ+).  The one major base I haven't covered is testing on an actual low res screen.

<details><summary>Screenshots (Before then After)</summary>

Desktop:
<img width="113" alt="Screen Shot 2022-10-16 at 9 27 46 PM" src="https://user-images.githubusercontent.com/25233703/196091943-559d6383-9407-43c6-8c06-54669f555c12.png">
<img width="115" alt="Screen Shot 2022-10-16 at 9 27 28 PM" src="https://user-images.githubusercontent.com/25233703/196091966-99ab29b7-089e-4c3e-bad6-949535618253.png">

Squashed:
<img width="55" alt="Screen Shot 2022-10-16 at 9 26 50 PM" src="https://user-images.githubusercontent.com/25233703/196091976-98e53e19-3f39-412e-a0cb-12fe77ede76a.png">
<img width="59" alt="Screen Shot 2022-10-16 at 9 26 44 PM" src="https://user-images.githubusercontent.com/25233703/196091988-75f84436-e953-4ac9-80f1-b18151ef80b2.png">

Portrait:
<img width="89" alt="Screen Shot 2022-10-16 at 9 25 56 PM" src="https://user-images.githubusercontent.com/25233703/196091999-a88149eb-a74d-4a19-bbf2-a048e6b929b9.png">
<img width="92" alt="Screen Shot 2022-10-16 at 9 25 49 PM" src="https://user-images.githubusercontent.com/25233703/196092005-f70d7f0d-0d92-4ad8-9b32-aae7c7727174.png">

</details>


