### PR TITLE
PlayControls: unsubscribe from goban events after unmount.

### DIFF
--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -45,17 +45,31 @@ export function generateGobanHook<T, G extends GobanCore | null>(
                 return;
             }
 
-            const events_with_load: Array<keyof GobanEvents> = ["load", ...events];
-            for (const e of events_with_load) {
-                goban.on(e, syncProp);
-            }
-            return () => {
-                for (const e of events_with_load) {
-                    goban.off(e, syncProp);
-                }
-            };
+            return subscribeAllEvents(goban, events, syncProp);
         }, [goban]);
         return prop;
+    };
+}
+
+/**
+ * @param goban the goban object
+ * @param events the events to which we want to subscribe (excluding load)
+ * @param cb the callback which should be triggered on emit.
+ * @returns a callback that will unsubscribe from all events that were just subscribed.
+ */
+export function subscribeAllEvents(
+    goban: GobanCore,
+    events: Array<keyof Omit<GobanEvents, "load">> = [],
+    cb: () => void,
+) {
+    const events_with_load: Array<keyof GobanEvents> = ["load", ...events];
+    for (const e of events_with_load) {
+        goban.on(e, cb);
+    }
+    return () => {
+        for (const e of events_with_load) {
+            goban.off(e, cb);
+        }
     };
 }
 

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -247,3 +247,23 @@ test("Renders conditional moves", () => {
     expect(screen.getByText("Conditional Move Planner")).toBeDefined();
     expect(screen.getByText("A19")).toBeDefined();
 });
+
+test("Unsubscribe from all events on unmount", () => {
+    const goban = new Goban({ game_id: 1234 });
+    data.set("user", TEST_USER);
+
+    const getListenerCounts = (emitter: Goban) =>
+        Object.fromEntries(emitter.eventNames().map((key) => [key, emitter.listenerCount(key)]));
+
+    // Goban may set up listeners on itself
+    const listeners_before = getListenerCounts(goban);
+
+    const { unmount } = render(
+        <WrapTest goban={goban}>
+            <PlayControls {...PLAY_CONTROLS_DEFAULTS} />
+        </WrapTest>,
+    );
+    unmount();
+
+    expect(getListenerCounts(goban)).toEqual(listeners_before);
+});


### PR DESCRIPTION
Fixes memory leaks caused by subscribing to goban without cleaning up. In actual practice, this might happen when resizing the window.  Unlikely to have significant memory impact, but a leak nonetheless.

## Proposed Changes

  - Write a test to catch memory leak caused by `PlayControls` subscription.
  - Add unsubscribes to the cleanup function.

## Dependency

Unit test relies on https://github.com/online-go/goban/pull/107