### PR TITLE
Use REMOTE_OVERWRITES_LOCAL for 'ignored-reports'

### DIFF
--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -321,7 +321,7 @@ class ReportManager extends EventEmitter<Events> {
                 delete ignored[key];
             }
         }
-        data.set("ignored-reports", ignored);
+        data.set("ignored-reports", ignored, data.Replication.REMOTE_OVERWRITES_LOCAL);
         this.update();
     }
 


### PR DESCRIPTION
## Motivation

I am finding that I need to ignore the same report across multiple devices.  I feel like the "right thing" is to have the "Ignore" propagate to all devices.

## Proposed Changes

See title.