### PR TITLE
Add specific template first ack of first escape

### DIFF
--- a/src/views/ReportsCenter/MessageTemplate.tsx
+++ b/src/views/ReportsCenter/MessageTemplate.tsx
@@ -269,9 +269,9 @@ export const WARNING_TEMPLATES: MessageTemplates = {
 
 export const REPORTER_RESPONSE_TEMPLATES: MessageTemplates = {
     "Good Report": {
-        "Asked opponent to be respectful of time": {
+        "Asked beginner opponent to be respectful of time": {
             message: `
-                Thanks for your report, I have asked your opponent to be more
+                Thanks for your report, I have asked your newcomer opponent to be more
                 respectful of people’s time.`,
             show_warning_button: false,
         },
@@ -286,6 +286,11 @@ export const REPORTER_RESPONSE_TEMPLATES: MessageTemplates = {
         "First warning given": {
             message: `
                 Thank you for your report, the player has been given a formal warning.`,
+            show_warning_button: false,
+        },
+        "First warning given - escaping": {
+            message: `
+                Thank you for your report, the player has been given a formal warning regarding escaping.`,
             show_warning_button: false,
         },
         "Final warning given": {
@@ -334,7 +339,7 @@ export const REPORTER_RESPONSE_TEMPLATES: MessageTemplates = {
             message: `
                 Thank you for bringing the possible instance of sandbagging to
                 our attention. We looked into the report and found little
-                evidence of deliberate underperformance. But we’ll still keep an
+                evidence of deliberate losing on purpose. But we’ll still keep an
                 eye on the situation and take appropriate action if necessary.
                 Thank you for helping keep OGS enjoyable for everyone. We
                 appreciate it.`,


### PR DESCRIPTION
 also tweak other wording

Fixes typing "regarding escaping"

## Proposed Changes

  - Add "first warning given - escaping"
  - Clarify that respectful of time is for beginners
  - Say "losing on purpose" instead of "underperformance"
