### PR TITLE
Format warnings with white-space: pre-line to honour paragraphs

### DIFF
--- a/src/components/AccountWarning/AccountWarning.styl
+++ b/src/components/AccountWarning/AccountWarning.styl
@@ -55,6 +55,7 @@
     .AutoTranslate {
         font-size: 1.5rem;
         text-align: center;
+        white-space: pre-line; // we have paragraphs in warning messages :)
     }
 
     .space  {

--- a/src/components/AccountWarning/AccountWarning.styl
+++ b/src/components/AccountWarning/AccountWarning.styl
@@ -56,6 +56,7 @@
         font-size: 1.5rem;
         text-align: center;
         white-space: pre-line; // we have paragraphs in warning messages :)
+        line-height: 1;  // We have lots to say, not so much room to say in :)
     }
 
     .space  {


### PR DESCRIPTION
Fixes warning template with paragraphs getting smooshed up

## Proposed Changes

format warnings with white-space: pre-line
