### PR TITLE
issue-2275: reduce clickable area for invite-only games

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -966,7 +966,29 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                         )}
                     </div>
                 </div>
+                {!(this.props.playerId || null) && (mode === "open" || null) && (
+                    <div className="form-group">
+                        <label className="control-label" htmlFor="challenge-invite-only">
+                            {pgettext(
+                                "A checkbox to make a challenge open only to invited people who have the link to it",
+                                "Invite-only",
+                            )}
+                        </label>
 
+                        <div className="controls">
+                            {(mode !== "demo" || null) && (
+                                <div className="checkbox">
+                                    <input
+                                        type="checkbox"
+                                        id="challenge-invite-only"
+                                        checked={this.state.challenge.invite_only}
+                                        onChange={this.update_invite_only}
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
                 {(mode === "open" || null) && (
                     <div className="form-group">
                         <label className="control-label" htmlFor="rengo-option">
@@ -1720,29 +1742,6 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                         </button>
                     )}
                 </div>
-                {!(this.props.playerId || null) && (mode === "open" || null) && (
-                    <div className="form-group invite-only-challenge-selector">
-                        <label className="control-label">
-                            {pgettext(
-                                "A checkbox to make a challenge open only to invited people who have the link to it",
-                                "Invite-only",
-                            )}
-                        </label>
-
-                        <div className="controls">
-                            {(mode !== "demo" || null) && (
-                                <div className="checkbox">
-                                    <input
-                                        type="checkbox"
-                                        id="challenge-invite-only"
-                                        checked={this.state.challenge.invite_only}
-                                        onChange={this.update_invite_only}
-                                    />
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                )}
                 {(mode !== "demo" || null) && this.preferredGameSettings()}
             </div>
         );


### PR DESCRIPTION
Fixes #2275 

## Proposed Changes
Simple change in ChallengeModel.tsx to remove the htmlFor tag from the label alongside the checkbox, making it none-clickable 
  -
  -
  -
