### PR TITLE
Don't show conditional move planner on player's turn

### DIFF
--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -318,6 +318,13 @@ export function GameDock({
             .catch(errorAlerter);
     };
 
+    // Not the same as engine.playerToMove(), which changes when you place a
+    // provisional stone on the board (in submit-move or double-click mode).
+    const currentPlayer =
+        engine.getMoveNumber() === engine.getCurrentMoveNumber()
+            ? engine.playerToMove()
+            : engine.playerNotToMove();
+
     return (
         <Dock>
             {(tournament_id || null) && (
@@ -388,7 +395,7 @@ export function GameDock({
                 <a
                     style={{
                         visibility:
-                            goban.mode === "play" && engine.playerToMove() !== user?.id
+                            goban.mode === "play" && currentPlayer !== user?.id
                                 ? "visible"
                                 : "hidden",
                     }}


### PR DESCRIPTION
I think this fixes #876.  

The conditional move planner would sometimes be visible to players on their turn even though it doesn't work.

# Proposed changes

- Don't show the conditional move planner when the player places a provisional stone on the board