### PR TITLE
Selecting a template claims a report

### DIFF
--- a/src/views/ReportsCenter/MessageTemplate.tsx
+++ b/src/views/ReportsCenter/MessageTemplate.tsx
@@ -391,6 +391,7 @@ export function MessageTemplate({
     game_id,
     gpt,
     logByDefault,
+    onSelect,
 }: {
     title: string;
     player: PlayerCacheEntry;
@@ -398,6 +399,7 @@ export function MessageTemplate({
     game_id: number | undefined;
     gpt: string | null;
     logByDefault: boolean;
+    onSelect?: () => void | null;
 }): JSX.Element {
     const [uid] = React.useState(Math.random());
     const [selectedTemplate, setSelectedTemplate] = React.useState<string>(gpt ? "gpt" : "");
@@ -474,16 +476,20 @@ export function MessageTemplate({
         clear();
     };
 
+    const selectTemplate = (e: any) => {
+        setSelectedTemplate(e);
+        if (onSelect) {
+            onSelect();
+        }
+    };
+
     return (
         <div className="MessageTemplate">
             <h3>
                 {title}: <Player user={player} />
             </h3>
             <div className="top">
-                <select
-                    value={selectedTemplate}
-                    onChange={(e) => setSelectedTemplate(e.target.value)}
-                >
+                <select value={selectedTemplate} onChange={(e) => selectTemplate(e.target.value)}>
                     <option value="">-- Select template --</option>
                     <option value="gpt">ChatGPT Automod</option>
                     {Object.keys(templates).map((category) => (

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -173,6 +173,13 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
         [report],
     );
 
+    const claimReport = () => {
+        if (report.moderator?.id !== user.id) {
+            setReportState("claimed");
+            void report_manager.claim(report.id);
+        }
+    };
+
     if (!report || report_id === 0) {
         return (
             <div id="ViewReport">
@@ -334,14 +341,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                             )}
                         </>
                     ) : (
-                        <button
-                            className="primary xs"
-                            onClick={() => {
-                                report.moderator = user;
-                                setReportState("claimed");
-                                void report_manager.claim(report.id);
-                            }}
-                        >
+                        <button className="primary xs" onClick={claimReport}>
                             {_("Claim")}
                         </button>
                     )}
@@ -435,10 +435,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
             <div className="actions">
                 <div className="actions-left">
                     {!claimed_by_me && !report.moderator && (
-                        <button
-                            className="primary"
-                            onClick={() => void report_manager.claim(report.id)}
-                        >
+                        <button className="primary" onClick={claimReport}>
                             Claim
                         </button>
                     )}
@@ -506,6 +503,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     game_id={report.reported_game}
                     gpt={report.automod_to_reported}
                     logByDefault={true}
+                    onSelect={claimReport}
                 />
 
                 <MessageTemplate
@@ -515,6 +513,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     game_id={report.reported_game}
                     gpt={report.automod_to_reporter}
                     logByDefault={false}
+                    onSelect={claimReport}
                 />
             </div>
 


### PR DESCRIPTION
Fixes doing all the stuff without remembering to claim

## Proposed Changes

- Add selection callback to MessageTemplate, use it to claim the report
- Tidy up report claiming, so it happens the same way in all three cases