### PR TITLE
Fix display of game's name when it is too long

### DIFF
--- a/src/views/Overview/ChallengesList.styl
+++ b/src/views/Overview/ChallengesList.styl
@@ -33,6 +33,7 @@
 
             .name {
                 flex-grow: 1;
+                min-width: 0;
             }
 
             .PlayerIcon {
@@ -43,6 +44,8 @@
 
             h4 {
                 margin: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
         }
 
@@ -51,6 +54,7 @@
         }
         .fab {
             float: right;
+            flex-shrink: 0;
         }
     }
 }

--- a/src/views/Overview/ChallengesList.tsx
+++ b/src/views/Overview/ChallengesList.tsx
@@ -89,12 +89,13 @@ export class ChallengesList extends React.PureComponent<{ onAccept: () => void }
                                                 onClick={this.acceptChallenge.bind(this, challenge)}
                                             />
                                         )}
-                                        <FabX
-                                            onClick={this.deleteChallenge.bind(this, challenge)}
-                                        />
-                                        <h4>"{profanity_filter(challenge.game.name)}"</h4>
+
+                                        <h4 title={profanity_filter(challenge.game.name)}>
+                                            "{profanity_filter(challenge.game.name)}"
+                                        </h4>
                                         <Player user={opponent} />
                                     </div>
+                                    <FabX onClick={this.deleteChallenge.bind(this, challenge)} />
                                 </div>
                                 <div>{challenge_text_description(challenge)}</div>
                             </Card>

--- a/src/views/Overview/InviteList.styl
+++ b/src/views/Overview/InviteList.styl
@@ -40,9 +40,12 @@
                 flex-grow: 1;
                 display: flex;
                 align-items: center;
+                min-width: 0;
 
                 h4 {
                     margin: 0 0.3rem 0 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
                 }
             }
 

--- a/src/views/Overview/InviteList.tsx
+++ b/src/views/Overview/InviteList.tsx
@@ -240,7 +240,7 @@ export function InviteList(): JSX.Element {
                     return (
                         <Card key={challenge.challenge_id}>
                             <div className="name-and-buttons">
-                                <div className="name">
+                                <div className="name" title={profanity_filter(challenge.game_name)}>
                                     <h4>"{profanity_filter(challenge.game_name)}"</h4>
                                     <ChallengeLinkButton uuid={challenge.uuid} />
                                 </div>


### PR DESCRIPTION
Fixes #2049 

## Proposed Changes

  - Clip the string and display an ellipsis 
  - Show a tooltip on hover to see the full name 
 

## Screenshots
![online-go fix name too long](https://user-images.githubusercontent.com/88938117/220556865-46fbd48e-16bb-468b-bb2e-dc4b8e782375.png)

![online-go fix hover](https://user-images.githubusercontent.com/88938117/220556898-f3b625d3-597b-4b9c-9ed6-2396ea57fd23.png)


