### PR TITLE
Update Go Commentary video link

### DIFF
--- a/src/views/docs/GoResources.tsx
+++ b/src/views/docs/GoResources.tsx
@@ -377,7 +377,7 @@ export const GoResources = () => {
                             <BasicResource
                                 countries={[en]}
                                 title="Go Commentary Videos"
-                                href="http://www.gocommentary.com/free-tutorial-videos.html"
+                                href="https://www.youtube.com/@GoCommentary/"
                             />,
                             <BasicResource
                                 countries={[en]}


### PR DESCRIPTION
Original link is broken as the domain name lapsed. The new link points directly to YouTube Channel instead.

## Proposed Changes

- Updates Go Commentary video link
