### PR TITLE
Switch GameList to sort based on JGOFClock

### DIFF
--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -42,6 +42,7 @@ interface GobanLineSummaryProps {
     white: UserType;
     player?: { id: number };
     gobanRef?: (goban: Goban) => void;
+    onFirstClock?: () => void;
     width?: number;
     height?: number;
     rengo_teams?: {
@@ -116,6 +117,18 @@ export class GobanLineSummary extends React.Component<
 
             if (this.props.gobanRef) {
                 this.props.gobanRef(this.goban);
+            }
+
+            // Let the caller know the once we have a valid JGOFClock.
+            if (this.props.onFirstClock) {
+                const onFirstClock = this.props.onFirstClock;
+                if (this.goban.last_emitted_clock === undefined) {
+                    this.goban.once("clock", () => {
+                        onFirstClock();
+                    });
+                } else {
+                    onFirstClock();
+                }
             }
         });
     }


### PR DESCRIPTION
Change GameList over to sorting based on the JGOFClock instead of AdHocClock. Computing remaining time is simpler and easier to get right, especially for paused games.

The downside is that we don't initially have a JGOFClock available.  Here's how that's handled:

- New callback to `GobanLineSummary`, called the first time a `JGOFClock` is available.
- New field `force_render` in `GameList`'s state, which gets bumped by the callback.  When `render()` gets called again, the sort will be reevaluated.

Note: `force_render` is named generically because there might be other (non-clock) reasons to force `GameList.render()` to be called in the future.

Fixes #2451