### PR TITLE
Tighten up game list entries that aren't paused

### DIFF
--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -28,11 +28,13 @@ export function Clock({
     color,
     className,
     compact,
+    lineSummary,
 }: {
     goban: Goban;
     color: clock_color;
     className?: string;
     compact?: boolean;
+    lineSummary?: boolean;
 }): JSX.Element {
     const [clock, setClock] = useState<JGOFClockWithTransmitting>(null);
     const [submitting_move, _setSubmittingMove] = useState<boolean>(false);
@@ -101,8 +103,6 @@ export function Clock({
         const need_small_main_time_font = prettyTime(player_clock.main_time).length > 8;
 
         const show_pause = !compact && clock.pause_state;
-        const show_transmitting =
-            (submitting_move && player_id !== data.get("user").id) || transmitting > 0;
 
         return (
             <span className={clock_className}>
@@ -168,9 +168,10 @@ export function Clock({
                         </React.Fragment>
                     )}
 
-                {(show_pause || show_transmitting) && (
+                {(show_pause || !lineSummary) && (
                     <div className="pause-and-transmit">
-                        {show_transmitting ? (
+                        {(submitting_move && player_id !== data.get("user").id) ||
+                        transmitting > 0 ? (
                             <span
                                 className="transmitting fa fa-wifi"
                                 title={transmitting.toFixed(0)}

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -100,6 +100,10 @@ export function Clock({
         // use use a smaller font
         const need_small_main_time_font = prettyTime(player_clock.main_time).length > 8;
 
+        const show_pause = !compact && clock.pause_state;
+        const show_transmitting =
+            (submitting_move && player_id !== data.get("user").id) || transmitting > 0;
+
         return (
             <span className={clock_className}>
                 {player_clock.main_time > 0 && (
@@ -164,16 +168,19 @@ export function Clock({
                         </React.Fragment>
                     )}
 
-                <div className="pause-and-transmit">
-                    {(submitting_move && player_id !== data.get("user").id) || transmitting > 0 ? (
-                        <span className="transmitting fa fa-wifi" title={transmitting.toFixed(0)} />
-                    ) : (
-                        <span className="transmitting" />
-                    )}
-                    {!compact && clock.pause_state && (
-                        <ClockPauseReason clock={clock} player_id={player_id} />
-                    )}
-                </div>
+                {(show_pause || show_transmitting) && (
+                    <div className="pause-and-transmit">
+                        {show_transmitting ? (
+                            <span
+                                className="transmitting fa fa-wifi"
+                                title={transmitting.toFixed(0)}
+                            />
+                        ) : (
+                            <span className="transmitting" />
+                        )}
+                        {show_pause && <ClockPauseReason clock={clock} player_id={player_id} />}
+                    </div>
+                )}
             </span>
         );
     }

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -195,10 +195,10 @@ export class GobanLineSummary extends React.Component<
                             <Player user={opponent} fakelink rank />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color={player_color} />
+                            <Clock goban={this.goban} color={player_color} lineSummary={true} />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color={opponent_color} />
+                            <Clock goban={this.goban} color={opponent_color} lineSummary={true} />
                         </div>
                     </>
                 )}
@@ -209,13 +209,13 @@ export class GobanLineSummary extends React.Component<
                             <Player user={this.props.black} fakelink rank />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color="black" />
+                            <Clock goban={this.goban} color="black" lineSummary={true} />
                         </div>
                         <div className="player">
                             <Player user={this.props.white} fakelink />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color="white" />
+                            <Clock goban={this.goban} color="white" lineSummary={true} />
                         </div>
                     </>
                 )}


### PR DESCRIPTION
cae93c525 added the display of transmission problems to the game list. Perhaps inadvertently, this doubled the vertical space used for all games in the list.

Only use the vertical space when there is something to show.

Fixes #2418 
