### PR TITLE
Use last_emitted_clock in AntiEscaping

### DIFF
--- a/src/views/Game/AntiGrief.tsx
+++ b/src/views/Game/AntiGrief.tsx
@@ -103,13 +103,13 @@ function AntiEscaping(): JSX.Element {
     const user = useUser();
     const goban = useGoban();
     const [phase, setPhase] = React.useState(goban?.engine?.phase);
-    const [clock, setClock] = React.useState<JGOFClockWithTransmitting>(goban?.last_clock as any);
+    const [clock, setClock] = React.useState<JGOFClockWithTransmitting>(goban?.last_emitted_clock);
     const [expiration, setExpiration] = React.useState<number>(null);
     const [show, setShow] = React.useState(false);
 
     React.useEffect(() => {
         setShow(false);
-        setClock(goban?.last_clock as any);
+        setClock(goban?.last_emitted_clock);
         goban.on("clock", setClock);
 
         return () => {


### PR DESCRIPTION
Since the type being used JGOFClockWithTransmitting, the intent must have been `last_emitted_clock`, not `last_clock`.

N.B., from src/Goban.ts in the goban repo:

    public last_clock?: AdHocClock;
    public last_emitted_clock?: JGOFClockWithTransmitting;

Also drop the `as any` which was probably added to suppress the type error.