### PR TITLE
Corner case handling for community moderator actions

### DIFF
--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -181,7 +181,7 @@ export function IncidentReportTracker(): JSX.Element {
         navigate(`/reports-center/all/${report_id}`);
     };
 
-    const reports = report_manager.sorted_active_incident_reports;
+    const reports = report_manager.getAvailableReports();
     const hide_indicator = (reports.length === 0 && !user.is_moderator) || prefer_hidden;
 
     function getReportType(report: Report): string {

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -16,13 +16,12 @@
  */
 
 import * as React from "react";
-import { Report } from "report_manager";
-import { pgettext } from "translate";
+import { _, pgettext } from "translate";
 
 import * as DynamicHelp from "react-dynamic-help";
 
 interface ModerationActionSelectorProps {
-    report: Report;
+    available_actions: string[];
     enable: boolean;
     claim: () => void;
     submit: (action: string) => void;
@@ -60,7 +59,7 @@ const ACTION_PROMPTS = {
 };
 
 export function ModerationActionSelector({
-    report,
+    available_actions,
     enable,
     claim,
     submit,
@@ -76,37 +75,46 @@ export function ModerationActionSelector({
     const { ref: voting_pane } = registerTargetItem("voting-pane");
     const { ref: escalate_option } = registerTargetItem("escalate-option");
 
+    const action_choices = available_actions ? available_actions : ["escalate"];
+
     return (
-        <div className="voting" ref={voting_pane}>
+        <div className="voting-pane" ref={voting_pane}>
             <h4>
                 {pgettext(
                     "The heading for community moderators 'action choices' section",
                     "Actions",
                 )}
             </h4>
-            {report.available_actions.map((a) => (
-                <div
-                    key={a}
-                    className="action-selector"
-                    ref={a === "escalate" ? escalate_option : null}
-                >
-                    <input
-                        id={a}
-                        name="availableActions"
-                        type="radio"
-                        checked={selectedOption === a}
-                        value={a}
-                        onChange={updateSelectedAction}
-                    />
-                    <label htmlFor={a}>{ACTION_PROMPTS[a]}</label>
+            {(!available_actions || null) && (
+                <div className="no-report-actions-note">
+                    {_("This report has no available actions yet.  You can escalate or ignore it.")}
                 </div>
-            ))}
-            {(report.available_actions || null) && (
-                <button
-                    className="success"
-                    disabled={!enable}
-                    onClick={() => submit(selectedOption)}
-                >
+            )}
+            {!enable && (
+                <div className="diabled-actions-note">
+                    {_("This report was handled after you decided to look at it!")}
+                </div>
+            )}
+            {enable &&
+                action_choices.map((a) => (
+                    <div
+                        key={a}
+                        className="action-selector"
+                        ref={a === "escalate" ? escalate_option : null}
+                    >
+                        <input
+                            id={a}
+                            name="availableActions"
+                            type="radio"
+                            checked={selectedOption === a}
+                            value={a}
+                            onChange={updateSelectedAction}
+                        />
+                        <label htmlFor={a}>{ACTION_PROMPTS[a]}</label>
+                    </div>
+                ))}
+            {((action_choices && enable) || null) && (
+                <button className="success" onClick={() => submit(selectedOption)}>
                     {pgettext("A label on a button for submitting a vote", "Vote")}
                 </button>
             )}

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -40,6 +40,15 @@ reports_center_content_width=56rem
         }
     }
 
+
+    .voting-pane {
+        padding-bottom: 0.5rem; // intended to create margin for rdh highlighter
+
+        .no-report-actions-note,  .disabled-actions-note {
+            padding: 0 1rem 1rem 1rem;
+        }
+    }
+
     .actions {
         display: grid;
         grid-template-columns: 1fr 1fr;

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -59,11 +59,15 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
     const [reportState, setReportState] = React.useState(report?.state);
     const [isAnnulQueueModalOpen, setIsAnnulQueueModalOpen] = React.useState(false);
     const [annulQueue, setAnnulQueue] = React.useState<null | any[]>(report?.detected_ai_games);
+    const [availableActions, setAvailableActions] = React.useState<string[]>(null);
 
     const related = report_manager.getRelatedReports(report_id);
 
     React.useEffect(() => {
         if (report_id) {
+            // For some reason we have to capture the state of the report at the time that report_id goes valid
+            // It's not clear why, but there are subsequent renders where the report state goes away, so ...
+            // capture what you want to use here! ...
             report_manager
                 .getReport(report_id)
                 .then((report) => {
@@ -72,6 +76,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     setModeratorId(report?.moderator?.id);
                     setReportState(report?.state);
                     setAnnulQueue(report?.detected_ai_games);
+                    setAvailableActions(report?.available_actions);
                 })
                 .catch((err) => {
                     console.error(err);
@@ -448,9 +453,9 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                 {((!user.is_moderator && user.moderator_powers) || null) && (
                     <div className="voting">
                         <ModerationActionSelector
-                            report={report}
+                            available_actions={availableActions}
                             claim={() => {
-                                /* dont claim*/
+                                /* community moderators don't claim reports */
                             }}
                             submit={(action) => {
                                 void report_manager.vote(report.id, action);


### PR DESCRIPTION
... , and let moderators see all reports for now.

Fixes:
 - Reports eligible for community moderation languishing without anyone to look at them
 - Errors on cornercases like "report was created before community moderation actions defined" and "moderator stole the report while community moderator looking at it"

## Proposed Changes

 - Detect "no actions" and always provide an "escalate" action, explaining to the community moderator in that case
 - Put in hardwired constant to control if moderators see community eligible reports - and make them see them
 - Make IncidentReportList only show eligible reports to the user
 