### PR TITLE
Get rid of `profile-edit-link` help item reference from User.tsx...

### DIFF
--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -23,8 +23,6 @@ import { parse } from "query-string";
 import * as data from "data";
 import * as moment from "moment";
 
-import * as DynamicHelp from "react-dynamic-help";
-
 import * as preferences from "preferences";
 import * as player_cache from "player_cache";
 
@@ -97,14 +95,6 @@ export function User(props: { user_id?: number }): JSX.Element {
     const [titles, setTitles] = React.useState<rest_api.FullPlayerDetail["titles"]>();
     const [trophies, setTrophies] = React.useState<rest_api.FullPlayerDetail["trophies"]>();
     const [vs, setVs] = React.useState<rest_api.FullPlayerDetail["vs"]>();
-
-    const { signalUsed } = React.useContext(DynamicHelp.Api);
-
-    try {
-        signalUsed("profile-edit-link"); // they have arrived here now, so they don't need to be told how to get here anymore
-    } catch (e) {
-        console.error(e);
-    }
 
     const show_graph_type_toggle = !preferences.get("rating-graph-always-use");
 


### PR DESCRIPTION
...  it is no longer a thing.

Fixes - being forced to wrap that in a try to make things work.

## Proposed Changes

Don't refer to `profile-edit-link`, because it was a old nav system thing.
