### PR TITLE
Fix byoyomi off-by-one in game-list sorting

### DIFF
--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -116,12 +116,16 @@ export class GameList extends React.PureComponent<GameListProps, GameListState> 
             case "simple":
                 return player_clock.main_time;
 
-            case "byoyomi":
+            case "byoyomi": {
+                // JGOFClock.periods_left includes the current, partially used,
+                // period, but we just need to count the full ones.
+                const full_periods_left = (player_clock.periods_left || 1) - 1;
                 return (
                     player_clock.main_time +
                     (player_clock.period_time_left || 0) +
-                    (player_clock.periods_left || 0) * ((time_control.period_time as number) * 1000)
+                    full_periods_left * (time_control.period_time as number) * 1000
                 );
+            }
             case "canadian":
                 return player_clock.main_time + (player_clock.block_time_left || 0);
         }


### PR DESCRIPTION
#2451 had an off-by-one in game-list sorting of byoyomi time control. Note the "SD" (sudden death) entry in this screenshot:
<img width="166" alt="Image" src="https://github.com/online-go/online-go.com/assets/1334620/b697c100-3f5c-432a-b69a-16264ab83710">

In the screenshot, we're sorting as if there's an extra 24h period. The reason is that `JGOF.periods_left` includes the current, partially used, period, not just the full ones (as the calculation incorrectly assumed).