### PR TITLE
More ViewReport compaction tweaks

### DIFF
--- a/src/views/ReportsCenter/MessageTemplate.tsx
+++ b/src/views/ReportsCenter/MessageTemplate.tsx
@@ -283,7 +283,7 @@ export const WARNING_TEMPLATES: MessageTemplates = {
 
 export const REPORTER_RESPONSE_TEMPLATES: MessageTemplates = {
     "Good Report": {
-        "Asked beginner opponent to be respectful of time": {
+        "Beginner escaper": {
             message: `
                 Thanks for your report about #REPORTED, I have asked your newcomer opponent to be more
                 respectful of people’s time.`,

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -101,7 +101,7 @@ reports_center_content_width=56rem
             margin-right: 1rem;
             margin-top: 0;
             margin-bottom: 0;
-            min-height: 7rem;
+            min-height: 4rem;
         }
 
         textarea {

--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -80,6 +80,16 @@
         }
     }
 
+    .related-reports {
+        ul li {
+            font-size: smaller; // so that reports related three ways don't wrap
+        }
+    }
+
+    .actions-right {
+        align-items: flex-end; // put the buttons down close-ish to the send-warning buttons
+    }
+
     .automod-analysis {
         margin-bottom: 1rem;
         .analysis {

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -418,20 +418,22 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
             </div>
 
             <div className="actions">
-                {related.length > 0 && (
-                    <div className="related-reports">
-                        <h4>{_("Related Reports")}</h4>
-                        <ul>
-                            {related.map((r) => (
-                                <li key={r.report.id}>
-                                    <Link to={`/reports-center/all/${r.report.id}`}>
-                                        {R(r.report.id)}: {r.relationship}
-                                    </Link>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
+                <div className="related-reports">
+                    {related.length > 0 && (
+                        <>
+                            <h4>{_("Related Reports")}</h4>
+                            <ul>
+                                {related.map((r) => (
+                                    <li key={r.report.id}>
+                                        <Link to={`/reports-center/all/${r.report.id}`}>
+                                            {R(r.report.id)}: {r.relationship}
+                                        </Link>
+                                    </li>
+                                ))}
+                            </ul>
+                        </>
+                    )}
+                </div>
 
                 <div className="actions-right">
                     {reportState !== "resolved" && claimed_by_me && (


### PR DESCRIPTION
Ensure that the close buttons end up sensibly-near to the messaging buttons always, stop the related reports from wrapping and taking up more vertical space (and also tweak a message template title so it fits in the space)

Fixes stuff going off the bottom of the page

## Proposed Changes

Fix the layout after previous squishing up.
