### PR TITLE
Anti griefing features

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "express": "^4.17.1",
         "express-http-proxy": "^1.6.0",
         "fork-ts-checker-webpack-plugin": "^8.0.0",
-        "goban": "=0.7.11",
+        "goban": "=0.7.13",
         "gulp": "^4.0.2",
         "gulp-clean-css": "^4.3.0",
         "gulp-eslint-new": "^1.7.1",

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -155,8 +155,9 @@ export function uuid(): string {
     });
 }
 export function getOutcomeTranslation(outcome: string) {
-    /* Note: for the case statements, don't simply do `pgettext("Game outcome", outcome)`,
-     * the system to parse out strings to translate needs the text. */
+    /* Note: Do not simply do `pgettext("Game outcome", outcome)`
+     * The translation system needs to read these strings to parse them out and
+     * prepare them for translating. */
     switch (outcome) {
         case "resign":
         case "r":
@@ -176,6 +177,10 @@ export function getOutcomeTranslation(outcome: string) {
             return pgettext("Game outcome", "Moderator Decision");
         case "Abandonment":
             return pgettext("Game outcome", "Abandonment");
+    }
+
+    if (outcome.indexOf("Server Decision") === 0) {
+        return pgettext("Game outcome", "Server Decision") + " " + outcome.substring(16);
     }
 
     if (/[0-9.]+/.test(outcome)) {

--- a/src/views/Game/AntiGrief.styl
+++ b/src/views/Game/AntiGrief.styl
@@ -16,7 +16,7 @@
  */
 
 
-.AntiStalling {
+.AntiStalling, .AntiEscaping {
     display: flex;
     align-items: center;
     justify-content: space-around;

--- a/src/views/Game/AntiGrief.styl
+++ b/src/views/Game/AntiGrief.styl
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+.AntiStalling {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    flex-direction: column;
+    min-height: 8rem;
+    font-size: 1.1rem;
+}

--- a/src/views/Game/AntiGrief.styl
+++ b/src/views/Game/AntiGrief.styl
@@ -17,10 +17,18 @@
 
 
 .AntiStalling, .AntiEscaping {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: space-around;
     flex-direction: column;
+    margin: 0.5rem;
+    width: calc(100% - 2.2rem) !important;
     min-height: 8rem;
+    text-align: center;
     font-size: 1.1rem;
+    border-radius: 0.5rem;
+
+    button {
+        white-space: nowrap !important;
+    }
 }

--- a/src/views/Game/AntiGrief.tsx
+++ b/src/views/Game/AntiGrief.tsx
@@ -185,7 +185,7 @@ function AntiEscaping(): JSX.Element {
                 >
                     {pgettext(
                         "This button is shown when one player has left the game, it allows the other player to end the game and claim victory",
-                        "End game",
+                        "Claim victory",
                     )}
                 </button>
 

--- a/src/views/Game/AntiGrief.tsx
+++ b/src/views/Game/AntiGrief.tsx
@@ -55,7 +55,7 @@ function checkForLeavingLiveGame(pathname: string) {
             const t = toast(
                 <div>
                     {_(
-                        "You are leaving a live game. If you do not return you will forfeit the match.",
+                        "You have left a live game. If you do not return you will forfeit the match.",
                     )}
                 </div>,
             );
@@ -189,17 +189,18 @@ function AntiEscaping(): JSX.Element {
                     )}
                 </button>
 
+                {/*
                 <button
                     className="danger"
                     onClick={() => goban?.sendPreventEscaping(my_color, true)}
                 >
                     {pgettext(
                         "This button is shown when one player has left the game, it allows the other player to end the game and claim victory",
-                        "End game and annul the result",
+                        "End game and don't rate",
                     )}
                 </button>
-            </div>
-            <div>
+                </div> <div>
+                */}
                 <button onClick={() => goban?.pauseGame()}>{_("Pause game")}</button>
             </div>
         </Card>

--- a/src/views/Game/AntiGrief.tsx
+++ b/src/views/Game/AntiGrief.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { Card } from "material";
+import { pgettext, _ } from "translate";
+import { useGoban } from "./goban_context";
+import { useUser } from "hooks";
+
+export function AntiGrief(): JSX.Element {
+    return (
+        <>
+            <AntiStalling />
+        </>
+    );
+}
+
+function AntiStalling(): JSX.Element {
+    const user = useUser();
+    const goban = useGoban();
+    const [estimate, setEstimate] = React.useState(null);
+    const [phase, setPhase] = React.useState(goban?.engine?.phase);
+
+    React.useEffect(() => {
+        const onScoreEstimate = (estimate) => {
+            setEstimate(estimate);
+        };
+
+        onScoreEstimate(goban.config?.stalling_score_estimate);
+        goban.on("stalling_score_estimate", onScoreEstimate);
+
+        return () => {
+            goban.off("stalling_score_estimate", onScoreEstimate);
+        };
+    }, [goban, goban.config?.stalling_score_estimate]);
+
+    React.useEffect(() => {
+        setPhase(goban?.engine?.phase);
+    }, [goban?.engine?.phase]);
+
+    if (!estimate) {
+        return null;
+    }
+
+    if (phase !== "play") {
+        return null;
+    }
+
+    if (
+        user.id !== goban?.engine?.config?.black_player_id &&
+        user.id !== goban?.engine?.config?.white_player_id &&
+        !user.is_moderator
+    ) {
+        return null;
+    }
+
+    // capitalize first letter
+    const predicted_winner =
+        estimate.predicted_winner.charAt(0).toUpperCase() + estimate.predicted_winner.slice(1);
+    const win_rate = (
+        (estimate.win_rate > 0.5 ? estimate.win_rate : 1.0 - estimate.win_rate) * 100.0
+    ).toFixed(1);
+
+    return (
+        <Card className="AntiStalling">
+            <div>
+                {pgettext(
+                    "This message is shown when the server thinks the game is over, but one player is stalling the game by continually playing useless moves",
+                    "Predicted winner: ",
+                )}{" "}
+                {_(predicted_winner)} ({win_rate}%)
+            </div>
+            <div>
+                <button
+                    className="danger"
+                    onClick={() => goban?.sendPreventStalling(estimate.predicted_winner)}
+                >
+                    {pgettext(
+                        "This message is shown when the server thinks the game is over, but one player is stalling the game by continually playing useless moves",
+                        "Accept predicted winner and end game",
+                    )}
+                </button>
+            </div>
+        </Card>
+    );
+}

--- a/src/views/Game/AntiGrief.tsx
+++ b/src/views/Game/AntiGrief.tsx
@@ -178,7 +178,7 @@ function AntiStalling(): JSX.Element {
         return null;
     }
 
-    if (phase !== "play") {
+    if (phase !== "play" && phase !== "stone removal") {
         return null;
     }
 
@@ -187,6 +187,11 @@ function AntiStalling(): JSX.Element {
         user.id !== goban?.engine?.config?.white_player_id &&
         !user.is_moderator
     ) {
+        return null;
+    }
+
+    if (estimate.move_number + 1 < goban.engine?.cur_move?.move_number) {
+        // If we've placed a move since the estimate was made, we don't need to show it anymore
         return null;
     }
 

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -271,8 +271,6 @@ export function PlayControls({
                     </span>
                 )}
 
-                <AntiGrief />
-
                 {((mode === "play" && phase === "stone removal") || null) && (
                     <span>{_("Stone Removal Phase")}</span>
                 )}
@@ -472,6 +470,7 @@ export function PlayControls({
                     </div>
                 </div>
             )}
+            <AntiGrief />
             {(mode === "conditional" || null) && (
                 <div className="conditional-move-planner">
                     <div className="buttons">

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -57,6 +57,7 @@ import { is_valid_url } from "url_validation";
 import { enableTouchAction } from "./touch_actions";
 import { ConditionalMoveTreeDisplay } from "./ConditionalMoveTreeDisplay";
 import { useUser } from "hooks";
+import { AntiGrief } from "./AntiGrief";
 
 import * as moment from "moment";
 
@@ -269,6 +270,9 @@ export function PlayControls({
                         )}
                     </span>
                 )}
+
+                <AntiGrief />
+
                 {((mode === "play" && phase === "stone removal") || null) && (
                     <span>{_("Stone Removal Phase")}</span>
                 )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5352,10 +5352,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-goban@=0.7.11:
-  version "0.7.11"
-  resolved "https://registry.yarnpkg.com/goban/-/goban-0.7.11.tgz#e8fedbc1605b65119f76e45b1b59512fdb97407e"
-  integrity sha512-49viNOEoE6fQvRGKTiCRKmvFtLYu3AMq9ipK4/TjwP42U8gNzyaoo+vygGUFIK0t/Jd1R7QRm65OeSKuxKArwA==
+goban@=0.7.13:
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/goban/-/goban-0.7.13.tgz#a17ca1ab1931dc8b313c72ca894cdfbea463a8e3"
+  integrity sha512-sKoHlvBiexrjYSDXPvmIeW/ciGJkOkuKOt2E2dLwmTFqF9yfUTcDGFXHTATDDLEJt8XrgLXCa1vD00pJYEtFlA==
   dependencies:
     eventemitter3 "^5.0.0"
 


### PR DESCRIPTION
This patch includes two features to help thwart people being rude and unsportsmanlike.

The Anti-stalling code will appear if your opponent is not passing, the game is toward the end, and KataGo thinks there is a >99% chance that one of the players will be victorious. In that case, the players will be given a special control box under their play controls to end the game:

![image](https://github.com/online-go/online-go.com/assets/168460/0c9c96bb-ea55-487e-aa0a-1d6a439d66d3)


Similarly, the anti-escaping code will appear if a player has seemingly left a live game without finishing it. This box will show up after 30 seconds has passed and gives the opportunity to the remaining player to end the game immediately or continue waiting to see if their opponent returns.

![image](https://github.com/online-go/online-go.com/assets/168460/dde1c39b-3753-4263-a76a-b43982ca9b55)


The person who left the game will also be shown a `Toast` in the upper left informing them that this will happen, clicking the toast will bring them back to the game.

![image](https://github.com/online-go/online-go.com/assets/168460/ee07cf30-a382-4991-b3d8-3e8a3bf0e889)


