### PR TITLE
Fix marks getting set before themes load?

### DIFF
--- a/src/views/Game/GameLogModal.tsx
+++ b/src/views/Game/GameLogModal.tsx
@@ -157,9 +157,9 @@ export function LogData({
                             key={k}
                             config={{
                                 ...config,
-                                marks,
                                 removed: "",
                             }}
+                            marks={marks}
                             move_number={data.move_number}
                             removal_string={data.current_removal_string}
                         />,

--- a/src/views/ReportsCenter/ScoringEventThumbnail.tsx
+++ b/src/views/ReportsCenter/ScoringEventThumbnail.tsx
@@ -23,10 +23,12 @@ import { PersistentElement } from "../../components/PersistentElement";
 export function ScoringEventThumbnail({
     config,
     move_number,
+    marks,
     removal_string,
 }: {
     config: GobanConfig;
     move_number: number | undefined;
+    marks: any;
     removal_string: string | undefined;
 }) {
     const goban_div = React.useRef<HTMLDivElement>(
@@ -55,6 +57,7 @@ export function ScoringEventThumbnail({
                 },
             );
         }
+        goban.current?.setMarks(marks);
         const score = engine.computeScore();
         goban.current?.showScores(score);
     }, [config]);


### PR DESCRIPTION
Partially fixes slow board loads.

## Proposed Changes

Set marks *after* the Goban has fully loaded.  Apparently the themes are not initialized when `setMarks` is first called in the (post)constructor.  This raises an error that is logged to the console, and that is CPU intensive.  It's probably a bug in goban that marks cause an error when passed in the config, but this PR is meant to demonstrate the improvement.

## Flame graphs

### Before

The console.error inside setMarks accounts for most of the compute. On my machine, this accounted for about 16 seconds on 50 boards.

<img width="1187" alt="Screenshot 2024-01-09 at 11 39 07 PM" src="https://github.com/online-go/online-go.com/assets/25233703/65e8c4c8-ea95-4362-b071-a3c8a0732e51">

https://profiler.firefox.com/from-browser/flame-graph/?globalTrackOrder=b0wa&hiddenGlobalTracks=1w9&hiddenLocalTracksByPid=88828-1w4~88831-0&implementation=js&thread=g&v=10

### After

setMarks is no longer a major contributor to CPU usage.  On my machine, `setMarks` uses less than 80ms for 50 boards.  However, `load` and `jumpToOfficialMove` are still reasonably heavy (~4 seconds).

<img width="1342" alt="Screenshot 2024-01-09 at 11 39 48 PM" src="https://github.com/online-go/online-go.com/assets/25233703/50c9a2db-13fe-44aa-934a-049275ab3d20">

https://profiler.firefox.com/from-browser/flame-graph/?globalTrackOrder=c0wb&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=88828-1w5~88831-0&implementation=js&thread=j&v=10
