### PR TITLE
Use separate logic for cancelling rengo and normal challenges... 

### DIFF
--- a/src/lib/rengo_utils.ts
+++ b/src/lib/rengo_utils.ts
@@ -75,7 +75,7 @@ export function startOwnRengoChallenge(the_challenge: Challenge): Promise<void> 
     });
 }
 
-export function cancelChallenge(the_challenge: Challenge): Promise<void> {
+export function cancelRengoChallenge(the_challenge: Challenge): Promise<void> {
     return del("challenges/%%", the_challenge.challenge_id);
 }
 

--- a/src/views/Overview/InviteList.tsx
+++ b/src/views/Overview/InviteList.tsx
@@ -19,9 +19,9 @@ import * as React from "react";
 
 import * as rengo_utils from "rengo_utils";
 import * as rengo_balancer from "rengo_balancer";
-
+import { alert } from "swal_config";
 import { errorAlerter } from "misc";
-import { pgettext } from "translate";
+import { _, pgettext } from "translate";
 import { del, get } from "requests";
 import { useUser } from "hooks";
 
@@ -111,16 +111,27 @@ export function InviteList(): JSX.Element {
             .catch(errorAlerter);
     };
 
-    // technically this is the same as deleteChallenge, but it seems good to keep
-    // rengo and normal challenges using a separate interface
     const cancelRengoChallenge = (challenge: Challenge) => {
         setShowDetails(null);
-        rengo_utils
-            .cancelChallenge(challenge)
-            .then(() => {
-                removeChallenge(challenge);
+
+        alert
+            .fire({
+                text: _("Are you sure you want to delete this rengo challenge?"),
+                showCancelButton: true,
+                confirmButtonText: _("Yes"),
+                cancelButtonText: _("Cancel"),
             })
-            .catch(errorAlerter);
+            .then(({ value: yes }) => {
+                if (yes) {
+                    rengo_utils
+                        .cancelRengoChallenge(challenge)
+                        .then(() => {
+                            removeChallenge(challenge);
+                        })
+                        .catch(errorAlerter);
+                }
+            })
+            .catch(() => 0);
     };
 
     const unNominate = (challenge: Challenge) => {
@@ -262,7 +273,8 @@ export function InviteList(): JSX.Element {
                                                   )}
                                         </button>
                                     )}
-                                    {(challenge.user_id === user.id || null) && (
+                                    {((challenge.user_id === user.id && !challenge.rengo) ||
+                                        null) && (
                                         <FabX onClick={() => deleteChallenge(challenge)} />
                                     )}
                                 </div>

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -18,6 +18,7 @@
 import * as React from "react";
 import * as data from "data";
 import * as DynamicHelp from "react-dynamic-help";
+import { del } from "requests";
 
 import * as preferences from "preferences";
 import * as player_cache from "player_cache";
@@ -260,7 +261,7 @@ export class Play extends React.Component<{}, PlayState> {
             .catch(errorAlerter);
     };
 
-    cancelOpenChallenge = (challenge: Challenge) => {
+    cancelOpenRengoChallenge = (challenge: Challenge) => {
         alert
             .fire({
                 text: _("Are you sure you want to delete this rengo challenge?"),
@@ -274,11 +275,14 @@ export class Play extends React.Component<{}, PlayState> {
                     this.closeChallengeManagementPane(challenge.challenge_id);
 
                     // do the action
-                    rengo_utils.cancelChallenge(challenge).catch(errorAlerter);
+                    rengo_utils.cancelRengoChallenge(challenge).catch(errorAlerter);
                 }
             })
             .catch(() => 0);
+    };
 
+    cancelOpenChallenge = (challenge: Challenge) => {
+        del("challenges/%%", challenge.challenge_id).catch(errorAlerter);
         this.unfreezeChallenges();
     };
 
@@ -700,7 +704,7 @@ export class Play extends React.Component<{}, PlayState> {
                         challenge_id={rengo_challenge_to_show.challenge_id}
                         rengo_challenge_list={this.state.rengo_list}
                         startRengoChallenge={rengo_utils.startOwnRengoChallenge}
-                        cancelChallenge={this.cancelOpenChallenge}
+                        cancelChallenge={this.cancelOpenRengoChallenge}
                         withdrawFromRengoChallenge={this.unNominateForRengoChallenge}
                         joinRengoChallenge={rengo_utils.nominateForRengoChallenge}
                     >
@@ -1205,7 +1209,7 @@ export class Play extends React.Component<{}, PlayState> {
                             challenge_id={C.challenge_id}
                             rengo_challenge_list={this.state.rengo_list}
                             startRengoChallenge={this.startOwnRengoChallenge}
-                            cancelChallenge={this.cancelOpenChallenge}
+                            cancelChallenge={this.cancelOpenRengoChallenge}
                             withdrawFromRengoChallenge={this.unNominateForRengoChallenge}
                             joinRengoChallenge={rengo_utils.nominateForRengoChallenge}
                             dontShowCancelButton={true}
@@ -1237,7 +1241,7 @@ export class Play extends React.Component<{}, PlayState> {
                 <td className={"cell rengo-list-buttons"}>
                     {user.is_moderator && (
                         <button
-                            onClick={this.cancelOpenChallenge.bind(this, C)}
+                            onClick={this.cancelOpenRengoChallenge.bind(this, C)}
                             className="btn danger xs pull-left "
                         >
                             <i className="fa fa-trash" />
@@ -1246,7 +1250,7 @@ export class Play extends React.Component<{}, PlayState> {
 
                     {(C.user_challenge || null) && (
                         <button
-                            onClick={this.cancelOpenChallenge.bind(this, C)}
+                            onClick={this.cancelOpenRengoChallenge.bind(this, C)}
                             className="btn reject xs"
                         >
                             {_("Remove")}


### PR DESCRIPTION
…so that rengo challenge cancel is confirmed, and normal challenge cancel is not.

Fixes [inappropriate confirm dialog](https://forums.online-go.com/t/rengo-status/40415/1256?u=greenasjade)

## Proposed Changes

Completely separate cancel for rengo and normal challenges.