### PR TITLE
Handle went away

### DIFF
--- a/src/components/NetworkStatus/NetworkStatus.styl
+++ b/src/components/NetworkStatus/NetworkStatus.styl
@@ -23,6 +23,7 @@
     justify-content: center;
     font-weight: bold;
     padding-right: 1rem;
+    border-radius: 0.3rem;
 
     .icon {
         position: relative;

--- a/src/components/NetworkStatus/NetworkStatus.tsx
+++ b/src/components/NetworkStatus/NetworkStatus.tsx
@@ -24,8 +24,10 @@ import { socket } from "sockets";
 // Don't warn about the network for this amount of time
 const INITIAL_CONNECTION_TIME = 6000;
 
+type NetworkStatusState = "connected" | "disconnected" | "timeout";
+
 export function NetworkStatus(): JSX.Element {
-    const [state, setState] = React.useState("connected");
+    const [state, setState] = React.useState<NetworkStatusState>("connected");
 
     React.useEffect(() => {
         const clear = () => {
@@ -67,8 +69,9 @@ export function NetworkStatus(): JSX.Element {
         // This funky little thing builds an icon that is intended to say
         // "no wifi!", by superimposing a large "ban" icon over a normal sized
         // "wifi" icon.
-        // That is a achieved by the accompanying css - which also causes
-        // the whole thing to be hidden if `hidden` is true.
+
+        // We don't show this if they're 'connected' (see above, return null)
+
         <div className={"NetworkStatus " + state}>
             <span className="icon">
                 <i className="fa fa-2x fa-ban" />


### PR DESCRIPTION
Fixes "disconnect" showing when the socket goes down for legitimate reasons, like browsing away

## Proposed Changes
 * Notice if it went down for a legitimate reason, don't show an error.

Needs: https://github.com/online-go/goban/pull/133

Is on top of #2385