### PR TITLE
Bug fix: Link to review SGFs if both game_id and review_id are present.

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1462,8 +1462,6 @@ export function Game(): JSX.Element {
                         {((view_mode === "portrait" && !zen_mode) || null) && (
                             <GameDock
                                 annulled={annulled}
-                                review_id={review_id}
-                                game_id={game_id}
                                 selected_ai_review_uuid={selected_ai_review_uuid}
                                 tournament_id={tournament_id.current}
                                 ladder_id={ladder_id.current}
@@ -1515,8 +1513,6 @@ export function Game(): JSX.Element {
 
                             <GameDock
                                 annulled={annulled}
-                                review_id={review_id}
-                                game_id={game_id}
                                 selected_ai_review_uuid={selected_ai_review_uuid}
                                 tournament_id={tournament_id.current}
                                 ladder_id={ladder_id.current}

--- a/src/views/Game/GameDock.test.tsx
+++ b/src/views/Game/GameDock.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { GameDock } from "./GameDock";
+import { Goban } from "goban";
+import { GobanContext } from "./goban_context";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const BASE_PROPS = {
+    annulled: false,
+    selected_ai_review_uuid: "",
+    ai_review_enabled: false,
+    historical_black: undefined,
+    historical_white: undefined,
+    onZenClicked: jest.fn(),
+    onCoordinatesClicked: jest.fn(),
+    onAIReviewClicked: jest.fn(),
+    onAnalyzeClicked: jest.fn(),
+    onConditionalMovesClicked: jest.fn(),
+    onPauseClicked: jest.fn(),
+    onEstimateClicked: jest.fn(),
+    onGameAnnulled: jest.fn(),
+    onTimingClicked: jest.fn(),
+    onCoordinatesMarked: jest.fn(),
+    onReviewClicked: jest.fn(),
+};
+
+test("providing both Game ID and Review ID cause SGF buttons to link to review SGFs", () => {
+    const goban = new Goban({ game_id: 123456, review_id: 123 });
+
+    render(
+        <Router>
+            <GobanContext.Provider value={goban}>
+                <GameDock {...BASE_PROPS} />
+            </GobanContext.Provider>
+        </Router>,
+    );
+    const sgf_button = screen.getByText("Download SGF");
+    expect(sgf_button).toBeDefined();
+    expect(sgf_button.getAttribute("href")).toBe("/api/v1/reviews/123/sgf?without-comments=1");
+
+    const sgf_button_with_comments = screen.getByText("SGF with comments");
+    expect(sgf_button_with_comments).toBeDefined();
+    expect(sgf_button_with_comments.getAttribute("href")).toBe("/api/v1/reviews/123/sgf");
+});

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -37,8 +37,6 @@ import { useGoban } from "./goban_context";
 
 interface DockProps {
     annulled: boolean;
-    review_id?: number;
-    game_id?: number;
     selected_ai_review_uuid: string | null;
     tournament_id?: number;
     ladder_id?: number;
@@ -59,8 +57,6 @@ interface DockProps {
 }
 export function GameDock({
     annulled,
-    review_id,
-    game_id,
     selected_ai_review_uuid,
     tournament_id,
     ladder_id,
@@ -92,13 +88,15 @@ export function GameDock({
     const unannulable = annulled && engine.config.ranked;
     const user_is_player = useUserIsParticipant(goban);
 
+    const review_id: number = goban.config.review_id;
+    const game_id = Number(goban.config.game_id);
+
     const review = !!review_id;
     const game = !!game_id;
     if (review) {
         superuser_ai_review_ready = false;
         mod = false;
         annul = false;
-        game_id = Number(goban.config.game_id);
     }
 
     let sgf_download_enabled = false;
@@ -108,20 +106,16 @@ export function GameDock({
         // ignore error
     }
 
-    const sgf_url = game_id
-        ? api1(`games/${game_id}/sgf`)
-        : api1(`reviews/${review_id}/sgf?without-comments=1`);
-    let sgf_with_comments_url: string | null = null;
-    let sgf_with_ai_review_url: string | null = null;
-    if (game_id) {
-        if (selected_ai_review_uuid) {
-            sgf_with_ai_review_url = api1(
-                `games/${game_id}/sgf?ai_review=${selected_ai_review_uuid}`,
-            );
-        }
-    } else {
-        sgf_with_comments_url = api1(`reviews/${review_id}/sgf`);
-    }
+    const sgf_url = review_id
+        ? api1(`reviews/${review_id}/sgf?without-comments=1`)
+        : api1(`games/${game_id}/sgf`);
+    const sgf_with_ai_review_url: string | null =
+        game_id && selected_ai_review_uuid
+            ? `games/${game_id}/sgf?ai_review=${selected_ai_review_uuid}`
+            : null;
+    const sgf_with_comments_url: string | null = review_id
+        ? api1(`reviews/${review_id}/sgf`)
+        : null;
 
     const openACL = () => {
         if (game_id) {


### PR DESCRIPTION
Fixes issue from [OGS forums: Some reviews do not have "SGF with comments"](https://forums.online-go.com/t/some-reviews-do-not-have-sgf-with-comments/45362/3).  Regression likely occurred in https://github.com/online-go/online-go.com/pull/1865.

- Bug: "SGF with comments" button was missing from reviews.
- Root cause: `game_id` is present on reviews, because `game_id` is used to link to the original game.

## Proposed Changes

  - Remove `game_id` and `review_id` from `GameDockProps`, and get these values from the goban.
  - Write a test that fails on the bug.
  - Fix the bug.

