### PR TITLE
Switch to Fetch based requests, get rid of %% based url templates

### DIFF
--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -47,13 +47,13 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
 
         if ("game_id" in props) {
             this.url = `games/${props.game_id}/acl`;
-            this.del_url = `games/acl/%%`;
+            this.del_url = `games/acl/`;
         } else if ("review_id" in props) {
             this.url = `reviews/${props.review_id}/acl`;
-            this.del_url = `reviews/acl/%%`;
+            this.del_url = `reviews/acl/`;
         } else if ("puzzle_collection_id" in props) {
             this.url = `puzzles/collections/${props.puzzle_collection_id}/acl`;
-            this.del_url = `puzzles/collections/acl/%%`;
+            this.del_url = `puzzles/collections/acl/`;
         } else {
             throw new Error(`ACLModal created with invalid parameters`);
         }
@@ -79,7 +79,7 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
         }
         this.setState({ acl: new_acl });
 
-        del(this.del_url, obj.id)
+        del(this.del_url + obj.id)
             .then(this.refresh)
             .catch((e) => {
                 this.refresh();

--- a/src/components/BlockPlayer/BlockPlayer.ts
+++ b/src/components/BlockPlayer/BlockPlayer.ts
@@ -50,7 +50,7 @@ export function setIgnore(player_id: number, tf: boolean) {
             block_states[player_id] = new BlockState(player_id);
         }
         block_states[player_id].block_chat = tf;
-        put("players/%%/block", player_id, { block_chat: tf ? 1 : 0 })
+        put(`players/${player_id}/block`, { block_chat: tf ? 1 : 0 })
             .then(() => {
                 ITC.send("update-blocks", true);
             })
@@ -64,7 +64,7 @@ export function setGameBlock(player_id: number, tf: boolean) {
             block_states[player_id] = new BlockState(player_id);
         }
         block_states[player_id].block_games = tf;
-        put("players/%%/block", player_id, { block_games: tf ? 1 : 0 })
+        put(`players/${player_id}/block`, { block_games: tf ? 1 : 0 })
             .then(() => {
                 ITC.send("update-blocks", true);
             })
@@ -78,7 +78,7 @@ export function setAnnouncementBlock(player_id: number, tf: boolean) {
             block_states[player_id] = new BlockState(player_id);
         }
         block_states[player_id].block_announcements = tf;
-        put("players/%%/block", player_id, { block_announcements: tf ? 1 : 0 })
+        put(`players/${player_id}/block`, { block_announcements: tf ? 1 : 0 })
             .then(() => {
                 ITC.send("update-blocks", true);
             })

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -625,7 +625,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
         this.saveSettings();
         this.close();
 
-        post(player_id ? "players/%%/challenge" : "challenges", player_id, challenge)
+        post(player_id ? `players/${player_id}/challenge` : "challenges", challenge)
             .then((res) => {
                 // console.log("Challenge response: ", res);
 
@@ -669,7 +669,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                                 off();
                                 if (accept) {
                                     // cancel challenge
-                                    void del("me/challenges/%%", challenge_id);
+                                    void del(`me/challenges/${challenge_id}`);
                                 }
                             })
                             .catch(() => {

--- a/src/components/GameAcceptModal/GameAcceptModal.tsx
+++ b/src/components/GameAcceptModal/GameAcceptModal.tsx
@@ -48,7 +48,7 @@ export class GameAcceptModal extends Modal<Events, GameAcceptModalProperties, {}
             allowEscapeKey: false,
         });
 
-        post("challenges/%%/accept", this.props.challenge.challenge_id, {})
+        post(`challenges/${this.props.challenge.challenge_id}/accept`, {})
             .then(() => {
                 alert.close();
                 this.close();

--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -52,12 +52,12 @@ export function IncidentReportTracker(): JSX.Element {
         const onReport = (report: Report) => {
             if (report.state !== "resolved") {
                 report.unclaim = () => {
-                    post("moderation/incident/%%", report.id, { id: report.id, action: "unclaim" })
+                    post(`moderation/incident/${report.id}`, { id: report.id, action: "unclaim" })
                         .then(ignore)
                         .catch(errorAlerter);
                 };
                 report.good_report = () => {
-                    post("moderation/incident/%%", report.id, {
+                    post(`moderation/incident/${report.id}`, {
                         id: report.id,
                         action: "resolve",
                         was_helpful: true,
@@ -66,7 +66,7 @@ export function IncidentReportTracker(): JSX.Element {
                         .catch(errorAlerter);
                 };
                 report.bad_report = () => {
-                    post("moderation/incident/%%", report.id, {
+                    post(`moderation/incident/${report.id}`, {
                         id: report.id,
                         action: "resolve",
                         was_helpful: false,
@@ -75,7 +75,7 @@ export function IncidentReportTracker(): JSX.Element {
                         .catch(errorAlerter);
                 };
                 report.steal = () => {
-                    post("moderation/incident/%%", report.id, { id: report.id, action: "steal" })
+                    post(`moderation/incident/${report.id}`, { id: report.id, action: "steal" })
                         .then((res) => {
                             if (res.vanished) {
                                 void alert.fire("Report was removed");
@@ -84,7 +84,7 @@ export function IncidentReportTracker(): JSX.Element {
                         .catch(errorAlerter);
                 };
                 report.claim = () => {
-                    post("moderation/incident/%%", report.id, { id: report.id, action: "claim" })
+                    post(`moderation/incident/${report.id}`, { id: report.id, action: "claim" })
                         .then((res) => {
                             if (res.vanished) {
                                 void alert.fire("Report was removed");
@@ -96,7 +96,7 @@ export function IncidentReportTracker(): JSX.Element {
                         .catch(errorAlerter);
                 };
                 report.cancel = () => {
-                    post("moderation/incident/%%", report.id, { id: report.id, action: "cancel" })
+                    post(`moderation/incident/${report.id}`, { id: report.id, action: "cancel" })
                         .then(ignore)
                         .catch(errorAlerter);
                 };
@@ -110,7 +110,7 @@ export function IncidentReportTracker(): JSX.Element {
                         })
                         .then(({ value: txt, isConfirmed }) => {
                             if (isConfirmed) {
-                                post("moderation/incident/%%", report.id, {
+                                post(`moderation/incident/${report.id}`, {
                                     id: report.id,
                                     action: "note",
                                     note: txt,

--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -44,7 +44,7 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
     }
 
     componentDidMount() {
-        get("players/%%/full", this.props.playerId)
+        get(`players/${this.props.playerId}/full`)
             .then((result) => {
                 console.log(result);
                 this.setState(

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -200,7 +200,7 @@ class NotificationEntry extends React.Component<{ notification }, any> {
                             <FabX
                                 onClick={() => {
                                     this.setState({ message: _("Declining") });
-                                    del("me/challenges/%%", notification.challenge_id)
+                                    del(`me/challenges/${notification.challenge_id}`)
                                         .then(this.del)
                                         .catch(this.onError);
                                 }}
@@ -208,7 +208,7 @@ class NotificationEntry extends React.Component<{ notification }, any> {
                             <FabCheck
                                 onClick={() => {
                                     this.setState({ message: _("Accepting") });
-                                    post("me/challenges/%%/accept", notification.challenge_id, {})
+                                    post(`me/challenges/${notification.challenge_id}/accept`, {})
                                         .then(() => {
                                             this.del();
                                             if (

--- a/src/components/PlayerAutocomplete/PlayerAutocomplete.tsx
+++ b/src/components/PlayerAutocomplete/PlayerAutocomplete.tsx
@@ -164,8 +164,7 @@ function _PlayerAutocomplete(props: PlayerAutocompleteProperties, ref): JSX.Elem
                     //complete(value);
                 }
             }).catch((err) => {
-                if (err.status !== 0) {
-                    // status === 0 is an abort
+                if (err.name !== "AbortError") {
                     console.log(err);
                 }
             });

--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -804,7 +804,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
                         .attr("title", _("Remove challenge"))
                         .click(() => {
                             //console.log("Remove");
-                            del("challenges/%%", C.challenge_id)
+                            del(`challenges/${C.challenge_id}`)
                                 .then(() => e.html(_("Challenge removed")))
                                 .catch(() => alert.fire(_("Error removing challenge")));
                         }),

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -248,6 +248,10 @@ export function getPrintableError(err) {
     }
 
     if (err instanceof Error) {
+        if (err.name === "AbortError") {
+            /* ignore aborted requests' */
+            return;
+        }
         console.error(err.stack);
         return err.toString();
     }
@@ -277,11 +281,6 @@ export function getPrintableError(err) {
             }
             return "An unknown error has occurred!";
         }
-    }
-
-    if (obj.status === 0 && obj.statusText === "abort") {
-        /* ignore aborted requests' */
-        return;
     }
 
     /*

--- a/src/lib/rengo_balancer.ts
+++ b/src/lib/rengo_balancer.ts
@@ -169,14 +169,14 @@ export async function balanceTeams(challenge: Challenge): Promise<RengoParticipa
         Math.abs(result.blackAverageRating - result.whiteAverageRating),
     );
 
-    return put("challenges/%%/team", challenge.challenge_id, {
+    return put(`challenges/${challenge.challenge_id}/team`, {
         assign_black: result.black.map(user_id),
         assign_white: result.white.map(user_id),
     });
 }
 
 export function unassignPlayers(challenge: Challenge): Promise<RengoParticipantsDTO> {
-    return put("challenges/%%/team", challenge.challenge_id, {
+    return put(`challenges/${challenge.challenge_id}/team`, {
         unassign: challenge.rengo_participants,
     });
 }

--- a/src/lib/rengo_utils.ts
+++ b/src/lib/rengo_utils.ts
@@ -32,7 +32,7 @@ export function nominateForRengoChallenge(c: Challenge): Promise<RengoParticipan
         allowEscapeKey: false,
     });
 
-    return put("challenges/%%/join", c.challenge_id, {}).then((res) => {
+    return put(`challenges/${c.challenge_id}/join`, {}).then((res) => {
         alert.close();
         return res;
     });
@@ -50,7 +50,7 @@ export function assignToTeam(
             ? "assign_white"
             : "unassign";
 
-    return put("challenges/%%/team", challenge.challenge_id, {
+    return put(`challenges/${challenge.challenge_id}/team`, {
         [assignment]: [player_id], // back end expects an array of changes, but we only ever send one at a time.
     });
 }
@@ -70,13 +70,13 @@ export function startOwnRengoChallenge(the_challenge: Challenge): Promise<void> 
         allowEscapeKey: false,
     });
 
-    return post("challenges/%%/start", the_challenge.challenge_id, {}).then(() => {
+    return post(`challenges/${the_challenge.challenge_id}/start`, {}).then(() => {
         alert.close();
     });
 }
 
 export function cancelRengoChallenge(the_challenge: Challenge): Promise<void> {
-    return del("challenges/%%", the_challenge.challenge_id);
+    return del(`challenges/${the_challenge.challenge_id}`);
 }
 
 export function unNominate(the_challenge: Challenge): Promise<RengoParticipantsDTO> {
@@ -88,7 +88,7 @@ export function unNominate(the_challenge: Challenge): Promise<RengoParticipantsD
         allowEscapeKey: false,
     });
 
-    return del("challenges/%%/join", the_challenge.challenge_id, {}).then((res) => {
+    return del(`challenges/${the_challenge.challenge_id}/join`, {}).then((res) => {
         alert.close();
         return res;
     });

--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -318,7 +318,7 @@ class ReportManager extends EventEmitter<Events> {
     public async close(report_id: number, helpful: boolean): Promise<Report> {
         delete this.active_incident_reports[report_id];
         this.update();
-        const res = await post("moderation/incident/%%", report_id, {
+        const res = await post(`moderation/incident/${report_id}`, {
             id: report_id,
             action: "resolve",
             was_helpful: helpful,
@@ -337,7 +337,7 @@ class ReportManager extends EventEmitter<Events> {
         return res;
     }
     public async unclaim(report_id: number): Promise<Report> {
-        const res = await post("moderation/incident/%%", report_id, {
+        const res = await post(`moderation/incident/${report_id}`, {
             id: report_id,
             action: "unclaim",
         });
@@ -345,7 +345,7 @@ class ReportManager extends EventEmitter<Events> {
         return res;
     }
     public async claim(report_id: number): Promise<Report> {
-        const res = await post("moderation/incident/%%", report_id, {
+        const res = await post(`moderation/incident/${report_id}`, {
             id: report_id,
             action: "claim",
         }).then((res) => {

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -123,12 +123,14 @@ function request(method: Method): RequestFunction {
                 }
             }
 
+            const same_origin = url.indexOf("://") < 0 || url.indexOf(window.location.origin) === 0;
+
             fetch(url, {
                 signal,
                 method,
-                credentials: "include",
+                credentials: same_origin ? "include" : undefined,
                 keepalive: true,
-                mode: csrf_safe ? "no-cors" : "cors",
+                mode: same_origin ? (csrf_safe ? "no-cors" : "cors") : undefined,
                 cache: cacheable ? "default" : "no-cache",
                 body: prepared_data as any,
                 headers,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -312,3 +312,6 @@ window["data"] = data;
 window["preferences"] = preferences;
 window["player_cache"] = player_cache;
 window["GoMath"] = GoMath;
+
+import * as requests from "requests";
+window["requests"] = requests;

--- a/src/models/games.d.ts
+++ b/src/models/games.d.ts
@@ -259,7 +259,7 @@ declare namespace rest_api {
         }
 
         /**
-         * The active_games list in the /players/%%/full
+         * The active_games list in the /players/${id}/full
          */
         interface Game {
             black: game.Player;

--- a/src/views/AnnouncementCenter/AnnouncementCenter.tsx
+++ b/src/views/AnnouncementCenter/AnnouncementCenter.tsx
@@ -106,7 +106,7 @@ export function AnnouncementCenter(): JSX.Element {
             .catch(errorAlerter);
     };
     const deleteAnnouncement = (announcement) => {
-        del("announcements/%%", announcement.id).then(refresh).catch(errorAlerter);
+        del(`announcements/${announcement.id}`).then(refresh).catch(errorAlerter);
     };
 
     const can_create = !!text;

--- a/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
+++ b/src/views/ChallengeLinkLanding/ChallengeLinkLanding.tsx
@@ -61,7 +61,7 @@ export function ChallengeLinkLanding(): JSX.Element {
         });
 
         if (challenge.rengo) {
-            put("challenges/%%/join", challenge.challenge_id, {})
+            put(`challenges/${challenge.challenge_id}/join`, {})
                 .then(() => {
                     alert.close();
                     if (challenge.invite_only) {
@@ -77,7 +77,7 @@ export function ChallengeLinkLanding(): JSX.Element {
                     errorAlerter(err);
                 });
         } else {
-            post("challenges/%%/accept", challenge.challenge_id, {})
+            post(`challenges/${challenge.challenge_id}/accept`, {})
                 .then(() => {
                     alert.close();
                     navigate(`/game/${challenge.game_id}`, { replace: true });

--- a/src/views/ForceUsernameChange/ForceUsernameChange.tsx
+++ b/src/views/ForceUsernameChange/ForceUsernameChange.tsx
@@ -36,7 +36,7 @@ export function ForceUsernameChange(): JSX.Element {
     });
 
     function saveUsername() {
-        put("players/%%", user.id, { username })
+        put(`players/${user.id}`, { username })
             .then(() => {
                 cached.refresh.config(() => window.location.reload());
             })

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1328,15 +1328,15 @@ export function Game(): JSX.Element {
                     }
                 })
                 .catch((e) => {
-                    if (e.statusText === "abort") {
-                        console.error("Error: abort", e);
+                    if (e.name === "AbortError") {
+                        //console.error("Error: abort", e);
                         return;
                     }
-                    if (e.statusText === "Not Found") {
+                    if (e.status === 404 || e.statusText === "Not Found") {
                         console.error("Error: not found, handled 10s later by socket.ts", e);
                         return;
                     }
-                    console.error(e);
+                    console.error(e.name, e);
                     void alert.fire({
                         title: "Failed to load game data: " + e.statusText,
                         icon: "error",

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -646,7 +646,7 @@ export function Game(): JSX.Element {
                 })
                 .then(({ value: accept }) => {
                     if (accept) {
-                        post("games/%%/reviews", game_id, {})
+                        post(`games/${game_id}/reviews`, {})
                             .then((res) => browserHistory.push(`/review/${res.id}`))
                             .catch(errorAlerter);
                     }
@@ -1271,7 +1271,7 @@ export function Game(): JSX.Element {
         }
 
         if (game_id) {
-            get("games/%%", game_id)
+            get(`games/${game_id}`)
                 .then((game: rest_api.GameDetails) => {
                     if (game.players.white.id) {
                         player_cache.update(game.players.white, true);
@@ -1345,7 +1345,7 @@ export function Game(): JSX.Element {
         }
 
         if (review_id) {
-            get("reviews/%%", review_id)
+            get(`reviews/${review_id}`)
                 .then((review) => {
                     if (review.game && review.game.historical_ratings) {
                         set_historical_black(review.game.historical_ratings.black);

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -225,7 +225,7 @@ export function GameDock({
             moderation_note = moderation_note.trim();
         } while (moderation_note === "");
 
-        post("games/%%/moderate", game_id, {
+        post(`games/${game_id}/moderate`, {
             decide: winner,
             moderation_note: moderation_note,
         }).catch(errorAlerter);
@@ -248,7 +248,7 @@ export function GameDock({
             moderation_note = moderation_note.trim();
         } while (moderation_note === "");
 
-        post("games/%%/moderate", game_id, {
+        post(`games/${game_id}/moderate`, {
             autoscore: true,
             moderation_note: moderation_note,
         }).catch(errorAlerter);

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -290,7 +290,7 @@ test("Pause buttons show up", () => {
         </WrapTest>,
     );
     act(() => {
-        // It would be more realistic to mock the "game/%%/clock" socket event,
+        // It would be more realistic to mock the "game/${id}/clock" socket event,
         // but AdHocClock is a complicated object and I'm not sure what params
         // to use to get the goban to actually pause.
         goban.pause_control = {

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -161,7 +161,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
     resolve(group_id: number) {
         const user = data.get("user");
 
-        get("groups/%%", group_id)
+        get(`groups/${group_id}`)
             .then((group: GroupInfo) => {
                 window.document.title = group.name;
 
@@ -181,7 +181,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                 });
             })
             .catch(errorAlerter);
-        get("groups/%%/news/", group_id)
+        get(`groups/${group_id}/news/`)
             .then((news) => {
                 this.setState({ news: news.results });
             })
@@ -202,14 +202,14 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
     }
 
     leaveGroup = () => {
-        post("groups/%%/members", this.state.group_id, { delete: true })
+        post(`groups/${this.state.group_id}/members`, { delete: true })
             .then(() => {
                 this.resolve(this.state.group_id);
             })
             .catch(errorAlerter);
     };
     joinGroup = () => {
-        post("groups/%%/members", this.state.group_id, {})
+        post(`groups/${this.state.group_id}/members`, {})
             .then((res) => {
                 if (res.success) {
                     this.resolve(this.state.group_id);
@@ -245,7 +245,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
         });
         image_resizer(files[0], 512, 512)
             .then((file: Blob) => {
-                put("group/%%/icon", this.state.group_id, file)
+                put(`group/${this.state.group_id}/icon`, file)
                     .then((res) => {
                         console.log("Upload successful", res);
                     })
@@ -259,7 +259,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
         });
         image_resizer(files[0], 2560, 512)
             .then((file: Blob) => {
-                put("group/%%/banner", this.state.group_id, file)
+                put(`group/${this.state.group_id}/banner`, file)
                     .then((res) => {
                         console.log("Upload successful", res);
                     })
@@ -373,7 +373,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
             return;
         }
         this.toggleNewNewsPost();
-        post("group/%%/news/", this.state.group_id, {
+        post(`group/${this.state.group_id}/news/`, {
             title: this.state.new_news_title,
             content: this.state.new_news_body,
         })
@@ -407,7 +407,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    post("group/%%/news/", this.state.group_id, {
+                    post(`group/${this.state.group_id}/news/`, {
                         id: entry.id,
                         delete: true,
                     })
@@ -459,7 +459,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
 
     inviteUser = () => {
         const username = this.state.user_to_invite.username;
-        post("group/%%/members", this.state.group_id, { username })
+        post(`group/${this.state.group_id}/members`, { username })
             .then((res) => {
                 console.log(res);
                 this.setState({
@@ -1185,7 +1185,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    del("groups/%%", this.state.group.id)
+                    del(`groups/${this.state.group_id}`)
                         .then(() => {
                             browserHistory.push("/groups/");
                         })
@@ -1203,7 +1203,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    put("groups/%%/members", this.state.group_id, {
+                    put(`groups/${this.state.group_id}/members`, {
                         player_id: player_id,
                         is_admin: true,
                     })
@@ -1222,7 +1222,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    put("groups/%%/members", this.state.group_id, {
+                    put(`groups/${this.state.group_id}/members`, {
                         player_id: player_id,
                         is_admin: false,
                     })
@@ -1241,7 +1241,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    post("groups/%%/members", this.state.group_id, {
+                    post(`groups/${this.state.group_id}/members`, {
                         delete: true,
                         player_id: player_id,
                     })

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -77,7 +77,7 @@ class _Ladder extends React.PureComponent<LadderProperties, LadderState> {
     }
 
     resolve(ladder_id) {
-        get("ladders/%%", ladder_id)
+        get(`ladders/${ladder_id}`)
             .then((ladder) => {
                 this.setState({
                     ladder: ladder,
@@ -91,7 +91,7 @@ class _Ladder extends React.PureComponent<LadderProperties, LadderState> {
     }
 
     join = () => {
-        post("ladders/%%/players", this.props.match.params.ladder_id, {})
+        post(`ladders/${this.props.match.params.ladder_id}/players`, {})
             .then(() => {
                 this.invalidate();
                 this.resolve(this.props.match.params.ladder_id);
@@ -112,7 +112,7 @@ class _Ladder extends React.PureComponent<LadderProperties, LadderState> {
             })
             .then(({ value: yes }) => {
                 if (yes) {
-                    del("ladders/%%/players", this.props.match.params.ladder_id)
+                    del(`ladders/${this.props.match.params.ladder_id}/players`)
                         .then(() => {
                             this.invalidate();
                             this.resolve(this.props.match.params.ladder_id);
@@ -472,8 +472,7 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
             .then(({ value: new_rank }) => {
                 if (new_rank) {
                     put(
-                        "ladders/%%/players/moderate",
-                        this.props.ladder.props.match.params.ladder_id,
+                        `ladders/${this.props.ladder.props.match.params.ladder_id}/players/moderate`,
                         {
                             moderation_note: "Adjusting ladder position",
                             player_id: player.id,
@@ -619,8 +618,7 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
             .then(({ value: yes }) => {
                 if (yes) {
                     post(
-                        "ladders/%%/players/challenge",
-                        this.props.ladder.props.match.params.ladder_id,
+                        `ladders/${this.props.ladder.props.match.params.ladder_id}/players/challenge`,
                         {
                             player_id: ladder_player.player.id,
                         },

--- a/src/views/LadderList/LadderList.tsx
+++ b/src/views/LadderList/LadderList.tsx
@@ -70,7 +70,7 @@ export function LadderList(): JSX.Element {
     }
 
     const join = (ladder_id: number) => {
-        post("ladders/%%/players", ladder_id, {})
+        post(`ladders/${ladder_id}/players`, {})
             .then(() => {
                 fetchLadders();
             })

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -128,7 +128,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
         abort_requests_in_flight("library/");
     }
     refresh(player_id: IdType) {
-        const promise = get("library/%%", player_id);
+        const promise = get(`library/${player_id}`);
 
         promise
             .then((library) => {
@@ -256,9 +256,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
     uploadSGFs = (files) => {
         if (parseInt(this.props.match.params.player_id) === data.get("user").id) {
             files = files.filter((file) => /.sgf$/i.test(file.name));
-            Promise.all(
-                files.map((file) => post("me/games/sgf/%%", this.state.collection_id, file)),
-            )
+            Promise.all(files.map((file) => post(`me/games/sgf/${this.state.collection_id}`, file)))
                 .then(() => {
                     this.refresh(this.props.match.params.player_id).then(ignore).catch(ignore);
                 })
@@ -274,7 +272,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
                 type: "application/x-go-sgf",
                 lastModified: new Date().getTime(),
             });
-            post("me/games/sgf/%%", this.state.collection_id, file)
+            post(`me/games/sgf/${this.state.collection_id}`, file)
                 .then(() => {
                     this.refresh(this.props.match.params.player_id).then(ignore).catch(ignore);
                 })
@@ -306,7 +304,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
         this.setState({ new_collection_private: ev.target.checked });
     };
     createCollection = () => {
-        post("library/%%/collections", this.state.player_id, {
+        post(`library/${this.state.player_id}/collections`, {
             parent_id: this.state.collection_id,
             name: this.state.new_collection_name,
             private: this.state.new_collection_private ? 1 : 0,
@@ -320,7 +318,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
     };
     deleteCollection = () => {
         const parent = this.state.collections[this.state.collection_id].parent;
-        post("library/%%", this.state.player_id, {
+        post(`library/${this.state.player_id}`, {
             delete_collections: [this.state.collection_id],
         })
             .then(() => {
@@ -331,7 +329,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
             .catch(errorAlerter);
     };
     deleteGames = () => {
-        post("library/%%", this.state.player_id, {
+        post(`library/${this.state.player_id}`, {
             delete_entries: Object.keys(this.state.games_checked),
         })
             .then(() => {

--- a/src/views/Overview/ChallengesList.tsx
+++ b/src/views/Overview/ChallengesList.tsx
@@ -48,11 +48,11 @@ export class ChallengesList extends React.PureComponent<{ onAccept: () => void }
     };
 
     deleteChallenge(challenge) {
-        del("me/challenges/%%", challenge.id).then(ignore).catch(ignore);
+        del(`me/challenges/${challenge.id}`).then(ignore).catch(ignore);
         this.setState({ challenges: this.state.challenges.filter((c) => c.id !== challenge.id) });
     }
     acceptChallenge(challenge) {
-        post("me/challenges/%%/accept", challenge.id, {})
+        post(`me/challenges/${challenge.id}/accept`, {})
             .then((res) => {
                 if (res.time_per_move > 0 && res.time_per_move < 1800) {
                     browserHistory.push(`/game/${res.game}`);

--- a/src/views/Overview/InviteList.tsx
+++ b/src/views/Overview/InviteList.tsx
@@ -104,7 +104,7 @@ export function InviteList(): JSX.Element {
     };
 
     const deleteChallenge = (challenge: Challenge) => {
-        del("challenges/%%", challenge.challenge_id)
+        del(`challenges/${challenge.challenge_id}`)
             .then(() => {
                 removeChallenge(challenge);
             })

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -282,7 +282,7 @@ export class Play extends React.Component<{}, PlayState> {
     };
 
     cancelOpenChallenge = (challenge: Challenge) => {
-        del("challenges/%%", challenge.challenge_id).catch(errorAlerter);
+        del(`challenges/${challenge.challenge_id}`).catch(errorAlerter);
         this.unfreezeChallenges();
     };
 

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -371,7 +371,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
     };
 
     ratePuzzle = (value) => {
-        put("puzzles/%%/rate", +this.props.match.params.puzzle_id, { rating: value })
+        put(`puzzles/${this.props.match.params.puzzle_id}/rate`, { rating: value })
             .then(ignore)
             .catch(errorAlerter);
         this.setState({
@@ -424,7 +424,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
 
         if (parseInt(this.props.match.params.puzzle_id)) {
             /* save */
-            put("puzzles/%%", +this.props.match.params.puzzle_id, { puzzle: puzzle })
+            put(`puzzles/${this.props.match.params.puzzle_id}`, { puzzle: puzzle })
                 .then(() => {
                     window.location.reload();
                 })
@@ -616,7 +616,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    del("puzzles/%%", +this.props.match.params.puzzle_id)
+                    del(`puzzles/${this.props.match.params.puzzle_id}`)
                         .then(() =>
                             browserHistory.push(
                                 `/puzzle-collection/${this.state.puzzle.puzzle_collection}`,

--- a/src/views/Puzzle/PuzzleEditing.ts
+++ b/src/views/Puzzle/PuzzleEditing.ts
@@ -145,9 +145,9 @@ export class PuzzleEditor {
         }
 
         Promise.all([
-            get("puzzles/%%", puzzle_id),
-            get("puzzles/%%/collection_summary", puzzle_id),
-            get("puzzles/%%/rate", puzzle_id),
+            get(`puzzles/${puzzle_id}`),
+            get(`puzzles/${puzzle_id}/collection_summary`),
+            get(`puzzles/${puzzle_id}/rate`),
         ])
             .then((arr: [rest_api.PuzzleDetail, any, any]) => {
                 const rating = arr[2];

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -75,7 +75,7 @@ export function ReportedGame({ game_id }: { game_id: number }): JSX.Element {
                 moderation_note = moderation_note.trim();
             } while (moderation_note === "");
 
-            post("games/%%/moderate", game_id, {
+            post(`games/${game_id}/moderate`, {
                 decide: winner,
                 moderation_note: moderation_note,
             }).catch(errorAlerter);
@@ -122,7 +122,7 @@ export function ReportedGame({ game_id }: { game_id: number }): JSX.Element {
 
     React.useEffect(() => {
         if (game_id) {
-            get("games/%%", game_id)
+            get(`games/${game_id}`)
                 .then((game: rest_api.GameDetails) => {
                     setGame(game);
                     setAnnulled(game.annulled);

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -144,7 +144,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
 
                 if (!report_note_update_timeout) {
                     report_note_update_timeout = setTimeout(() => {
-                        post("moderation/incident/%%", report.id, {
+                        post(`moderation/incident/${report.id}`, {
                             id: report.id,
                             action: "note",
                             note: report_note_text,
@@ -164,7 +164,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
     const assignToModerator = React.useCallback(
         (id: number) => {
             setModeratorId(id);
-            post("moderation/incident/%%", report.id, {
+            post(`moderation/incident/${report.id}`, {
                 id: report.id,
                 action: "assign",
                 moderator_id: id,

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -230,7 +230,7 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
 
         image_resizer(files[0], 512, 512)
             .then((file: Blob) => {
-                put("players/%%/icon", user.id, file)
+                put(`players/${user.id}/icon`, file)
                     .then((res) => {
                         console.log("Upload successful", res);
                         user.icon = res.icon;
@@ -245,7 +245,7 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
     };
     const clearIcon = () => {
         setNewIcon(null);
-        del("players/%%/icon", user.id)
+        del(`players/${user.id}/icon`)
             .then((res) => {
                 console.log("Cleared icon", res);
                 user.icon = res.icon;
@@ -268,7 +268,7 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
                 email,
                 website,
             };
-            put("players/%%", user.id, data)
+            put(`players/${user.id}`, data)
                 .then(() => {
                     cached.refresh.config(() => window.location.reload());
                     toast(<span>{_("Account settings updated successfully!")}</span>, 5000);

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -200,7 +200,7 @@ export function Tournament(): JSX.Element {
             resolve();
         }
         if (new_tournament_group_id) {
-            get("groups/%%", new_tournament_group_id)
+            get(`groups/${new_tournament_group_id}`)
                 .then((group) => {
                     tournament_ref.current.group = group;
                     refresh();
@@ -222,7 +222,7 @@ export function Tournament(): JSX.Element {
     const resolve = () => {
         abort_requests();
 
-        const tournament_info_promise = get("tournaments/%%", tournament_id).then((t) => {
+        const tournament_info_promise = get(`tournaments/${tournament_id}`).then((t) => {
             tournament_ref.current = t;
             setInfoLoaded(true);
             refresh();
@@ -231,7 +231,7 @@ export function Tournament(): JSX.Element {
 
         Promise.all([
             tournament_info_promise,
-            get("tournaments/%%/rounds", tournament_id),
+            get(`tournaments/${tournament_id}/rounds`),
             refreshPlayerList(),
         ])
             .then((res) => {
@@ -280,7 +280,7 @@ export function Tournament(): JSX.Element {
         resolve();
     };
     const refreshPlayerList = () => {
-        const ret = get("tournaments/%%/players/all", tournament_id);
+        const ret = get(`tournaments/${tournament_id}/players/all`);
 
         ret.then((players) => {
             for (const id in players) {
@@ -402,7 +402,7 @@ export function Tournament(): JSX.Element {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    post("tournaments/%%/start", tournament_ref.current.id, {})
+                    post(`tournaments/${tournament_ref.current.id}/start`, {})
                         .then(ignore)
                         .catch(errorAlerter);
                 }
@@ -417,7 +417,7 @@ export function Tournament(): JSX.Element {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    del("tournaments/%%", tournament_ref.current.id)
+                    del(`tournaments/${tournament_ref.current.id}`)
                         .then(() => {
                             browserHistory.push("/");
                         })
@@ -434,7 +434,7 @@ export function Tournament(): JSX.Element {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    post("tournaments/%%/end", tournament_ref.current.id, {})
+                    post(`tournaments/${tournament_ref.current.id}/end`, {})
                         .then(() => {
                             reloadTournament();
                         })
@@ -448,7 +448,7 @@ export function Tournament(): JSX.Element {
         }
 
         const username = user_to_invite.username;
-        post("tournaments/%%/players", tournament_id, { username })
+        post(`tournaments/${tournament_id}/players`, { username })
             .then((res) => {
                 console.log(res);
                 setInviteResult(interpolate(_("Invited {{username}}"), { username }));
@@ -465,14 +465,14 @@ export function Tournament(): JSX.Element {
             });
     };
     const joinTournament = () => {
-        post("tournaments/%%/players", tournament_id, {})
+        post(`tournaments/${tournament_id}/players`, {})
             .then(() => {
                 setIsJoined(true);
             })
             .catch(errorAlerter);
     };
     const partTournament = () => {
-        post("tournaments/%%/players", tournament_id, { delete: true })
+        post(`tournaments/${tournament_id}/players`, { delete: true })
             .then(() => {
                 setIsJoined(false);
             })
@@ -1373,7 +1373,7 @@ export function Tournament(): JSX.Element {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    post("tournaments/%%/players", tournament_ref.current.id, {
+                    post(`tournaments/${tournament_ref.current.id}/players`, {
                         delete: true,
                         player_id: user.id,
                     })
@@ -1422,7 +1422,7 @@ export function Tournament(): JSX.Element {
                 const adjustments = {};
                 adjustments[user.id] = v;
 
-                put("tournaments/%%/players", tournament_ref.current.id, {
+                put(`tournaments/${tournament_ref.current.id}/players`, {
                     adjust: adjustments,
                 })
                     .then(ignore)
@@ -1442,7 +1442,7 @@ export function Tournament(): JSX.Element {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    put("tournaments/%%/players", tournament_ref.current.id, {
+                    put(`tournaments/${tournament_ref.current.id}/players`, {
                         disqualify: user.id,
                     })
                         .then(ignore)
@@ -3236,7 +3236,7 @@ function OpenGothaTournamentUploadDownload({
     }
 
     function uploadFile(files) {
-        put("tournaments/%%/opengotha", tournament.id, files[0])
+        put(`tournaments/${tournament.id}/opengotha`, files[0])
             .then((res) => {
                 console.log("Upload successful", res);
                 openMergeReportModal(res.merge_report);

--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -157,7 +157,7 @@ export function AvatarCard({
 
         image_resizer(files[0], 512, 512)
             .then((file: Blob) => {
-                put("players/%%/icon", user.id, file)
+                put(`players/${user.id}/icon`, file)
                     .then((res) => {
                         console.log("Upload successful", res);
                         user.icon = res.icon;
@@ -172,7 +172,7 @@ export function AvatarCard({
     };
     const clearIcon = () => {
         setNewIcon(null);
-        del("players/%%/icon", user.id)
+        del(`players/${user.id}/icon`)
             .then((res) => {
                 console.log("Cleared icon", res);
                 user.icon = res.icon;

--- a/src/views/User/ModTools.tsx
+++ b/src/views/User/ModTools.tsx
@@ -69,7 +69,7 @@ export function ModTools(props: ModToolsProps): JSX.Element {
 
     React.useEffect(() => {
         if (props.collapse_same_users) {
-            get(`players/${props.user_id}/aliases/`, undefined, { page_size: 100 })
+            get(`players/${props.user_id}/aliases/`, { page_size: 100 })
                 .then((data: any) => {
                     const aliases = data.results;
                     setAliases(aliases);

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -109,8 +109,8 @@ export function User(props: { user_id?: number }): JSX.Element {
             return;
         }
 
-        // Cheaper API calls provide partial profile data before players/%%/full
-        Promise.all([get("players/%%", user_id), get("/termination-api/player/%%", user_id)])
+        // Cheaper API calls provide partial profile data before players/{user_id}/full
+        Promise.all([get(`players/${user_id}`), get(`/termination-api/player/${user_id}`)])
             .then((responses: [rest_api.PlayerDetail, rest_api.termination_api.Player]) => {
                 if (resolved) {
                     return;
@@ -138,7 +138,7 @@ export function User(props: { user_id?: number }): JSX.Element {
             })
             .catch(console.log);
 
-        get("players/%%/full", user_id)
+        get(`players/${user_id}/full`)
             .then((response: rest_api.FullPlayerDetail) => {
                 setResolved(true);
                 try {
@@ -184,7 +184,7 @@ export function User(props: { user_id?: number }): JSX.Element {
             }),
         );
         if (user) {
-            put("players/%%", user.id, {
+            put(`players/${user.id}`, {
                 ...profile_card_changes,
                 about: user.about,
             })


### PR DESCRIPTION
This patch overhauls our `requests` utility functions in two ways:

1) We've moved away from using jQuery's XHRHttpRequest wrapper to using the now standard fetch API.

2) We've moved away from using the `%%` as an ID place holder in our URLs. The original purpose of the change *to* `%%` was to enable typing of our http requests (the change predated typescript's template literal types that would have obviated that change), however there was never any follow-through on that and now with the advancements in typescript we can achieve typing without the need to have the `%%` placeholders anyways, so this PR makes the change back to the clearer less error prone string template style of specifying URLs.

