### PR TITLE
Further prevent users from selecting time control values outside the allowable min/max range

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -39,8 +39,6 @@ import { PlayerIcon } from "PlayerIcon";
 import {
     shortShortTimeControl,
     isLiveGame,
-    getDefaultTimeControl,
-    TimeControlTypes,
     TimeControlPicker,
     timeControlSystemText,
     TimeControl,
@@ -63,7 +61,11 @@ import {
 import { copyChallengeLinkURL } from "ChallengeLinkButton";
 
 import { alert } from "swal_config";
-import { updateSystem } from "TimeControl/TimeControlUpdates";
+import {
+    recallTimeControlSettings,
+    saveTimeControlSettings,
+    updateSystem,
+} from "TimeControl/TimeControlUpdates";
 
 type ChallengeDetails = rest_api.ChallengeDetails;
 
@@ -346,23 +348,15 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
         });
     }
 
-    saveTimeControlSettings() {
-        const speed = this.state.time_control.speed as TimeControlTypes.TimeControlSpeed;
-        const system = this.state.time_control.system as TimeControlTypes.TimeControlSystem;
-        data.set(`time_control.speed`, speed);
-        data.set(`time_control.system`, system);
-        data.set(`time_control.${speed}.${system}`, this.state.time_control);
-    }
-
     loadLastTimeControlSettings(): TimeControl {
         const speed = data.get(`time_control.speed`, "correspondence");
         const system = data.get(`time_control.system`, "byoyomi");
-        return data.get(`time_control.${speed}.${system}`, getDefaultTimeControl(speed, system));
+        return recallTimeControlSettings(speed, system);
     }
 
     saveSettings() {
         const next = this.next();
-        this.saveTimeControlSettings();
+        saveTimeControlSettings(this.state.time_control);
         const speed = data.get("challenge.speed", "live");
         data.set(`challenge.challenge.${speed}`, next.challenge);
         data.set("challenge.bot", next.conf.bot_id);


### PR DESCRIPTION
Fixes #1628 (see https://forums.online-go.com/t/0-periods-byo-yomi/40409/ as well) and cleans up some unused code.

The two properties affected were "periods" on Byoyomi games and "stones_per_period" on Canadian games.

There were already some checks to ensure proper values, but it seems some users were (accidentally or otherwise) pressing "create challenge" before the value could be clamped to the allowable range. As with previous time control picker bugs, these malformed settings had the potential to be persisted in local storage and come back again and again.

Note that even after this fix, users can still create malformed challenge requests (not using the UI), so there should still be more validation on the backend. There may be validation already for "stones_per_period", but it appears there isn't any on "periods".

