### PR TITLE
"Cancellation support" for OOLs

### DIFF
--- a/src/views/OnlineLeagueLanding/OnlineLeagueLanding.tsx
+++ b/src/views/OnlineLeagueLanding/OnlineLeagueLanding.tsx
@@ -102,8 +102,11 @@ export function OnlineLeagueLanding(): JSX.Element {
                 }
             })
             .catch((err) => {
+                // Note: some expected use-cases come through here, including a person trying to use the link of a cancelled game
+                // The server is expected to provide a sensible error message in those cases.
                 alert.close();
                 errorAlerter(err);
+                navigate("/", { replace: true });
             });
     };
 


### PR DESCRIPTION
Fixes  the player being left on the landing page with a spinner if they use a link to a cancelled game
Fixes  the player being left on the landing page with a spinner if any server error happens when they use a link to an OOL match

## Proposed Changes

Navigate to the home page if the server 400's the OOL link PUT.