### PR TITLE
Let community moderators see and edit the mod notes.

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -457,7 +457,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     </div>
                 )}
 
-                {(user.is_moderator || null) && (
+                {(user.is_moderator || user.moderator_powers || null) && (
                     <div className="notes">
                         <h4>Moderator Notes</h4>
                         <textarea value={moderatorNote} onChange={setAndSaveModeratorNote} />


### PR DESCRIPTION
Fixes Community Moderator desire to explain why they are escalating

## Proposed Changes

  - Let Community Moderators see and edit Mod Notes

 
Needs https://github.com/online-go/ogs/pull/1866