### PR TITLE
Use the same selected_chat_log for GameChat and PlayControls.

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -44,7 +44,7 @@ import { setExtraActionCallback, PlayerDetails } from "Player";
 import * as player_cache from "player_cache";
 import { notification_manager } from "Notifications";
 import { Resizable } from "Resizable";
-import { chat_manager, ChatChannelProxy } from "chat_manager";
+import { chat_manager, ChatChannelProxy, inGameModChannel } from "chat_manager";
 import { sfx, SFXSprite, ValidSound } from "sfx";
 import { AIReview } from "./AIReview";
 import { GameChat, ChatMode } from "./GameChat";
@@ -110,7 +110,10 @@ export function Game(): JSX.Element {
     const [autoplaying, set_autoplaying] = React.useState(false);
     const [review_list, set_review_list] = React.useState([]);
     const defaultChatMode = preferences.get("chat-mode") as ChatMode;
-    const [selected_chat_log, set_selected_chat_log] = React.useState<ChatMode>(defaultChatMode);
+    const in_game_mod_channel = !review_id && inGameModChannel(game_id);
+    const [selected_chat_log, set_selected_chat_log] = React.useState<ChatMode>(
+        in_game_mod_channel ? "hidden" : defaultChatMode,
+    );
     const [variation_name, set_variation_name] = React.useState("");
     const [historical_black, set_historical_black] = React.useState<rest_api.games.Player | null>(
         null,

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -69,14 +69,11 @@ interface GameChatLineProperties {
 export function GameChat(props: GameChatProperties): JSX.Element {
     const user = data.get("user");
     const goban = useGoban();
-    const in_game_mod_channel = !props.review_id && inGameModChannel(props.game_id);
     const defaultChatMode = preferences.get("chat-mode") as ChatMode;
     const ref_chat_log = React.useRef<HTMLDivElement>(null);
     const scrolled_to_bottom = React.useRef(true);
     const [show_quick_chat, setShowQuickChat] = React.useState(false);
-    const [selected_chat_log, setSelectedChatLog] = React.useState<ChatMode>(
-        in_game_mod_channel ? "hidden" : defaultChatMode,
-    );
+    const { selected_chat_log, onSelectedChatModeChange } = props;
     const [show_player_list, setShowPlayerList] = React.useState(false);
 
     const chat_log_hash = React.useRef<{ [k: string]: boolean }>({});
@@ -154,9 +151,9 @@ export function GameChat(props: GameChatProperties): JSX.Element {
         const onAnonymousOverrideChange = () => {
             const in_game_mod_channel = inGameModChannel(props.game_id || props.review_id);
             if (in_game_mod_channel) {
-                setSelectedChatLog("hidden");
+                onSelectedChatModeChange("hidden");
             } else {
-                setSelectedChatLog(defaultChatMode);
+                onSelectedChatModeChange(defaultChatMode);
             }
         };
 
@@ -213,7 +210,7 @@ export function GameChat(props: GameChatProperties): JSX.Element {
 
     const toggleChatLog = (isModerator: boolean) => {
         const new_chat_log = nextChatMode(selected_chat_log, isModerator);
-        setSelectedChatLog(new_chat_log);
+        onSelectedChatModeChange(new_chat_log);
         setShowQuickChat(false);
         props.onSelectedChatModeChange(new_chat_log);
     };


### PR DESCRIPTION
Fixes this issue from the forums: [Bug: Variations Going to Chat when Malkovich is On](https://forums.online-go.com/t/bug-variations-going-to-chat-when-malkovich-is-on/48157)

## Proposed Changes

  - use the selected_chat_log from the top level Game component instead of a separate variable in the GameChat component.
 - Note: if you navigate to a different game (say by clicking the TurnIndicator), this will change the chat back to the default mode.  I think this was the intent in #2274, tagging @andymarden for confirmation.