### PR TITLE
Notice if a person is playing live with high latency and warn them

### DIFF
--- a/src/components/NetworkStatus/NetworkStatus.tsx
+++ b/src/components/NetworkStatus/NetworkStatus.tsx
@@ -40,8 +40,10 @@ export function NetworkStatus(): JSX.Element {
     }, [state]);
 
     React.useEffect(() => {
-        const clear = () => {
-            setState("connected");
+        const clear = (current_latency: number) => {
+            if (current_latency < socket.options.timeout_delay) {
+                setState("connected");
+            }
         };
         const timeout = () => {
             setState("timeout");


### PR DESCRIPTION
Fixes:
 - Not warning someone if they are playing with latencies that don't match their game timing
 - Flashing the warning every pong instead of leaving it there, while the problem persists

## Proposed Changes

 - Check if a person is playing live, and if so make sure that they have at least a reasonable latency based on time settings
 - Don't take away the warning until the latency is reasonable again