### PR TITLE
Add to SGF Library Directly From Game

### DIFF
--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -313,6 +313,7 @@ export function GameDock({
             : engine.playerNotToMove();
 
     const showLibraryModal = () => {
+        // Pull user data prior to opening modal preventing component from rendering prior to obtaining needed data
         const user = data.get("user");
         const promise = get("library/%%", user.id);
         promise

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -20,7 +20,7 @@ import * as data from "data";
 import * as preferences from "preferences";
 import { MAX_DOCK_DELAY } from "SettingsCommon";
 import { useUser } from "hooks";
-import { api1, post, del } from "requests";
+import { api1, post, del, get } from "requests";
 import { Dock } from "Dock";
 import { Link } from "react-router-dom";
 import { toast } from "toast";
@@ -28,6 +28,7 @@ import { _, pgettext } from "translate";
 import { openACLModal } from "ACLModal";
 import { openGameLinkModal } from "./GameLinkModal";
 import { openGameLogModal } from "./GameLogModal";
+import { openGameLibraryModal } from "./GameLibraryModal";
 import { sfx } from "sfx";
 import { alert } from "swal_config";
 import { challengeFromBoardPosition } from "ChallengeModal/ForkModal";
@@ -311,6 +312,18 @@ export function GameDock({
             ? engine.playerToMove()
             : engine.playerNotToMove();
 
+    const showLibraryModal = () => {
+        const user = data.get("user");
+        const promise = get("library/%%", user.id);
+        promise
+            .then(async (library) => {
+                const test = await library.collections;
+                console.log(typeof library.collections);
+                openGameLibraryModal(test);
+            })
+            .catch(errorAlerter);
+    };
+
     return (
         <Dock>
             {(tournament_id || null) && (
@@ -501,6 +514,16 @@ export function GameDock({
                     <i className="fa fa-download"></i> {_("Download SGF")}
                 </a>
             )}
+
+            {/* Flotsam */}
+            {
+                <Tooltip tooltipRequired={tooltipRequired} title={_("Yur")}>
+                    <a onClick={showLibraryModal}>
+                        <i className="fa fa-download"></i> {_("Yur")}
+                    </a>
+                </Tooltip>
+            }
+
             {sgf_download_enabled && sgf_with_ai_review_url && (
                 <Tooltip tooltipRequired={tooltipRequired} title={_("SGF with AI Review")}>
                     <a href={sgf_with_ai_review_url} target="_blank">

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -318,7 +318,7 @@ export function GameDock({
         promise
             .then(async (library) => {
                 const userLibrary = await library.collections;
-                openGameLibraryModal(userLibrary, game_id);
+                openGameLibraryModal(user.id, userLibrary, game_id);
             })
             .catch(errorAlerter);
     };

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -317,8 +317,8 @@ export function GameDock({
         const promise = get("library/%%", user.id);
         promise
             .then(async (library) => {
-                const test = await library.collections;
-                openGameLibraryModal(test, game_id);
+                const userLibrary = await library.collections;
+                openGameLibraryModal(userLibrary, game_id);
             })
             .catch(errorAlerter);
     };

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -318,8 +318,7 @@ export function GameDock({
         promise
             .then(async (library) => {
                 const test = await library.collections;
-                console.log(typeof library.collections);
-                openGameLibraryModal(test);
+                openGameLibraryModal(test, game_id);
             })
             .catch(errorAlerter);
     };
@@ -515,11 +514,11 @@ export function GameDock({
                 </a>
             )}
 
-            {/* Flotsam */}
+            {/* Add To Library functionality */}
             {
-                <Tooltip tooltipRequired={tooltipRequired} title={_("Yur")}>
+                <Tooltip tooltipRequired={tooltipRequired} title={_("Save to Library")}>
                     <a onClick={showLibraryModal}>
-                        <i className="fa fa-download"></i> {_("Yur")}
+                        <i className="fa fa-book"></i> {_("Save to Library")}
                     </a>
                 </Tooltip>
             }

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -516,13 +516,6 @@ export function GameDock({
             )}
 
             {/* Add To Library functionality */}
-            {
-                <Tooltip tooltipRequired={tooltipRequired} title={_("Save to Library")}>
-                    <a onClick={showLibraryModal}>
-                        <i className="fa fa-book"></i> {_("Save to Library")}
-                    </a>
-                </Tooltip>
-            }
 
             {sgf_download_enabled && sgf_with_ai_review_url && (
                 <Tooltip tooltipRequired={tooltipRequired} title={_("SGF with AI Review")}>
@@ -531,6 +524,13 @@ export function GameDock({
                     </a>
                 </Tooltip>
             )}
+            {
+                <Tooltip tooltipRequired={tooltipRequired} title={_("Save to Library")}>
+                    <a onClick={showLibraryModal}>
+                        <i className="fa fa-book"></i> {_("Save to Library")}
+                    </a>
+                </Tooltip>
+            }
             {sgf_download_enabled && sgf_with_comments_url && (
                 <Tooltip tooltipRequired={tooltipRequired} title={_("SGF with comments")}>
                     <a href={sgf_with_comments_url} target="_blank">

--- a/src/views/Game/GameLibraryModal.styl
+++ b/src/views/Game/GameLibraryModal.styl
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.GameLibraryModal.Modal {
+  width: 100%;
+  max-width 40rem;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  
+  
+  h1 {
+    text-align: center;
+  }
+
+  // long specifier to make sure this specific column is not overriden
+    #collection-list .collection-row .cell.rengo-list-buttons {
+        text-align: center;
+        width: 10rem;
+        padding-right: 1rem;
+        //vertical-align: baseline; // attempting to line up with rest of cell rows
+
+
+  .cell {
+            padding-left: 0.5em;
+            display: table-cell;
+            text-align: left;
+            position: relative;
+        }
+}

--- a/src/views/Game/GameLibraryModal.styl
+++ b/src/views/Game/GameLibraryModal.styl
@@ -17,28 +17,35 @@
 
 .GameLibraryModal.Modal {
   width: 100%;
-  max-width 40rem;
-  justify-content: center;
-  align-items: center;
+  max-width: 40rem;
+  padding: 1rem;
   display: flex;
-  
-  
-  h1 {
-    text-align: center;
+  flex-direction: row;
+  align-items: center;
+
+  .file-name-inputfield{
+    margin: 1rem;  
   }
+}
+.collection-list {
+  display:flex;
+  width: 100%;
+  flex-direction: column;
+  align-content: stretch;
+  align-items: center;
+}
 
-  // long specifier to make sure this specific column is not overriden
-    #collection-list .collection-row .cell.rengo-list-buttons {
-        text-align: center;
-        width: 10rem;
-        padding-right: 1rem;
-        //vertical-align: baseline; // attempting to line up with rest of cell rows
+.collection-row {
+  width: 100%
+  display:flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
 
-
-  .cell {
-            padding-left: 0.5em;
-            display: table-cell;
-            text-align: left;
-            position: relative;
-        }
+.cell {
+  max-width: 20rem;
+  padding-left: 0.5em;
+  display: table-cell;
+  text-align: left;
+  position: relative;
 }

--- a/src/views/Game/GameLibraryModal.tsx
+++ b/src/views/Game/GameLibraryModal.tsx
@@ -32,6 +32,7 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
         super(props);
     }
 
+    /*
     addToLibrary = () => {
         //goto url endpoint that downloads the sgf file
         fetch(api1(`games/${this.props.gameID}/sgf`))
@@ -44,6 +45,29 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
 
         // If im correct then we call post("me/games/sgf/%%", collection_id, file) to have this file saved to the given library
     };
+    */
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async addToLibrary(collection_id) {
+        const url = api1(`games/${this.props.gameID}/sgf`);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const gameSGF = await fetch(url, {
+            method: "GET",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                const blob = new Blob([data as BlobPart]);
+                const file = new File([blob], "foo.txt", { type: "application/json" });
+                return file;
+            })
+            .catch(errorAlerter);
+
+        // This part comes later once i manipulate the response correctly
+        //post("me/games/sgf/%%", collection_id, gameSGF).catch(errorAlerter);
+    }
 
     render() {
         const data: any = JSON.stringify(this.props.userLibrary);
@@ -61,7 +85,7 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
                                 <h1>{data[index]}</h1>
                             </span>
                             <span className="cell">
-                                <button onClick={() => this.addToLibrary()}>add</button>
+                                <button onClick={() => this.addToLibrary(data.id)}>add</button>
                             </span>
                         </div>
                     ))}

--- a/src/views/Game/GameLibraryModal.tsx
+++ b/src/views/Game/GameLibraryModal.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { openModal, Modal } from "Modal";
+//import { get } from "requests";
+//import * as data from "data";
+//import { errorAlerter } from "misc";
+
+interface Events {}
+
+interface GameLibraryModalProperties {
+    userLibrary: any;
+}
+
+export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, {}> {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        const data: any = JSON.stringify(this.props.userLibrary);
+        const json = JSON.parse(data);
+        json.map((data) => {
+            console.log(data[1]);
+        });
+        return (
+            <div className="Modal GameLibraryModal">
+                <div className="collection-list">
+                    <h1>Libraries</h1>
+                    {json.map((data, index) => (
+                        <div className="collection-row" key={data.id}>
+                            <span className="cell">
+                                <i className="fa fa-book" />
+                            </span>
+                            <span className="cell">
+                                <h1>{data[index]}</h1>
+                            </span>
+                            <span className="cell">
+                                <button>add</button>
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+}
+
+export function openGameLibraryModal(userLibrary: any): void {
+    openModal(<GameLibraryModal userLibrary={userLibrary} fastDismiss />);
+}

--- a/src/views/Game/GameLibraryModal.tsx
+++ b/src/views/Game/GameLibraryModal.tsx
@@ -17,14 +17,14 @@
 
 import * as React from "react";
 import { openModal, Modal } from "Modal";
-//import { get } from "requests";
-//import * as data from "data";
-//import { errorAlerter } from "misc";
+import { api1 } from "requests";
+import { errorAlerter } from "misc";
 
 interface Events {}
 
 interface GameLibraryModalProperties {
     userLibrary: any;
+    gameID: number;
 }
 
 export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, {}> {
@@ -32,12 +32,22 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
         super(props);
     }
 
+    addToLibrary = () => {
+        //goto url endpoint that downloads the sgf file
+        fetch(api1(`games/${this.props.gameID}/sgf`))
+            .then((data) => {
+                // data should contain the sgf file which is automatically downloaded when a user visits the same endpoint
+                const file = data;
+                console.log(file);
+            })
+            .catch(errorAlerter);
+
+        // If im correct then we call post("me/games/sgf/%%", collection_id, file) to have this file saved to the given library
+    };
+
     render() {
         const data: any = JSON.stringify(this.props.userLibrary);
         const json = JSON.parse(data);
-        json.map((data) => {
-            console.log(data[1]);
-        });
         return (
             <div className="Modal GameLibraryModal">
                 <div className="collection-list">
@@ -51,7 +61,7 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
                                 <h1>{data[index]}</h1>
                             </span>
                             <span className="cell">
-                                <button>add</button>
+                                <button onClick={() => this.addToLibrary()}>add</button>
                             </span>
                         </div>
                     ))}
@@ -61,6 +71,6 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
     }
 }
 
-export function openGameLibraryModal(userLibrary: any): void {
-    openModal(<GameLibraryModal userLibrary={userLibrary} fastDismiss />);
+export function openGameLibraryModal(userLibrary: any, gameID: number): void {
+    openModal(<GameLibraryModal userLibrary={userLibrary} gameID={gameID} fastDismiss />);
 }

--- a/src/views/Game/GameLibraryModal.tsx
+++ b/src/views/Game/GameLibraryModal.tsx
@@ -36,6 +36,7 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
             gameName: "",
             collectionName: "",
             collections: [],
+            gameAdded: false,
         };
     }
 
@@ -82,6 +83,7 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
                 post("me/games/sgf/%%", collection[0], gameFile).catch(errorAlerter);
                 this.resetTextFields();
                 this.close(); // Closes modal after creating post request
+                this.setState({ gameAdded: true });
             })
             .catch(errorAlerter);
     }
@@ -107,28 +109,46 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
             <div className="Modal GameLibraryModal">
                 <div className="collection-list">
                     <h1>Libraries</h1>
-                    <input
-                        className="file-name-inputfield"
-                        type="text"
-                        value={this.state.gameName}
-                        onChange={this.setGameName}
-                        placeholder={_("Insert SGF File Name")}
-                    />
+
                     {/* If user has collections in their library map and render them. Otherwise; allow user to create collection */}
                     {this.state.collections.length > 0 ? (
-                        this.state.collections.map((data) => (
-                            <div className="collection-row" key={data.id}>
-                                <span className="cell">
-                                    <h1>{data[1]}</h1>
-                                </span>
-                                <span className="cell">
-                                    <button onClick={() => this.addToLibrary(data)}>add</button>
-                                </span>
-                            </div>
-                        ))
+                        <>
+                            <span>
+                                <i className="fa fa-file" />
+                                <input
+                                    className="file-name-inputfield"
+                                    type="text"
+                                    value={this.state.gameName}
+                                    onChange={this.setGameName}
+                                    placeholder={_("Insert SGF File Name")}
+                                />
+                            </span>
+
+                            {this.state.collections.map((data) => (
+                                <div className="collection-row" key={data.id}>
+                                    <span className="cell">
+                                        <h1>{data[1]}</h1>
+                                    </span>
+                                    <span className="cell">
+                                        <button onClick={() => this.addToLibrary(data)}>add</button>
+                                    </span>
+                                </div>
+                            ))}
+                        </>
                     ) : (
-                        <div>
+                        <div className="collection-row">
                             <span className="cell">
+                                <i className="fa fa-file" />
+                                <input
+                                    className="file-name-inputfield"
+                                    type="text"
+                                    value={this.state.gameName}
+                                    onChange={this.setGameName}
+                                    placeholder={_("Insert SGF File Name")}
+                                />
+                            </span>
+                            <span className="cell">
+                                <i className="fa fa-folder" />
                                 <input
                                     type="text"
                                     value={this.state.collectionName}

--- a/src/views/Game/GameLibraryModal.tsx
+++ b/src/views/Game/GameLibraryModal.tsx
@@ -40,9 +40,9 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
     }
 
     componentDidMount(): void {
-        const data: any = JSON.stringify(this.props.userLibrary);
-        const json = JSON.parse(data);
-        this.setState({ collections: json });
+        const userLibrary: any = JSON.stringify(this.props.userLibrary);
+        const userlibraryJSON = JSON.parse(userLibrary);
+        this.setState({ collections: userlibraryJSON });
     }
 
     setGameName = (ev) => {
@@ -53,36 +53,50 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
         this.setState({ collectionName: ev.target.value });
     };
 
+    resetTextFields = () => {
+        this.setState({ gameName: "" });
+        this.setState({ collectionName: "" });
+    };
+
     async addToLibrary(collection) {
         const url = api1(`games/${this.props.gameID}/sgf`);
         await fetch(url, {
             method: "GET",
-            // Specifically set header otherwise 415 error
+            // Specify the content-type of the request otherwise the "games/%%/sgf" endpoint will respond with a 415 error code
             headers: {
                 "Content-Type": "application/json",
             },
         })
             .then((response) => response.blob())
             .then((data) => {
-                const sgfName = `${this.state.gameName}.sgf`;
-                const gameFile = new File([data as BlobPart], sgfName, {
+                // Pull sgfName from value implemented by user setting a default value if empty
+                let gameName = this.state.gameName;
+                if (this.state.gameName === "") {
+                    gameName = `My Game #${this.props.gameID}`;
+                }
+                const gameFile = new File([data as BlobPart], `${gameName}.sgf`, {
                     type: "application/x-go-sgf",
                     lastModified: new Date().getTime(),
                 });
-                this.setState({ gameName: "" });
+                // Create post request adding SGF File to the given collection using collection's id
                 post("me/games/sgf/%%", collection[0], gameFile).catch(errorAlerter);
+                this.resetTextFields();
+                this.close(); // Closes modal after creating post request
             })
             .catch(errorAlerter);
     }
 
-    createCollection() {
-        console.log("clicked!");
+    async createCollection() {
+        if (this.state.collectionName === "") {
+            await this.setState({ collectionName: "My_Collection" });
+        }
+        // Create a new library within the user's libraries
         post("library/%%/collections", this.props.userID, {
             name: this.state.collectionName,
         })
             .then((res) => {
+                // Pull the newly created collection's id to be used to identify which collection we add our SGF File too
                 const collection_id = [res.collection_id];
-                console.log("HERE " + collection_id);
                 this.addToLibrary(collection_id).catch(errorAlerter);
             })
             .catch(errorAlerter);
@@ -94,17 +108,16 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
                 <div className="collection-list">
                     <h1>Libraries</h1>
                     <input
+                        className="file-name-inputfield"
                         type="text"
                         value={this.state.gameName}
                         onChange={this.setGameName}
                         placeholder={_("Insert SGF File Name")}
                     />
+                    {/* If user has collections in their library map and render them. Otherwise; allow user to create collection */}
                     {this.state.collections.length > 0 ? (
                         this.state.collections.map((data) => (
                             <div className="collection-row" key={data.id}>
-                                <span className="cell">
-                                    <i className="fa fa-book" />
-                                </span>
                                 <span className="cell">
                                     <h1>{data[1]}</h1>
                                 </span>
@@ -122,6 +135,8 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
                                     onChange={this.setCollectionName}
                                     placeholder={_("Insert Collection Name")}
                                 />
+                            </span>
+                            <span className="cell">
                                 <button onClick={() => this.createCollection()}>
                                     Create Collection
                                 </button>

--- a/src/views/Game/GameLibraryModal.tsx
+++ b/src/views/Game/GameLibraryModal.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { openModal, Modal } from "Modal";
 import { api1, post } from "requests";
 import { errorAlerter } from "misc";
+import { _ } from "translate";
 
 interface Events {}
 
@@ -27,27 +28,19 @@ interface GameLibraryModalProperties {
     gameID: number;
 }
 
-export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, {}> {
+export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, any> {
     constructor(props) {
         super(props);
+        this.state = {
+            gameName: "",
+        };
     }
 
-    /*
-    addToLibrary = () => {
-        //goto url endpoint that downloads the sgf file
-        fetch(api1(`games/${this.props.gameID}/sgf`))
-            .then((data) => {
-                // data should contain the sgf file which is automatically downloaded when a user visits the same endpoint
-                const file = data;
-                console.log(file);
-            })
-            .catch(errorAlerter);
-
-        // If im correct then we call post("me/games/sgf/%%", collection_id, file) to have this file saved to the given library
+    setGameName = (ev) => {
+        console.log("HERE " + ev.target.value);
+        this.setState({ gameName: ev.target.value });
     };
-    */
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async addToLibrary(collection) {
         const url = api1(`games/${this.props.gameID}/sgf`);
         await fetch(url, {
@@ -59,21 +52,15 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
         })
             .then((response) => response.blob())
             .then((data) => {
-                const gameFile = new File([data as BlobPart], `Game# ${this.props.gameID}.sgf`, {
+                const sgfName = `${this.state.gameName}.sgf`;
+                const gameFile = new File([data as BlobPart], sgfName, {
                     type: "application/x-go-sgf",
                     lastModified: new Date().getTime(),
                 });
-                const reader = new FileReader();
-                reader.readAsText(gameFile);
-                reader.onload = function () {
-                    //console.log(collection);
-                };
+                this.setState({ gameName: "" });
                 post("me/games/sgf/%%", collection[0], gameFile).catch(errorAlerter);
             })
             .catch(errorAlerter);
-
-        // This part comes later once i manipulate the response correctly
-        //post("me/games/sgf/%%", collection_id, gameSGF).catch(errorAlerter);
     }
 
     render() {
@@ -83,13 +70,19 @@ export class GameLibraryModal extends Modal<Events, GameLibraryModalProperties, 
             <div className="Modal GameLibraryModal">
                 <div className="collection-list">
                     <h1>Libraries</h1>
-                    {json.map((data, index) => (
+                    <input
+                        type="text"
+                        value={this.state.gameName}
+                        onChange={this.setGameName}
+                        placeholder={_("Insert SGF File Name")}
+                    />
+                    {json.map((data) => (
                         <div className="collection-row" key={data.id}>
                             <span className="cell">
                                 <i className="fa fa-book" />
                             </span>
                             <span className="cell">
-                                <h1>{data[index]}</h1>
+                                <h1>{data[1]}</h1>
                             </span>
                             <span className="cell">
                                 <button onClick={() => this.addToLibrary(data)}>add</button>


### PR DESCRIPTION
## Summery of Issue and Implementation
There is a feature request to add an in game option to save the given game to a user's SGF Library #2210.

I wish to attempt this issue and have begun implementing a very rough Modal and Tooltip component to allow for this request.
However, it seems I've run into 2 issues while working with this.

Firstly, It seems from looking through other post requests made in the code. The only way to add a file to library is to make a post to `me/games/sgf/%%`. With the additional parameters of `collection_id` and a `SGF file`. But the only way to obtain the SGF file without the user having to manually download then upload it themselves is to access the `api1('games/${game_id}/sgf')` endpoint directly. This doesn't seem like a major issue, we would simply use api1 to receive the file at the endpoint and use that to then make the post call to have the same file added to the user's library.

Unfortunately I run into my second issue being that the api1 endpoint does not work in the development environment (or at least not for me). So I'm unsure if simply calling a fetch (or get?) on it would actually result in obtaining the file, and without being able to test that myself I can't move forward with seeing if I can post the fetched file into the user's library.

I'm hoping for a bit of guidance from those more comfortable with this codebase to either confirm my current thinking and setup "should" work or if there is a simpler/better way to access the SGF file using some request I'm unaware of. From there I would make a more official PR to test the functionality and move on with my implementation from there.
