### PR TITLE
Issue #2150: Feature request: Zen Mode default option

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -111,7 +111,7 @@ export const defaults = {
     "translation-dialog-never-show": false,
     "unicode-filter": false,
     "variations-in-chat-enabled": true,
-
+    "zen-mode": false,
     "show-empty-chat-notification": true,
     "chat-subscribe-group-chat-unread": true,
     "chat-subscribe-group-mentions": true,

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -106,7 +106,7 @@ export function Game(): JSX.Element {
     const [estimating_score, set_estimating_score] = React.useState<boolean>(false);
     const [analyze_pencil_color, set_analyze_pencil_color] = React.useState<string>("#004cff");
     const user_is_player = useUserIsParticipant(goban.current);
-    const [zen_mode, set_zen_mode] = React.useState(false);
+    const [zen_mode, set_zen_mode] = React.useState(preferences.get("zen-mode"));
     const [autoplaying, set_autoplaying] = React.useState(false);
     const [review_list, set_review_list] = React.useState([]);
     const [selected_chat_log, set_selected_chat_log] = React.useState<ChatMode>("main");

--- a/src/views/Settings/GamePreferences.tsx
+++ b/src/views/Settings/GamePreferences.tsx
@@ -54,6 +54,7 @@ export function GamePreferences(): JSX.Element {
     const [visual_undo_request_indicator, setVisualUndoRequestIndicator] = usePreference(
         "visual-undo-request-indicator",
     );
+    const [zen_mode_by_default, _setZenModeByDefault] = usePreference("zen-mode");
 
     function setDockDelay(ev) {
         const new_delay = parseFloat(ev.target.value);
@@ -65,6 +66,9 @@ export function GamePreferences(): JSX.Element {
     }
     function toggleVariationsInChat(checked) {
         _setVariationsInChat(!checked);
+    }
+    function toggleZenMode(checked) {
+        _setZenModeByDefault(checked);
     }
 
     function getSubmitMode(speed) {
@@ -241,6 +245,10 @@ export function GamePreferences(): JSX.Element {
                 )}
             >
                 <Toggle checked={!variations_in_chat} onChange={toggleVariationsInChat} />
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Always enter game(s) in Zen mode")}>
+                <Toggle checked={zen_mode_by_default} onChange={toggleZenMode} />
             </PreferenceLine>
 
             <PreferenceLine


### PR DESCRIPTION
Fixes #2150 Feature request: Zen Mode default option

This pull request introduces a new toggle in `Settings > Game Preferences` as the title suggests. 

![game preferences](https://user-images.githubusercontent.com/5171823/221833068-da669384-b56e-4f7f-85e0-e5150005f285.png)

![zen mode toggle](https://user-images.githubusercontent.com/5171823/221833110-d7782096-7ea1-44a2-aa62-822e68b35e01.png)

This toggle works exactly the same as other toggles in the menu. I basically used them as examples. 

By "switching on" the Zen mode button, the user will enter every game in Zen mode. 

For example: I have these two test games: 
![active games](https://user-images.githubusercontent.com/5171823/221833619-da3b0edd-afd1-4e1e-8105-06d046d94083.png)

Clicking on any of them will take you to the game in Zen mode: 
![Screenshot 2023-02-28 at 9 19 53 pm](https://user-images.githubusercontent.com/5171823/221833683-7e4e6d54-cab2-4067-b7b2-a9a2d4ebe735.png)

Functionally, Zen mode works as normal. Pressing escape in the game above will take the user back to normal mode:
![Screenshot 2023-02-28 at 9 20 06 pm](https://user-images.githubusercontent.com/5171823/221833941-a78f5e2b-55e0-4508-9e09-85516cfac72a.png)

