### PR TITLE
Clarify annul related naming, hide annul button on player cards of ongoing games

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -132,7 +132,7 @@ export const defaults = {
         };
     },
     "moderator.report-sort-order": "oldest-first" as "oldest-first" | "newest-first",
-    "moderator.hide-next-game-arrows": false,
+    "moderator.hide-player-card-mod-controls": false,
 
     "table-color-default-on": false,
 

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -57,6 +57,7 @@ interface DockProps {
     onCoordinatesMarked: (stones: string) => void;
     onReviewClicked: () => void;
 }
+
 export function GameDock({
     annulled,
     selected_ai_review_uuid,
@@ -84,8 +85,8 @@ export function GameDock({
     const user = useUser();
 
     let superuser_ai_review_ready = user?.is_superuser && phase === "finished";
-    let mod = user?.is_moderator && phase !== "finished";
-    let annul = user?.is_moderator && phase === "finished";
+    let user_can_intervene = user?.is_moderator && phase !== "finished";
+    let user_can_annul = user?.is_moderator && phase === "finished";
     const annulable = !annulled && engine.config.ranked;
     const unannulable = annulled && engine.config.ranked;
     const user_is_player = useUserIsParticipant(goban);
@@ -97,8 +98,8 @@ export function GameDock({
     const game = !!game_id;
     if (review) {
         superuser_ai_review_ready = false;
-        mod = false;
-        annul = false;
+        user_can_intervene = false;
+        user_can_annul = false;
     }
 
     let sgf_download_enabled = false;
@@ -385,7 +386,8 @@ export function GameDock({
                     <i className="fa fa-exchange"></i> {_("Plan conditional moves")}
                 </a>
             )}
-            {((!review_id && (user_is_player || mod) && phase !== "finished") || null) && (
+            {((!review_id && (user_is_player || user_can_intervene) && phase !== "finished") ||
+                null) && (
                 <a onClick={onPauseClicked}>
                     <i className="fa fa-pause"></i> {_("Pause game")}
                 </a>
@@ -464,45 +466,40 @@ export function GameDock({
                     <i className="fa fa-download"></i> {_("SGF with comments")}
                 </a>
             )}
-            {(mod || annul) && <hr />}
-            {mod && (
+            {(user_can_intervene || user_can_annul) && <hr />}
+            {user_can_intervene && (
                 <a onClick={decide_black}>
                     <i className="fa fa-gavel"></i> {_("Black Wins")}
                 </a>
             )}
-            {mod && (
+            {user_can_intervene && (
                 <a onClick={decide_white}>
                     <i className="fa fa-gavel"></i> {_("White Wins")}
                 </a>
             )}
-            {mod && (
+            {user_can_intervene && (
                 <a onClick={decide_tie}>
                     <i className="fa fa-gavel"></i> {_("Tie")}
                 </a>
             )}
-            {mod && (
+            {user_can_intervene && (
                 <a onClick={force_autoscore}>
                     <i className="fa fa-gavel"></i> {_("Auto-score")}
                 </a>
             )}
 
+            {user_can_annul && annulable && (
+                <a onClick={() => do_annul(true)}>
+                    <i className="fa fa-gavel"></i> {_("Annul")}
+                </a>
+            )}
+            {user_can_annul && unannulable && (
+                <a onClick={() => do_annul(false)}>
+                    <i className="fa fa-gavel unannulable"></i> {"Remove annulment"}
+                </a>
+            )}
             {
-                annul && annulable && (
-                    <a onClick={() => do_annul(true)}>
-                        <i className="fa fa-gavel"></i> {_("Annul")}
-                    </a>
-                ) /* mod can annul this game */
-            }
-            {
-                annul &&
-                    unannulable && (
-                        <a onClick={() => do_annul(false)}>
-                            <i className="fa fa-gavel unannulable"></i> {"Remove annulment"}
-                        </a>
-                    ) /* mod can't annul, presumably because it's already annulled */
-            }
-            {
-                annul &&
+                user_can_annul &&
                     !annulable &&
                     !unannulable && (
                         <div>
@@ -511,18 +508,18 @@ export function GameDock({
                     ) /* This is a "do nothing" icon for when the game is unranked */
             }
 
-            {(mod || annul) && <hr />}
-            {(mod || annul) && (
+            {(user_can_intervene || user_can_annul) && <hr />}
+            {(user_can_intervene || user_can_annul) && (
                 <a onClick={onTimingClicked}>
                     <i className="fa fa-clock-o"></i> {_("Timing")}
                 </a>
             )}
-            {(mod || annul) && (
+            {(user_can_intervene || user_can_annul) && (
                 <a onClick={showLogModal}>
                     <i className="fa fa-list-alt"></i> {"Log"}
                 </a>
             )}
-            {(mod || annul) && (
+            {(user_can_intervene || user_can_annul) && (
                 <a onClick={toggleAnonymousModerator}>
                     <i className="fa fa-user-secret"></i> {"Cloak of Invisibility"}
                 </a>

--- a/src/views/Game/PlayerCards.styl
+++ b/src/views/Game/PlayerCards.styl
@@ -3,7 +3,7 @@
         color: #FF8B00;
     }
 }
-.next-game-arrows {
+.player-card-mod-controls {
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -222,11 +222,14 @@ function PlayerCard({
     const score = useScore(goban)[color];
     const { game_id, review_id } = goban;
     const chat_channel = game_id ? `game-${game_id}` : `review-${review_id}`;
-    const [hide_next_game_arrows] = usePreference("moderator.hide-next-game-arrows");
+    const [hide_player_card_mod_controls] = usePreference(
+        "moderator.hide-player-card-mod-controls",
+    );
 
     const user = useUser();
 
-    const show_next_game_arrows = user.is_moderator && game_id && !hide_next_game_arrows;
+    const show_player_card_mod_controls =
+        user.is_moderator && game_id && !hide_player_card_mod_controls;
 
     const jumpToPrevGame = () => {
         get(`games/${game_id}/prev/${player.id}`)
@@ -251,7 +254,7 @@ function PlayerCard({
     };
 
     const annulWithBlame = () => {
-        doAnnul(engine.config, true, null, ` ${color} `); // spaces make it easy to put the cursor before or after, they are trimmed later
+        doAnnul(engine.config, true, null, ` ${color} `); // spaces make it easy for the user to put the cursor before or after, they are trimmed later
     };
 
     // In rengo we always will have a player icon to show (after initialisation).
@@ -315,11 +318,13 @@ function PlayerCard({
                 </span>
             )}
 
-            {(show_next_game_arrows || null) && (
-                <div className="next-game-arrows">
+            {(show_player_card_mod_controls || null) && (
+                <div className="player-card-mod-controls">
                     <i className="fa fa-2x fa-angle-left" onClick={jumpToPrevGame} />
-                    <div className="next-arrow-mod-controls">
-                        <i className="fa fa-gavel" onClick={annulWithBlame} />
+                    <div className="middle-mod-controls">
+                        {(engine.phase === "finished" || null) && (
+                            <i className="fa fa-gavel" onClick={annulWithBlame} />
+                        )}
                     </div>
                     <i className="fa fa-2x fa-angle-right" onClick={jumpToNextGame} />
                 </div>

--- a/src/views/Settings/ModeratorPreferences.tsx
+++ b/src/views/Settings/ModeratorPreferences.tsx
@@ -34,8 +34,8 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
     );
     const [hide_flags, setHideFlags] = usePreference("moderator.hide-flags");
     const [hide_profile, setHideProfile] = usePreference("moderator.hide-profile-information");
-    const [hide_next_game_arrows, setHideNextGameArrows] = usePreference(
-        "moderator.hide-next-game-arrows",
+    const [hide_player_card_mod_controls, setHidePlayerCardModControls] = usePreference(
+        "moderator.hide-player-card-mod-controls",
     );
 
     const user = data.get("user");
@@ -67,8 +67,11 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
             <PreferenceLine title="Hide moderator information on profile pages">
                 <Toggle checked={hide_profile} onChange={setHideProfile} />
             </PreferenceLine>
-            <PreferenceLine title="Hide 'next game' arrows on player cards">
-                <Toggle checked={hide_next_game_arrows} onChange={setHideNextGameArrows} />
+            <PreferenceLine title="Hide moderator controls on player cards">
+                <Toggle
+                    checked={hide_player_card_mod_controls}
+                    onChange={setHidePlayerCardModControls}
+                />
             </PreferenceLine>
             <ReportsCenterSettings />
         </div>


### PR DESCRIPTION
Fixes various annul confusions

## Proposed Changes

 - Rename annul flags in GameDock.tsx, for clarity
 - Change "next-game-arrow" labels to "player-card-mod-controls"
 - Hide the annul-with-blame hammer while the game is in progress
 