### PR TITLE
Use wearerequired/lint-action to autofix PRs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+/*.js
+node_modules
+dist
+i18n
+typings_manual
+.github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the devel branch
   push:
@@ -23,11 +23,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-      
+
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-          
+
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v2
@@ -46,15 +46,16 @@ jobs:
       - name: Build CSS
         run: npx gulp min_styl
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Prettier
-        run: npm run prettier:check
+      - name: Run linters
+        uses: wearerequired/lint-action@v2
+        with:
+          auto_fix: ${{ github.event_name == 'pull_request' }}
+          eslint: true
+          eslint_extensions: "ts,tsx"
 
       - name: Webpack
         run: npx webpack --optimization-minimize --devtool=source-map
-        
+
       - name: Tests
         run: npx jest
 
@@ -64,6 +65,6 @@ jobs:
           gzip -9 dist/ogs.min.js | wc -c
           gzip -9 dist/vendor.min.js | wc -c
           gzip -9 dist/ogs.min.css | wc -c
-    
-          
-      
+
+
+


### PR DESCRIPTION
Fixes contributors having to wrestle with the linter (possibly without a proper dev environment).  Now a bot will push a commit fixing lints if necessary. Check out https://github.com/benjaminpjones/online-go.com/pull/4 to see this bot in action!

## Proposed Changes

  - Replace existing lint step with one involving [wearerequired/lint-action](https://github.com/marketplace/actions/lint-action)
      - Sorry for the extra whitespace changes.  I tried to only change the necessary lines, but after a few iterations of making changes I stopped trying.  At any rate, no trailing space is probably a good thing...
  - Add .eslintignore
      - This is because the lint action doesn't specify src/ as the  directory to check by default
      - Incidentally, this fixes my IDE's complaints every time I open a config file.
