### PR TITLE
Add support for creating groups with admin only tournaments

### DIFF
--- a/src/views/Group/Group.styl
+++ b/src/views/Group/Group.styl
@@ -30,7 +30,6 @@
         .fa-picture-o:hover {
             themed color shade2
         }
-        
     }
     .admins {
         margin-bottom: 1rem;
@@ -45,6 +44,7 @@
         top: 1rem;
         right: 1rem;
         cursor: pointer;
+        padding-left: 1rem;
     }
 
     .Dropzone {

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -55,6 +55,7 @@ interface GroupInfo {
     website: string;
     location: string;
     is_public: boolean;
+    admin_only_tournaments: boolean;
     require_invitation: boolean;
     hide_details: boolean;
     invitation_requests: any[];
@@ -119,6 +120,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                 website: "",
                 location: "",
                 is_public: false,
+                admin_only_tournaments: false,
                 require_invitation: false,
                 hide_details: false,
                 invitation_requests: [],
@@ -645,18 +647,26 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                                                     >
                                                         {_("Leave Group")}
                                                     </button>
-                                                    <button
-                                                        className="primary sm"
-                                                        onClick={this.createTournament}
-                                                    >
-                                                        {_("Create tournament")}
-                                                    </button>
-                                                    <button
-                                                        className="primary sm"
-                                                        onClick={this.createTournamentRecord}
-                                                    >
-                                                        {_("Create tournament record")}
-                                                    </button>
+                                                    {(!group.admin_only_tournaments ||
+                                                        this.state.is_admin ||
+                                                        null) && (
+                                                        <span>
+                                                            <button
+                                                                className="primary sm"
+                                                                onClick={this.createTournament}
+                                                            >
+                                                                {_("Create tournament")}
+                                                            </button>
+                                                            <button
+                                                                className="primary sm"
+                                                                onClick={
+                                                                    this.createTournamentRecord
+                                                                }
+                                                            >
+                                                                {_("Create tournament record")}
+                                                            </button>
+                                                        </span>
+                                                    )}
                                                 </div>
                                             )
                                         ) : group.is_public ? (

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -342,6 +342,13 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
             group: Object.assign({}, this.state.group, { require_invitation: ev.target.checked }),
         });
     };
+    setAdminOnlyTournaments = (ev) => {
+        this.setState({
+            group: Object.assign({}, this.state.group, {
+                admin_only_tournaments: ev.target.checked,
+            }),
+        });
+    };
     setNewNewsTitle = (ev) => {
         this.setState({ new_news_title: ev.target.value });
     };
@@ -528,7 +535,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                             {/* Main card  */}
                             {(this.state.is_admin || user.is_moderator || null) && (
                                 <i
-                                    className={editing ? "fa fa-save" : "fa fa-pencil"}
+                                    className={editing ? "fa fa-lg fa-save" : "fa fa-pencil"}
                                     onClick={this.toggleEdit}
                                 />
                             )}
@@ -576,7 +583,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                                         <input
                                             type="text"
                                             placeholder={_("Group name")}
-                                            style={{ width: "calc(100% - 30px)" }}
+                                            style={{ width: "calc(100% - 3rem)" }}
                                             value={group.name}
                                             onChange={this.setGroupName}
                                         />
@@ -751,6 +758,21 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                                                 />
                                                 <label htmlFor="public-group">
                                                     {_("Public group")}
+                                                </label>
+                                            </div>
+                                        )}
+                                    </div>
+                                    <div className="pad">
+                                        {(editing || null) && (
+                                            <div>
+                                                <input
+                                                    type="checkbox"
+                                                    id="admin-only-tournaments"
+                                                    checked={group.admin_only_tournaments}
+                                                    onChange={this.setAdminOnlyTournaments}
+                                                />
+                                                <label htmlFor="admin-only-tournaments">
+                                                    {_("Only admins can create tournaments")}
                                                 </label>
                                             </div>
                                         )}

--- a/src/views/GroupCreate/GroupCreate.tsx
+++ b/src/views/GroupCreate/GroupCreate.tsx
@@ -26,6 +26,7 @@ interface GroupCreateState {
     require_invitation: boolean;
     is_public: boolean;
     hide_details: boolean;
+    admin_only_tournaments: boolean;
 }
 
 export class GroupCreate extends React.PureComponent<{}, GroupCreateState> {
@@ -38,6 +39,7 @@ export class GroupCreate extends React.PureComponent<{}, GroupCreateState> {
             require_invitation: false,
             is_public: true,
             hide_details: false,
+            admin_only_tournaments: false,
         };
     }
 
@@ -48,6 +50,7 @@ export class GroupCreate extends React.PureComponent<{}, GroupCreateState> {
                 require_invitation: this.state.require_invitation,
                 is_public: this.state.is_public,
                 hide_details: this.state.hide_details,
+                admin_only_tournaments: this.state.admin_only_tournaments,
             };
             post("groups/", group)
                 .then((group) => {
@@ -63,6 +66,8 @@ export class GroupCreate extends React.PureComponent<{}, GroupCreateState> {
     set_is_public = (ev) => this.setState({ is_public: ev.target.checked });
     set_require_invitation = (ev) => this.setState({ require_invitation: ev.target.checked });
     set_hide_details = (ev) => this.setState({ hide_details: ev.target.checked });
+    set_admin_only_tournaments = (ev) =>
+        this.setState({ admin_only_tournaments: ev.target.checked });
 
     render() {
         return (
@@ -116,6 +121,26 @@ export class GroupCreate extends React.PureComponent<{}, GroupCreateState> {
                                     </div>
                                 </div>
                             </div>
+
+                            <div className="form-group">
+                                <label
+                                    className="col-sm-5 control-label"
+                                    htmlFor="group-admin-only-tournaments"
+                                >
+                                    {_("Only admins create tournaments")}
+                                </label>
+                                <div className="col-sm-6">
+                                    <div className="checkbox">
+                                        <input
+                                            type="checkbox"
+                                            id="group-admin-only-tournaments"
+                                            checked={this.state.admin_only_tournaments}
+                                            onChange={this.set_admin_only_tournaments}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+
                             {(!this.state.is_public || null) && (
                                 <div className="form-group">
                                     <label


### PR DESCRIPTION
Fixes organisations being unable to prevent members creating tournaments

## Proposed Changes

Use the `admin_only_tournaments` field to turn off create tournament buttons for users


** Needs https://github.com/online-go/ogs/pull/1802
