### PR TITLE
Issue 2273 - Default chat mode

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -34,6 +34,7 @@ export const defaults = {
     "chat.show-all-group-channels": true,
     "chat.show-all-tournament-channels": true,
     "chat.user-sort-order": "rank",
+    "chat-mode": "main",
     "desktop-notifications": true,
     "desktop-notifications-require-interaction": false,
     "dock-delay": 0, // seconds.

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -109,7 +109,8 @@ export function Game(): JSX.Element {
     const [zen_mode, set_zen_mode] = React.useState(preferences.get("start-in-zen-mode"));
     const [autoplaying, set_autoplaying] = React.useState(false);
     const [review_list, set_review_list] = React.useState([]);
-    const [selected_chat_log, set_selected_chat_log] = React.useState<ChatMode>("main");
+    const defaultChatMode = preferences.get("chat-mode") as ChatMode;
+    const [selected_chat_log, set_selected_chat_log] = React.useState<ChatMode>(defaultChatMode);
     const [variation_name, set_variation_name] = React.useState("");
     const [historical_black, set_historical_black] = React.useState<rest_api.games.Player | null>(
         null,
@@ -1341,7 +1342,7 @@ export function Game(): JSX.Element {
             }
             console.log("unmounting, going to destroy", goban);
             chat_proxy.current.part();
-            set_selected_chat_log("main");
+            set_selected_chat_log(defaultChatMode);
             delete game_control.creator_id;
             ladder_id.current = null;
             tournament_id.current = null;

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -70,12 +70,12 @@ export function GameChat(props: GameChatProperties): JSX.Element {
     const user = data.get("user");
     const goban = useGoban();
     const in_game_mod_channel = !props.review_id && inGameModChannel(props.game_id);
-
+    const defaultChatMode = preferences.get("chat-mode") as ChatMode;
     const ref_chat_log = React.useRef<HTMLDivElement>(null);
     const scrolled_to_bottom = React.useRef(true);
     const [show_quick_chat, setShowQuickChat] = React.useState(false);
     const [selected_chat_log, setSelectedChatLog] = React.useState<ChatMode>(
-        in_game_mod_channel ? "hidden" : "main",
+        in_game_mod_channel ? "hidden" : defaultChatMode,
     );
     const [show_player_list, setShowPlayerList] = React.useState(false);
 
@@ -156,7 +156,7 @@ export function GameChat(props: GameChatProperties): JSX.Element {
             if (in_game_mod_channel) {
                 setSelectedChatLog("hidden");
             } else {
-                setSelectedChatLog("main");
+                setSelectedChatLog(defaultChatMode);
             }
         };
 

--- a/src/views/Settings/GamePreferences.tsx
+++ b/src/views/Settings/GamePreferences.tsx
@@ -38,6 +38,7 @@ export function GamePreferences(): JSX.Element {
     const [_corr_submit_mode, _setCorrSubmitMode]: [string, (x: string) => void] = React.useState(
         getSubmitMode("correspondence"),
     );
+    const [chat_mode, _setChatMode] = usePreference("chat-mode");
     const [board_labeling, setBoardLabeling] = usePreference("board-labeling");
 
     const [autoadvance, setAutoAdvance] = usePreference("auto-advance-after-submit");
@@ -77,6 +78,11 @@ export function GamePreferences(): JSX.Element {
         const dbl = preferences.get(`double-click-submit-${speed}` as ValidPreference);
         return single ? "single" : dbl ? "double" : "button";
     }
+
+    function setChatMode(value) {
+        _setChatMode(value);
+    }
+
     function setSubmitMode(speed, mode) {
         switch (mode) {
             case "single":
@@ -256,6 +262,23 @@ export function GamePreferences(): JSX.Element {
             </PreferenceLine>
 
             <PreferenceLine
+                title={_("Set default game chat mode")}
+                description={_(
+                    "The chat mode that is defaulted to when a game is initiated or when the game page is refreshed.",
+                )}
+            >
+                <PreferenceDropdown
+                    value={chat_mode}
+                    options={[
+                        { value: "main", label: _("Chat") },
+                        { value: "malkovich", label: _("Malkovich") },
+                        { value: "personal", label: _("Personal") },
+                    ]}
+                    onChange={setChatMode}
+                />
+            </PreferenceLine>
+
+            <PreferenceLine
                 title={_("Activate Zen Mode by default")}
                 description={_(
                     'When enabled, games you play or view will start off in the full screen "Zen Mode". This can be toggled off in game by clicking the Z icon.',
@@ -283,7 +306,7 @@ export function GamePreferences(): JSX.Element {
             <PreferenceLine
                 title={_("Variation max move count")}
                 description={_(
-                    "Choose the max number of moves shown in variations. 1-9 (0 is the default)",
+                    "Choose the max number of moves shown at a time in variations. 1-9 (0 is the default)",
                 )}
             >
                 <input


### PR DESCRIPTION
Fixes #2273 

## Proposed Changes
Changes in GamePreference.tsx and preferences.tsx to select the default mode (defaults to "main")
Changes in Game.tsx and GameChat.tsx - anywhere where it was hardcoded to default to "main" for the chat mode it now uses the preference
Snuck in an unrelate change to th3 description of the Variation Move count to make the setting clearer.
  -
  -
  -
