### PR TITLE
Clarify that auto-zen applies to live games.

### DIFF
--- a/src/views/Settings/GamePreferences.tsx
+++ b/src/views/Settings/GamePreferences.tsx
@@ -292,7 +292,7 @@ export function GamePreferences(): JSX.Element {
             <PreferenceLine
                 title={_("Activate Zen Mode by default")}
                 description={_(
-                    'When enabled, games you play or view will start off in the full screen "Zen Mode". This can be toggled off in game by clicking the Z icon.',
+                    'When enabled, live games you play or view will start off in the full screen "Zen Mode". This can be toggled off in game by clicking the Z icon.',
                 )}
             >
                 <Toggle checked={zen_mode_by_default} onChange={toggleZenMode} />


### PR DESCRIPTION
Fixes inaccurate descriptive text :)

## Proposed Changes

  - Say "live games ..." instead of "games..."
  