### PR TITLE
Type use of Reports in ViewReport

### DIFF
--- a/src/lib/report_manager.ts
+++ b/src/lib/report_manager.ts
@@ -57,6 +57,10 @@ export interface Report {
     moderator_note: string;
     system_note: string;
 
+    automod_to_moderator?: string; // Suggestions from "automod"
+    automod_to_reporter?: string;
+    automod_to_reported?: string;
+
     unclaim: () => void;
     claim: () => void;
     steal: () => void;

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -51,7 +51,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
     const user = useUser();
     const [moderatorNote, setModeratorNote] = React.useState("");
     const [moderators, setModerators] = React.useState(cached_moderators);
-    const [report, setReport] = React.useState(null);
+    const [report, setReport] = React.useState<Report>(null);
     const [error, setError] = React.useState(null);
     const [moderator_id, setModeratorId] = React.useState(report?.moderator?.id);
     const [reportState, setReportState] = React.useState(report?.state);


### PR DESCRIPTION
Fixes untyped state variable

## Proposed Changes

 Declare the type of `report` and extend the type to add the extra fields that come from the server.