### PR TITLE
Standardization #2271

### DIFF
--- a/src/views/Settings/AnnouncementPreferences.tsx
+++ b/src/views/Settings/AnnouncementPreferences.tsx
@@ -33,7 +33,7 @@ import { Toggle } from "Toggle";
 import { PreferenceLine } from "SettingsCommon";
 
 export function AnnouncementPreferences(): JSX.Element {
-    const [blocked_players, setBlockedPlayers]: [
+    const [blocked_players, _setBlockedPlayers]: [
         Array<any> | null,
         (x: Array<any> | null) => void,
     ] = React.useState(null);
@@ -47,12 +47,24 @@ export function AnnouncementPreferences(): JSX.Element {
             .catch(errorAlerter);
     }, []);
 
-    const [mute_stream_announcements, toggleMuteStreamAnnouncements] = usePreference(
+    function setBlockedPlayers(blocks) {
+        _setBlockedPlayers(blocks);
+    }
+
+    const [mute_stream_announcements, _toggleMuteStreamAnnouncements] = usePreference(
         "mute-stream-announcements",
     );
-    const [mute_event_announcements, toggleMuteEventAnnouncements] = usePreference(
+    const [mute_event_announcements, _toggleMuteEventAnnouncements] = usePreference(
         "mute-event-announcements",
     );
+
+    function toggleMuteStreamAnnouncements() {
+        _toggleMuteStreamAnnouncements;
+    }
+
+    function toggleMuteEventAnnouncements() {
+        _toggleMuteEventAnnouncements;
+    }
 
     return (
         <div id="AnnouncementPreferences">

--- a/src/views/Settings/AnnouncementPreferences.tsx
+++ b/src/views/Settings/AnnouncementPreferences.tsx
@@ -47,7 +47,7 @@ export function AnnouncementPreferences(): JSX.Element {
             .catch(errorAlerter);
     }, []);
 
-    function setBlockedPlayers(blocks) {
+    function setBlockedPlayers(blocks: Array<any> | null) {
         _setBlockedPlayers(blocks);
     }
 

--- a/src/views/Settings/BlockedPlayerPreferences.tsx
+++ b/src/views/Settings/BlockedPlayerPreferences.tsx
@@ -34,7 +34,7 @@ export function BlockedPlayerPreferences(): JSX.Element {
             .catch(errorAlerter);
     }, []);
 
-    function setBlockedPlayers(blocks) {
+    function setBlockedPlayers(blocks: Array<any> | null) {
         _setBlockedPlayers(blocks);
     }
 

--- a/src/views/Settings/BlockedPlayerPreferences.tsx
+++ b/src/views/Settings/BlockedPlayerPreferences.tsx
@@ -23,7 +23,7 @@ import { errorAlerter } from "misc";
 import { BlockPlayerModal, getAllBlocksWithUsernames } from "BlockPlayer";
 
 export function BlockedPlayerPreferences(): JSX.Element {
-    const [blocked_players, setBlockedPlayers]: [
+    const [blocked_players, _setBlockedPlayers]: [
         Array<any> | null,
         (x: Array<any> | null) => void,
     ] = React.useState(null);
@@ -33,6 +33,10 @@ export function BlockedPlayerPreferences(): JSX.Element {
             .then((blocks) => setBlockedPlayers(blocks))
             .catch(errorAlerter);
     }, []);
+
+    function setBlockedPlayers(blocks) {
+        _setBlockedPlayers(blocks);
+    }
 
     if (blocked_players === null) {
         return <div id="BlockedPlayers"></div>;

--- a/src/views/Settings/ChatPreferences.tsx
+++ b/src/views/Settings/ChatPreferences.tsx
@@ -26,21 +26,37 @@ import { Toggle } from "Toggle";
 import { PreferenceLine } from "SettingsCommon";
 
 export function ChatPreferences(): JSX.Element {
-    const [show_empty_chat_notification, toggleEmptyChatNotification] = usePreference(
+    const [show_empty_chat_notification, _toggleEmptyChatNotification] = usePreference(
         "show-empty-chat-notification",
     );
-    const [group_chat_unread, toggleGroupChatUnread] = usePreference(
+    const [group_chat_unread, _toggleGroupChatUnread] = usePreference(
         "chat-subscribe-group-chat-unread",
     );
-    const [group_chat_mentions, toggleGroupChatMentions] = usePreference(
+    const [group_chat_mentions, _toggleGroupChatMentions] = usePreference(
         "chat-subscribe-group-mentions",
     );
-    const [tournament_chat_unread, toggleTournamentChatUnread] = usePreference(
+    const [tournament_chat_unread, _toggleTournamentChatUnread] = usePreference(
         "chat-subscribe-tournament-chat-unread",
     );
-    const [tournament_chat_mentions, toggleTournamentChatMentions] = usePreference(
+    const [tournament_chat_mentions, _toggleTournamentChatMentions] = usePreference(
         "chat-subscribe-tournament-mentions",
     );
+
+    function toggleEmptyChatNotification() {
+        _toggleEmptyChatNotification;
+    }
+    function toggleGroupChatUnread() {
+        _toggleGroupChatUnread;
+    }
+    function toggleGroupChatMentions() {
+        _toggleGroupChatMentions;
+    }
+    function toggleTournamentChatUnread() {
+        _toggleTournamentChatUnread;
+    }
+    function toggleTournamentChatMentions() {
+        _toggleTournamentChatMentions;
+    }
 
     return (
         <div>

--- a/src/views/Settings/GamePreferences.tsx
+++ b/src/views/Settings/GamePreferences.tsx
@@ -44,13 +44,13 @@ export function GamePreferences(): JSX.Element {
         getSubmitMode("correspondence"),
     );
     const [chat_mode, _setChatMode] = usePreference("chat-mode");
-    const [board_labeling, setBoardLabeling] = usePreference("board-labeling");
+    const [board_labeling, _setBoardLabeling] = usePreference("board-labeling");
 
-    const [autoadvance, setAutoAdvance] = usePreference("auto-advance-after-submit");
-    const [always_disable_analysis, setAlwaysDisableAnalysis] =
+    const [autoadvance, _setAutoAdvance] = usePreference("auto-advance-after-submit");
+    const [always_disable_analysis, _setAlwaysDisableAnalysis] =
         usePreference("always-disable-analysis");
-    const [dynamic_title, setDynamicTitle] = usePreference("dynamic-title");
-    const [function_keys_enabled, setFunctionKeysEnabled] = usePreference("function-keys-enabled");
+    const [dynamic_title, _setDynamicTitle] = usePreference("dynamic-title");
+    const [function_keys_enabled, _setFunctionKeysEnabled] = usePreference("function-keys-enabled");
     const [autoplay_delay, _setAutoplayDelay]: [number, (x: number) => void] = React.useState(
         preferences.get("autoplay-delay") / 1000,
     );
@@ -58,7 +58,7 @@ export function GamePreferences(): JSX.Element {
         "variation-stone-transparency",
     );
     const [variation_move_count, _setVariationMoveCount] = usePreference("variation-move-count");
-    const [visual_undo_request_indicator, setVisualUndoRequestIndicator] = usePreference(
+    const [visual_undo_request_indicator, _setVisualUndoRequestIndicator] = usePreference(
         "visual-undo-request-indicator",
     );
     const [zen_mode_by_default, _setZenModeByDefault] = usePreference("start-in-zen-mode");
@@ -136,6 +136,24 @@ export function GamePreferences(): JSX.Element {
             _setAutoplayDelay(value);
             preferences.set("autoplay-delay", 1000 * value);
         }
+    }
+    function setBoardLabeling() {
+        _setBoardLabeling;
+    }
+    function setAutoAdvance() {
+        _setAutoAdvance;
+    }
+    function setDynamicTitle() {
+        _setDynamicTitle;
+    }
+    function setFunctionKeysEnabled() {
+        _setFunctionKeysEnabled;
+    }
+    function setVisualUndoRequestIndicator() {
+        _setVisualUndoRequestIndicator;
+    }
+    function setAlwaysDisableAnalysis() {
+        _setAlwaysDisableAnalysis;
     }
 
     return (

--- a/src/views/Settings/GeneralPreferences.tsx
+++ b/src/views/Settings/GeneralPreferences.tsx
@@ -41,33 +41,32 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
 
     const [game_list_threshold, _setGameListThreshold]: [number, (x: number) => void] =
         React.useState(preferences.get("game-list-threshold"));
-    const [_desktop_notifications, setDesktopNotifications] =
+    const [_desktop_notifications, _setDesktopNotifications] =
         usePreference("desktop-notifications");
     /*
     const [desktop_notifications_require_interaction, setDesktopNotificationsRequireInteraction] =
         usePreference("desktop-notifications-require-interaction");
     */
-    const [show_offline_friends, setShowOfflineFriends] = usePreference("show-offline-friends");
-    const [show_seek_graph, setShowSeekGraph] = usePreference("show-seek-graph");
-    const [unicode_filter_usernames, setUnicodeFilterUsernames] = usePreference("unicode-filter");
-    const [translation_dialog_never_show, setTranslationDialogNeverShow] = usePreference(
+    const [show_offline_friends, _setShowOfflineFriends] = usePreference("show-offline-friends");
+    const [show_seek_graph, _setShowSeekGraph] = usePreference("show-seek-graph");
+    const [unicode_filter_usernames, _setUnicodeFilterUsernames] = usePreference("unicode-filter");
+    const [translation_dialog_never_show, _setTranslationDialogNeverShow] = usePreference(
         "translation-dialog-never-show",
     );
-    const [hide_ui_class, setHideUiClass]: [boolean, (x: boolean) => void] = React.useState(
+    const [hide_ui_class, _setHideUiClass]: [boolean, (x: boolean) => void] = React.useState(
         props.state.hide_ui_class,
     );
-    const [show_tournament_indicator, setShowTournamentIndicator] = usePreference(
+    const [show_tournament_indicator, _setShowTournamentIndicator] = usePreference(
         "show-tournament-indicator",
     );
-    const [show_tournament_indicator_on_mobile, setShowTournamentIndicatorOnMobile] = usePreference(
-        "show-tournament-indicator-on-mobile",
-    );
-    const [hide_ranks, setHideRanks] = usePreference("hide-ranks");
-    const [rating_graph_always_use, setAlwaysUse] = usePreference("rating-graph-always-use");
-    const [rating_graph_plot_by_games, setPlotByGames] = usePreference(
+    const [show_tournament_indicator_on_mobile, _setShowTournamentIndicatorOnMobile] =
+        usePreference("show-tournament-indicator-on-mobile");
+    const [hide_ranks, _setHideRanks] = usePreference("hide-ranks");
+    const [rating_graph_always_use, _setAlwaysUse] = usePreference("rating-graph-always-use");
+    const [rating_graph_plot_by_games, _setPlotByGames] = usePreference(
         "rating-graph-plot-by-games",
     );
-    const [enable_v6, setEnableV6]: [boolean, (x: boolean) => void] = React.useState(
+    const [enable_v6, _setEnableV6]: [boolean, (x: boolean) => void] = React.useState(
         data.get("experiments.v6") === "enabled",
     );
 
@@ -121,7 +120,7 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
         }
 
         try {
-            setDesktopNotifications(enabled);
+            _setDesktopNotifications(enabled);
 
             if (enabled) {
                 if ((Notification as any).permission === "denied") {
@@ -171,7 +170,7 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
     }
 
     function updateHideUIClass(checked) {
-        setHideUiClass(!checked);
+        _setHideUiClass(!checked);
         put(`me/settings`, {
             site_preferences: {
                 hide_ui_class: !checked,
@@ -191,6 +190,34 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
         preferences.set("language", language_code);
         setCurrentLanguage(language_code);
         window.location.reload();
+    }
+
+    function setShowTournamentIndicator() {
+        _setShowTournamentIndicator;
+    }
+    function setShowTournamentIndicatorOnMobile() {
+        _setShowTournamentIndicatorOnMobile;
+    }
+    function setShowOfflineFriends() {
+        _setShowOfflineFriends;
+    }
+    function setShowSeekGraph() {
+        _setShowSeekGraph;
+    }
+    function setUnicodeFilterUsernames() {
+        _setUnicodeFilterUsernames;
+    }
+    function setHideRanks() {
+        _setHideRanks;
+    }
+    function setAlwaysUse() {
+        _setAlwaysUse;
+    }
+    function setPlotByGames() {
+        _setPlotByGames;
+    }
+    function setEnableV6(tf: boolean) {
+        _setEnableV6(tf);
     }
 
     // Render...

--- a/src/views/Settings/GeneralPreferences.tsx
+++ b/src/views/Settings/GeneralPreferences.tsx
@@ -219,6 +219,9 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
     function setEnableV6(tf: boolean) {
         _setEnableV6(tf);
     }
+    function setTranslationDialogNeverShow() {
+        _setTranslationDialogNeverShow;
+    }
 
     // Render...
     return (

--- a/src/views/Settings/HelpSettings.tsx
+++ b/src/views/Settings/HelpSettings.tsx
@@ -46,7 +46,11 @@ export function HelpSettings(): JSX.Element {
     // we need a state to trigger re-reander after changing a flow visibility,
     // because DynamicHelp can't trigger a re-render in that circumstance.
 
-    const [reload, setReload] = React.useState(false);
+    const [reload, _setReload] = React.useState(false);
+
+    function setReload(tf: boolean) {
+        _setReload(tf);
+    }
 
     const show = (flow: DynamicHelp.FlowInfo) => {
         enableFlow(flow.id);

--- a/src/views/Settings/ModeratorPreferences.tsx
+++ b/src/views/Settings/ModeratorPreferences.tsx
@@ -24,19 +24,41 @@ import { SettingGroupPageProps, PreferenceLine } from "SettingsCommon";
 import { ReportsCenterSettings } from "ReportsCenter";
 
 export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element {
-    const [incident_report_notifications, setIncidentReportNotifications] = usePreference(
+    const [incident_report_notifications, _setIncidentReportNotifications] = usePreference(
         "notify-on-incident-report",
     );
-    const [hide_incident_reports, setHideIncidentReports] = usePreference("hide-incident-reports");
-    const [hide_claimed_reports, setHideClaimedReports] = usePreference("hide-claimed-reports");
-    const [join_games_anonymously, setJoinGamesAnonymously] = usePreference(
+    const [hide_incident_reports, _setHideIncidentReports] = usePreference("hide-incident-reports");
+    const [hide_claimed_reports, _setHideClaimedReports] = usePreference("hide-claimed-reports");
+    const [join_games_anonymously, _setJoinGamesAnonymously] = usePreference(
         "moderator.join-games-anonymously",
     );
-    const [hide_flags, setHideFlags] = usePreference("moderator.hide-flags");
-    const [hide_profile, setHideProfile] = usePreference("moderator.hide-profile-information");
-    const [hide_player_card_mod_controls, setHidePlayerCardModControls] = usePreference(
+    const [hide_flags, _setHideFlags] = usePreference("moderator.hide-flags");
+    const [hide_profile, _setHideProfile] = usePreference("moderator.hide-profile-information");
+    const [hide_player_card_mod_controls, _setHidePlayerCardModControls] = usePreference(
         "moderator.hide-player-card-mod-controls",
     );
+
+    function setIncidentReportNotifications() {
+        _setIncidentReportNotifications;
+    }
+    function setHideIncidentReports() {
+        _setHideIncidentReports;
+    }
+    function setHideClaimedReports() {
+        _setHideClaimedReports;
+    }
+    function setJoinGamesAnonymously() {
+        _setJoinGamesAnonymously;
+    }
+    function setHideFlags() {
+        _setHideFlags;
+    }
+    function setHideProfile() {
+        _setHideProfile;
+    }
+    function setHidePlayerCardModControls() {
+        _setHidePlayerCardModControls;
+    }
 
     const user = data.get("user");
 

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -53,11 +53,11 @@ import { Supporter } from "Supporter";
 
 export function Settings(): JSX.Element {
     const { category } = useParams();
-    const [settings_state, setSettingsState]: [SettingsState, (s: SettingsState) => void] =
+    const [settings_state, _setSettingsState]: [SettingsState, (s: SettingsState) => void] =
         React.useState({});
-    const [vacation_base_time, set_vacation_base_time]: [number, (s: number) => void] =
+    const [vacation_base_time, _set_vacation_base_time]: [number, (s: number) => void] =
         React.useState(Date.now());
-    const [loaded, set_loaded]: [number, (b: number) => void] = React.useState(0);
+    const [loaded, _set_loaded]: [number, (b: number) => void] = React.useState(0);
 
     const { registerTargetItem, signalUsed } = React.useContext(DynamicHelp.Api);
 
@@ -66,6 +66,16 @@ export function Settings(): JSX.Element {
     const { ref: accountSettingsButton } = registerTargetItem("account-settings-button"); // cleared on AccountSettings page
 
     React.useEffect(refresh, []);
+
+    function setSettingsState(s: SettingsState) {
+        _setSettingsState(s);
+    }
+    function set_vacation_base_time(s: number) {
+        _set_vacation_base_time(s);
+    }
+    function set_loaded(b: number) {
+        _set_loaded(b);
+    }
 
     function select(s: string): void {
         data.set("settings.page-selected", s);

--- a/src/views/Settings/VacationSettings.tsx
+++ b/src/views/Settings/VacationSettings.tsx
@@ -26,9 +26,13 @@ import { durationString } from "TimeControl";
 import { SettingGroupPageProps } from "SettingsCommon";
 
 export function VacationSettings(props: SettingGroupPageProps): JSX.Element {
-    const [vacation_left, set_vacation_left]: [number, (x: number) => void] = React.useState(
+    const [vacation_left, _set_vacation_left]: [number, (x: number) => void] = React.useState(
         props.state.profile.vacation_left - (Date.now() - props.vacation_base_time) / 1000,
     );
+
+    function set_vacation_left(x: number) {
+        _set_vacation_left(x);
+    }
 
     React.useEffect(() => {
         const vacation_interval = setInterval(() => {


### PR DESCRIPTION
# Summary of Issue - [#2271](https://github.com/online-go/online-go.com/issues/2271)

The Settings folder was noted to contain a preferred scheme for the setters of state and preferences.
Where the set function prefixed with an underscore ("_setterExample"), acts as the "real" internal setter.
While another setter without the prefix ("setterExample"),
offers to perform any extra logic required prior to then calling the internal setter.
However, this format was not applied universally to the files within the Settings Folder.

## Description of Changes
Within the files of the Settings folder all state and preferences which did not use a prefixed setter were altered.
The prefix setter was added and a function to the external setter was implemented with type parameters when able.


For Instance: **_HelpSettings.tsx_**
`const [reload, setReload] = React.useState(false);`
`React.useEffect(() => {
        if (reload) {
            setReload(false);
        }
    });`

Was changed to:
`const [reload, _setReload] = React.useState(false);`
`function setReload(tf: boolean) {
        _setReload(tf);
    }`
`React.useEffect(() => {
        if (reload) {
            setReload(false);
        }
    });`


As noted, this change was implemented to create commonality within the Settings folder.
Furthermore, while the above example does not currently contain additional logic prior to changing the setReload state.
We are now provided a clear function to handle any logic we may wish to implement in the future, for any state/preference.

# Testing

To ensure these changes didn't introduce any issues, the tests provided within the repo were run with results below.

![image](https://github.com/online-go/online-go.com/assets/59673146/922f436e-8136-4bb4-b21b-90d181436534)

### Aside

👋 Hey! 

First pull request for an open-source project. Looking to get my feet wet and contribute to real codebases outside of a couple small personal projects. I would greatly appreciate any constructive criticism regarding these changes 😊