### PR TITLE
Respect ai-review-use-score in AIDemoReview.renderAnalysis

### DIFF
--- a/src/views/Game/AIDemoReview.tsx
+++ b/src/views/Game/AIDemoReview.tsx
@@ -341,6 +341,7 @@ function renderAnalysis(goban: Goban, data: any) {
     if (!preferences.get("ai-review-enabled")) {
         return;
     }
+    const use_score = preferences.get("ai-review-use-score");
 
     const analysis = data.analysis;
     const branches = analysis.branches;
@@ -381,7 +382,6 @@ function renderAnalysis(goban: Goban, data: any) {
                 ? JGOFNumericPlayerColor.WHITE
                 : JGOFNumericPlayerColor.BLACK;
 
-        const use_score = false;
         const delta: number = use_score
             ? next_player === JGOFNumericPlayerColor.WHITE
                 ? analysis.score - branch.score


### PR DESCRIPTION
This is a fix-up for new feature for AI reviews in demo and review boards. With this commit, the analysis rendering will respect the `ai-review-use-score`. Currently it's always a percentage. ~~(Let me know if you'd like me to file an issue first.)~~

Fixes #2433 _(see there for screenshots of the bug)_