### PR TITLE
OOL Spectators who arrive after the games starts want to go straight there

### DIFF
--- a/src/views/OnlineLeagueSpectatorLanding/OnlineLeagueSpectatorLanding.tsx
+++ b/src/views/OnlineLeagueSpectatorLanding/OnlineLeagueSpectatorLanding.tsx
@@ -66,6 +66,9 @@ export function OnlineLeagueSpectatorLanding(): JSX.Element {
         if (!match) {
             get(`online_league/match/${match_id}`)
                 .then((match: rest_api.online_league.MatchStatus) => {
+                    if (match.started) {
+                        navigate(`/game/${match.game}`, { replace: true });
+                    }
                     set_match(match);
                     set_loading(false);
                     console.log(match);


### PR DESCRIPTION


Fixes  late spectators being left on the landing page.

## Proposed Changes

Send them straight to a game that started