### PR TITLE
Took individual file /// references out ...

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// <reference path="../typings_manual/index.d.ts" />
 import * as Sentry from "@sentry/browser";
 import { apply_polyfills } from "polyfills";
 apply_polyfills();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,8 @@
     "files": [
         "./src/main.tsx",
         "typings_manual/index.d.ts",
-        "node_modules/@types/jquery/index.d.ts"
+        "node_modules/@types/jquery/index.d.ts",
+        "node_modules/jest-chain/types/index.d.ts",
     ],
     "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,9 @@
         "jsx": "react"
     },
     "files": [
-        "./src/main.tsx"
+        "./src/main.tsx",
+        "typings_manual/index.d.ts",
+        "node_modules/@types/jquery/index.d.ts"
     ],
     "include": ["src"]
 }

--- a/typings_manual/jquery.flot.d.ts
+++ b/typings_manual/jquery.flot.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="../node_modules/@types/jquery/index.d.ts" />
-
 declare module jquery.flot {
     interface plotOptions {
         colors?: any[];


### PR DESCRIPTION
(but left collector in typings_manual)

Fixes using unrecommended /// reference approach to individual typings

## Proposed Changes

Use the tsconfig method instead.

Except for typings_manual/index , where it seems to make sense to have explicit collection of references?
