### PR TITLE
Add missing sensitivities to text-update useEffect in MessageTemplate

### DIFF
--- a/src/views/ReportsCenter/MessageTemplate.tsx
+++ b/src/views/ReportsCenter/MessageTemplate.tsx
@@ -444,7 +444,7 @@ export function MessageTemplate({
         } else {
             setTemplate(null);
         }
-    }, [selectedTemplate]);
+    }, [selectedTemplate, gpt, templates, game_id]);
 
     React.useEffect(() => {
         if (gpt && selectedTemplate === "" && text === "") {
@@ -507,7 +507,7 @@ export function MessageTemplate({
             <div className="top">
                 <select value={selectedTemplate} onChange={(e) => selectTemplate(e.target.value)}>
                     <option value="">-- Select template --</option>
-                    <option value="gpt">ChatGPT Automod</option>
+                    <option value="gpt">Automod suggestion</option>
                     {Object.keys(templates).map((category) => (
                         <optgroup label={category} key={category}>
                             {Object.keys(templates[category]).map((title) => (


### PR DESCRIPTION
… (and tweak gtp option name)

Fixes moderator message templates not updating when moving from report to report.

## Proposed Changes

 * Put all the props used in the text-setting `useEffect` into the sensitivity list
 * Entitle the default template as "automod suggestion" (get rid of GPT since it can come from other places too)
 