### PR TITLE
Larger relative font added using media query for mobile devices

### DIFF
--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -388,13 +388,25 @@
     }
 
     .Clock {
+        @media screen and (max-width 600px) {
+            font-size: 1.2em;
+        }
+
         .main-time {
             font-size: font-size-small;
+
+            @media screen and (max-width 600px) {
+                font-size: 1em;    
+            }
         }
         .byo-yomi-container,
         .canadian-container
         {
             font-size: font-size-extra-small;
+
+            @media screen and (max-width 600px) {
+                font-size: 0.8em;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1625 

## Proposed Changes

  - Added media query for styling clock on mobile devices.
  - On mobile devices clock font would be based on ems instead of px.
  - Increased base .Clock font-size to 1.2em
  - .main-time set to 1em and .byo-yomi-container/.canadian-container set to 0.8 em to preserve the 10px to 8px ratio used on larger device screens.
