### PR TITLE
Shorten names for tournament/ladder games in game lists

### DIFF
--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -28,11 +28,13 @@ export function Clock({
     color,
     className,
     compact,
+    lineSummary,
 }: {
     goban: Goban;
     color: clock_color;
     className?: string;
     compact?: boolean;
+    lineSummary?: boolean;
 }): JSX.Element {
     const [clock, setClock] = useState<JGOFClockWithTransmitting>(null);
     const [submitting_move, _setSubmittingMove] = useState<boolean>(false);
@@ -101,8 +103,6 @@ export function Clock({
         const need_small_main_time_font = prettyTime(player_clock.main_time).length > 8;
 
         const show_pause = !compact && clock.pause_state;
-        const show_transmitting =
-            (submitting_move && player_id !== data.get("user").id) || transmitting > 0;
 
         return (
             <span className={clock_className}>
@@ -168,9 +168,10 @@ export function Clock({
                         </React.Fragment>
                     )}
 
-                {(show_pause || show_transmitting) && (
+                {(show_pause || !lineSummary) && (
                     <div className="pause-and-transmit">
-                        {show_transmitting ? (
+                        {(submitting_move && player_id !== data.get("user").id) ||
+                        transmitting > 0 ? (
                             <span
                                 className="transmitting fa fa-wifi"
                                 title={transmitting.toFixed(0)}

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -35,6 +35,13 @@ interface UserType {
     professional?: boolean;
 }
 
+export type GameNameForList = {
+    original: string;
+    text: string;
+    span?: string;
+    prefix?: string;
+};
+
 interface GobanLineSummaryProps {
     id: number;
     black: UserType;
@@ -177,6 +184,7 @@ export class GobanLineSummary extends React.Component<
             opponent = player_color === "black" ? this.props.white : this.props.black;
         }
 
+        const list_name = parseGameName(this.state.game_name);
         return (
             <Link
                 to={`/game/${this.props.id}`}
@@ -187,7 +195,14 @@ export class GobanLineSummary extends React.Component<
                 }
             >
                 <div className="move-number">{this.state.move_number}</div>
-                <div className="game-name">{this.state.game_name}</div>
+                <div className="game-name">
+                    {list_name.span && (
+                        <>
+                            <span className={list_name.span} />
+                        </>
+                    )}
+                    <span title={list_name.original}>{list_name.text}</span>
+                </div>
 
                 {this.props.lineSummaryMode === "opponent-only" && (
                     <>
@@ -248,4 +263,28 @@ function playerColor(props: GobanLineSummaryProps): PlayerColor | null {
         }
     }
     return null;
+}
+
+function stripNamePrefix(name: string, prefix: string): string | null {
+    if (!name) {
+        return null;
+    }
+    return name.startsWith(prefix) ? name.substr(prefix.length) : null;
+}
+
+export function parseGameName(name: string): GameNameForList | null {
+    const spans = {
+        "Tournament Game:": "fa fa-trophy",
+        "Ladder Challenge:": "fa fa-list-ol",
+    };
+    const list_name: GameNameForList = { original: name };
+    for (const prefix in spans) {
+        if ((list_name.text = stripNamePrefix(name, prefix))) {
+            list_name.prefix = prefix;
+            list_name.span = spans[prefix];
+            return list_name;
+        }
+    }
+    list_name.text = name;
+    return list_name;
 }

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -272,19 +272,23 @@ function stripNamePrefix(name: string, prefix: string): string | null {
     return name.startsWith(prefix) ? name.substr(prefix.length) : null;
 }
 
-export function parseGameName(name: string): GameNameForList | null {
+export function parseGameName(name: string): GameNameForList {
     const spans = {
         "Tournament Game:": "fa fa-trophy",
         "Ladder Challenge:": "fa fa-list-ol",
     };
-    const list_name: GameNameForList = { original: name };
     for (const prefix in spans) {
-        if ((list_name.text = stripNamePrefix(name, prefix))) {
-            list_name.prefix = prefix;
-            list_name.span = spans[prefix];
+        let text: string = null;
+        if ((text = stripNamePrefix(name, prefix))) {
+            const list_name: GameNameForList = {
+                original: name,
+                text: text,
+                prefix: prefix,
+                span: spans[prefix],
+            };
             return list_name;
         }
     }
-    list_name.text = name;
+    const list_name: GameNameForList = { original: name, text: name };
     return list_name;
 }

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -195,10 +195,10 @@ export class GobanLineSummary extends React.Component<
                             <Player user={opponent} fakelink rank />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color={player_color} />
+                            <Clock goban={this.goban} color={player_color} lineSummary={true} />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color={opponent_color} />
+                            <Clock goban={this.goban} color={opponent_color} lineSummary={true} />
                         </div>
                     </>
                 )}
@@ -209,13 +209,13 @@ export class GobanLineSummary extends React.Component<
                             <Player user={this.props.black} fakelink rank />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color="black" />
+                            <Clock goban={this.goban} color="black" lineSummary={true} />
                         </div>
                         <div className="player">
                             <Player user={this.props.white} fakelink />
                         </div>
                         <div>
-                            <Clock goban={this.goban} color="white" />
+                            <Clock goban={this.goban} color="white" lineSummary={true} />
                         </div>
                     </>
                 )}

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -181,7 +181,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
             item.speed = capitalize(speed);
             item.speed_icon_class = getSpeedClass(speed);
 
-            item.name = parseGameName(r.name);
+            item.name = r.name ? parseGameName(r.name) : null;
 
             if (item.name && item.name.text.trim() === "") {
                 item.name.text = item.href;

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -35,6 +35,7 @@ import { Speed } from "src/lib/types";
 import { usePreference } from "preferences";
 import { openAnnulQueueModal, AnnulQueueModal } from "AnnulQueueModal";
 import { useUser } from "hooks";
+import { parseGameName, GameNameForList } from "GobanLineSummary";
 
 interface GameHistoryProps {
     user_id: number;
@@ -60,7 +61,7 @@ interface GroomedGame {
     width: number;
     height: number;
     href: `/game/${number}`;
-    name: string;
+    name: GameNameForList;
     black: PlayerCacheEntry;
     white: PlayerCacheEntry;
     result_class: ResultClass;
@@ -180,10 +181,10 @@ export function GameHistoryTable(props: GameHistoryProps) {
             item.speed = capitalize(speed);
             item.speed_icon_class = getSpeedClass(speed);
 
-            item.name = r.name;
+            item.name = parseGameName(r.name);
 
-            if (item.name && item.name.trim() === "") {
-                item.name = item.href;
+            if (item.name && item.name.text.trim() === "") {
+                item.name.text = item.href;
             }
 
             item.href = `/game/${item.id}`;
@@ -390,7 +391,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                     "game_name" + (X && X.annulled ? " annulled" : ""),
                                 render: (X) => (
                                     <Link to={X.href} onClick={(e) => handleLinkClick(e)}>
-                                        {X.name ||
+                                        {!X.name &&
                                             interpolate(
                                                 "{{black_username}} vs. {{white_username}}",
                                                 {
@@ -398,6 +399,16 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                                     white_username: X.white.username,
                                                 },
                                             )}
+                                        {X.name && (
+                                            <>
+                                                {X.name.span && (
+                                                    <>
+                                                        <span className={X.name.span} />
+                                                    </>
+                                                )}
+                                                <span title={X.name.original}>{X.name.text}</span>
+                                            </>
+                                        )}
                                     </Link>
                                 ),
                             },


### PR DESCRIPTION
Show more of the relevant part of the game name in game lists before the text overflows, by replacing:

- the "Tournament Game:" prefix with the trophy icon and
- the "Ladder Challenge:" prefix with the ladder icon.

Without this change, the now-shortened prefix was the only visible text in such games.

This fixes both `GobanLineSummary` and `GameHistoryTable`.

Fixes #2424