### PR TITLE
Change the second level sort for rengo to be by created

### DIFF
--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -1347,7 +1347,22 @@ export function time_per_move_challenge_sort(A: Challenge, B: Challenge) {
 
     if (comparison) {
         return comparison;
-    } else {
-        return challenge_sort(A, B);
     }
+
+    if (A.eligible && !B.eligible) {
+        return -1;
+    }
+    if (!A.eligible && B.eligible) {
+        return 1;
+    }
+    if (A.user_challenge && !B.user_challenge) {
+        return -1;
+    }
+    if (!A.user_challenge && B.user_challenge) {
+        return 1;
+    }
+
+    const createdA = A.created ? new Date(A.created).getTime() : -Infinity;
+    const createdB = B.created ? new Date(B.created).getTime() : -Infinity;
+    return createdA - createdB;
 }


### PR DESCRIPTION
(after eligible and user's own)

Improves:
 - Users looking at older ones first, encouraging older ones to get going
 - Moderators seeing old ones that need to be prodded.

## Proposed Changes

Make the rengo challenge list sort by created after move-timing (while keeping eligible and other people's before ineligible and our own)
