### PR TITLE
Community Moderator support: Moderator power: annul

### DIFF
--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -24,6 +24,8 @@ import { proRankList } from "rank_utils";
 import { Modal, openModal } from "Modal";
 import { lookup } from "player_cache";
 
+import { MOD_POWER_ANNUL } from "misc";
+
 interface Events {}
 
 interface ModerateUserProperties {
@@ -50,7 +52,7 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                 this.setState(
                     Object.assign({ loading: false }, result.user, {
                         bot_owner: result.user.bot_owner ? result.user.bot_owner.id : null,
-                        can_annul: result.user.moderator_powers & 1,
+                        can_annul: result.user.moderator_powers & MOD_POWER_ANNUL,
                     }),
                 );
             })

--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -50,6 +50,7 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                 this.setState(
                     Object.assign({ loading: false }, result.user, {
                         bot_owner: result.user.bot_owner ? result.user.bot_owner.id : null,
+                        can_annul: result.user.moderator_powers & 1,
                     }),
                 );
             })
@@ -92,6 +93,10 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                     settings[f] = this.state[f];
                 }
 
+                // Can-annul is bit zero of moderator_powers
+                settings["moderator_powers"] =
+                    (this.state.moderator_powers & ~1) | this.state.can_annul;
+
                 settings.moderation_note = reason;
 
                 put(`players/${this.props.playerId}/moderate`, settings)
@@ -104,6 +109,7 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
     setLockedUsername = (ev) => this.setState({ locked_username: ev.target.checked });
     setSupporter = (ev) => this.setState({ supporter: ev.target.checked });
     setAnnouncer = (ev) => this.setState({ is_announcer: ev.target.checked });
+    setCanAnnul = (ev) => this.setState({ can_annul: ev.target.checked });
     setProfessional = (ev) => this.setState({ professional: ev.target.checked });
     //setBanned = (ev) => this.setState({ is_banned: ev.target.checked });
     setShadowbanned = (ev) => this.setState({ is_shadowbanned: ev.target.checked });
@@ -221,6 +227,17 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                                                 onChange={this.setBotOwner}
                                             />
                                         )}
+                                    </dd>
+                                    <dt>
+                                        <label htmlFor="annul">Can Annul</label>
+                                    </dt>
+                                    <dd>
+                                        <input
+                                            id="annul"
+                                            type="checkbox"
+                                            checked={this.state.can_annul}
+                                            onChange={this.setCanAnnul}
+                                        />
                                     </dd>
                                 </dl>
                             </div>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -41,6 +41,8 @@ import { logout } from "auth";
 import { useUser, useData } from "hooks";
 import { OmniSearch } from "./OmniSearch";
 
+import { MOD_POWER_ANNUL } from "misc";
+
 const body = $(document.body);
 
 function _update_theme(theme: string) {
@@ -275,7 +277,7 @@ export function NavBar(): JSX.Element {
                         {_("Rating Calculator")}
                     </Link>
 
-                    {(user.is_moderator || !!(user.moderator_powers & 1)) && (
+                    {(user.is_moderator || !!(user.moderator_powers & MOD_POWER_ANNUL)) && (
                         <Link className="admin-link" to="/reports-center">
                             <i className="fa fa-exclamation-triangle"></i>
                             {_("Reports Center")}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -275,7 +275,7 @@ export function NavBar(): JSX.Element {
                         {_("Rating Calculator")}
                     </Link>
 
-                    {(user.is_moderator || user.moderator_powers & 1) && (
+                    {(user.is_moderator || !!(user.moderator_powers & 1)) && (
                         <Link className="admin-link" to="/reports-center">
                             <i className="fa fa-exclamation-triangle"></i>
                             {_("Reports Center")}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -275,7 +275,7 @@ export function NavBar(): JSX.Element {
                         {_("Rating Calculator")}
                     </Link>
 
-                    {user.is_moderator && (
+                    {(user.is_moderator || user.moderator_powers & 1) && (
                         <Link className="admin-link" to="/reports-center">
                             <i className="fa fa-exclamation-triangle"></i>
                             {_("Reports Center")}

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -21,6 +21,8 @@ import { browserHistory } from "ogsHistory";
 import * as preferences from "preferences";
 import { alert } from "swal_config";
 
+export const MOD_POWER_ANNUL = 1; // Matches back-end MOD_POWER
+
 export type Timeout = ReturnType<typeof setTimeout>;
 
 export function updateDup(obj: any, field: string, value: any) {

--- a/src/lib/report_manager.ts
+++ b/src/lib/report_manager.ts
@@ -180,11 +180,11 @@ class ReportManager extends EventEmitter<Events> {
     public getAvailableReports(): Report[] {
         const user = data.get("user");
 
+        console.log(this.sorted_active_incident_reports);
         return this.sorted_active_incident_reports.filter((report) => {
             if (this.getIgnored(report.id)) {
                 return false;
             }
-
             return report.moderator === null || report.moderator.id === user.id;
         });
     }

--- a/src/lib/report_manager.ts
+++ b/src/lib/report_manager.ts
@@ -180,9 +180,11 @@ class ReportManager extends EventEmitter<Events> {
     public getAvailableReports(): Report[] {
         const user = data.get("user");
 
-        console.log(this.sorted_active_incident_reports);
         return this.sorted_active_incident_reports.filter((report) => {
             if (this.getIgnored(report.id)) {
+                return false;
+            }
+            if (!user.is_moderator && !(report.report_type === "score_cheating")) {
                 return false;
             }
             return report.moderator === null || report.moderator.id === user.id;
@@ -210,7 +212,6 @@ class ReportManager extends EventEmitter<Events> {
             }
 
             if (report.reported_review && other.reported_review === report.reported_review) {
-                console.log(other.reported_review, report.reported_review);
                 relationships.push("Same review");
             }
 

--- a/src/models/user.d.ts
+++ b/src/models/user.d.ts
@@ -61,6 +61,7 @@ declare namespace rest_api {
         is_moderator: boolean;
         is_superuser: boolean;
         is_tournament_moderator: boolean;
+        moderator_powers: number;
         supporter: boolean;
         supporter_level: number;
         tournament_admin: boolean;
@@ -115,6 +116,7 @@ declare namespace rest_api {
             ui_class_extra: null;
             is_moderator: boolean;
             is_superuser: boolean;
+            moderator_powers: number;
             is_tournament_moderator: boolean;
             is_bot: boolean;
             timeout_provisional: boolean;

--- a/src/models/user.d.ts
+++ b/src/models/user.d.ts
@@ -27,6 +27,7 @@ type Server =
     | "yike"
     | "goquest"
     | "badukpop";
+
 declare namespace rest_api {
     interface RatingsConfig {
         rating: number;
@@ -61,7 +62,7 @@ declare namespace rest_api {
         is_moderator: boolean;
         is_superuser: boolean;
         is_tournament_moderator: boolean;
-        moderator_powers: number;
+        moderator_powers: number; // a bit-field of MOD_POWER (see lib/misc)
         supporter: boolean;
         supporter_level: number;
         tournament_admin: boolean;

--- a/src/views/Game/GameDock.test.tsx
+++ b/src/views/Game/GameDock.test.tsx
@@ -22,6 +22,7 @@ const TEST_USER = {
     can_create_tournaments: true,
     is_moderator: false,
     is_superuser: false,
+    moderator_powers: 0,
     is_tournament_moderator: false,
     supporter: true,
     supporter_level: 4,

--- a/src/views/Game/PlayButtons.test.tsx
+++ b/src/views/Game/PlayButtons.test.tsx
@@ -22,6 +22,7 @@ const LOGGED_IN_USER = {
     can_create_tournaments: true,
     is_moderator: false,
     is_superuser: false,
+    moderator_powers: 0,
     is_tournament_moderator: false,
     supporter: true,
     supporter_level: 4,

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -23,6 +23,7 @@ const TEST_USER = {
     can_create_tournaments: true,
     is_moderator: false,
     is_superuser: false,
+    moderator_powers: 0,
     is_tournament_moderator: false,
     supporter: true,
     supporter_level: 4,

--- a/src/views/Game/PlayerCards.test.tsx
+++ b/src/views/Game/PlayerCards.test.tsx
@@ -23,6 +23,7 @@ const TEST_USER = {
     can_create_tournaments: true,
     is_moderator: false,
     is_superuser: false,
+    moderator_powers: 0,
     is_tournament_moderator: false,
     supporter: true,
     supporter_level: 4,

--- a/src/views/OnlineLeaguePlayerLanding/OnlineLeaguePlayerLanding.test.tsx
+++ b/src/views/OnlineLeaguePlayerLanding/OnlineLeaguePlayerLanding.test.tsx
@@ -31,6 +31,7 @@ const TEST_USER = {
     is_moderator: false,
     is_superuser: false,
     is_tournament_moderator: false,
+    moderator_powers: 0,
     supporter: false,
     supporter_level: 0,
     tournament_admin: false,

--- a/src/views/ReportsCenter/MessageTemplate.tsx
+++ b/src/views/ReportsCenter/MessageTemplate.tsx
@@ -23,6 +23,7 @@ import { alert } from "swal_config";
 import { post, put } from "requests";
 import { errorAlerter } from "misc";
 import { toast } from "toast";
+import { useUser } from "hooks";
 
 interface TemplateEntry {
     message: string;
@@ -434,6 +435,7 @@ export function MessageTemplate({
     const [template, setTemplate] = React.useState<TemplateEntry | null>(null);
     const [text, setText] = React.useState<string>(gpt ? gpt : "");
     const [log, setLog] = React.useState<boolean>(logByDefault);
+    const user = useUser();
 
     React.useEffect(() => {
         if (selectedTemplate && selectedTemplate !== "gpt") {
@@ -545,15 +547,17 @@ export function MessageTemplate({
                 <button className="clear" onClick={clear}>
                     Clear
                 </button>
-                <span className="log">
-                    <label htmlFor={"log" + uid}>Log</label>
-                    <input
-                        type="checkbox"
-                        id={"log" + uid}
-                        checked={log}
-                        onChange={(e) => setLog(e.target.checked)}
-                    />
-                </span>
+                {(user.is_moderator || null) && (
+                    <span className="log">
+                        <label htmlFor={"log" + uid}>Log</label>
+                        <input
+                            type="checkbox"
+                            id={"log" + uid}
+                            checked={log}
+                            onChange={(e) => setLog(e.target.checked)}
+                        />
+                    </span>
+                )}
             </div>
 
             <textarea value={text} onChange={(e) => setText(e.target.value)} />

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -289,7 +289,7 @@ function GameLog({ goban }: { goban: Goban }): JSX.Element {
                                 <td className="timestamp">
                                     {moment(entry.timestamp).format("L LTS")}
                                 </td>
-                                <td className="event">{entry.event}</td>
+                                <td className="event">{entry.event.replace(/_/g, " ")}</td>
                                 <td className="data">
                                     <LogData
                                         config={goban.engine.config}

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -41,6 +41,7 @@ import { Goban } from "goban";
 import { Resizable } from "Resizable";
 import { socket } from "sockets";
 import { Player } from "Player";
+import { useUser } from "hooks";
 
 export function ReportedGame({ game_id }: { game_id: number }): JSX.Element {
     const [goban, setGoban] = React.useState<Goban>(null);
@@ -53,6 +54,8 @@ export function ReportedGame({ game_id }: { game_id: number }): JSX.Element {
     const [game, setGame] = React.useState<rest_api.GameDetails>(null);
     const [, /* aiReviewUuid */ setAiReviewUuid] = React.useState<string | null>(null);
     const [annulled, setAnnulled] = React.useState<boolean>(false);
+
+    const user = useUser();
 
     const decide = React.useCallback(
         (winner: string) => {
@@ -221,18 +224,20 @@ export function ReportedGame({ game_id }: { game_id: number }): JSX.Element {
                         </div>
 
                         <div className="col">
-                            <GameTimings
-                                moves={goban.engine.config.moves}
-                                start_time={goban.engine.config.start_time}
-                                end_time={goban.engine.config.end_time}
-                                free_handicap_placement={
-                                    goban.engine.config.free_handicap_placement
-                                }
-                                handicap={goban.engine.config.handicap}
-                                black_id={goban.engine.config.black_player_id}
-                                white_id={goban.engine.config.white_player_id}
-                            />
-
+                            {(user.is_moderator /* community moderators don't see this secret stuff :o */ ||
+                                null) && (
+                                <GameTimings
+                                    moves={goban.engine.config.moves}
+                                    start_time={goban.engine.config.start_time}
+                                    end_time={goban.engine.config.end_time}
+                                    free_handicap_placement={
+                                        goban.engine.config.free_handicap_placement
+                                    }
+                                    handicap={goban.engine.config.handicap}
+                                    black_id={goban.engine.config.black_player_id}
+                                    white_id={goban.engine.config.white_player_id}
+                                />
+                            )}
                             <GameLog goban={goban} />
                         </div>
 

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -133,6 +133,10 @@ reports_center_content_width=56rem
             justify-content: stretch;
             align-content: stretch;
             padding: 0.5rem;
+
+            .event {
+                padding-right: 0.3rem;
+            }
         }
     }
 

--- a/src/views/ReportsCenter/ReportsCenter.tsx
+++ b/src/views/ReportsCenter/ReportsCenter.tsx
@@ -51,6 +51,7 @@ const categories: (ReportDescription | OtherView)[] = [
         { special: "history", title: "History" },
         { special: "settings", title: "Settings" },
     ]);
+
 const category_priorities: { [type: string]: number } = {};
 for (let i = 0; i < report_categories.length; ++i) {
     category_priorities[report_categories[i].type] = i;
@@ -118,7 +119,7 @@ export function ReportsCenter(): JSX.Element {
         navigateTo(`/reports-center/${category}`);
     }, []);
 
-    if (!user.is_moderator) {
+    if (!user.is_moderator && !user.moderator_powers) {
         return null;
     }
 
@@ -130,6 +131,11 @@ export function ReportsCenter(): JSX.Element {
         }
     };
 
+    const visible_categories = user.is_moderator
+        ? categories
+        : // community moderators only get to see score cheating reports at the moment
+          [report_categories.find((category) => category.type === "score_cheating")];
+
     return (
         <div className="ReportsCenter container">
             <h2 className="page-title">
@@ -139,7 +145,7 @@ export function ReportsCenter(): JSX.Element {
 
             <div id="ReportsCenterContainer">
                 <div id="ReportsCenterCategoryList">
-                    {categories.map((report_type, idx) => {
+                    {visible_categories.map((report_type, idx) => {
                         if ("type" in report_type) {
                             const ct = counts[report_type.type] || 0;
                             return (

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -352,7 +352,6 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     )}
                 </span>
             </div>
-
             <div className="reported-user">
                 <h3 className="users">
                     <span className="reported-user">
@@ -371,7 +370,6 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     </div>
                 </h3>
             </div>
-
             <div className="notes-container">
                 {(report.reporter_note || null) && (
                     <div className="notes">
@@ -416,10 +414,9 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     </div>
                 )}
             </div>
-
             <div className="actions">
                 <div className="related-reports">
-                    {related.length > 0 && (
+                    {related.length > 0 && user.is_moderator && (
                         <>
                             <h4>{_("Related Reports")}</h4>
                             <ul>
@@ -470,14 +467,11 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     )}
                 </div>
             </div>
-
             <hr />
-
             <div className="automod-analysis">
                 <b>Automod Analysis:</b>{" "}
                 <span className="analysis">{report.automod_to_moderator}</span>
             </div>
-
             <div className="message-templates">
                 <MessageTemplate
                     title="Accused"
@@ -498,35 +492,27 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     templates={REPORTER_RESPONSE_TEMPLATES}
                     game_id={report.reported_game}
                     gpt={report.automod_to_reporter}
-                    logByDefault={false}
+                    logByDefault={!user.is_moderator} // log community moderator actions
                     onSelect={claimReport}
                     onMessage={claimReport}
                 />
             </div>
-
             <hr />
-
-            <UserHistory user={report.reported_user} />
-
+            {(user.is_moderator || null) && <UserHistory user={report.reported_user} />}
             <hr />
-
             {(report.url || null) && (
                 <a href={report.url} target="_blank">
                     {report.url}
                 </a>
             )}
-
             {report.reported_game && <ReportedGame game_id={report.reported_game} />}
-
             {report.report_type === "appeal" && <AppealView user_id={report.reported_user.id} />}
-
             {report.reported_review && (
                 <span>
                     {_("Review")}:{" "}
                     <Link to={`/review/${report.reported_review}`}>##{report.reported_review}</Link>
                 </span>
             )}
-
             {report.reported_conversation && (
                 <div className="reported-conversation">
                     {report.reported_conversation.content.map((line, index) => (

--- a/src/views/Settings/AccountSettings.test.tsx
+++ b/src/views/Settings/AccountSettings.test.tsx
@@ -29,6 +29,7 @@ const TEST_USER = {
     can_create_tournaments: false,
     is_moderator: false,
     is_superuser: false,
+    moderator_powers: 0,
     is_tournament_moderator: false,
     supporter: false,
     supporter_level: 0,

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -120,6 +120,7 @@ export function User(props: { user_id?: number }): JSX.Element {
                     professional: responses[0].ui_class.indexOf("professional") >= 0,
                     is_moderator: responses[0].ui_class.indexOf("moderator") >= 0,
                     is_superuser: responses[0].ui_class.indexOf("admin") >= 0,
+                    moderator_powers: 0,
                     is_tournament_moderator: false,
                     is_watched: false,
                     on_vacation: false,


### PR DESCRIPTION
Fixes too few people attending to score cheat reports.

## Proposed Changes

Users can be given `MOD_POWER_ANNUL` as a `moderator_power`, via the edit user modal.

Users with `moderator_powers` can see score cheat reports, and claim them.   They can send warnings, system PMs.

Users with the `MOD_POWER_ANNUL` bit set can  annul games.

All community moderator messages, warnings are logged (forced, no choice)

Some sections of reports remain hidden (the anticipation is that these would be shown to users with `MOD_POWER_SEE_AI_TOOLS`).


Needs https://github.com/online-go/ogs/pull/1827 and https://github.com/online-go/ogs-node/pull/40

