### PR TITLE
Use flex-end instead of end

### DIFF
--- a/src/views/ReportsCenter/ReportsCenterHistory.styl
+++ b/src/views/ReportsCenter/ReportsCenterHistory.styl
@@ -8,7 +8,7 @@
     .history-options {
         display: flex;
         justify-content: flex-end;
-        align-items: end;
+        align-items: flex-end;
         width: 100%;
         margin-bottom: 10px;
     }


### PR DESCRIPTION
Fixes css warning "end value has mixed support, consider using flex-end instead"

## Proposed Changes

use flex-end instead of end on history-options align-items
