### PR TITLE
Neutralize humble_rating

### DIFF
--- a/src/lib/rank_utils.test.ts
+++ b/src/lib/rank_utils.test.ts
@@ -337,7 +337,7 @@ test("allRanks", () => {
 });
 
 test("humble_rating", () => {
-    expect(humble_rating(1500, 350)).toBe(1150);
+    expect(humble_rating(1500, 350)).toBe(1500);
 });
 
 test("effective_outcome", () => {

--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -357,14 +357,9 @@ export function allRanks(): IRankInfo[] {
  * https://forums.online-go.com/t/i-think-the-13k-default-rank-is-doing-harm/13480/192
  * for the history surrounding that.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function humble_rating(rating: number, deviation: number): number {
-    return (
-        rating -
-        ((Math.min(350, Math.max(PROVISIONAL_RATING_CUTOFF, deviation)) -
-            PROVISIONAL_RATING_CUTOFF) /
-            (350 - PROVISIONAL_RATING_CUTOFF)) *
-            deviation
-    );
+    return rating;
 }
 
 export interface EffectiveOutcome {


### PR DESCRIPTION
Update `humble_rating` to return the `rating` parameter directly, rather than modifying it using the deviation, effectively neutralizing it.

After this lands, we should follow up by deleting the function entirely, but this commit as-written is much less likely to develop conflicts while we're waiting to land it and/or if we have to revert it.

Relates to #2445.

(Starting with a draft pull request, since we're not ready to land this yet...)