### PR TITLE
Change default AI review to use score

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -23,7 +23,7 @@ import { DataSchema } from "./data_schema";
 
 export const defaults = {
     "ai-review-enabled": true,
-    "ai-review-use-score": false,
+    "ai-review-use-score": true,
     "ai-summary-table-show": false,
     "always-disable-analysis": false,
     "asked-to-enable-desktop-notifications": false,


### PR DESCRIPTION
## Proposed Changes

  - Changes default AI review to use score instead of win percentage

Maybe this is only at lower levels where this is a problem, but the win % just jumps between 99% black winning and 99% white winning, rarely anything in between. The score is much more useful because it's easier to compare how big your mistakes are and how narrow the margin of victory is expected to be. I assume that it's only very high level players where the win percentages don't jump so drastically. If that's the case, it seems like using the score is a better default, and high level players can change it to win % if they'd like.
