### PR TITLE
Migrate to use new computeAverageMoveTime function

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "express": "^4.17.1",
         "express-http-proxy": "^1.6.0",
         "fork-ts-checker-webpack-plugin": "^6.3.4",
-        "goban": "=0.5.114",
+        "goban": "=0.5.115",
         "gulp": "^4.0.2",
         "gulp-clean-css": "^4.3.0",
         "gulp-eslint-new": "^1.4.4",

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -557,7 +557,11 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
 
         const challenge = this.getChallenge();
 
-        const live = isLiveGame(challenge.game.time_control_parameters); // save for after the post, below, when TimeControlPicker is gone
+        const live = isLiveGame(
+            challenge.game.time_control_parameters,
+            challenge.game.width,
+            challenge.game.height,
+        ); // save for after the post, below, when TimeControlPicker is gone
 
         let open_now = false;
         if (live && !this.state.challenge.invite_only) {
@@ -1294,6 +1298,8 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                     <TimeControlPicker
                         value={this.state.initial_time_control}
                         ref={this.ref_time_control_picker}
+                        boardWidth={challenge.game.width}
+                        boardHeight={challenge.game.height}
                         force_system={
                             challenge.game.rengo && challenge.game.rengo_casual_mode
                                 ? "simple"

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -247,7 +247,13 @@ class NotificationEntry extends React.Component<{ notification }, any> {
                                     post("me/challenges/%%/accept", notification.challenge_id, {})
                                         .then(() => {
                                             this.del();
-                                            if (isLiveGame(notification.time_control)) {
+                                            if (
+                                                isLiveGame(
+                                                    notification.time_control,
+                                                    notification.width,
+                                                    notification.height,
+                                                )
+                                            ) {
                                                 browserHistory.push(
                                                     "/game/" + notification.game_id,
                                                 );

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -466,7 +466,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
         this.width = w;
         this.height = h;
 
-        if (w < 200 || h < 100) {
+        if (w < 295 || h < 100) {
             this.text_size = 7;
         } else {
             this.text_size = 10;
@@ -575,11 +575,11 @@ export class SeekGraph extends TypedEventEmitter<Events> {
             let metrics = ctx.measureText(word);
             ctx.fillText(word, padding + (blitz_line - padding - metrics.width) / 2, baseline);
 
-            word = _("Normal");
+            word = _("Live");
             metrics = ctx.measureText(word);
             ctx.fillText(word, blitz_line + (live_line - blitz_line - metrics.width) / 2, baseline);
 
-            word = _("Long");
+            word = _("Correspondence");
             metrics = ctx.measureText(word);
             ctx.fillText(word, live_line + (w - live_line - metrics.width) / 2, baseline);
         } catch (e) {

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -29,7 +29,7 @@ import { getRelativeEventPosition, errorAlerter } from "misc";
 import { rankString, bounded_rank, MaxRank } from "rank_utils";
 import { kb_bind, kb_unbind, Binding } from "KBShortcut";
 import { Player } from "Player";
-import { validateCanvas } from "goban";
+import { computeAverageMoveTime, validateCanvas } from "goban";
 import * as player_cache from "player_cache";
 
 import { nominateForRengoChallenge } from "rengo_utils";
@@ -434,7 +434,8 @@ export class SeekGraph extends TypedEventEmitter<Events> {
             const C = sorted[j];
 
             const rank_ratio = rankRatio(C.rank);
-            const time_ratio = timeRatio(C.time_per_move);
+            const tpm = computeAverageMoveTime(C.time_control_parameters, C.width, C.height);
+            const time_ratio = timeRatio(tpm);
 
             const cx = this.xCoordinate(time_ratio);
             const cy = this.yCoordinate(rank_ratio);
@@ -727,15 +728,16 @@ export class SeekGraph extends TypedEventEmitter<Events> {
                     this.closeChallengeList();
                 }),
         );
-        if (first_hit.time_per_move) {
+        if (first_hit.time_control_parameters) {
+            const tpm = computeAverageMoveTime(
+                first_hit.time_control_parameters,
+                first_hit.width,
+                first_hit.height,
+            );
             header.append(
                 $("<span>")
                     .addClass("pull-right")
-                    .html(
-                        "~" +
-                            shortDurationString(first_hit.time_per_move).replace(/ /g, "") +
-                            "/move",
-                    ),
+                    .html("~" + shortDurationString(tpm).replace(/ /g, "") + "/move"),
             );
         } else {
             header.append($("<span>").addClass("pull-right").html(_("No time limit")));

--- a/src/components/SeekGraph/SeekGraphPalettes.tsx
+++ b/src/components/SeekGraph/SeekGraphPalettes.tsx
@@ -99,14 +99,16 @@ export class SeekGraphPalettes {
             return palette.ineligible;
         }
 
-        if (challenge.width === 19) {
-            return palette.size19;
-        }
-        if (challenge.width === 13) {
-            return palette.size13;
-        }
-        if (challenge.width === 9) {
-            return palette.size9;
+        if (challenge.width === challenge.height) {
+            if (challenge.width === 19) {
+                return palette.size19;
+            }
+            if (challenge.width === 13) {
+                return palette.size13;
+            }
+            if (challenge.width === 9) {
+                return palette.size9;
+            }
         }
         return palette.sizeOther;
     }

--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { computeAverageMoveTime } from "goban";
+import { computeAverageMoveTime, JGOFTimeControl } from "goban";
 import { _, pgettext, ngettext, interpolate } from "translate";
 import { TimeControl, TimeControlTypes } from "./TimeControl";
 
@@ -240,8 +240,8 @@ export function parseIntWithDefaultValue(
     return Math.max(min, Math.min(max, parsedInt));
 }
 
-export function makeTimeControlParameters(tc: any): TimeControl {
-    const tpm = computeAverageMoveTime(tc);
+export function makeTimeControlParameters(tc: any, width?: number, height?: number): TimeControl {
+    const tpm = computeAverageMoveTime(tc, width, height);
     const speed: TimeControlTypes.TimeControlSpeed =
         tpm === 0 || tpm > 3600 ? "correspondence" : tpm < 10 ? "blitz" : "live";
 
@@ -574,8 +574,8 @@ export function validateTimeControl(tc: TimeControl): boolean {
             return !error;
     }
 }
-export function isLiveGame(time_control) {
-    const average_move_time = computeAverageMoveTime(time_control);
+export function isLiveGame(time_control: JGOFTimeControl, w?: number, h?: number) {
+    const average_move_time = computeAverageMoveTime(time_control, w, h);
     return average_move_time > 0 && average_move_time < 3600;
 }
 

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -664,7 +664,7 @@ export function lookingAtOurLiveGame(): boolean {
     return (
         goban &&
         goban.engine.phase !== "finished" &&
-        isLiveGame(goban.engine.time_control) &&
+        isLiveGame(goban.engine.time_control, goban.engine.width, goban.engine.height) &&
         goban.engine.isParticipant(player_id)
     );
 }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -154,8 +154,9 @@ export function Game(): JSX.Element {
                 goban.current.engine &&
                 goban.current.engine.playerNotToMove() === user.id
             ) {
+                const engine = goban.current.engine;
                 if (
-                    !isLiveGame(goban.current.engine.time_control) &&
+                    !isLiveGame(engine.time_control, engine.width, engine.height) &&
                     preferences.get("auto-advance-after-submit")
                 ) {
                     if (notification_manager.anyYourMove()) {
@@ -1151,7 +1152,7 @@ export function Game(): JSX.Element {
 
         goban.current.on("gamedata", (gamedata) => {
             try {
-                if (isLiveGame(gamedata.time_control)) {
+                if (isLiveGame(gamedata.time_control, gamedata.width, gamedata.height)) {
                     goban.current.one_click_submit = preferences.get("one-click-submit-live");
                     goban.current.double_click_submit = preferences.get("double-click-submit-live");
                 } else {

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -94,7 +94,10 @@ export function PlayButtons({ show_cancel = true }: PlayButtonsProps): JSX.Eleme
     };
 
     const pass = () => {
-        if (!isLiveGame(goban.engine.time_control) || !preferences.get("one-click-submit-live")) {
+        if (
+            !isLiveGame(goban.engine.time_control, goban.engine.width, goban.engine.height) ||
+            !preferences.get("one-click-submit-live")
+        ) {
             void alert
                 .fire({ text: _("Are you sure you want to pass?"), showCancelButton: true })
                 .then(({ value: accept }) => {

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -215,7 +215,7 @@ export class Play extends React.Component<{}, PlayState> {
 
             if (C.rengo) {
                 rengo.push(C);
-            } else if (isLiveGame(C.time_control_parameters)) {
+            } else if (isLiveGame(C.time_control_parameters, C.width, C.height)) {
                 live.push(C);
             } else {
                 corr.push(C);
@@ -603,10 +603,10 @@ export class Play extends React.Component<{}, PlayState> {
         };
 
         const own_live_rengo_challenge = this.ownRengoChallengesPending().find((c) =>
-            isLiveGame(c.time_control_parameters),
+            isLiveGame(c.time_control_parameters, c.width, c.height),
         );
         const joined_live_rengo_challenge = this.joinedRengoChallengesPending().find((c) =>
-            isLiveGame(c.time_control_parameters),
+            isLiveGame(c.time_control_parameters, c.width, c.height),
         );
 
         const rengo_challenge_to_show = own_live_rengo_challenge || joined_live_rengo_challenge;
@@ -1022,10 +1022,10 @@ export class Play extends React.Component<{}, PlayState> {
         const user = data.get("user");
 
         const live_list = this.state.rengo_list.filter((c) =>
-            isLiveGame(c.time_control_parameters),
+            isLiveGame(c.time_control_parameters, c.width, c.height),
         );
         const corr_list = this.state.rengo_list.filter(
-            (c) => !isLiveGame(c.time_control_parameters),
+            (c) => !isLiveGame(c.time_control_parameters, c.width, c.height),
         );
 
         return (

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -59,7 +59,7 @@ interface TournamentInterface {
     director: player_cache.PlayerCacheEntry;
     time_start: string;
 
-    board_size: string | number;
+    board_size: number;
     rules: GoEngineRules;
     description: string;
     handicap: string;
@@ -121,7 +121,7 @@ export function Tournament(): JSX.Element {
         director: tournament_id === 0 ? data.get("user") : ({} as any),
         time_start: moment(new Date()).add(1, "hour").startOf("hour").format(),
 
-        board_size: "19",
+        board_size: 19,
         rules: "japanese",
         description: "",
         handicap: "0",
@@ -1328,7 +1328,7 @@ export function Tournament(): JSX.Element {
         refresh();
     };
     const setBoardSize = (ev) => {
-        tournament_ref.current.board_size = ev.target.value;
+        tournament_ref.current.board_size = parseInt(ev.target.value);
         refresh();
     };
     const setAnalysisEnabled = (ev) => {
@@ -1615,7 +1615,11 @@ export function Tournament(): JSX.Element {
         cant_join_reason = _("Your rank is too high to join this tournament");
     }
 
-    const time_per_move = computeAverageMoveTime(tournament.time_control_parameters);
+    const time_per_move = computeAverageMoveTime(
+        tournament.time_control_parameters,
+        tournament.board_size,
+        tournament.board_size,
+    );
 
     if (
         tournament.tournament_type === "elimination" ||
@@ -1770,6 +1774,8 @@ export function Tournament(): JSX.Element {
                         <TimeControlPicker
                             value={tournament.time_control_parameters}
                             onChange={setTimeControl}
+                            boardWidth={tournament.board_size}
+                            boardHeight={tournament.board_size}
                         />
                     )}
                     {!editing ? (
@@ -2921,8 +2927,8 @@ export function Tournament(): JSX.Element {
                                                 <MiniGoban
                                                     key={idx}
                                                     id={m.gameid}
-                                                    width={tournament.board_size as number}
-                                                    height={tournament.board_size as number}
+                                                    width={tournament.board_size}
+                                                    height={tournament.board_size}
                                                     black={players[m.black]}
                                                     white={players[m.white]}
                                                 />

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -456,7 +456,7 @@ function mk32icon(path) {
     return path.replace(/-[0-9]+.png/, "-32.png");
 }
 function speedIcon(e) {
-    const tpm = computeAverageMoveTime(e.time_control_parameters);
+    const tpm = computeAverageMoveTime(e.time_control_parameters, e.size, e.size);
     if (tpm === 0 || tpm > 3600) {
         return "ogs-turtle";
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5096,10 +5096,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-goban@=0.5.114:
-  version "0.5.114"
-  resolved "https://registry.yarnpkg.com/goban/-/goban-0.5.114.tgz#551e9f21794d865a49191719df4a6269c5ccf054"
-  integrity sha512-4YGSX0ntnbdoJVsA1VNMtDlN7lxoGlOkFgxN1uqZL9CdAk1twMylb3sCSVkVTu73feO1CHqaKzQOZEOSLw/WfA==
+goban@=0.5.115:
+  version "0.5.115"
+  resolved "https://registry.yarnpkg.com/goban/-/goban-0.5.115.tgz#43d93a0c72a5fc90b5c15b250880aeacc6e80c84"
+  integrity sha512-GDd3WKnLYWcDIs5pQBjXksOZUV9mBRe6WevWteljAgBM9V69Naxhw/4i3z1G8zOqOUcCRFEaYL3p2IUO6EVXRg==
 
 google-auth-library@^8.0.2:
   version "8.5.2"


### PR DESCRIPTION
Average time-per-move calculations now consider the board size. The most important side-effect is that `isLiveGame` also considers the board size, which makes sense.

This PR also aligns the seek graph more closely with the site definitions of blitz, live, and correspondence games.