### PR TITLE
Restored display of komi in player cards

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -17,7 +17,7 @@
 
 import * as data from "data";
 import { GobanSelectedThemes, GoThemes, LabelPosition } from "goban";
-import React from "react";
+import * as React from "react";
 import { current_language } from "translate";
 import { DataSchema } from "./data_schema";
 

--- a/src/views/Game/PlayerCards.test.tsx
+++ b/src/views/Game/PlayerCards.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import * as React from "react";
+import { PlayerCard } from "./PlayerCards";
+import { Goban } from "goban";
+import { GobanContext } from "./goban_context";
+import { BrowserRouter as Router } from "react-router-dom";
+import * as data from "data";
+
+const TEST_USER = {
+    anonymous: false,
+    id: 123,
+    username: "test_user",
+    registration_date: "2022-05-10 11:03:24.299562+00:00",
+    ratings: {
+        version: 5,
+        overall: { rating: 1500, deviation: 350, volatility: 0.06 },
+    },
+    country: "un",
+    professional: false,
+    ranking: 23,
+    provisional: 0,
+    can_create_tournaments: true,
+    is_moderator: false,
+    is_superuser: false,
+    is_tournament_moderator: false,
+    supporter: true,
+    supporter_level: 4,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "https://secure.gravatar.com/avatar/8d809ecc50408afc399a4cb7c8fd4510?s=32&d=retro",
+    email: "",
+    email_validated: false,
+    is_announcer: false,
+} as const;
+
+const BASE_PROPS = {
+    color: "white" as const,
+    historical: null,
+    estimating_score: false,
+    show_score_breakdown: false,
+    zen_mode: false,
+    flags: null,
+    onScoreClick: jest.fn(),
+};
+
+test("make sure komi is displayed", () => {
+    data.set("user", TEST_USER);
+    data.set("preferences.moderator.hide-flags", false);
+    data.set("preferences.moderator.hide-player-card-mod-controls", false);
+
+    const goban = new Goban({ game_id: 123456, komi: 5 });
+
+    const props = { goban: goban, ...BASE_PROPS };
+
+    const { container } = render(
+        <Router>
+            <GobanContext.Provider value={goban}>
+                <PlayerCard {...props} />
+            </GobanContext.Provider>
+        </Router>,
+    );
+    const divElement = container.querySelector(".komi");
+
+    expect(divElement).toHaveTextContent("5.0");
+});

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -203,7 +203,7 @@ interface PlayerCardProps {
     flags: null | rest_api.GamePlayerFlags;
 }
 
-function PlayerCard({
+export function PlayerCard({
     color,
     goban,
     historical,

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -350,6 +350,7 @@ function PlayerCard({
                     zen_mode={zen_mode}
                     hidden={show_points && !estimating_score}
                 />
+                {!show_points && <div className="komi">{komiString(score.komi)}</div>}
                 <div id={`${color}-score-details`} className="score-details">
                     <ScorePopup goban={goban} color={color} show={show_score_breakdown} />
                 </div>
@@ -403,6 +404,14 @@ function PlayerFlag({ player_id }: { player_id: number }): JSX.Element {
         return <Flag country={country} big />;
     }
     return null;
+}
+
+function komiString(komi: number) {
+    if (!komi) {
+        return "";
+    }
+    const abs_komi = Math.abs(komi).toFixed(1);
+    return komi > 0 ? `+ ${abs_komi}` : `- ${abs_komi}`;
 }
 
 function useAutoResignExpiration(goban: GobanCore, color: "black" | "white") {


### PR DESCRIPTION
Fixes people complaining about komi not appearing anymore 😝

## Proposed Changes

Restore the code that displays komi in PlayerCards

Note that to make the test work, I had to change the import of React in PlayerCards.tsx.

Not sure what that's about, but it seems to work.

I also exported PlayerCard so the test could import it.  Not sure if that's "normal" 🤨  I suspect that in theory if something needs to be tested, it should be in it's own file, but meh 😝
