### PR TITLE
Put RDH popups at the bottom of the screen on phones

### DIFF
--- a/src/views/HelpFlows/HelpFlows.styl
+++ b/src/views/HelpFlows/HelpFlows.styl
@@ -25,6 +25,15 @@
     padding: 0.2rem;
     font-size: 1.0rem;
     box-shadow: 0 0.2rem 0.5rem 0.2rem rgba(0,0,0,0.2);
+
+    // Don't try to position RDH popups near the target on a phone
+    // Instead, put them at the bottom of the screen.
+    @media only screen and (max-width 800px) {
+        bottom: 0 !important;
+        left: 0 !important;
+        right: auto !important;
+        top: auto !important;
+    }
 }
 
 .rdh-help-item>.rdh-popup-dismissers {


### PR DESCRIPTION
Fixes RDH popups getting squished and not being readable on small phone layouts

## Proposed Changes

  - Put RDH popups at the bottom of the screen on phones.
  
  