### PR TITLE
Increased font size on portrait mode.

### DIFF
--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -389,12 +389,12 @@
 
     .Clock {
         .main-time {
-            font-size: font-size-small;
+            font-size: 1.2em;
         }
         .byo-yomi-container,
         .canadian-container
         {
-            font-size: font-size-extra-small;
+            font-size: 0.8 * 1.2em;
         }
     }
 }


### PR DESCRIPTION
Fixes #1625 

## Proposed Changes

  - Changed size from absolute (px) to relative (em)
  - Increased font size for clock on portrait mode while keeping 0.8 ratio between main-time and byo-yomi / canadian.
