### PR TITLE
Noted that report_types are a back-end enumeration

### DIFF
--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -27,7 +27,8 @@ import { setIgnore } from "BlockPlayer";
 import { useUser } from "hooks";
 
 export type ReportType =
-    | "all"
+    | "all" // not a type, just useful for the enumeration
+    // These need to match those defined in the IncidentReport model on the back end
     | "stalling"
     | "inappropriate_content"
     | "score_cheating"


### PR DESCRIPTION
Just highlighting that the ReportTypes are an enumeration on the back end.

Matches https://github.com/online-go/ogs/pull/1829
