### PR TITLE
Display "created" date in RengoManagementPane

### DIFF
--- a/src/components/RengoManagementPane/RengoManagementPane.styl
+++ b/src/components/RengoManagementPane/RengoManagementPane.styl
@@ -27,7 +27,14 @@
     flex-grow: 1;
 
     .rengo-challenge-status {
-        // nothing special yet
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+
+        .challenge-created-at {
+            font-size: smaller;
+            padding-right: 2rem; // avoid collision wiuth dismiss button
+        }
     }
 
     // this is the child: the team management pane component (the second div we instantiate)

--- a/src/components/RengoManagementPane/RengoManagementPane.tsx
+++ b/src/components/RengoManagementPane/RengoManagementPane.tsx
@@ -17,14 +17,14 @@
 
 import * as React from "react";
 import * as DynamicHelp from "react-dynamic-help";
-
+import { Challenge } from "challenge_utils";
 import { useUser } from "hooks";
 import { _, pgettext, interpolate } from "translate";
 
 interface RengoManagementPaneProperties {
     user: rest_api.UserConfig;
     challenge_id: number;
-    rengo_challenge_list: any[];
+    rengo_challenge_list: Array<Challenge>;
 
     startRengoChallenge: (challenge: any) => Promise<void>;
     cancelChallenge: (challenge: any) => void;
@@ -72,15 +72,22 @@ export function RengoManagementPane(props: RengoManagementPaneProperties): JSX.E
         the_challenge.rengo_black_team.length -
         the_challenge.rengo_white_team.length;
 
+    const created_at = the_challenge.created
+        ? the_challenge.created.slice(0, 10)
+        : "before 2023-05-26"; // can get rid of this when old challenges are gone
+
     return (
         <div className="RengoManagementPane" ref={rengoManagementPane}>
             {!the_challenge.rengo_auto_start && (
                 <div className="rengo-challenge-status">
-                    {own_challenge && challenge_ready_to_start
-                        ? _("Waiting for your decision to start...")
-                        : challenge_ready_to_start
-                        ? _("Waiting for organiser to start...")
-                        : _("Waiting for Rengo players...")}
+                    <span>
+                        {own_challenge && challenge_ready_to_start
+                            ? _("Waiting for your decision to start...")
+                            : challenge_ready_to_start
+                            ? _("Waiting for organiser to start...")
+                            : _("Waiting for Rengo players...")}
+                    </span>
+                    <span className="challenge-created-at">(created: {created_at})</span>
                 </div>
             )}
             {!!the_challenge.rengo_auto_start && (

--- a/src/models/challenges.d.ts
+++ b/src/models/challenges.d.ts
@@ -55,6 +55,7 @@ declare namespace socket_api {
             rengo_participants: number[]; // array of player ids
             invite_only: boolean;
             uuid: string;
+            created?: string | null; // ISO 8601 format datetime
 
             // All this stuff seems to get added *after* we get a challenge from the api
             // but I don't have a good idea where to put it for now... (benjito)


### PR DESCRIPTION
Fixes wondering how long Rengo challenges have been hanging around.

## Proposed Changes

 - Add optional `created` field to seekgraph challenge payload definition
 - Display the value in the RengoManagementPane

Needs https://github.com/online-go/ogs/pull/1809 in order to tell the truth.
  