### PR TITLE
Only show 'Inspect & Annul' button on system generated reports

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -490,7 +490,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                         </div>
 
                         <div className="actions-right">
-                            {reportState !== "resolved" && report.detected_ai_games ? (
+                            {reportState !== "resolved" && report.detected_ai_games.length > 0 ? (
                                 <button
                                     onClick={() => openAnnulQueueModal(setIsAnnulQueueModalOpen)}
                                 >


### PR DESCRIPTION
Bug fix for the "Inspect & Annul Games" button showing on all reports rather than only system generated AI detection reports
