### PR TITLE
Do single game annulling using the /moderation endpoint

### DIFF
--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -41,17 +41,25 @@ export function doAnnul(
             .replace(/(white)\b/gi, `player ${engine.players.white.id}`);
     } while (moderation_note === "");
 
-    post("games/%%/annul", engine.game_id, {
-        annul: tf ? 1 : 0,
+    const annul_request: rest_api.moderation.MassAnnulList = {
+        games: [engine.game_id as number],
+        annul: tf,
         moderation_note: moderation_note,
-    })
-        .then(() => {
-            if (tf) {
-                void alert.fire({ text: _("Game has been annulled") });
+    };
+
+    post("moderation/mass_annul", annul_request)
+        .then((result: rest_api.moderation.MassAnnulResult) => {
+            console.log("annul result", result);
+            if (!result["failed"].length) {
+                if (tf) {
+                    void alert.fire({ text: _("Game has been annulled") });
+                } else {
+                    void alert.fire({ text: _("Game ranking has been restored") });
+                }
+                onGameAnnulled && onGameAnnulled(tf);
             } else {
-                void alert.fire({ text: _("Game ranking has been restored") });
+                void alert.fire({ text: _("Something went wrong, no action taken!") });
             }
-            onGameAnnulled && onGameAnnulled(tf);
         })
         .catch(errorAlerter);
 }

--- a/src/models/moderation.d.ts
+++ b/src/models/moderation.d.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)   Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare namespace rest_api {
+    namespace moderation {
+        interface MassAnnulList {
+            games: Array<number>; // game ids.  Do we have a type for them?
+            annul: boolean;
+            moderation_note: string;
+        }
+
+        interface MassAnnulResult {
+            done: Array<number>;
+            failed: Array<number>;
+        }
+    }
+}


### PR DESCRIPTION
Fixes two ways to do the same thing being used.

## Proposed Changes

Do single-game annul using the /moderation endpoint.

*** Needs https://github.com/online-go/ogs/pull/1803

This also adds the API definition file for that new endpoint, hopefully coincides with @RubyMineshaft  definition