### PR TITLE
Improve spacing for voting buttons

### DIFF
--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -125,6 +125,7 @@
         .action-selector {
             display: flex;
             align-items: center
+            padding: 0.3rem;
 
             input {
                 margin-bottom: 3px; // override bizarre default 0 margin bottom so text lines up properly
@@ -147,6 +148,10 @@
         display: inline-flex;
         width: 100%;
         max-width: 100vw;
+    }
+
+    .voting {
+        flex-basis: 100%;
     }
 }
 }


### PR DESCRIPTION
I'm finding the options have a tendency to run together on mobile.  I think we can fill the space horizontally, and add some vertical space to improve the situation.

## Proposed Changes

- Add space between each option
- Fill horizontal space on mobile

## Screenshots

### Mobile (before/after)

<img src="https://github.com/online-go/online-go.com/assets/25233703/16718892-2592-4970-b1fe-983d136ac8cb" width="360">
<img src="https://github.com/online-go/online-go.com/assets/25233703/4b93ab26-8c31-40b5-b65b-3be484184210" width="360">

### Desktop (before/after)

<img width="394" alt="Screenshot 2023-12-31 at 11 25 55 PM" src="https://github.com/online-go/online-go.com/assets/25233703/a6d68f03-efdf-4a9c-a7ca-126b9b4c8de3">
<img width="399" alt="Screenshot 2023-12-31 at 11 25 29 PM" src="https://github.com/online-go/online-go.com/assets/25233703/c3710d76-c6d8-4076-9404-64b87abeb883">
