### PR TITLE
Got rid of the word "mass" from the annul endpoint

### DIFF
--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -41,14 +41,14 @@ export function doAnnul(
             .replace(/(white)\b/gi, `player ${engine.players.white.id}`);
     } while (moderation_note === "");
 
-    const annul_request: rest_api.moderation.MassAnnulList = {
+    const annul_request: rest_api.moderation.AnnulList = {
         games: [engine.game_id as number],
         annul: tf,
         moderation_note: moderation_note,
     };
 
-    post("moderation/mass_annul", annul_request)
-        .then((result: rest_api.moderation.MassAnnulResult) => {
+    post("moderation/annul", annul_request)
+        .then((result: rest_api.moderation.AnnulResult) => {
             console.log("annul result", result);
             if (!result["failed"].length) {
                 if (tf) {

--- a/src/models/moderation.d.ts
+++ b/src/models/moderation.d.ts
@@ -15,15 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+//  `/moderation/annul` endpoint
+
 declare namespace rest_api {
     namespace moderation {
-        interface MassAnnulList {
+        interface AnnulList {
             games: Array<number>; // game ids.  Do we have a type for them?
             annul: boolean;
             moderation_note: string;
         }
 
-        interface MassAnnulResult {
+        interface AnnulResult {
             done: Array<number>;
             failed: Array<number>;
         }


### PR DESCRIPTION
Fixes needless and confusing reference to the word "mass" on the "annul" endpoint, in line with this backend change


** Needs https://github.com/online-go/ogs/pull/1805
  