### PR TITLE
Add a type of report called "Troll" for ... tracking Troll incidents.

### DIFF
--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -37,7 +37,8 @@ export type ReportType =
     | "escaping"
     | "appeal"
     | "other"
-    | "warning"; // for moderators only
+    | "warning" // for moderators only
+    | "troll"; // system generated, for moderators only
 
 export interface ReportDescription {
     type: ReportType;
@@ -139,6 +140,18 @@ export const report_categories: ReportDescription[] = [
         description: pgettext(
             "An option for moderators only, to warn players",
             "Type the warning text below",
+        ),
+        moderator_only: true,
+    },
+    {
+        type: "troll",
+        title: pgettext(
+            "An option for moderators only, alert moderators to troll accounts",
+            "Troll",
+        ),
+        description: pgettext(
+            "Moderators can record information about suspect accounts",
+            "Put any information below",
         ),
         moderator_only: true,
     },


### PR DESCRIPTION
Fixes complaints that its boring watching the moderator page looking for troll signs ;)

## Proposed Changes

 - Have a Troll type report that the system can generate when it sees whatever we decide we want to flag
 - https://github.com/online-go/ogs/pull/1816 is needed for the server-side report generation