### PR TITLE
Improve handling reviews/demos without historical rating

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1326,7 +1326,7 @@ export function Game(): JSX.Element {
         if (review_id) {
             get("reviews/%%", review_id)
                 .then((review) => {
-                    if (review.game) {
+                    if (review.game && review.game.historical_ratings) {
                         set_historical_black(review.game.historical_ratings.black);
                         set_historical_white(review.game.historical_ratings.white);
                     }


### PR DESCRIPTION
Freshly created demo boards don't necessarily provide the historical ratings object. This can easily be observed by loading an appropriate demo board with Firebug open and "Pause on exceptions" active.