### PR TITLE
Show the networks status warning only to live game participants on the page

### DIFF
--- a/src/components/NetworkStatus/NetworkStatus.tsx
+++ b/src/components/NetworkStatus/NetworkStatus.tsx
@@ -16,7 +16,6 @@
  */
 
 import * as React from "react";
-import { useLocation } from "react-router-dom";
 import { _ } from "translate";
 import { socket } from "sockets";
 
@@ -32,8 +31,18 @@ export function NetworkStatus(): JSX.Element {
 
     const stateRef = React.useRef(state);
 
-    const location = useLocation();
-    const on_game_page = location.pathname.includes("/game/");
+    // If they're in a live game then we make sure that they see this with a banner
+    // Otherwise it's a discreet little icon
+    // (note: we don't check if it's their turn because it might become their turn at any time, they
+    //  could do with knowing their internet is bad anyhow.)
+    const in_live_game =
+        typeof window !== "undefined" &&
+        window["global_goban"] &&
+        window["global_goban"].engine &&
+        window["global_goban"].engine.phase === "play" &&
+        window["global_goban"].engine.time_control !== "correspondence" &&
+        window["user"] &&
+        window["user"].id in window["global_goban"].engine.player_pool;
 
     React.useEffect(() => {
         stateRef.current = state; // needed so we can refer to the current value in the async timer below
@@ -81,14 +90,14 @@ export function NetworkStatus(): JSX.Element {
 
     return (
         // We don't show this if they're 'connected' (see above, return null)
-        <div className={"NetworkStatus" + (on_game_page ? "" : " non-game")}>
+        <div className={"NetworkStatus" + (in_live_game ? "" : " non-game")}>
             {/* This funky little thing builds an icon that is intended to say "no wifi!",
                 by superimposing a large "ban" icon over a normal sized "wifi" icon. */}
             <span className="icon">
                 <i className="fa fa-2x fa-ban" />
                 <i className="fa fa-wifi" />
             </span>
-            {on_game_page && (
+            {in_live_game && (
                 <span>
                     {(state === "timeout" || null) && _("Slow internet")}
                     {(state === "disconnected" || null) && _("Disconnected")}

--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -99,6 +99,7 @@ socket.on("latency", (latency, drift) => {
     if (
         typeof window !== "undefined" &&
         window["global_goban"] &&
+        window["global_goban"].engine &&
         window["global_goban"].engine.phase === "play" &&
         window["user"]
     ) {


### PR DESCRIPTION
(also added engine validity check in sockets just in case)

Fixes seeing the distracting banned unless absolutely necessary

## Proposed Changes

  - Show banner only to participants on a live game page.
  
  