### PR TITLE
fix: add visual feedback for 500 error

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1302,7 +1302,21 @@ export function Game(): JSX.Element {
                         goban_div.current.removeAttribute("data-tournament-id");
                     }
                 })
-                .catch(ignore);
+                .catch((e) => {
+                    if (e.statusText === "abort") {
+                        console.error("Error: abort", e);
+                        return;
+                    }
+                    if (e.statusText === "Not Found") {
+                        console.error("Error: not found, handled 10s later by socket.ts", e);
+                        return;
+                    }
+                    console.error(e);
+                    void alert.fire({
+                        title: "Failed to load game data: " + e.statusText,
+                        icon: "error",
+                    });
+                });
         }
 
         if (review_id) {


### PR DESCRIPTION
Fixes #50

This commit only adds a visual feedback and doesn't change anything else.

## Proposed Changes

- Add an `alert` only on game file not found.

## Possible Improvements
- refactor the `.then`/`.catch` with `try..catch`+`async`/`await`
    The `async`/`await` is a syntactic sugar doesn't change any functionality (so we don't lose anything). Yet they offer SLIGHTLY more readability and improve debugging experience. With the current implementation, when debugging, we have to split the `.then()` to many `.then().catch().then().catch()`... and in comparison with `try..catch`, we just remove the outer `try{}` and we can see clearly where the error is thrown. But the change can be too so subtle for the work needed.
- improve error handling when web socket returns a 404 / 500: they should have consistent behaviour
    Currently, the https://github.com/online-go/online-go.com/blob/a0cb2908be96f79d1f0b30f8934cb7623f3c90e2/src/main.tsx#L281-L282 (from https://github.com/online-go/online-go.com/issues/50#issuecomment-1304527096) handles 404 with a 10 second delay correctly, but the 415/500 was not dealt with the same procedure. And I reckon this as the real reason that causes #50. We can either extract the error handling function from the `errorAlerter` or handle all WS errors in in `sockets`. (I'm not very sure about this, just feeling the inconsistency.)

Does any of these two worths creating an issue?
