### PR TITLE
Created .styl for PlayControls and added a min width to avoid compone…

### DIFF
--- a/src/views/Game/PlayControls.styl
+++ b/src/views/Game/PlayControls.styl
@@ -1,0 +1,3 @@
+.play-controls {
+  min-height: 5rem;
+}


### PR DESCRIPTION
# Summery of Issue
It was noted in issue #1941 that when a user creates a variation then hovers over said variation. The chat area shakes and creates a visual bug.

The perceived cause of this issue being when a user hovers a variation, it removes the span `game-state`. This causes the `play-controls`  div to shrink in size with the chat area filling in the missing space. Since this moves elements on the screen the mouse will no longer be hovering over the variation and so `game-state` will now have a span element rendered again. increasing its size. Which in turn pushes the chat area back down placing the user's cursor on the variation once again, cycling infinitely.

## Description of Changes 

Added a .styl file for `PlayControls` and gave it a min-height. Allowing it to maintain a consistent size whether or not the `game-state` span is rendered.

5 rems was chosen as play-controls takes up a consistent 77.59 pixels when testing in my browser. Given the default size of a rem is 16px, we get 16*5 = 80 pixels which while technically larger is visually identical to the previous dimension.

## Testing
https://github.com/online-go/online-go.com/assets/59673146/e52d4cfc-6585-4b2d-bc16-23c01fa23a68

