### PR TITLE
Add an experimental option to have the `right-col` fill the space more.

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -60,7 +60,7 @@ goban-view-bar-width=400px
 .MainGobanView {
     display: flex;
     flex-direction: row;
-    align-items: stretch;
+    align-items: stretch; // this is the default, I wonder why we need to say it?
     //align-content: stretch;
     //justify-content: stretch;
 
@@ -198,6 +198,11 @@ goban-view-bar-width=400px
         }
     }
 
+    // See if we can make folk who want wider chat happy
+    &.wide .right-col.experimental {
+        flex-grow: 1 !important
+        margin-left: 2rem;
+    }
 
     .conditional-move-planner {
         text-align: center;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1425,6 +1425,8 @@ export function Game(): JSX.Element {
     );
     const review = !!review_id;
 
+    const experimental: boolean = data.get("experiments.v6") === "enabled";
+
     return (
         <div>
             <div
@@ -1499,7 +1501,7 @@ export function Game(): JSX.Element {
                     </div>
 
                     {(view_mode !== "portrait" || null) && (
-                        <div className="right-col">
+                        <div className={"right-col" + (experimental ? " experimental" : "")}>
                             {(zen_mode || null) && <div className="align-col-start"></div>}
                             {(view_mode === "square" || view_mode === "wide" || null) && (
                                 <PlayerCards


### PR DESCRIPTION
Fixes years of begging (*), as noted [here](https://forums.online-go.com/t/what-made-me-leave-ogs/48191/6?u=greenasjade) .

## Proposed Changes

Have `right-col` expand to fit the space in `wide` layouts (with a bit of margin)  - enabled by the experimental settings option.

![Screenshot 2023-06-07 at 8 02 41 pm (2)](https://github.com/online-go/online-go.com/assets/61894/8731fe42-7339-480d-a43d-af0329668ab4)


---
(*)  😆