### PR TITLE
Add a proxy for the firewall config backend routes

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -239,6 +239,7 @@ function dev_server(done) {
     devserver.use("/disconnect", backend_proxy("/disconnect"));
     devserver.use("/OGSScoreEstimator", backend_proxy("/OGSScoreEstimator"));
     devserver.use("/oje", backend_proxy("/oje"));
+    devserver.use("/firewall", backend_proxy("/firewall"));
 
     devserver.get("/locale/*", (req, res) => {
         let options = {


### PR DESCRIPTION
Fixes 404s when trying to test firewall config features

## Proposed Changes

 - Add a backend proxy for `/firewall` to the dev server