### PR TITLE
Analysis is always enabled for finished games

### DIFF
--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -64,6 +64,10 @@ export function configure_goban() {
         },
 
         isAnalysisDisabled: (goban: Goban, perGameSettingAppliesToNonPlayers = false): boolean => {
+            if (goban.engine.phase === "finished") {
+                return false;
+            }
+
             // The player's preference setting to always disable analysis overrides the per-game setting for
             // their own games.
             if (

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -335,7 +335,7 @@ export function Game(): JSX.Element {
         if (
             goban.current.mode === "play" &&
             goban.current.engine.phase !== "stone removal" &&
-            (!goban.current.isAnalysisDisabled() || goban.current.engine.phase === "finished")
+            !goban.current.isAnalysisDisabled()
         ) {
             set_variation_name("");
             goban.current.setMode("analyze");
@@ -466,7 +466,7 @@ export function Game(): JSX.Element {
         }
     };
     const gameAnalyze = () => {
-        if (goban.current.isAnalysisDisabled() && goban.current.engine.phase !== "finished") {
+        if (goban.current.isAnalysisDisabled()) {
             //alert.fire(_("Analysis mode has been disabled for this game"));
         } else {
             const last_estimate_move = stopEstimatingScore();
@@ -616,7 +616,7 @@ export function Game(): JSX.Element {
         goban.current.score_estimate = null;
     };
     const enterConditionalMovePlanner = () => {
-        if (goban.current.isAnalysisDisabled() && goban.current.engine.phase !== "finished") {
+        if (goban.current.isAnalysisDisabled()) {
             //alert.fire(_("Conditional moves have been disabled for this game."));
         } else {
             stashed_conditional_moves.current = goban.current.conditional_tree.duplicate();
@@ -632,11 +632,7 @@ export function Game(): JSX.Element {
             user.id === goban.current.engine.players.black.id ||
             user.id === goban.current.engine.players.white.id;
 
-        if (
-            goban.current.isAnalysisDisabled() &&
-            goban.current.engine.phase !== "finished" &&
-            is_player
-        ) {
+        if (goban.current.isAnalysisDisabled() && is_player) {
             //alert.fire(_("Analysis mode has been disabled for this game, you can start a review after the game has concluded."));
         } else {
             alert
@@ -661,11 +657,7 @@ export function Game(): JSX.Element {
             user.id === goban.current.engine.players.white.id ||
             shared_ip_with_player_map[game_id];
 
-        if (
-            goban.current.isAnalysisDisabled() &&
-            goban.current.engine.phase !== "finished" &&
-            is_player
-        ) {
+        if (goban.current.isAnalysisDisabled() && is_player) {
             return null;
         }
 

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -109,7 +109,7 @@ export function GameDock({
 
     let sgf_download_enabled = false;
     try {
-        sgf_download_enabled = phase === "finished" || !goban.isAnalysisDisabled(true);
+        sgf_download_enabled = !goban.isAnalysisDisabled(true);
     } catch (e) {
         // ignore error
     }
@@ -134,11 +134,7 @@ export function GameDock({
     };
 
     const fork = () => {
-        if (
-            !user.anonymous &&
-            !engine.rengo &&
-            (!goban.isAnalysisDisabled() || phase === "finished")
-        ) {
+        if (!user.anonymous && !engine.rengo && !goban.isAnalysisDisabled()) {
             challengeFromBoardPosition(goban);
         }
     };
@@ -384,9 +380,7 @@ export function GameDock({
                 <Tooltip tooltipRequired={tooltipRequired} title={_("Analyze game")}>
                     <a
                         onClick={onAnalyzeClicked}
-                        className={
-                            phase !== "finished" && goban.isAnalysisDisabled() ? "disabled" : ""
-                        }
+                        className={goban.isAnalysisDisabled() ? "disabled" : ""}
                     >
                         <i className="fa fa-sitemap"></i> {_("Analyze game")}
                     </a>
@@ -401,9 +395,7 @@ export function GameDock({
                                     ? "visible"
                                     : "hidden",
                         }}
-                        className={
-                            phase !== "finished" && goban.isAnalysisDisabled() ? "disabled" : ""
-                        }
+                        className={goban.isAnalysisDisabled() ? "disabled" : ""}
                         onClick={onConditionalMovesClicked}
                     >
                         <i className="fa fa-exchange"></i> {_("Plan conditional moves")}
@@ -426,11 +418,7 @@ export function GameDock({
                                 return onReviewClicked();
                             }
                         }}
-                        className={
-                            (phase !== "finished" && goban.isAnalysisDisabled()) || user.anonymous
-                                ? "disabled"
-                                : ""
-                        }
+                        className={goban.isAnalysisDisabled() || user.anonymous ? "disabled" : ""}
                     >
                         <i className="fa fa-refresh"></i> {_("Review this game")}
                     </a>
@@ -439,7 +427,7 @@ export function GameDock({
             <Tooltip tooltipRequired={tooltipRequired} title={_("Estimate score")}>
                 <a
                     onClick={onEstimateClicked}
-                    className={phase !== "finished" && goban.isAnalysisDisabled() ? "disabled" : ""}
+                    className={goban.isAnalysisDisabled() ? "disabled" : ""}
                 >
                     <i className="fa fa-tachometer"></i> {_("Estimate score")}
                 </a>
@@ -448,9 +436,7 @@ export function GameDock({
                 <a
                     onClick={fork}
                     className={
-                        user.anonymous ||
-                        engine.rengo ||
-                        (goban.isAnalysisDisabled() && phase !== "finished")
+                        user.anonymous || engine.rengo || goban.isAnalysisDisabled()
                             ? "disabled"
                             : ""
                     }


### PR DESCRIPTION
Update the `isAnalysisDisabled` hook for the Goban engine to always return `false` when the game is finished.

This is a speculative fix for #2392. I can't test right now because beta.online-go.com isn't available. Posting anyway in case someone else gets a chance to test before I do.