### PR TITLE
Display the owner of (the person responsible for) each firewall rule

### DIFF
--- a/src/views/Firewall/Firewall.styl
+++ b/src/views/Firewall/Firewall.styl
@@ -21,6 +21,13 @@
     margin-left: auto;
     margin-right: auto;
 
+    .firewall-rule-header {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding-bottom: 0.5rem;
+    }
+
     .new-rule {
         themed background-color shade5
         margin-top: 2rem;
@@ -28,7 +35,7 @@
         margin-bottom: 4rem;
     }
 
-    .header {
+    .config {
         > span, > input {
             margin-left: 1rem;
         }
@@ -69,7 +76,7 @@
     .buttons {
         text-align: right;
         margin: 1rem;
-        padding-bottom: 5rem;
+        padding-bottom: 3rem;
     }
 
     .test-results {
@@ -83,7 +90,7 @@
         display: inline-block;
         width: 50rem;
         max-width: 90vw;
-        
+
         > span { 
             margin-left: 1rem;
         }

--- a/src/views/Firewall/Firewall.tsx
+++ b/src/views/Firewall/Firewall.tsx
@@ -90,6 +90,7 @@ interface Network {
 
 interface FirewallRule {
     id: number;
+    owner?: number;
     active: boolean;
     priority: number;
     rule: Rule;
@@ -251,7 +252,23 @@ function FirewallRuleRow({
 
     return (
         <div className="FirewallRuleRow">
-            <div className="header">
+            <div className="firewall-rule-header">
+                <input
+                    className="notes"
+                    placeholder="Notes"
+                    value={notes}
+                    onChange={(ev: React.ChangeEvent<HTMLInputElement>) => {
+                        firewall_rule.notes = ev.target.value;
+                        setNotes(ev.target.value);
+                    }}
+                />
+                {(firewall_rule.owner || null) && (
+                    <span>
+                        Responsible: <Player user={firewall_rule.owner} />
+                    </span>
+                )}
+            </div>
+            <div className="config">
                 <label>{firewall_rule.active ? "Active" : "Inactive"}</label>
                 <input
                     type="checkbox"
@@ -277,16 +294,6 @@ function FirewallRuleRow({
                 </select>
 
                 <span className="priority">Priority: {firewall_rule.priority}</span>
-
-                <input
-                    className="notes"
-                    placeholder="Notes"
-                    value={notes}
-                    onChange={(ev: React.ChangeEvent<HTMLInputElement>) => {
-                        firewall_rule.notes = ev.target.value;
-                        setNotes(ev.target.value);
-                    }}
-                />
             </div>
 
             <div>


### PR DESCRIPTION
Fixes not having a person to blame for this rule :)

## Proposed Changes

 - Make a new "header" row in firewall rule table
 - Display the firewall rule owner, if it is supplied by the back end, in the header, along with the "notes:
 - Layout tweaks associated
 
Needs https://github.com/online-go/ogs/pull/1819 to get the actual owner value