### PR TITLE
Bug Fix: Resend validation email button missing.

### DIFF
--- a/src/views/Settings/AccountSettings.test.tsx
+++ b/src/views/Settings/AccountSettings.test.tsx
@@ -1,0 +1,79 @@
+import { AccountSettings } from "./AccountSettings";
+import * as React from "react";
+import { act, render, screen } from "@testing-library/react";
+import * as requests from "requests";
+import * as ogs_hooks from "hooks";
+import { OgsHelpProvider } from "OgsHelpProvider";
+
+const BASE_PROPS = {
+    state: { profile: { email: "" } },
+    vacation_base_time: 0,
+    refresh: () => () => {
+        return;
+    },
+    updateSelfReportedAccountLinkages: () => {
+        return;
+    },
+};
+
+const TEST_USER = {
+    username: "testuser",
+    anonymous: false,
+    id: 0,
+    registration_date: "",
+    ratings: undefined,
+    country: "",
+    professional: false,
+    ranking: 0,
+    provisional: 0,
+    can_create_tournaments: false,
+    is_moderator: false,
+    is_superuser: false,
+    is_tournament_moderator: false,
+    supporter: false,
+    supporter_level: 0,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "",
+    email: "",
+    email_validated: "",
+    is_announcer: false,
+} as const;
+
+const BASE_API_RESPONSE = {
+    username: "testuser",
+    first_name: "",
+    last_name: "",
+    country: "",
+    website: "",
+    email: "",
+    real_name_is_private: true,
+    is_bot: false,
+    password_is_set: true,
+    email_validated: "2000-01-01T00:00:00.000000Z",
+    social_auth_accounts: [],
+};
+
+describe("Verify email", () => {
+    test("shows resend validation email if not verified", async () => {
+        jest.spyOn(requests, "get").mockReturnValue(
+            Promise.resolve({
+                ...BASE_API_RESPONSE,
+                email: "asdf@ogsmail.com",
+                email_validated: undefined,
+            }),
+        );
+
+        jest.spyOn(ogs_hooks, "useUser").mockReturnValue(TEST_USER);
+
+        await act(async () => {
+            render(
+                <OgsHelpProvider>
+                    <AccountSettings {...BASE_PROPS} />
+                </OgsHelpProvider>,
+            );
+        });
+
+        expect(screen.getByText("Resend validation email")).toBeDefined();
+    });
+});

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -94,7 +94,7 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
                 setCountry(settings.country);
                 setWebsite(settings.website);
                 setEmailValidated(settings.email_validated);
-                setEmailValidated(settings.email);
+                setEmail(settings.email);
                 setLoading(false);
             })
             .catch(errorLogger);


### PR DESCRIPTION
Fixes issue discussed at [OGS Forums: Account Verification](https://forums.online-go.com/t/account-verification/45360/6). The regression likely happened in 1722cd6fb33de4f46eb13754b6ef6215747227a9, although I didn't actually go back and run it.

The issue is that this message/button is missing:

<img width="477" alt="Screen Shot 2022-11-04 at 12 41 45 AM" src="https://user-images.githubusercontent.com/25233703/199919305-909c8158-48d1-475c-9c5a-bb7cdb7a8d70.png">

## Proposed Changes

  - Fix Bug
  - Write a test that would have caught said bug
