### PR TITLE
Changes the default joseki filter to blank

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1443,7 +1443,7 @@ class PlayPane extends React.Component<PlayProps, any> {
             this.props.current_filter.source === null) {
             // Set up a Joseki filter by default
             this.props.set_variation_filter({
-                tags:[null,
+                tags: null,
                 contributor: null,
                 source: null
             });

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1443,7 +1443,7 @@ class PlayPane extends React.Component<PlayProps, any> {
             this.props.current_filter.source === null) {
             // Set up a Joseki filter by default
             this.props.set_variation_filter({
-                tags:[this.props.joseki_tag_id],
+                tags:[null,
                 contributor: null,
                 source: null
             });


### PR DESCRIPTION
The default filter hides a lot of sequences, the intention with the change was to increase engagement with the filter feature but there are too many cases of users being confused about not seeing many variations.

There is probably more code that can be removed regarding forced filter but simply removing this tag does the job.