### PR TITLE
Adds "next game" arrows on PlayerCards

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -130,6 +130,7 @@ export const defaults = {
             visible: boolean;
         };
     },
+    "moderator.hide-next-game-arrows": false,
 
     "table-color-default-on": false,
 

--- a/src/views/Game/PlayerCards.styl
+++ b/src/views/Game/PlayerCards.styl
@@ -3,3 +3,10 @@
         color: #FF8B00;
     }
 }
+.next-game-arrows {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 0 0.5rem 0 0.5rem;
+    align-items: center;
+}

--- a/src/views/Settings/ModeratorPreferences.tsx
+++ b/src/views/Settings/ModeratorPreferences.tsx
@@ -34,6 +34,9 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
     );
     const [hide_flags, setHideFlags] = usePreference("moderator.hide-flags");
     const [hide_profile, setHideProfile] = usePreference("moderator.hide-profile-information");
+    const [hide_next_game_arrows, setHideNextGameArrows] = usePreference(
+        "moderator.hide-next-game-arrows",
+    );
 
     const user = data.get("user");
 
@@ -63,6 +66,9 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
             </PreferenceLine>
             <PreferenceLine title="Hide moderator information on profile pages">
                 <Toggle checked={hide_profile} onChange={setHideProfile} />
+            </PreferenceLine>
+            <PreferenceLine title="Hide 'next game' arrows on player cards">
+                <Toggle checked={hide_next_game_arrows} onChange={setHideNextGameArrows} />
             </PreferenceLine>
             <ReportsCenterSettings />
         </div>


### PR DESCRIPTION
For moderators to step through a person's games

## Proposed Changes

arrow-buttons on PlayerCards, for moderators, which go to the player's next and prev games
moderator-option to hide these arrows, which default  on


**Needs https://github.com/online-go/ogs/pull/1780

**Improved by:  https://github.com/online-go/ogs/pull/1781  (sort by ended, started instead of id)