### PR TITLE
Seek graph improvements

### DIFF
--- a/src/components/ChallengeDetailsReviewPane/ChallengeDetailsReviewPane.tsx
+++ b/src/components/ChallengeDetailsReviewPane/ChallengeDetailsReviewPane.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { pgettext, _ } from "translate";
 
 import { timeControlDescription, usedForCheating } from "TimeControl";
-import { yesno } from "misc";
+import { rulesText, yesno } from "misc";
 
 type Challenge = socket_api.seekgraph_global.Challenge;
 
@@ -85,6 +85,8 @@ export function ChallengeDetailsReviewPane(
                 <dd>{challenge.ranked ? _("Yes") : _("No")}</dd>
                 <dt>{_("Handicap")}</dt>
                 <dd>{handicapText(challenge.handicap)}</dd>
+                <dt>{_("Rules")}</dt>
+                <dd>{rulesText(challenge.rules)}</dd>
                 <dt>{_("Komi")}</dt>
                 <dd>
                     {challenge.komi ? (

--- a/src/components/KBShortcut/KBShortcut.tsx
+++ b/src/components/KBShortcut/KBShortcut.tsx
@@ -20,7 +20,7 @@ import * as preferences from "preferences";
 
 let binding_id = 0;
 
-class Binding {
+export class Binding {
     id: number;
     shortcut: string;
     fn: (evt: any) => void;

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -398,9 +398,10 @@ export class SeekGraph extends TypedEventEmitter<Events> {
             return ret;
         }
 
+        const hitTolerance = 1.25 * this.square_size;
         for (const id in this.challenges) {
             const C = this.challenges[id];
-            if (dist(C, pos) < this.square_size * 2) {
+            if (dist(C, pos) < hitTolerance) {
                 ret.push(C);
             }
         }
@@ -715,7 +716,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
         const win_top = window.scrollY || document.documentElement.scrollTop;
         const win_left = window.scrollX || document.documentElement.scrollLeft;
         const win_right = $(window).width() + win_left;
-        const win_bottom = $(window).height() + win_top - 5;
+        const win_bottom = $(window).height() + win_top;
 
         const list_width = this.$list.width();
         const list_height = this.$list.height();
@@ -725,7 +726,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
         }
 
         if (listAnchor.y + list_height > win_bottom) {
-            listAnchor.y = win_bottom - list_height;
+            listAnchor.y = win_bottom - list_height - 5;
         }
 
         listAnchor.x = Math.max(0, listAnchor.x);

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -890,6 +890,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
 
             let details_html =
                 ", " +
+                (C.rengo ? _("Rengo") + ", " : "") +
                 (C.ranked ? _("Ranked") : _("Unranked")) +
                 ", " +
                 C.width +

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -493,12 +493,13 @@ export class SeekGraph extends TypedEventEmitter<Events> {
     drawAxes(ctx: CanvasRenderingContext2D, palette: SeekGraphColorPalette) {
         const w = this.width;
         const h = this.height;
+        const padding = this.padding;
+
         if (w < 30 || h < 30) {
             return;
         }
 
         ctx.font = "bold " + this.text_size + "px Verdana,Courier,Arial,serif";
-        const padding = this.padding;
         ctx.lineWidth = 1;
 
         /* Rank */
@@ -603,9 +604,12 @@ export class SeekGraph extends TypedEventEmitter<Events> {
     }
 
     getFontHeight(ctx: CanvasRenderingContext2D) {
-        ctx.font = "bold " + this.text_size + "px Verdana,Courier,Arial,serif";
-        const metrics = ctx.measureText(""); // string passed here doesn't matter since font attributes are invariant
-        return metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
+        const metrics = ctx.measureText("ABCgy");
+        if (metrics.fontBoundingBoxAscent) {
+            return metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
+        }
+        // Firefox
+        return metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent;
     }
 
     moveChallengeList(ev) {

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -395,30 +395,15 @@ export class SeekGraph extends TypedEventEmitter<Events> {
 
     getHits(ev: JQueryEventObject) {
         const pos = getRelativeEventPosition(ev);
-        const ret = [];
 
         if (!pos) {
-            return ret;
+            return [];
         }
 
         const hitTolerance = 1.25 * this.square_size;
-        for (const id in this.challenges) {
-            const C = this.challenges[id];
-            if (dist(C, pos) < hitTolerance) {
-                ret.push(C);
-            }
-        }
-
-        // if (this.show_live_games) {
-        //     for (const id in this.live_games) {
-        //         const C = this.live_games[id];
-        //         if (dist(C, pos) < this.square_size * 2) {
-        //             ret.push(C);
-        //         }
-        //     }
-        // }
-
-        return ret;
+        return Object.values(this.challenges).filter((c: Challenge) => {
+            return dist(c, pos) < hitTolerance && shouldDisplayChallenge(c, this.challengeFilter);
+        });
     }
 
     setFilter(f: ChallengeFilter) {

--- a/src/components/SeekGraph/SeekGraphLegend.styl
+++ b/src/components/SeekGraph/SeekGraphLegend.styl
@@ -17,6 +17,7 @@
 
  .seek-graph-legend {
     margin: 1rem auto;
+    display: flex;
     
     canvas {
         margin-right: 0.5rem;

--- a/src/components/SeekGraph/SeekGraphLegend.styl
+++ b/src/components/SeekGraph/SeekGraphLegend.styl
@@ -16,6 +16,8 @@
  */
 
  .seek-graph-legend {
+    margin: 1rem auto;
+    
     canvas {
         margin-right: 0.5rem;
         width: 20px;
@@ -23,6 +25,7 @@
     }
 
     td {
+        padding: 0 1rem;
         vertical-align: middle;
     }
     

--- a/src/components/SeekGraph/SeekGraphLegend.styl
+++ b/src/components/SeekGraph/SeekGraphLegend.styl
@@ -15,5 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export * from "./SeekGraph";
-export * from "./SeekGraphLegend";
+ .seek-graph-legend {
+    canvas {
+        margin-left: 0.5rem;
+        width: 20px;
+        height: 10px;
+    }
+    span {
+        display: flex;
+    }
+    
+    
+}

--- a/src/components/SeekGraph/SeekGraphLegend.styl
+++ b/src/components/SeekGraph/SeekGraphLegend.styl
@@ -16,11 +16,12 @@
  */
 
  .seek-graph-legend {
-    margin: 1rem auto;
-    display: flex;
+    margin: 1rem 0;
+    // display: flex;
+    width: 100%;
     
     canvas {
-        margin-right: 0.5rem;
+        margin-right: 2px;
         width: 20px;
         height: 10px;
     }
@@ -29,6 +30,33 @@
         padding: 0 1rem;
         vertical-align: middle;
     }
+
+    .legend-item {
+        margin: 0 5px;
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+    }
+
+    @media (max-width:720px) {
+        .legend-group {
+            width: 50%;
+        }
+    }
+
+     @media (min-width:720px) {
+        .legend-group {
+            width: 100%;
+        }
+    }
     
+    .grid {
+        display: grid;
+        grid-template-columns: repeat( auto-fit, minmax(125px, 1fr) );
+        // display: flex;
+        // flex-wrap: wrap;
+        // align-items: center;
+        
+    }
     
 }

--- a/src/components/SeekGraph/SeekGraphLegend.styl
+++ b/src/components/SeekGraph/SeekGraphLegend.styl
@@ -17,12 +17,13 @@
 
  .seek-graph-legend {
     canvas {
-        margin-left: 0.5rem;
+        margin-right: 0.5rem;
         width: 20px;
         height: 10px;
     }
-    span {
-        display: flex;
+
+    td {
+        vertical-align: middle;
     }
     
     

--- a/src/components/SeekGraph/SeekGraphLegend.tsx
+++ b/src/components/SeekGraph/SeekGraphLegend.tsx
@@ -141,12 +141,6 @@ export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
         <div className="seek-graph-legend">
             <Card>
                 <table>
-                    <thead>
-                        <tr>
-                            <th>{_("Board Sizes")}</th>
-                            <th>{_("Game Types")}</th>
-                        </tr>
-                    </thead>
                     <tbody>
                         {[0, 1, 2, 3, 4].map((i) => (
                             <tr>

--- a/src/components/SeekGraph/SeekGraphLegend.tsx
+++ b/src/components/SeekGraph/SeekGraphLegend.tsx
@@ -26,7 +26,7 @@ import {
 } from "./SeekGraphSymbols";
 import { ChallengePointStyle, SeekGraphColorPalette, SeekGraphPalettes } from "./SeekGraphPalettes";
 import * as data from "data";
-import { ChallengeFilter, ChallengeFilterKey } from "src/views/Play";
+import { ChallengeFilter, ChallengeFilterKey } from "challenge_utils";
 // import { SeekGraph } from "./SeekGraph";
 // import { SeekGraphColorPalette } from "./SeekGraphPalettes";
 

--- a/src/components/SeekGraph/SeekGraphLegend.tsx
+++ b/src/components/SeekGraph/SeekGraphLegend.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { Card } from "material";
+import { _ } from "translate";
+import {
+    drawChallengeCircle,
+    drawChallengeSquare,
+    drawChallengeTriangle,
+    drawLegendKey,
+} from "./SeekGraphSymbols";
+import { ChallengePointStyle, SeekGraphColorPalette, SeekGraphPalettes } from "./SeekGraphPalettes";
+import * as data from "data";
+import { ChallengeFilter, ChallengeFilterKey } from "src/views/Play";
+// import { SeekGraph } from "./SeekGraph";
+// import { SeekGraphColorPalette } from "./SeekGraphPalettes";
+
+interface SeekGraphLegendProps {
+    filter: ChallengeFilter;
+    toggleHandler: (key: ChallengeFilterKey) => void;
+}
+
+export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
+    const [currentPalette, setCurrentPalette] = React.useState<SeekGraphColorPalette>(
+        SeekGraphPalettes.DARK,
+    );
+    React.useEffect(() => {
+        data.watch("theme", (theme) => {
+            setCurrentPalette(SeekGraphPalettes.getPalette(theme));
+        });
+    }, []);
+
+    const legendItem = (
+        text: string,
+        icon: JSX.Element,
+        filterKey: ChallengeFilterKey,
+    ): JSX.Element => {
+        return (
+            <>
+                <input
+                    id={text}
+                    type="checkbox"
+                    checked={props.filter[filterKey]}
+                    onChange={() => props.toggleHandler(filterKey)}
+                ></input>
+                <label htmlFor={text}>{text}</label>
+                {icon}
+            </>
+        );
+    };
+
+    const sizeFilters = [
+        legendItem(_("19x19"), BoardSizeLegendIcon(currentPalette.size19), "show19x19"),
+        legendItem(_("13x13"), BoardSizeLegendIcon(currentPalette.size13), "show13x13"),
+        legendItem(_("9x9"), BoardSizeLegendIcon(currentPalette.size9), "show9x9"),
+        legendItem(_("Other"), BoardSizeLegendIcon(currentPalette.sizeOther), "showOtherSizes"),
+    ];
+    const typeFilters = [
+        legendItem(
+            _("Ranked"),
+            LegendIcon((ctx) =>
+                drawChallengeSquare(
+                    ICON_CENTER.x,
+                    ICON_CENTER.y,
+                    ICON_HEIGHT - 2,
+                    currentPalette.legend,
+                    ctx,
+                ),
+            ),
+            "showRanked",
+        ),
+        legendItem(
+            _("Unranked"),
+            LegendIcon((ctx) =>
+                drawChallengeTriangle(
+                    ICON_CENTER.x,
+                    ICON_CENTER.y,
+                    ICON_HEIGHT - 2,
+                    currentPalette.legend,
+                    ctx,
+                ),
+            ),
+            "showUnranked",
+        ),
+        legendItem(
+            _("Rengo"),
+            LegendIcon((ctx) =>
+                drawChallengeCircle(
+                    ICON_CENTER.x,
+                    ICON_CENTER.y,
+                    (ICON_HEIGHT - 2) / 2,
+                    currentPalette.legend,
+                    ctx,
+                ),
+            ),
+            "showRengo",
+        ),
+        legendItem(
+            _("Ineligible"),
+            BoardSizeLegendIcon(currentPalette.ineligible),
+            "showIneligible",
+        ),
+    ];
+
+    return (
+        <div className="seek-graph-legend">
+            <Card>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>{_("Board Sizes")}</th>
+                            <th>{_("Game Types")}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {[0, 1, 2, 3].map((i) => (
+                            <tr>
+                                <td>{sizeFilters[i]}</td>
+                                <td>{typeFilters[i]}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </Card>
+        </div>
+    );
+}
+
+const ICON_WIDTH = 20;
+const ICON_HEIGHT = 10;
+const ICON_CENTER = { x: ICON_WIDTH / 2, y: ICON_HEIGHT / 2 };
+const ICON_SCALE = 2;
+
+function LegendIcon(draw: (ctx: CanvasRenderingContext2D) => void): JSX.Element {
+    const canvas = React.useRef<HTMLCanvasElement>(null);
+    React.useEffect(() => {
+        const ctx: CanvasRenderingContext2D = canvas.current.getContext("2d");
+        // ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.resetTransform();
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        // This gives higher quality rendering while allowing canvas drawing code to use the "true" dimensions
+        // The CSS width/height are set to half of the below width and height (20, 10)
+        ctx.scale(ICON_SCALE, ICON_SCALE);
+        draw(ctx);
+    });
+    return (
+        <canvas ref={canvas} width={ICON_WIDTH * ICON_SCALE} height={ICON_HEIGHT * ICON_SCALE} />
+    );
+}
+
+function BoardSizeLegendIcon(style: ChallengePointStyle) {
+    return LegendIcon((ctx) => {
+        drawLegendKey(
+            ICON_CENTER.x,
+            ICON_CENTER.y,
+            ICON_WIDTH - 2,
+            ICON_HEIGHT - 2,
+            (ICON_HEIGHT - 2) / 2,
+            style,
+            ctx,
+        );
+    });
+}

--- a/src/components/SeekGraph/SeekGraphLegend.tsx
+++ b/src/components/SeekGraph/SeekGraphLegend.tsx
@@ -64,13 +64,23 @@ export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
         );
     };
 
-    const sizeFilters = [
+    const legendItemNoToggle = (text: string, icon: JSX.Element): JSX.Element => {
+        return (
+            <>
+                {icon}
+                <label htmlFor={text}>{text}</label>
+            </>
+        );
+    };
+
+    const leftColumn = [
         legendItem(_("19x19"), BoardSizeLegendIcon(currentPalette.size19), "show19x19"),
         legendItem(_("13x13"), BoardSizeLegendIcon(currentPalette.size13), "show13x13"),
         legendItem(_("9x9"), BoardSizeLegendIcon(currentPalette.size9), "show9x9"),
         legendItem(_("Other"), BoardSizeLegendIcon(currentPalette.sizeOther), "showOtherSizes"),
+        legendItemNoToggle(_("My challenges"), BoardSizeLegendIcon(currentPalette.user)),
     ];
-    const typeFilters = [
+    const rightColumn = [
         legendItem(
             _("Ranked"),
             LegendIcon((ctx) =>
@@ -115,6 +125,16 @@ export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
             BoardSizeLegendIcon(currentPalette.ineligible),
             "showIneligible",
         ),
+        legendItemNoToggle(
+            _("My rank"),
+            LegendIcon((ctx) => {
+                ctx.beginPath();
+                ctx.moveTo(0, ICON_CENTER.y);
+                ctx.lineTo(ICON_WIDTH, ICON_CENTER.y);
+                ctx.strokeStyle = currentPalette.rankLineColor;
+                ctx.stroke();
+            }),
+        ),
     ];
 
     return (
@@ -128,10 +148,10 @@ export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
                         </tr>
                     </thead>
                     <tbody>
-                        {[0, 1, 2, 3].map((i) => (
+                        {[0, 1, 2, 3, 4].map((i) => (
                             <tr>
-                                <td>{sizeFilters[i]}</td>
-                                <td>{typeFilters[i]}</td>
+                                <td>{leftColumn[i]}</td>
+                                <td>{rightColumn[i]}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/src/components/SeekGraph/SeekGraphLegend.tsx
+++ b/src/components/SeekGraph/SeekGraphLegend.tsx
@@ -52,6 +52,7 @@ export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
     ): JSX.Element => {
         return (
             <>
+                {icon}
                 <input
                     id={text}
                     type="checkbox"
@@ -59,7 +60,6 @@ export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
                     onChange={() => props.toggleHandler(filterKey)}
                 ></input>
                 <label htmlFor={text}>{text}</label>
-                {icon}
             </>
         );
     };

--- a/src/components/SeekGraph/SeekGraphLegend.tsx
+++ b/src/components/SeekGraph/SeekGraphLegend.tsx
@@ -143,7 +143,7 @@ export function SeekGraphLegend(props: SeekGraphLegendProps): JSX.Element {
                 <table>
                     <tbody>
                         {[0, 1, 2, 3, 4].map((i) => (
-                            <tr>
+                            <tr key={i}>
                                 <td>{leftColumn[i]}</td>
                                 <td>{rightColumn[i]}</td>
                             </tr>

--- a/src/components/SeekGraph/SeekGraphPalettes.tsx
+++ b/src/components/SeekGraph/SeekGraphPalettes.tsx
@@ -30,6 +30,7 @@ export interface SeekGraphColorPalette {
     // UNRANKED: ChallengePointStyle;
     ineligible: ChallengePointStyle;
     user: ChallengePointStyle;
+    legend: ChallengePointStyle;
 }
 
 export class SeekGraphPalettes {
@@ -41,6 +42,7 @@ export class SeekGraphPalettes {
         // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
         ineligible: { fill: "#6b6b6baa", stroke: "#bbb" },
         user: { fill: "#ed1f1faa", stroke: "#e37495" },
+        legend: { fill: "#FFFFFFAA", stroke: "#FFF" },
     };
     static readonly LIGHT: SeekGraphColorPalette = {
         size19: { fill: "#00ff00aa", stroke: "#00aa30" },
@@ -50,6 +52,7 @@ export class SeekGraphPalettes {
         // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
         ineligible: { fill: "#bbbbbbaa", stroke: "#6b6b6b" },
         user: { fill: "#e37495aa", stroke: "#ed1f1f" },
+        legend: { fill: "#222222AA", stroke: "#222" },
     };
     static readonly ACCESSIBLE: SeekGraphColorPalette = {
         size19: { fill: "#02a172aa", stroke: "#02a172" },
@@ -59,6 +62,7 @@ export class SeekGraphPalettes {
         // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
         ineligible: { fill: "#bbbbbbaa", stroke: "#bbb" },
         user: { fill: "#e6a100aa", stroke: "#e6a100" },
+        legend: { fill: "#FFFFFFAA", stroke: "#FFF" },
     };
 
     static getPalette(siteTheme: string): SeekGraphColorPalette {

--- a/src/components/SeekGraph/SeekGraphPalettes.tsx
+++ b/src/components/SeekGraph/SeekGraphPalettes.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+type Challenge = socket_api.seekgraph_global.Challenge;
+
+export interface ChallengePointStyle {
+    fill: string;
+    stroke: string;
+}
+
+export interface SeekGraphColorPalette {
+    size19: ChallengePointStyle;
+    size13: ChallengePointStyle;
+    size9: ChallengePointStyle;
+    sizeOther: ChallengePointStyle;
+    // UNRANKED: ChallengePointStyle;
+    ineligible: ChallengePointStyle;
+    user: ChallengePointStyle;
+}
+
+export class SeekGraphPalettes {
+    static readonly DARK: SeekGraphColorPalette = {
+        size19: { fill: "#00aa30", stroke: "#00ff00" },
+        size13: { fill: "#f000d0", stroke: "#ff60dd" },
+        size9: { fill: "#009090", stroke: "#00ffff" },
+        sizeOther: { fill: "#d06000", stroke: "#ff9000" },
+        // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
+        ineligible: { fill: "#bbb", stroke: "#aaa" },
+        user: { fill: "#ed1f1f", stroke: "#e25551" },
+    };
+    static readonly LIGHT: SeekGraphColorPalette = {
+        size19: { fill: "#00ff00", stroke: "#00aa30" },
+        size13: { fill: "#ff60dd", stroke: "#f000d0" },
+        size9: { fill: "#00ffff", stroke: "#009090" },
+        sizeOther: { fill: "#ff9000", stroke: "#d06000" },
+        // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
+        ineligible: { fill: "#aaa", stroke: "#bbb" },
+        user: { fill: "#e25551", stroke: "#ed1f1f" },
+    };
+    static readonly ACCESSIBLE: SeekGraphColorPalette = {
+        size19: { fill: "#00aa30", stroke: "#00ff00" },
+        size13: { fill: "#f000d0", stroke: "#ff60dd" },
+        size9: { fill: "#009090", stroke: "#00ffff" },
+        sizeOther: { fill: "#d06000", stroke: "#ff9000" },
+        // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
+        ineligible: { fill: "#bbb", stroke: "#aaa" },
+        user: { fill: "#ed1f1f", stroke: "#e25551" },
+    };
+
+    static getPalette(siteTheme: string): SeekGraphColorPalette {
+        if (siteTheme === "light") {
+            return SeekGraphPalettes.LIGHT;
+        }
+        if (siteTheme === "accessible") {
+            return SeekGraphPalettes.ACCESSIBLE;
+        }
+        return SeekGraphPalettes.DARK;
+    }
+
+    static getStyle(challenge: Challenge, palette: SeekGraphColorPalette): ChallengePointStyle {
+        if (challenge.user_challenge) {
+            return palette.user;
+        }
+        if (challenge.eligible === false) {
+            return palette.ineligible;
+        }
+
+        if (challenge.width === 19) {
+            return palette.size19;
+        }
+        if (challenge.width === 13) {
+            return palette.size13;
+        }
+        if (challenge.width === 9) {
+            return palette.size9;
+        }
+        return palette.sizeOther;
+    }
+}

--- a/src/components/SeekGraph/SeekGraphPalettes.tsx
+++ b/src/components/SeekGraph/SeekGraphPalettes.tsx
@@ -34,22 +34,22 @@ export interface SeekGraphColorPalette {
 
 export class SeekGraphPalettes {
     static readonly DARK: SeekGraphColorPalette = {
-        size19: { fill: "#00aa30", stroke: "#00ff00" },
-        size13: { fill: "#f000d0", stroke: "#ff60dd" },
-        size9: { fill: "#009090", stroke: "#00ffff" },
-        sizeOther: { fill: "#d06000", stroke: "#ff9000" },
+        size19: { fill: "#00aa30aa", stroke: "#00ff00" },
+        size13: { fill: "#f000d0aa", stroke: "#ff60dd" },
+        size9: { fill: "#009090aa", stroke: "#00ffff" },
+        sizeOther: { fill: "#d06000aa", stroke: "#ff9000" },
         // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
-        ineligible: { fill: "#bbb", stroke: "#aaa" },
-        user: { fill: "#ed1f1f", stroke: "#e25551" },
+        ineligible: { fill: "#6b6b6baa", stroke: "#bbb" },
+        user: { fill: "#ed1f1faa", stroke: "#e37495" },
     };
     static readonly LIGHT: SeekGraphColorPalette = {
-        size19: { fill: "#00ff00", stroke: "#00aa30" },
-        size13: { fill: "#ff60dd", stroke: "#f000d0" },
-        size9: { fill: "#00ffff", stroke: "#009090" },
-        sizeOther: { fill: "#ff9000", stroke: "#d06000" },
+        size19: { fill: "#00ff00aa", stroke: "#00aa30" },
+        size13: { fill: "#ff60ddaa", stroke: "#f000d0" },
+        size9: { fill: "#00ffffaa", stroke: "#009090" },
+        sizeOther: { fill: "#ff9000aa", stroke: "#d06000" },
         // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
-        ineligible: { fill: "#aaa", stroke: "#bbb" },
-        user: { fill: "#e25551", stroke: "#ed1f1f" },
+        ineligible: { fill: "#bbbbbbaa", stroke: "#6b6b6b" },
+        user: { fill: "#e37495aa", stroke: "#ed1f1f" },
     };
     static readonly ACCESSIBLE: SeekGraphColorPalette = {
         size19: { fill: "#00aa30", stroke: "#00ff00" },
@@ -57,8 +57,8 @@ export class SeekGraphPalettes {
         size9: { fill: "#009090", stroke: "#00ffff" },
         sizeOther: { fill: "#d06000", stroke: "#ff9000" },
         // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
-        ineligible: { fill: "#bbb", stroke: "#aaa" },
-        user: { fill: "#ed1f1f", stroke: "#e25551" },
+        ineligible: { fill: "#6b6b6b", stroke: "#bbb" },
+        user: { fill: "#ed1f1f", stroke: "#e37495" },
     };
 
     static getPalette(siteTheme: string): SeekGraphColorPalette {

--- a/src/components/SeekGraph/SeekGraphPalettes.tsx
+++ b/src/components/SeekGraph/SeekGraphPalettes.tsx
@@ -31,6 +31,10 @@ export interface SeekGraphColorPalette {
     ineligible: ChallengePointStyle;
     user: ChallengePointStyle;
     legend: ChallengePointStyle;
+    textColor: string;
+    axisColor: string;
+    rankLineColor: string;
+    timeLineColor: string;
 }
 
 export class SeekGraphPalettes {
@@ -43,6 +47,10 @@ export class SeekGraphPalettes {
         ineligible: { fill: "#6b6b6baa", stroke: "#bbb" },
         user: { fill: "#ed1f1faa", stroke: "#e37495" },
         legend: { fill: "#FFFFFFAA", stroke: "#FFF" },
+        textColor: "#dddddd",
+        axisColor: "#666666",
+        rankLineColor: "#ccccff",
+        timeLineColor: "#aaaaaa",
     };
     static readonly LIGHT: SeekGraphColorPalette = {
         size19: { fill: "#00ff00aa", stroke: "#00aa30" },
@@ -53,6 +61,10 @@ export class SeekGraphPalettes {
         ineligible: { fill: "#bbbbbbaa", stroke: "#6b6b6b" },
         user: { fill: "#e37495aa", stroke: "#ed1f1f" },
         legend: { fill: "#222222AA", stroke: "#222" },
+        textColor: "#000000",
+        axisColor: "#666666",
+        rankLineColor: "#ccccff",
+        timeLineColor: "#aaaaaa",
     };
     static readonly ACCESSIBLE: SeekGraphColorPalette = {
         size19: { fill: "#02a172aa", stroke: "#02a172" },
@@ -63,6 +75,10 @@ export class SeekGraphPalettes {
         ineligible: { fill: "#bbbbbbaa", stroke: "#bbb" },
         user: { fill: "#e6a100aa", stroke: "#e6a100" },
         legend: { fill: "#FFFFFFAA", stroke: "#FFF" },
+        textColor: "#dddddd",
+        axisColor: "#666666",
+        rankLineColor: "#ccccff",
+        timeLineColor: "#aaaaaa",
     };
 
     static getPalette(siteTheme: string): SeekGraphColorPalette {

--- a/src/components/SeekGraph/SeekGraphPalettes.tsx
+++ b/src/components/SeekGraph/SeekGraphPalettes.tsx
@@ -52,13 +52,13 @@ export class SeekGraphPalettes {
         user: { fill: "#e37495aa", stroke: "#ed1f1f" },
     };
     static readonly ACCESSIBLE: SeekGraphColorPalette = {
-        size19: { fill: "#00aa30", stroke: "#00ff00" },
-        size13: { fill: "#f000d0", stroke: "#ff60dd" },
-        size9: { fill: "#009090", stroke: "#00ffff" },
-        sizeOther: { fill: "#d06000", stroke: "#ff9000" },
+        size19: { fill: "#02a172aa", stroke: "#02a172" },
+        size13: { fill: "#cc73a8aa", stroke: "#cc73a8" },
+        size9: { fill: "#55b2ebaa", stroke: "#55b2eb" },
+        sizeOther: { fill: "#d55b00aa", stroke: "#d55b00" },
         // UNRANKED: { fill: "#d06000", stroke: "#ff9000" },
-        ineligible: { fill: "#6b6b6b", stroke: "#bbb" },
-        user: { fill: "#ed1f1f", stroke: "#e37495" },
+        ineligible: { fill: "#bbbbbbaa", stroke: "#bbb" },
+        user: { fill: "#e6a100aa", stroke: "#e6a100" },
     };
 
     static getPalette(siteTheme: string): SeekGraphColorPalette {

--- a/src/components/SeekGraph/SeekGraphSymbols.tsx
+++ b/src/components/SeekGraph/SeekGraphSymbols.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ChallengePointStyle } from "./SeekGraphPalettes";
+
+/**  Draws a square centered on the point (x,y) */
+export function drawChallengeSquare(
+    x: number,
+    y: number,
+    size: number,
+    style: ChallengePointStyle,
+    ctx: CanvasRenderingContext2D,
+) {
+    ctx.save();
+    ctx.fillStyle = style.fill;
+    ctx.strokeStyle = style.stroke;
+    const sx = x - size / 2;
+    const sy = y - size / 2;
+    ctx.fillRect(sx, sy, size, size);
+    ctx.strokeRect(sx, sy, size, size);
+    ctx.restore();
+}
+
+/**  Draws a circle centered on the point (x,y) */
+export function drawChallengeCircle(
+    x: number,
+    y: number,
+    radius: number,
+    style: ChallengePointStyle,
+    ctx: CanvasRenderingContext2D,
+) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.fillStyle = style.fill;
+    ctx.strokeStyle = style.stroke;
+    ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
+}
+
+/** Draws an equilateral triangle with side length 'size', centered vertically inside the square with side length 'size' centered on the point (x,y) */
+export function drawChallengeTriangle(
+    x: number,
+    y: number,
+    size: number,
+    style: ChallengePointStyle,
+    ctx: CanvasRenderingContext2D,
+) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.fillStyle = style.fill;
+    ctx.strokeStyle = style.stroke;
+    // The difference in height between a unit square and a unit equilateral triangle is (2 - √3) / 2
+    // split this evenly to get ~0.067
+    const margin = 0.067 * size;
+    const s = size / 2;
+    ctx.moveTo(x, y - s + margin);
+    ctx.lineTo(x + s, y + s - margin);
+    ctx.lineTo(x - s, y + s - margin);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
+}
+
+/** Draws a rounded rectangle centered on the point (x,y) */
+// Based on https://stackoverflow.com/questions/1255512/how-to-draw-a-rounded-rectangle-using-html-canvas
+export function drawLegendKey(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    radius: number,
+    style: ChallengePointStyle,
+    ctx: CanvasRenderingContext2D,
+) {
+    const tx = x - width / 2;
+    const ty = y - height / 2;
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(tx + radius, ty);
+    ctx.lineTo(tx + width - radius, ty);
+    ctx.quadraticCurveTo(tx + width, ty, tx + width, ty + radius);
+    ctx.lineTo(tx + width, ty + height - radius);
+    ctx.quadraticCurveTo(tx + width, ty + height, tx + width - radius, ty + height);
+    ctx.lineTo(tx + radius, ty + height);
+    ctx.quadraticCurveTo(tx, ty + height, tx, ty + height - radius);
+    ctx.lineTo(tx, ty + radius);
+    ctx.quadraticCurveTo(tx, ty, tx + radius, ty);
+    ctx.closePath();
+    ctx.fillStyle = style.fill;
+    ctx.strokeStyle = style.stroke;
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
+}

--- a/src/lib/challenge_utils.tsx
+++ b/src/lib/challenge_utils.tsx
@@ -36,6 +36,9 @@ export interface ChallengeFilter {
 export type ChallengeFilterKey = keyof ChallengeFilter;
 
 export function shouldDisplayChallenge(c: Challenge, filter: ChallengeFilter): boolean {
+    if (c.user_challenge) {
+        return true;
+    }
     const matchesSize =
         (filter.show19x19 && c.width === 19 && c.height === 19) ||
         (filter.show13x13 && c.width === 13 && c.height === 13) ||
@@ -46,7 +49,5 @@ export function shouldDisplayChallenge(c: Challenge, filter: ChallengeFilter): b
         (filter.showUnranked && !c.ranked && !c.rengo) ||
         (filter.showRanked && c.ranked) ||
         (filter.showRengo && c.rengo);
-    return (
-        (c.eligible || c.user_challenge || filter.showIneligible) && matchesRanked && matchesSize
-    );
+    return (c.eligible || filter.showIneligible) && matchesRanked && matchesSize;
 }

--- a/src/lib/challenge_utils.tsx
+++ b/src/lib/challenge_utils.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012-2022  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is the schema for the data functions (e.g. get(), set()).  It defines
+ * all the possible keys as well as the associated value types.
+ */
+
+export type Challenge = socket_api.seekgraph_global.Challenge;
+
+export interface ChallengeFilter {
+    showIneligible: boolean;
+    showRanked: boolean;
+    showUnranked: boolean;
+    show19x19: boolean;
+    show13x13: boolean;
+    show9x9: boolean;
+    showOtherSizes: boolean;
+    showRengo: boolean;
+}
+
+export type ChallengeFilterKey = keyof ChallengeFilter;
+
+export function shouldDisplayChallenge(c: Challenge, filter: ChallengeFilter): boolean {
+    const matchesSize =
+        (filter.show19x19 && c.width === 19 && c.height === 19) ||
+        (filter.show13x13 && c.width === 13 && c.height === 13) ||
+        (filter.show9x9 && c.width === 9 && c.height === 9) ||
+        (filter.showOtherSizes &&
+            (c.width !== c.height || (c.width !== 19 && c.width !== 13 && c.width !== 9)));
+    const matchesRanked =
+        (filter.showUnranked && !c.ranked && !c.rengo) ||
+        (filter.showRanked && c.ranked) ||
+        (filter.showRengo && c.rengo);
+    return (
+        (c.eligible || c.user_challenge || filter.showIneligible) && matchesRanked && matchesSize
+    );
+}

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -27,7 +27,7 @@ import { defaults as defaultPreferences, ValidPreference } from "./preferences";
 import { TimeControl, TimeControlTypes } from "src/components/TimeControl";
 import { AutomatchPreferences } from "src/components/AutomatchSettings";
 import { JosekiFilter } from "src/components/JosekiVariationFilter";
-import { Challenge } from "src/views/Play";
+import { Challenge } from "challenge_utils";
 
 interface CachedSchema {
     groups: GroupList;

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -75,6 +75,7 @@ export const defaults = {
     "show-13x13-challenges": true,
     "show-9x9-challenges": true,
     "show-other-boardsize-challenges": true,
+    "show-rengo-challenges": true,
     "show-move-numbers": true,
     "show-offline-friends": true,
     "show-ratings-in-rating-grid": false,

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -78,6 +78,7 @@ export const defaults = {
     "show-rengo-challenges": true,
     "show-move-numbers": true,
     "show-offline-friends": true,
+    "show-seek-graph": true,
     "show-ratings-in-rating-grid": false,
 
     "show-tournament-indicator": true, // implicitly on desktop

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -273,7 +273,7 @@
 #challenge-list-container {
     width: 100%;
     text-align: center;
-    margin-top: 3rem;
+    margin-top: 1rem;
     max-width: 100vw;
     overflow-y: auto;
 }

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -19,6 +19,10 @@
     // here
     max-width: 1110px;
 
+    .play-column {
+        margin: 0 auto;
+    }
+
     .seek-graph-container {
         width: 100%;
         height: 22em;

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -573,21 +573,21 @@ export class Play extends React.Component<{}, PlayState> {
 
                             <div style={{ marginTop: "2em" }}></div>
                         </div>
-                        <div id="challenge-list" onMouseMove={this.freezeChallenges}>
-                            <div className="challenge-row" style={{ marginTop: "1em" }}>
-                                <span className="cell break">{_("Rengo")}</span>
+                        {this.state.filter.showRengo && (
+                            <div id="challenge-list" onMouseMove={this.freezeChallenges}>
+                                <div className="challenge-row" style={{ marginTop: "1em" }}>
+                                    <span className="cell break">{_("Rengo")}</span>
+                                </div>
+                                <table id="rengo-table">
+                                    <thead>
+                                        {this.anyChallengesToShow(this.state.rengo_list)
+                                            ? this.rengoListHeaders()
+                                            : null}
+                                    </thead>
+                                    <tbody>{this.rengoList()}</tbody>
+                                </table>
                             </div>
-
-                            <table id="rengo-table">
-                                <thead>
-                                    {this.anyChallengesToShow(this.state.rengo_list)
-                                        ? this.rengoListHeaders()
-                                        : null}
-                                </thead>
-
-                                <tbody>{this.rengoList()}</tbody>
-                            </table>
-                        </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -464,6 +464,7 @@ export class Play extends React.Component<{}, PlayState> {
                 <div className="row">
                     <SeekGraphLegend
                         filter={this.state.filter}
+                        showIcons={preferences.get("show-seek-graph")}
                         toggleHandler={this.toggleFilterHandler}
                     ></SeekGraphLegend>
                 </div>

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -457,12 +457,11 @@ export class Play extends React.Component<{}, PlayState> {
                             </div>
                         </Card>
                     </div>
+                    <SeekGraphLegend
+                        filter={this.state.filter}
+                        toggleHandler={this.toggleFilterHandler}
+                    ></SeekGraphLegend>
                 </div>
-
-                <SeekGraphLegend
-                    filter={this.state.filter}
-                    toggleHandler={this.toggleFilterHandler}
-                ></SeekGraphLegend>
 
                 <div id="challenge-list-container">
                     <div id="challenge-list-inner-container">
@@ -542,8 +541,6 @@ export class Play extends React.Component<{}, PlayState> {
                                     <span className="cell"></span>
                                 </div>
                             ))}
-
-                            <div style={{ marginTop: "2em" }}></div>
 
                             <div className="custom-games-list-header-row">{_("Custom Games")}</div>
 

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -434,29 +434,34 @@ export class Play extends React.Component<{}, PlayState> {
             (uuid) => automatch_manager.active_correspondence_automatchers[uuid],
         );
         corr_automatchers.sort((a, b) => a.timestamp - b.timestamp);
+        const showSeekGraph = preferences.get("show-seek-graph");
 
         return (
             <div className="Play container">
                 <SupporterGoals />
                 <div className="row">
-                    <div className="col-sm-6">
+                    <div className="col-sm-6 play-column">
                         <Card>{this.automatchContainer()}</Card>
                     </div>
-                    <div className="col-sm-6">
-                        <Card>
-                            <div
-                                ref={(el) => (this.ref_container = el)}
-                                className="seek-graph-container"
-                            >
-                                <OgsResizeDetector
-                                    handleWidth
-                                    handleHeight
-                                    onResize={() => this.onResize()}
-                                />
-                                <PersistentElement elt={this.canvas} />
-                            </div>
-                        </Card>
-                    </div>
+                    {showSeekGraph && (
+                        <div className="col-sm-6 play-column">
+                            <Card>
+                                <div
+                                    ref={(el) => (this.ref_container = el)}
+                                    className="seek-graph-container"
+                                >
+                                    <OgsResizeDetector
+                                        handleWidth
+                                        handleHeight
+                                        onResize={() => this.onResize()}
+                                    />
+                                    <PersistentElement elt={this.canvas} />
+                                </div>
+                            </Card>
+                        </div>
+                    )}
+                </div>
+                <div className="row">
                     <SeekGraphLegend
                         filter={this.state.filter}
                         toggleHandler={this.toggleFilterHandler}

--- a/src/views/Settings/GeneralPreferences.tsx
+++ b/src/views/Settings/GeneralPreferences.tsx
@@ -44,6 +44,7 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
     const [_desktop_notifications, setDesktopNotifications] =
         usePreference("desktop-notifications");
     const [show_offline_friends, setShowOfflineFriends] = usePreference("show-offline-friends");
+    const [show_seek_graph, setShowSeekGraph] = usePreference("show-seek-graph");
     const [unicode_filter_usernames, setUnicodeFilterUsernames] = usePreference("unicode-filter");
     const [translation_dialog_never_show, setTranslationDialogNeverShow] = usePreference(
         "translation-dialog-never-show",
@@ -232,6 +233,10 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
                         <i>{_("Desktop notifications are not supported by your browser")}</i>
                     </div>
                 )}
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Show seek graph")}>
+                <Toggle checked={show_seek_graph} onChange={setShowSeekGraph} />
             </PreferenceLine>
 
             <PreferenceLine title={_("Show offline friends on list")}>


### PR DESCRIPTION
As proposed in #2050, this PR contains a number of improvements to the seek graph.

Notable changes:
- Improved resolution of seek graph
- Added shapes representing various challenge types (ranked, unranked, rengo)
- Moved challenge filters away from the bottom of the page, combining them with a legend explaining the symbols in the seek graph
- Made challenge filters affect the seek graph in addition to the challenge lists
- Added a challenge filter to hide/show rengo games
- Adjusted seek graph colors to match the current site theme
- Made the seek graph immediately respond to site theme changes
- Fixed a bug where the popover list would occasionally not show when mousing over a challenge in the bottom right of the seek graph

| Before  | After |
| ---------- | ---------- |
| <img width="500" alt="old_seekgraph" src="https://user-images.githubusercontent.com/35665417/197306508-b7a2b6d2-fa1e-4407-888a-fcc03537b403.png"> | <img width="500" alt="new_seekgraph" src="https://user-images.githubusercontent.com/35665417/197306445-5a5381e0-481a-4b0c-b2e6-7d7165204868.png">  |


