### PR TITLE
Annul queue modal bugfix 

### DIFF
--- a/src/components/AnnulQueueModal/AnnulQueueModal.styl
+++ b/src/components/AnnulQueueModal/AnnulQueueModal.styl
@@ -1,7 +1,11 @@
 .AnnulQueueModal {
     min-width: 80vw;
     min-height: 90vh;
-    margin-top: 5vh;
+    z-index: 1000;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 
     .header {
         justify-content: space-between;

--- a/src/components/AnnulQueueModal/AnnulQueueModal.tsx
+++ b/src/components/AnnulQueueModal/AnnulQueueModal.tsx
@@ -17,7 +17,6 @@
 
 import * as React from "react";
 import { _ } from "translate";
-import { openModal } from "Modal";
 import { MiniGoban } from "MiniGoban";
 import { Goban } from "goban";
 import { AIReview, GameTimings, ChatMode, GameChat, GobanContext } from "Game";
@@ -30,6 +29,7 @@ interface AnnulQueueModalProps {
     annulQueue: any[];
     setSelectModeActive: React.Dispatch<boolean>;
     setAnnulQueue: React.Dispatch<any[]>;
+    onClose: () => void;
 }
 
 // Define the AnnulQueueModal component
@@ -37,6 +37,7 @@ export function AnnulQueueModal({
     annulQueue,
     setSelectModeActive,
     setAnnulQueue,
+    onClose,
 }: AnnulQueueModalProps) {
     // Declare state variables
     const [selectedGameIndex, setSelectedGameIndex] = React.useState(0);
@@ -55,9 +56,6 @@ export function AnnulQueueModal({
     // Get the current game from the queue
     const currentGame = queue[selectedGameIndex];
 
-    // Get the modal container element
-    const container = document.getElementsByClassName("Modal-container")[0];
-
     // Define the debounce duration
     const DEBOUNCE_DURATION = 300;
 
@@ -68,16 +66,14 @@ export function AnnulQueueModal({
 
     // Close the modal
     const closeModal = () => {
-        container.parentNode?.removeChild(container);
-    };
-
-    // Close the modal and reset state variables
-    const onClose = () => {
         setAnnulQueue([]);
         setSelectModeActive(false);
         setShowAnnulOverlay(false);
         setAnnulResponse(null);
-        closeModal();
+        onClose();
+
+        // Re-enable body scroll
+        document.body.style.overflow = "";
     };
 
     // Navigate to the previous game in the queue
@@ -126,7 +122,7 @@ export function AnnulQueueModal({
     // Close modal if no games left after dequeue
     React.useEffect(() => {
         if (queue.length === 0) {
-            onClose();
+            closeModal();
         }
     }, [queue]);
 
@@ -197,7 +193,7 @@ export function AnnulQueueModal({
                         }`,
                     );
                     setTimeout(() => {
-                        onClose();
+                        closeModal();
                     }, 2000);
                 } else {
                     setAnnulResponse(
@@ -349,7 +345,7 @@ export function AnnulQueueModal({
                             </div>
                         </div>
                         <div className="close">
-                            <button className="close-btn" onClick={() => onClose()}>
+                            <button className="close-btn" onClick={() => closeModal()}>
                                 {_("Close")}
                             </button>
                         </div>
@@ -361,14 +357,16 @@ export function AnnulQueueModal({
 }
 
 // Open the AnnulQueueModal
-export function openAnnulQueueModal(annulQueue, setSelectModeActive, setAnnulQueue) {
-    return openModal(
-        <AnnulQueueModal
-            setSelectModeActive={setSelectModeActive}
-            annulQueue={annulQueue}
-            setAnnulQueue={setAnnulQueue}
-        />,
-    );
+export function openAnnulQueueModal(
+    annulQueue,
+    setSelectModeActive,
+    setAnnulQueue,
+    setIsAnnulQueueModalOpen,
+) {
+    setIsAnnulQueueModalOpen(true);
+
+    // Disable body scroll
+    document.body.style.overflow = "hidden";
 }
 
 // Spinner component

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -33,7 +33,7 @@ import { PlayerCacheEntry } from "src/lib/player_cache";
 import { TimeControl } from "src/components/TimeControl";
 import { Speed } from "src/lib/types";
 import { usePreference } from "preferences";
-import { openAnnulQueueModal } from "AnnulQueueModal";
+import { openAnnulQueueModal, AnnulQueueModal } from "AnnulQueueModal";
 import { useUser } from "hooks";
 
 interface GameHistoryProps {
@@ -77,6 +77,8 @@ export function GameHistoryTable(props: GameHistoryProps) {
     const [hide_flags] = usePreference("moderator.hide-flags");
     const [selectModeActive, setSelectModeActive] = React.useState<boolean>(false);
     const [annulQueue, setAnnulQueue] = React.useState<any[]>([]);
+    const [isAnnulQueueModalOpen, setIsAnnulQueueModalOpen] = React.useState(false);
+
     const user = useUser();
 
     function getBoardSize(size_filter: string): number {
@@ -112,6 +114,10 @@ export function GameHistoryTable(props: GameHistoryProps) {
         if (selectModeActive) {
             event.preventDefault();
         }
+    }
+
+    function handleCloseAnnulQueueModal() {
+        setIsAnnulQueueModalOpen(false);
     }
 
     function toggleBoardSizeFilter(size_filter: string) {
@@ -191,6 +197,14 @@ export function GameHistoryTable(props: GameHistoryProps) {
             <h2>{_("Game History")}</h2>
             <Card>
                 <div>
+                    {isAnnulQueueModalOpen && (
+                        <AnnulQueueModal
+                            setSelectModeActive={setSelectModeActive}
+                            annulQueue={annulQueue}
+                            setAnnulQueue={setAnnulQueue}
+                            onClose={handleCloseAnnulQueueModal}
+                        />
+                    )}
                     {/* loading-container="game_history.settings().$loading" */}
                     <div className="game-options">
                         <div className="search">
@@ -213,6 +227,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                                     annulQueue,
                                                     setSelectModeActive,
                                                     setAnnulQueue,
+                                                    setIsAnnulQueueModalOpen,
                                                 )
                                             }
                                         >


### PR DESCRIPTION
Currently, the annul queue modal is being rendered outside of the Router which causes the modal to crash if there is a review linked in the game chat. 

## Proposed Changes

  - Render annul queue modal from within the game history table instead of outside the Router

