### PR TITLE
added margin to center-col to resolve a dancing screen issue related …

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -288,8 +288,6 @@ goban-view-bar-width=400px
         }
     }
 
-
-
     .goban-container {
         flex-grow: 1;
         display: flex;
@@ -395,6 +393,7 @@ goban-view-bar-width=400px
         flex-direction: column;
         align-items: stretch;
         width: 100%;
+        margin: 0.5rem;
     }
     &.portrait .center-col {
         .cancel-button {


### PR DESCRIPTION
# Summary of Issue
Originally was attempting to recreate the issue described in #2164. Instead, managed to find a similar "dancing screen" bug related to the horizontal resizing of the site in a browser window. It seems at certain horizontal sizes the overlap between the center-col and adjacent containers would cause the flex-basis value to infinitely cycle between a range.

https://github.com/online-go/online-go.com/assets/59673146/e505101a-5aab-42fd-8a7d-6c63876dcc73

## Description of Changes
Within the styling of `center-col` in the `MainGobanView` container, a margin of 0.5 rem was added. This was done to create a consistent spacing between `center-col` and `right-col.` which in combination with the scroll bar appearing seemed to prevent `center-col` from choosing a consistent width/height value.

## Testing
This issue could potentially be browser specific so testing was done firstly in Opera GX then in Firefox. Both seeming to no longer contain this bug.