### PR TITLE
Unify sorting of MiniGobanList with LineSummaryTable

### DIFF
--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -42,7 +42,6 @@ interface GobanLineSummaryProps {
     white: UserType;
     player?: { id: number };
     gobanRef?: (goban: Goban) => void;
-    onFirstClock?: () => void;
     width?: number;
     height?: number;
     rengo_teams?: {
@@ -117,18 +116,6 @@ export class GobanLineSummary extends React.Component<
 
             if (this.props.gobanRef) {
                 this.props.gobanRef(this.goban);
-            }
-
-            // Let the caller know the once we have a valid JGOFClock.
-            if (this.props.onFirstClock) {
-                const onFirstClock = this.props.onFirstClock;
-                if (this.goban.last_emitted_clock === undefined) {
-                    this.goban.once("clock", () => {
-                        onFirstClock();
-                    });
-                } else {
-                    onFirstClock();
-                }
             }
         });
     }


### PR DESCRIPTION
Unify the logic between LineSummaryTable and MiniGobanList to fix sorting of MiniGobanList.

- Set `game.goban` so that `applyCurrentSort` can find the clock.
- Per 85a08f237e905d240b5c42917b47dc81d27983b2, force rendering once we have clocks for the gobans.

Before 85a08f237e905d240b5c42917b47dc81d27983b2, the initial sort for MiniGobanList was correct but wouldn't have updated over time. But that commit started depending on the link to `game.goban`, which `MiniGobanList` never set, and so it broke sorting entirely.

A couple of notes:

- Renamed `onFirstClock()` to `forceRender()` to better descript what it does.
- Moved onFirstClock logic from `LineSummaryTable.initializer()` to new method, `GameList.onGobanCreated()`, which can be reused. - Also added the setting of `game.goban` to the same method.
- Changed MiniGobanList to send in `onGobanCreated`. - Hypothetically, this would override `MiniGobanProps.onGobanCreated`, but users of `GameList` never set that. The only existing users of `onGobanCreated` use are directly using `MiniGoban`.
