### PR TITLE
Don't show the ranks of players in unranked games

### DIFF
--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -513,6 +513,11 @@ export function GameChatLine(props: GameChatLineProperties): JSX.Element {
     let chat_id = props.review_id ? "r." + props.review_id : "g." + props.game_id;
     chat_id += "." + line.channel + "." + line.chat_id;
 
+    const show_rank =
+        !(line.player_id in goban.engine.player_pool) ||
+        goban.engine.config.ranked ||
+        goban.engine.rengo;
+
     return (
         <div className={`chat-line-container`} data-chat-id={chat_id}>
             {move_number}
@@ -526,7 +531,9 @@ export function GameChatLine(props: GameChatLineProperties): JSX.Element {
                         ]{" "}
                     </span>
                 )}
-                {(line.player_id || null) && <Player user={line} flare disableCacheUpdate />}
+                {(line.player_id || null) && (
+                    <Player user={line} rank={show_rank} flare disableCacheUpdate />
+                )}
                 <span className="body">
                     {third_person ? " " : ": "}
                     <MarkupChatLine line={line} />

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -308,7 +308,11 @@ export function PlayerCard({
 
             {((player && player.rank !== -1) || null) && (
                 <div className={`${color} player-name-container`}>
-                    <Player user={player.id} historical={(!engine.rengo && historical) || player} />
+                    <Player
+                        user={player.id}
+                        historical={(!engine.rengo && historical) || player}
+                        rank={engine.config.ranked || engine.rengo}
+                    />
                 </div>
             )}
 


### PR DESCRIPTION
Attempts to address folk getting wound up about the rank of their opponent in unranked games.

## Proposed Changes

 - Don't show rank of players in the game in the PlayerCards or game chat if the game is unranked and not rengo.