### PR TITLE
Update Play.tsx

### DIFF
--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -729,7 +729,7 @@ export class Play extends React.Component<{}, PlayState> {
             return (
                 <div className="automatch-container">
                     <div className="automatch-header">
-                        <div>{_("Quick match finder")}</div>
+                        <div>{_("Automatch finder")}</div>
                         <div className="btn-group">
                             <button
                                 className={size_enabled("9x9") ? "primary sm" : "sm"}


### PR DESCRIPTION
Rename "Quick Match" to "Automatch" to be consistent with the settings page and also possibly prevent players assuming opponents need to play quickly.
