### PR TITLE
Separate undo briefings for requesting and accepting

### DIFF
--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -24,6 +24,7 @@ import { game_control } from "./game_control";
 import { alert } from "swal_config";
 import { useCurrentMoveNumber, usePlayerToMove, useShowUndoRequested } from "./GameHooks";
 import { useGoban } from "./goban_context";
+import * as DynamicHelp from "react-dynamic-help";
 
 interface PlayButtonsProps {
     // This option exists because Cancel Button is placed below
@@ -35,6 +36,10 @@ export function PlayButtons({ show_cancel = true }: PlayButtonsProps): JSX.Eleme
     const goban = useGoban();
     const engine = goban.engine;
     const phase = engine.phase;
+
+    const { registerTargetItem } = React.useContext(DynamicHelp.Api);
+    const { ref: accept_button, used: signalUndoAcceptUsed } =
+        registerTargetItem("accept-undo-button");
 
     const cur_move_number = useCurrentMoveNumber(goban);
     const player_to_move = usePlayerToMove(goban);
@@ -105,6 +110,11 @@ export function PlayButtons({ show_cancel = true }: PlayButtonsProps): JSX.Eleme
         }
     };
 
+    const acceptUndo = () => {
+        goban.acceptUndo();
+        signalUndoAcceptUsed();
+    };
+
     const [submitting_move, setSubmittingMove] = React.useState(false);
     React.useEffect(() => {
         goban.on("submitting-move", setSubmittingMove);
@@ -130,7 +140,8 @@ export function PlayButtons({ show_cancel = true }: PlayButtonsProps): JSX.Eleme
                                 {show_accept_undo && (
                                     <button
                                         className="sm primary bold accept-undo-button"
-                                        onClick={() => goban.acceptUndo()}
+                                        onClick={() => acceptUndo()}
+                                        ref={accept_button}
                                     >
                                         {_("Accept Undo")}
                                     </button>

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -50,6 +50,7 @@ import {
     useCurrentMoveNumber,
     useShowUndoRequested,
     useUserIsParticipant,
+    usePlayerToMove,
 } from "./GameHooks";
 import { useGoban } from "./goban_context";
 import { is_valid_url } from "url_validation";
@@ -175,6 +176,26 @@ export function PlayControls({
     const winner = useWinner(goban);
     const official_move_number = useOfficialMoveNumber(goban);
     const conditional_moves = useConditionalMoveTree(goban);
+    const user_is_player = useUserIsParticipant(goban);
+    const cur_move_number = useCurrentMoveNumber(goban);
+    const this_users_turn = usePlayerToMove(goban) === user.id;
+
+    React.useEffect(() => {
+        if (show_undo_requested && moment(user.registration_date).isBefore(moment("2023-06-14"))) {
+            // This condition protects against established users seeing this message introduced 2023-6-14
+            // Could be removed once all the "regulars" have done this
+            signalUsed("undo-requested-message"); // stops the following "triggerFlow" from doing anything.
+            signalUsed("accept-undo-button");
+        }
+
+        if (show_undo_requested && game_state_pane) {
+            if (this_users_turn) {
+                triggerFlow("undo-request-received-intro");
+            } else {
+                triggerFlow("undo-requested-intro");
+            }
+        }
+    }, [show_undo_requested, game_state_pane, user_is_player]);
 
     const goban_setMode_play = () => {
         goban.setMode("play");
@@ -231,20 +252,6 @@ export function PlayControls({
         goban.autoScore();
         return false;
     };
-
-    const user_is_player = useUserIsParticipant(goban);
-    const cur_move_number = useCurrentMoveNumber(goban);
-
-    // This condition protects against established users seeing this message introduced 2023-6-14
-    // Could be removed once all the "regulars" have done this
-
-    if (show_undo_requested && moment(user.registration_date).isBefore(moment("2023-06-14"))) {
-        signalUsed("undo-requested-message"); // stops the following "triggerFlow" from doing anything.
-    }
-
-    if (show_undo_requested && game_state_pane) {
-        triggerFlow("undo-intro");
-    }
 
     return (
         <div className="play-controls">

--- a/src/views/HelpFlows/HelpFlows.tsx
+++ b/src/views/HelpFlows/HelpFlows.tsx
@@ -24,7 +24,8 @@ import { GuestUserIntro } from "./GuestUserIntro";
 import { GuestUserIntroRengo } from "./GuestUserIntroRengo";
 import { OOLUserIntro } from "./OOLUserIntro";
 import { OOLSpectatorIntro } from "./OOLSpectatorIntro";
-import { UndoIntro } from "./UndoIntro";
+import { UndoRequestedIntro } from "./UndoIntro";
+import { UndoRequestReceivedIntro } from "./UndoIntro";
 
 /**
  * This component is a handy wrapper for all the Help Flows, and reset on login/logout
@@ -80,7 +81,8 @@ export function HelpFlows(): JSX.Element {
             <OOLUserIntro />
             <OOLSpectatorIntro />
 
-            <UndoIntro />
+            <UndoRequestedIntro />
+            <UndoRequestReceivedIntro />
         </>
     );
 }

--- a/src/views/HelpFlows/UndoIntro.tsx
+++ b/src/views/HelpFlows/UndoIntro.tsx
@@ -24,17 +24,45 @@ import { _, pgettext } from "translate";
  * A help flow shown when you first press the undo button
  */
 
-export function UndoIntro(): JSX.Element {
+export function UndoRequestedIntro(): JSX.Element {
     return (
         <HelpFlow
-            id="undo-intro"
+            id="undo-requested-intro"
             showInitially={false}
-            description={pgettext("Name of a dynamic help flow", "OGS Undo policy notification")}
+            description={pgettext(
+                "Name of a dynamic help flow helping with waiting for undo acceptance",
+                "OGS Undo policy notification (requested)",
+            )}
         >
             <HelpItem target="undo-requested-message" position={"bottom-center"} hideOptOut>
                 <div>
                     {_(
                         "Your opponent may now decide to accept the undo request or not. Please note they are not obliged to do so.",
+                    )}
+                </div>
+            </HelpItem>
+        </HelpFlow>
+    );
+}
+
+/**
+ * A help flow shown when you first get asked for undo
+ */
+
+export function UndoRequestReceivedIntro(): JSX.Element {
+    return (
+        <HelpFlow
+            id="undo-request-received-intro"
+            showInitially={false}
+            description={pgettext(
+                "Name of a dynamic help flow helping with receiving an undo",
+                "OGS Undo policy notification (received)",
+            )}
+        >
+            <HelpItem target="accept-undo-button" position={"bottom-left"} hideOptOut>
+                <div>
+                    {_(
+                        "Your opponent requested an undo: you may decide to accept the undo request or not - you are not obliged to do so.",
                     )}
                 </div>
             </HelpItem>


### PR DESCRIPTION
Fixes 
 - Players getting a confusing message about their opponent accepting when they need to accept
 - Firing the help flow at the wrong time (needs to be in use-effect to avoid warnings if not actual bugs)

## Proposed Changes

 - Add a separate flow for accepting compared to requesting undo
 - Put flow triggers into use effect
 - Attach the "accept" help popup to the accept button, not the undo requested message.
