### PR TITLE
Make it so that a report is claimed for a moderator if they simply send a message

### DIFF
--- a/src/views/ReportsCenter/MessageTemplate.tsx
+++ b/src/views/ReportsCenter/MessageTemplate.tsx
@@ -408,6 +408,7 @@ export function MessageTemplate({
     gpt,
     logByDefault,
     onSelect,
+    onMessage,
 }: {
     title: string;
     player: PlayerCacheEntry;
@@ -416,6 +417,7 @@ export function MessageTemplate({
     gpt: string | null;
     logByDefault: boolean;
     onSelect?: () => void | null;
+    onMessage?: () => void | null;
 }): JSX.Element {
     const [uid] = React.useState(Math.random());
     const [selectedTemplate, setSelectedTemplate] = React.useState<string>(gpt ? "gpt" : "");
@@ -467,6 +469,9 @@ export function MessageTemplate({
             })
             .catch(errorAlerter);
         clear();
+        if (onMessage) {
+            onMessage();
+        }
     };
     const sendSystemPM = () => {
         const pc = getPrivateChat(player.id, player.username);
@@ -479,6 +484,9 @@ export function MessageTemplate({
         }
 
         clear();
+        if (onMessage) {
+            onMessage();
+        }
     };
     const sendPM = () => {
         const pc = getPrivateChat(player.id, player.username);
@@ -490,6 +498,9 @@ export function MessageTemplate({
             });
         }
         clear();
+        if (onMessage) {
+            onMessage();
+        }
     };
 
     const selectTemplate = (e: any) => {

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -504,6 +504,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     gpt={report.automod_to_reported}
                     logByDefault={true}
                     onSelect={claimReport}
+                    onMessage={claimReport}
                 />
 
                 <MessageTemplate
@@ -514,6 +515,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     gpt={report.automod_to_reporter}
                     logByDefault={false}
                     onSelect={claimReport}
+                    onMessage={claimReport}
                 />
             </div>
 


### PR DESCRIPTION

Fixes moderators having to explicitly claim in the case where they don't select a template.

## Proposed Changes

- Give MessageTemplate an onMessage callback, called when the template view is used to send a message
- Use MessageTemplate.onMessage to claim the report