### PR TITLE
Bring back AdHocClock to seed sorting of GameList

### DIFF
--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -26,6 +26,9 @@ import {
     JGOFPauseState,
     JGOFClock,
     JGOFPlayerClock,
+    AdHocClock,
+    AdHocPlayerClock,
+    AdHocPauseControl,
     AdHocPackedMove,
     Goban,
 } from "goban";

--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -42,7 +42,10 @@ interface GameType {
     white: UserType;
     goban?: Goban;
     json?: {
+        clock: AdHocClock;
         moves: AdHocPackedMove[];
+        pause_control?: AdHocPauseControl;
+        time_control?: JGOFTimeControl;
         rengo_teams: {
             black: Array<UserType>;
             white: Array<UserType>;
@@ -88,11 +91,44 @@ export class GameList extends React.PureComponent<GameListProps, GameListState> 
         }
     };
 
-    isPaused(pause_control: JGOFPauseState | undefined) {
+    isPaused(pause_control: JGOFPauseState | AdHocPauseControl | undefined) {
         for (const _key in pause_control) {
             return true;
         }
         return false;
+    }
+
+    computeRemainingTimeAdHoc(
+        time_control: JGOFTimeControl | undefined,
+        clock: AdHocClock,
+        player_clock: AdHocPlayerClock | number,
+    ) {
+        // Inaccurate for paused clocks.
+        switch (time_control?.system) {
+            case "simple": {
+                const time: number = player_clock as number;
+                return time - clock.last_move;
+            }
+            case "absolute":
+            case "fischer": {
+                const time: AdHocPlayerClock = player_clock as AdHocPlayerClock;
+                return time.thinking_time * 1000;
+            }
+            case "byoyomi": {
+                const time: AdHocPlayerClock = player_clock as AdHocPlayerClock;
+                return (
+                    (time.thinking_time + (time.period_time as number) * (time.periods as number)) *
+                    1000
+                );
+            }
+            case "canadian": {
+                const time: AdHocPlayerClock = player_clock as AdHocPlayerClock;
+                return (time.thinking_time + (time.block_time as number)) * 1000;
+            }
+            case "none":
+            default:
+                return Number.MAX_SAFE_INTEGER;
+        }
     }
 
     computeRemainingTime(
@@ -131,14 +167,38 @@ export class GameList extends React.PureComponent<GameListProps, GameListState> 
         }
     }
 
-    extractClockSortFields(game: GameType, use_this_player: boolean) {
-        if (game?.goban?.last_emitted_clock === undefined) {
-            // No JGOFClock yet. Sort last.
+    extractClockSortFieldsAdHoc(game: GameType, use_this_player: boolean) {
+        if (game?.json?.clock === undefined) {
+            // No clock at all! Sort last.
             return {
                 paused: true,
                 is_current_player: false,
                 remaining: Number.MAX_SAFE_INTEGER,
             };
+        }
+
+        const clock = game.goban?.last_clock || game.json.clock;
+        const paused = this.isPaused(game.json?.pause_control);
+        const is_current_player = clock.current_player === this.props.player?.id;
+        const is_black = clock.black_player_id === this.props.player?.id;
+        const use_black = use_this_player === is_black;
+        const remaining = this.computeRemainingTimeAdHoc(
+            game.json?.time_control,
+            clock,
+            use_black ? clock.black_time : clock.white_time,
+        );
+
+        return {
+            paused: paused,
+            is_current_player: is_current_player,
+            remaining: remaining,
+        };
+    }
+
+    extractClockSortFields(game: GameType, use_this_player: boolean) {
+        if (game?.goban?.last_emitted_clock === undefined) {
+            // No JGOFClock yet. Use the AdHocClock.
+            return this.extractClockSortFieldsAdHoc(game, use_this_player);
         }
 
         const clock = game.goban.last_emitted_clock;


### PR DESCRIPTION
85a08f237e905d240b5c42917b47dc81d27983b2 switched to sorting using JGOFClock, which is more accurate, especially for paused games. This brings back sorting based on the AdHocClock until a JGOFClock is available.

[As reported on the forums](https://forums.online-go.com/t/new-better-sorting-for-active-games/50061/4), waiting until a JGOFClock is available made the mini-gobans (or line summaries) jump around a lot as things settled. If we seed the sort with AdHocClock, then only the parts it gets wrong will have to update.

Note that we can't use `AdHocClock.expiration` because we have nothing to compare it against on the `JGOFClock` side.
