### PR TITLE
Update ChatList style to avoid content shifting

### DIFF
--- a/src/components/Chat/ChatIndicator.styl
+++ b/src/components/Chat/ChatIndicator.styl
@@ -59,6 +59,7 @@
     .ChatList {
         display: flex;
         position: absolute;
+        box-sizing: border-box;
         themed background-color bg
         top: navbar-height;
         right: 0;


### PR DESCRIPTION
---
## Description
- Main content (including nav bar) shifts when toggling the ChatList.

https://github.com/online-go/online-go.com/assets/43846910/edf622c1-e95d-4a2e-b13f-717ea67a45ee

## Proposed Changes
  - Update the box-sizing property to `border-box` to account for border and padding in the width values.

https://github.com/online-go/online-go.com/assets/43846910/2f87aae6-419a-4f51-8e50-c40e49420b10


