### PR TITLE
Don't show the score during stone removal.

### DIFF
--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -277,7 +277,7 @@ export function PlayerCard({
     const highlight_their_turn = their_turn ? `their-turn` : "";
 
     const show_points =
-        (engine.phase === "finished" || engine.phase === "stone removal") &&
+        engine.phase === "finished" &&
         goban.mode !== "analyze" &&
         engine.outcome !== "Timeout" &&
         engine.outcome !== "Resignation" &&


### PR DESCRIPTION
Fixes tempting players to change the score by seeing the actual score there.

## Proposed Changes

Don't show score during stone removal.
