### PR TITLE
Make specific ratings fall back to the overall one

### DIFF
--- a/src/lib/rank_utils.test.ts
+++ b/src/lib/rank_utils.test.ts
@@ -182,6 +182,46 @@ test("getUserRating", () => {
     // With a size/speed that does not exist on the user's rating
     expect(getUserRating(user, "blitz", 9)).toEqual(
         expect.objectContaining({
+            rating: 1465,
+            volatility: 0.06,
+            provisional: true,
+            deviation: 350,
+            unset: true,
+        }),
+    );
+
+    // With a size that does not exist on the user's rating
+    expect(getUserRating(user, "correspondence", 9)).toEqual(
+        expect.objectContaining({
+            rating: 1480,
+            volatility: 0.06,
+            provisional: true,
+            deviation: 350,
+            unset: true,
+        }),
+    );
+
+    // With a speed that does not exist on the user's rating
+    expect(getUserRating(user, "live", 0)).toEqual(
+        expect.objectContaining({
+            bounded_rank: 24,
+            bounded_rank_label: "6k",
+            deviation: 350,
+            professional: false,
+            provisional: true,
+            rating: 1465,
+            unset: true,
+            volatility: 0.06,
+        }),
+    );
+
+    // When the rating is completely unknown
+    const unknown = {
+        pro: false,
+        ratings: {},
+    };
+    expect(getUserRating(unknown, "overall", 0)).toEqual(
+        expect.objectContaining({
             bounded_rank: 24,
             bounded_rank_label: "6k",
             deviation: 350,

--- a/src/lib/rank_utils.test.ts
+++ b/src/lib/rank_utils.test.ts
@@ -133,6 +133,11 @@ test("getUserRating", () => {
                 deviation: 62,
                 volatility: 0.0625,
             },
+            correspondence: {
+                rating: 1470,
+                deviation: 63,
+                volatility: 0.0625,
+            },
             "correspondence-19x19": {
                 rating: 1480,
                 deviation: 64,
@@ -193,7 +198,7 @@ test("getUserRating", () => {
     // With a size that does not exist on the user's rating
     expect(getUserRating(user, "correspondence", 9)).toEqual(
         expect.objectContaining({
-            rating: 1480,
+            rating: 1470,
             volatility: 0.06,
             provisional: true,
             deviation: 350,

--- a/src/lib/rank_utils.test.ts
+++ b/src/lib/rank_utils.test.ts
@@ -209,14 +209,11 @@ test("getUserRating", () => {
     // With a speed that does not exist on the user's rating
     expect(getUserRating(user, "live", 0)).toEqual(
         expect.objectContaining({
-            bounded_rank: 24,
-            bounded_rank_label: "6k",
-            deviation: 350,
-            professional: false,
-            provisional: true,
             rating: 1465,
-            unset: true,
             volatility: 0.06,
+            provisional: true,
+            deviation: 350,
+            unset: true,
         }),
     );
 


### PR DESCRIPTION
Make specific ratings (like blitz-19x19) fall back to the overall rating in a cascade (bottomming out at "overall").  If the requested rating uses a fallback from the cascade, keep the default (provisional) deviation and volatility.

This change makes it so that once we set an `"overall"` rating for a user during setup, it automatically cascades down to all the sub-ratings. It also has the side effect that if a user plays games on only one board size, their other board size ratings will follow (with high deviation) until they play games there.

Note that even though the rating cascades from `"overall"`, the *displayed* rating/rank will be different (for now). That's because currently OGS decreases the effective rating/rank when the deviation is high. Eventually we want to stop doing that, but not in this PR.

Here are some screenshots:

Old:
<img width="1065" alt="Image" src="https://github.com/online-go/online-go.com/assets/1334620/9fbb797d-ff19-4964-aead-ee31e3036b12">
<img width="1016" alt="Image" src="https://github.com/online-go/online-go.com/assets/1334620/99df2caa-00f4-4779-9907-b61cab86e77f">

New:
<img width="1049" alt="Image" src="https://github.com/online-go/online-go.com/assets/1334620/51c9fe59-a722-4fdf-8312-b3a22a341880">
<img width="1048" alt="Image 2" src="https://github.com/online-go/online-go.com/assets/1334620/1d1d847c-d532-412b-9cc4-1f7326fa068a">

Relates to #2445
