### PR TITLE
Correctly display invite only rengo created date, if provided by server

### DIFF
--- a/src/models/challenges.d.ts
+++ b/src/models/challenges.d.ts
@@ -112,6 +112,7 @@ declare namespace rest_api {
     // you would expect this to be what's on any route returning an Open (not Direct) challenge.
     interface OpenChallengeDTO {
         id: number;
+        created?: string | null;
         challenger: MinimalPlayerDTO;
         group: number;
         game?: GameDTO; // not clear why/when this would not be present

--- a/src/views/Overview/InviteList.tsx
+++ b/src/views/Overview/InviteList.tsx
@@ -54,6 +54,7 @@ type TimeControlSystem = TimeControlTypes.TimeControlSystem;
 function challengeDtoToSeekgraphChallengeSubset(c: ChallengeDTO, user_id: number): Challenge {
     return {
         challenge_id: c.id,
+        created: c.created,
         user_id: c.challenger.id, // number;
         username: c.challenger.username, // string;
 


### PR DESCRIPTION
Fixes wrong created date appearing in invite-only rengo challenge management pane

## Proposed Changes

 - Take the created date that we hope appears in the invite list response and use that in the challenge management pane

Needs https://github.com/online-go/ogs/pull/1823 to send the created date down this route.