### PR TITLE
Updated image resizer code to use webp and have a file size limit

### DIFF
--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -243,7 +243,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
         this.setState({
             new_icon: Object.assign(files[0], { preview: URL.createObjectURL(files[0]) }),
         });
-        image_resizer(files[0], 512, 512)
+        image_resizer(files[0], 512, 512, 65535)
             .then((file: Blob) => {
                 put(`group/${this.state.group_id}/icon`, file)
                     .then((res) => {
@@ -257,7 +257,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
         this.setState({
             new_banner: Object.assign(files[0], { preview: URL.createObjectURL(files[0]) }),
         });
-        image_resizer(files[0], 2560, 512)
+        image_resizer(files[0], 2560, 512, 65535)
             .then((file: Blob) => {
                 put(`group/${this.state.group_id}/banner`, file)
                     .then((res) => {

--- a/src/views/Settings/AccountSettings.tsx
+++ b/src/views/Settings/AccountSettings.tsx
@@ -228,7 +228,7 @@ export function AccountSettings(props: SettingGroupPageProps): JSX.Element {
         const file = files[0];
         setNewIcon(Object.assign(file, { preview: URL.createObjectURL(file) }));
 
-        image_resizer(files[0], 512, 512)
+        image_resizer(files[0], 512, 512, 65535)
             .then((file: Blob) => {
                 put(`players/${user.id}/icon`, file)
                     .then((res) => {

--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -155,7 +155,7 @@ export function AvatarCard({
         const file = files[0];
         setNewIcon(Object.assign(file, { preview: URL.createObjectURL(file) }));
 
-        image_resizer(files[0], 512, 512)
+        image_resizer(files[0], 512, 512, 65535)
             .then((file: Blob) => {
                 put(`players/${user.id}/icon`, file)
                     .then((res) => {


### PR DESCRIPTION
This is a workaround to fix #2406 where a chrome behavior (I say bug) causes a fetch error to occur if our resized files are larger than 64KiB. All resources I've found on the topic do not mention any such limit and it's unclear to me why this limit is being imposed, so it may be a temporary issue in Chrome or it may be something else that I'm not aware of. Regardless, the change to webp largely resolves the issue, and scaling images down if they are "large" is a fine solution too I think, so I think the resulting workaround is a desirable behavior regardless.

Fixes #2406