### PR TITLE
Clear vote on different reports.

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -476,6 +476,8 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                                 next();
                             }}
                             enable={report.state === "pending"}
+                            // clear the selection for subsequent reports
+                            key={report.id}
                         />
                     </div>
                 )}


### PR DESCRIPTION
The selection should be refreshed on each new report, but right now, the previous report's decision will remain populated.

## Proposed Changes

Use the `key` prop to force a remount of the voting options when the report id changes.

## Screen recordings

Before:
https://github.com/online-go/online-go.com/assets/25233703/8494e314-765c-4cb6-ac28-d79f0b793676

After:
https://github.com/online-go/online-go.com/assets/25233703/16d5046d-3cee-4d09-8574-368f467b14a7
