### PR TITLE
Show folk's OOLs on their profile

### DIFF
--- a/src/models/user.d.ts
+++ b/src/models/user.d.ts
@@ -154,6 +154,10 @@ declare namespace rest_api {
             name: string;
             icon: string; // URL
         }>;
+        online_leagues: Array<{
+            name: string;
+            membership_id: string;
+        }>;
         is_friend: boolean;
         friend_request_sent: boolean;
         friend_request_received: boolean;

--- a/src/views/OnlineLeagueGame/OnlineLeagueGame.tsx
+++ b/src/views/OnlineLeagueGame/OnlineLeagueGame.tsx
@@ -90,6 +90,7 @@ export function OnlineLeagueGame(): JSX.Element {
                     <UIPush event="online-league-game-commencement" action={jumpToGame} />
                     {(!logged_in || null) && (
                         <div className="membership-drive">
+                            {/* shenanigans to get a translated sentence with a link in it */}
                             <Link to={`/sign-in#${window.location.pathname}`}>
                                 {_("Log in or sign up")}
                             </Link>

--- a/src/views/User/ActivityCard.tsx
+++ b/src/views/User/ActivityCard.tsx
@@ -46,9 +46,19 @@ interface ActivityCardProps {
         name: string;
         icon: string;
     }>;
+    online_leagues?: Array<{
+        name: string;
+        membership_id: string;
+    }>;
 }
 
-export function ActivityCard({ user, ladders, groups, tournaments }: ActivityCardProps) {
+export function ActivityCard({
+    user,
+    ladders,
+    groups,
+    tournaments,
+    online_leagues,
+}: ActivityCardProps) {
     return (
         <Card className="activity-card">
             <h4>
@@ -110,6 +120,23 @@ export function ActivityCard({ user, ladders, groups, tournaments }: ActivityCar
             ) : (
                 <div>
                     <div>{_("Not a member of any groups")}</div>
+                </div>
+            )}
+            <h4>{_("Online Leagues")}</h4>
+            {online_leagues?.length ? (
+                <div>
+                    <dl className="activity-dl">
+                        {online_leagues.map((league, idx) => (
+                            <dd key={idx}>
+                                {league.name}
+                                {(league.membership_id || null) && `: ${league.membership_id}`}
+                            </dd>
+                        ))}
+                    </dl>
+                </div>
+            ) : (
+                <div>
+                    <div>{_("Not a member of any online leagues")}</div>
                 </div>
             )}
         </Card>

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -90,6 +90,8 @@ export function User(props: { user_id?: number }): JSX.Element {
     const [achievements, setAchievements] =
         React.useState<rest_api.FullPlayerDetail["achievements"]>();
     const [groups, setGroups] = React.useState<rest_api.FullPlayerDetail["groups"]>();
+    const [online_leagues, setOnlineLeagues] =
+        React.useState<rest_api.FullPlayerDetail["online_leagues"]>();
     const [tournaments, setTournaments] =
         React.useState<rest_api.FullPlayerDetail["tournaments"]>();
     const [titles, setTitles] = React.useState<rest_api.FullPlayerDetail["titles"]>();
@@ -156,6 +158,7 @@ export function User(props: { user_id?: number }): JSX.Element {
                     setLadders(response.ladders);
                     setTournaments(response.tournaments);
                     setGroups(response.groups);
+                    setOnlineLeagues(response.online_leagues);
                     setVs(response.vs);
 
                     window.document.title = response.user.username;
@@ -564,6 +567,7 @@ export function User(props: { user_id?: number }): JSX.Element {
                         ladders={ladders}
                         tournaments={tournaments}
                         groups={groups}
+                        online_leagues={online_leagues}
                     />
                 </div>
                 {/* end right col  */}


### PR DESCRIPTION
Fixes not being able to tell what leagues someone is in, and whether their membership id is correct

## Proposed Changes

Display people's OOL in their Profile, with the membership id visible if the backend sends it (which it only does if you're looking at your own profile, though we should add moderators  as well).

Needs https://github.com/online-go/ogs/pull/1757 to be able to show anything.