### PR TITLE
Fix time control picker bugs caused by residual entries from the old time control picker

### DIFF
--- a/src/components/TimeControl/TimeControlUpdates.ts
+++ b/src/components/TimeControl/TimeControlUpdates.ts
@@ -64,7 +64,14 @@ function recallTimeControlSettings(
         system = "byoyomi";
     }
     const fallback = getDefaultTimeControl(speed, system);
-    const tc = data.get(`time_control.${speed}.${system}`, fallback);
+    let tc = data.get(`time_control.${speed}.${system}`, fallback);
+    // The old time control picker occasionally wrote malformed entries, which unfortunately need to be
+    // accounted for.
+    if (tc.speed !== speed || tc.system !== system) {
+        console.log(`Repairing time_control.${speed}.${system}`);
+        data.remove(`time_control.${speed}.${system}`);
+        tc = fallback;
+    }
     return validateSettings(tc, boardWidth, boardHeight);
 }
 


### PR DESCRIPTION
Fixes #2105. The old time control picker is still causing problems from the grave!
