### PR TITLE
Firewall action: report

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -239,6 +239,7 @@ function dev_server(done) {
     devserver.use("/disconnect", backend_proxy("/disconnect"));
     devserver.use("/OGSScoreEstimator", backend_proxy("/OGSScoreEstimator"));
     devserver.use("/oje", backend_proxy("/oje"));
+    devserver.use("/firewall", backend_proxy("/firewall"));
 
     devserver.get("/locale/*", (req, res) => {
         let options = {

--- a/src/views/Firewall/Firewall.tsx
+++ b/src/views/Firewall/Firewall.tsx
@@ -65,8 +65,8 @@ interface Rule {
     value?: string | number | boolean;
 }
 
-type Action = "ACCEPT" | "REJECT" | "COLLECT_VPN_INFORMATION";
-const ACTIONS: Array<Action> = ["ACCEPT", "REJECT", "COLLECT_VPN_INFORMATION"];
+type Action = "ACCEPT" | "REJECT" | "REPORT" | "COLLECT_VPN_INFORMATION";
+const ACTIONS: Array<Action> = ["ACCEPT", "REJECT", "REPORT", "COLLECT_VPN_INFORMATION"];
 
 interface MatchHistoryEntry {
     id: number;


### PR DESCRIPTION
Fixes moderators wanting to be able to generate reports from the firewall.

## Proposed Changes

Have a firewall action type "REPORT" which the backend can use to generate reports for firewall configs.

Needs https://github.com/online-go/ogs/pull/1817 for backend support.

This is built on top of https://github.com/online-go/online-go.com/pull/2310 since I couldn't test it without that!
