### PR TITLE
Provide ACTION_PROMPTS for community moderator "call game" vote actions

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -55,7 +55,7 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
     ack_educated_beginner_score_cheat: (reported) =>
         interpolate(
             _(`
-            Thanks for the report about {{reported}}. It seems you were playing against a
+            Thanks for the report about {{reported}}. It seems that person was a
             complete beginner - we have tried to explain that games should
             be ended correctly, to pass when their opponent passes, and to accept promptly,
             trusting the auto-score.`),
@@ -64,7 +64,7 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
     ack_educated_beginner_score_cheat_and_annul: (reported) =>
         interpolate(
             _(`
-            Thanks for the report about {{reported}}. It seems you were playing against a
+            Thanks for the report about {{reported}}. It seems that person was a
             complete beginner - we have tried to explain that games should
             be ended correctly, to pass when their opponent passes, and to accept promptly,
             trusting the auto-score.   That incorrectly scored game has been annulled.`),

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -27,6 +27,8 @@ interface ModerationActionSelectorProps {
     submit: (action: string) => void;
 }
 
+// Translatable versions of the prompts for Community Moderators.
+// The set of keys (choices) here is determined by the server VotableActions class.
 const ACTION_PROMPTS = {
     annul_score_cheat: pgettext(
         "Label for a moderator to select this option",
@@ -40,6 +42,14 @@ const ACTION_PROMPTS = {
         "Label for a moderator to select this option",
         "No cheating - inform the reporter.",
     ),
+    call_score_cheat_for_black: pgettext(
+        "Label for a moderator to select this option",
+        "White is cheating - call the game for black, and warn white.",
+    ),
+    call_score_cheat_for_white: pgettext(
+        "Label for a moderator to select this option",
+        "Black is cheating - call the game for white, and warn black.",
+    ),
     annul_escaped: pgettext(
         "Label for a moderator to select this option",
         "Wrong result due to escape - annul and warn the escaper.",
@@ -47,6 +57,14 @@ const ACTION_PROMPTS = {
     warn_escaper: pgettext(
         "Label for a moderator to select this option",
         "The accused escaped - warn them.",
+    ),
+    call_escaped_game_for_black: pgettext(
+        "Label for a moderator to select this option",
+        "White escaped - call the game for black, and warn white.",
+    ),
+    call_escaped_game_for_white: pgettext(
+        "Label for a moderator to select this option",
+        "Black escaped - call the game for white, and warn black.",
     ),
     no_escaping: pgettext(
         "Label for a moderator to select this option",


### PR DESCRIPTION
(and fix a canned message)

Fixes  Community Moderators not being able to act on in-progress games.

(and a canned message assuming that a report was raised by a player)

## Proposed Changes

  - Add prompts to support the back-end "vote actions" for deciding a game
  

(Needs https://github.com/online-go/ogs/pull/1868 to actually do anything)
