### PR TITLE
Added the word "obstruct" into the Short Version.  

### DIFF
--- a/src/views/docs/legal.tsx
+++ b/src/views/docs/legal.tsx
@@ -30,7 +30,7 @@ export const TermsOfService = () => (
                     any other reason either.{" "}
                 </div>
 
-                <div className="legal-paragraph">Don't cheat or harass people.</div>
+                <div className="legal-paragraph">Don't cheat, obstruct, or harass people.</div>
 
                 <div className="legal-paragraph">
                     We reserve the right to, at our sole discretion, delete or freeze your account


### PR DESCRIPTION
We lean on the "don't obstruct" wording quite heavily in Moderation.

Fixes moderators having to quote the long version awkwardly.

## Proposed Changes

"Don't chat, obstruct, or harrass people"