### PR TITLE
Fix whitespace between menu item icon and text for Play

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -188,7 +188,8 @@ export function NavBar(): JSX.Element {
                 </Link>
                 <Menu title={_("Play")} to="/play">
                     <Link to="/play">
-                        <i className="ogs-goban"></i> {_("Play")}
+                        <i className="ogs-goban"></i>
+                        {_("Play")}
                     </Link>
                     <Link to="/tournaments">
                         <i className="fa fa-trophy"></i>


### PR DESCRIPTION
Fixes #

For the Play there is a bigger gap than for the other menu items.

## Proposed Changes
Before
![image](https://github.com/online-go/online-go.com/assets/852150/aecc487e-de2f-4737-a8f1-bf92eefc1646)

After
![image](https://github.com/online-go/online-go.com/assets/852150/e69b2c80-79ea-45b2-821e-3c61b333caad)