### PR TITLE
Skip empty transmitting in line summaries when paused

### DIFF
--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -170,15 +170,16 @@ export function Clock({
 
                 {(show_pause || !lineSummary) && (
                     <div className="pause-and-transmit">
-                        {(submitting_move && player_id !== data.get("user").id) ||
-                        transmitting > 0 ? (
-                            <span
-                                className="transmitting fa fa-wifi"
-                                title={transmitting.toFixed(0)}
-                            />
-                        ) : (
-                            <span className="transmitting" />
-                        )}
+                        {!lineSummary &&
+                            ((submitting_move && player_id !== data.get("user").id) ||
+                            transmitting > 0 ? (
+                                <span
+                                    className="transmitting fa fa-wifi"
+                                    title={transmitting.toFixed(0)}
+                                />
+                            ) : (
+                                <span className="transmitting" />
+                            ))}
                         {show_pause && <ClockPauseReason clock={clock} player_id={player_id} />}
                     </div>
                 )}


### PR DESCRIPTION
f2ebda37ecbe and b2f2565eeae8 already tightened up the display of line summaries for games that are NOT paused by removing the `<span>` for `transmitting`.

This follow-up also removes the span when the game IS paused. Otherwise, a blank line is added on really small screens (e.g., mobile), when the empty transmitting `<span>` and the word "Paused" don't fit on one line.

Fixes #2426