### PR TITLE
Layout tweaks to stablize and compact ViewReport

### DIFF
--- a/src/views/ReportsCenter/MessageTemplate.tsx
+++ b/src/views/ReportsCenter/MessageTemplate.tsx
@@ -529,7 +529,9 @@ export function MessageTemplate({
             <div className="top">
                 <select value={selectedTemplate} onChange={(e) => selectTemplate(e.target.value)}>
                     <option value="">-- Select template --</option>
-                    <option value="gpt">Automod suggestion</option>
+                    <optgroup label={"Automod"} key={"automod"}>
+                        <option value="gpt">Automod's suggestion</option>
+                    </optgroup>
                     {Object.keys(templates).map((category) => (
                         <optgroup label={category} key={category}>
                             {Object.keys(templates[category]).map((title) => (

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -82,7 +82,6 @@ reports_center_content_width=56rem
         align-items: stretch;
         justify-content: stretch;
         align-content: stretch;
-        margin-bottom: 1rem;
     }
 
     .notes {

--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -8,6 +8,10 @@
     textarea {
     }
 
+    .hide {
+        visibility: hidden;
+    }
+
     h3.users {
         display: flex;
         flex-direction: row;
@@ -26,12 +30,14 @@
     }
 
     .header {
+        margin-bottom: 1 rem;
+
         .report-id {
             margin-right: 1rem;
         }
         button {
-            margin-left: 1rem;
-            margin-right: 1rem;
+            margin-left: 0.5rem;
+            margin-right: 0.5rem;
         }
     }
 
@@ -60,10 +66,7 @@
     }
 
     .when {
-        font-size: 0.9rem;
-        font-weight: 400;
-        padding-left: 1rem;
-        float: right;
+        margin-left: 0.8rem; // this is the font size in this span
     }
 
     .newer-older-buttons {

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -230,20 +230,6 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
     return (
         <div id="ViewReport">
             <div className="header">
-                <div className="newer-older-buttons">
-                    {(prev_report && (
-                        <button className="default" onClick={prev}>
-                            &lt; Prev
-                        </button>
-                    )) || <span className="empty" />}
-
-                    {(next_report && (
-                        <button className="default" onClick={next}>
-                            Next &gt;
-                        </button>
-                    )) || <span className="empty" />}
-                </div>
-
                 {report_in_reports ? (
                     <Select
                         id="ReportsCenterSelectReport"
@@ -326,6 +312,14 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                         }}
                     />
 
+                    <button className={"default" + (prev_report ? "" : " hide")} onClick={prev}>
+                        &lt; Prev
+                    </button>
+
+                    <button className={"default" + (next_report ? "" : " hide")} onClick={next}>
+                        Next &gt;
+                    </button>
+
                     {report.moderator ? (
                         <>
                             {(report.moderator.id === user.id || null) && (
@@ -341,8 +335,19 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                             )}
                         </>
                     ) : (
-                        <button className="primary xs" onClick={claimReport}>
+                        <button className="primary" onClick={claimReport}>
                             {_("Claim")}
+                        </button>
+                    )}
+                    {!claimed_by_me && (
+                        <button
+                            className="default"
+                            onClick={() => {
+                                void report_manager.ignore(report.id);
+                                next();
+                            }}
+                        >
+                            Ignore
                         </button>
                     )}
                 </span>
@@ -351,46 +356,26 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
             <div className="reported-user">
                 <h3 className="users">
                     <span className="reported-user">
-                        {pgettext(
-                            "A label for the user name who has been reported to mods (followed by colon and the username)",
-                            "Reported User",
-                        )}
+                        {category?.title}
                         : <Player user={report.reported_user} />
                     </span>
-                    <span className="reporting-user">
-                        {pgettext(
-                            "A label for the user name that reported an incident (followed by colon and the username)",
-                            "Reported by",
-                        )}
-                        : <Player user={report.reporting_user} />
-                    </span>
+                    <div>
+                        <span className="reporting-user">
+                            {pgettext(
+                                "A label for the user name that reported an incident (followed by colon and the username)",
+                                "Reported by",
+                            )}
+                            : <Player user={report.reporting_user} />
+                            <span className="when">{moment(report.created).fromNow()}</span>
+                        </span>
+                    </div>
                 </h3>
             </div>
-
-            <h3>
-                {category?.title}
-                <span className="when">{moment(report.created).fromNow()}</span>
-            </h3>
-
-            {related.length > 0 && (
-                <div className="related-reports">
-                    <h4>{_("Related Reports")}</h4>
-                    <ul>
-                        {related.map((r) => (
-                            <li key={r.report.id}>
-                                <Link to={`/reports-center/all/${r.report.id}`}>
-                                    {R(r.report.id)}: {r.relationship}
-                                </Link>
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-            )}
 
             <div className="notes-container">
                 {(report.reporter_note || null) && (
                     <div className="notes">
-                        <h3>Reporter Notes</h3>
+                        <h4>Reporter Notes</h4>
                         <div className="Card">
                             {report.reporter_note_translation ? (
                                 <>
@@ -419,27 +404,35 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
 
                 {(report.system_note || null) && (
                     <div className="notes">
-                        <h3>System Notes</h3>
+                        <h4>System Notes</h4>
                         <div className="Card">{report.system_note}</div>
                     </div>
                 )}
 
                 {(user.is_moderator || null) && (
                     <div className="notes">
-                        <h3>Moderator Notes</h3>
+                        <h4>Moderator Notes</h4>
                         <textarea value={moderatorNote} onChange={setAndSaveModeratorNote} />
                     </div>
                 )}
             </div>
 
             <div className="actions">
-                <div className="actions-left">
-                    {!claimed_by_me && !report.moderator && (
-                        <button className="primary" onClick={claimReport}>
-                            Claim
-                        </button>
-                    )}
-                </div>
+                {related.length > 0 && (
+                    <div className="related-reports">
+                        <h4>{_("Related Reports")}</h4>
+                        <ul>
+                            {related.map((r) => (
+                                <li key={r.report.id}>
+                                    <Link to={`/reports-center/all/${r.report.id}`}>
+                                        {R(r.report.id)}: {r.relationship}
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+
                 <div className="actions-right">
                     {reportState !== "resolved" && claimed_by_me && (
                         <button
@@ -471,18 +464,6 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                             onClick={() => void report_manager.reopen(report.id)}
                         >
                             Re-open
-                        </button>
-                    )}
-
-                    {!claimed_by_me && (
-                        <button
-                            className="default"
-                            onClick={() => {
-                                void report_manager.ignore(report.id);
-                                next();
-                            }}
-                        >
-                            Ignore
                         </button>
                     )}
                 </div>


### PR DESCRIPTION
Fixes "ViewReport" layout shifting based on state, and lessens content "off the bottom"

## Proposed Changes
  - Put the next prev claim unclaim buttons all onto the moderator selector row
  - Put the time since created onto the reported by row
  - Make notes headers h4 instead of h3
  - Put Related Reports under notes, into the "grid cell" previously occupied by "claim"

Effects:
 - Claim and Ignore button are always in the same place
 - Notes are always in the same place
 - Send Warning etc buttons have a much better chance of being on the screen
 