### PR TITLE
Allow users to supply a URL for custom stone images

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.styl
+++ b/src/components/GobanThemePicker/GobanThemePicker.styl
@@ -23,7 +23,12 @@
     max-width: 100%;
     justify-content: center;
 
-    .theme-set {
+    .custom-theme-set {
+        justify-content: flex-start !important;
+        padding-left: 2rem;
+    }
+
+    .theme-set, .custom-theme-set {
         display: inline-flex;
         flex-direction: row;
         flex-wrap: wrap;
@@ -51,17 +56,48 @@
             border: 0;
         }
 
+        .board-color-selectors{
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+        }
         .color-reset {
             vertical-align: top;
             margin-top: 0.4rem;
+            margin-left: 0;
+            margin-right: 0;
+            padding-right: 0;
+            padding-left: 0;
+            .fa-undo {
+                margin-left: 0 !important;
+                margin-right: 0 !important;
+                padding-right: 0;
+                padding-left: 0;
+            }
         }
 
-        .customUrlSelector {
-            width: 212px;
-            height: 24px;
-            border: 1px solid lightgrey;
-            margin-top: 0px;
-            margin-bottom: 10px;
+        .custom-url-selection {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding-left: 0.4rem;
+
+            .customUrlSelector {
+                width: 212px;
+                height: 24px;
+                border: 1px solid lightgrey;
+            }
+
+        }
+    }
+
+    .show-customize-selector {
+        flex-grow: 1;
+        display: flex;
+        justify-content: center;
+        margin: 0.5rem;
+        .show-customize-toggle {
+            margin-left: 0.3rem;
         }
     }
 }

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -150,13 +150,13 @@ export class GobanThemePicker extends React.PureComponent<
         // The layout of this picker is highly tweaked for the specific themes that Goban provides.
 
         // They are assumed to be, in GoTheme arrays for each of board, black and white:
-        // - 5 board like themes for boards
-        // - 5 weirder coloured themes for boards
+        // - 6 board like themes for boards
+        // - 6 weirder coloured themes for boards
         // - 1 customizable colour board theme called "Plain" (it's a plain board with a single colour)
         // - 1 customizable board theme called "Custom" that needs a URL for the image
 
-        // - 5 standard stone themes for black and white
-        // - 1 customizable colour stone theme for white and black called "Plain" (it's a plain stone with a single colour)
+        // - 6 standard stone themes for black and white
+        // - 1 customizable colour stone theme for white and black called "Coloured" (it's a plain stone with a single colour)
         // - 1 customizable stone theme for black and white called "Custom" that needs a URL for the image
 
         // The assumption for laying this out nicely is that we're making the picker dropdown 5 pickers wide,
@@ -166,13 +166,13 @@ export class GobanThemePicker extends React.PureComponent<
         // These are shown all the time.
 
         const standard_themes = {
-            board: GoThemesSorted.board.slice(0, 5),
-            white: GoThemesSorted.white.slice(0, 5),
-            black: GoThemesSorted.black.slice(0, 5),
+            board: GoThemesSorted.board.slice(0, 6),
+            white: GoThemesSorted.white.slice(0, 6),
+            black: GoThemesSorted.black.slice(0, 6),
         };
 
         const extra_themes = {
-            board: GoThemesSorted.board.slice(5, 10),
+            board: GoThemesSorted.board.slice(6, 12),
             white: [],
             black: [],
         };
@@ -181,23 +181,23 @@ export class GobanThemePicker extends React.PureComponent<
         // (either "now", or in the past and chosen one of these)
 
         const plain_themes = {
-            board: [GoThemesSorted.board[10]], // an array just to allow consistent processing below
-            white: [GoThemesSorted.white[5]],
-            black: [GoThemesSorted.black[5]],
+            board: [GoThemesSorted.board[12]], // an array just to allow consistent processing below
+            white: [GoThemesSorted.white[6]],
+            black: [GoThemesSorted.black[6]],
         };
 
         const url_themes = {
-            board: [GoThemesSorted.board[11]],
-            white: [GoThemesSorted.white[6]],
-            black: [GoThemesSorted.black[6]],
+            board: [GoThemesSorted.board[13]],
+            white: [GoThemesSorted.white[7]],
+            black: [GoThemesSorted.black[7]],
         };
 
         let custom_theme_active = false;
 
         if (
-            GoThemesSorted["board"].findIndex((t) => t.theme_name === this.state.board) > 9 ||
-            GoThemesSorted["white"].findIndex((t) => t.theme_name === this.state.white) > 4 ||
-            GoThemesSorted["black"].findIndex((t) => t.theme_name === this.state.black) > 4
+            GoThemesSorted["board"].findIndex((t) => t.theme_name === this.state.board) > 11 ||
+            GoThemesSorted["white"].findIndex((t) => t.theme_name === this.state.white) > 5 ||
+            GoThemesSorted["black"].findIndex((t) => t.theme_name === this.state.black) > 5
         ) {
             custom_theme_active = true;
             // This is so that the custom section stays open if the try out a non-custom theme while it is open due to custom_theme_active
@@ -234,7 +234,7 @@ export class GobanThemePicker extends React.PureComponent<
                             style={theme.styles}
                             onClick={this.selectTheme["board"][theme.theme_name]}
                         >
-                            <PersistentElement elt={this.canvases.board[idx + 5]} />
+                            <PersistentElement elt={this.canvases.board[idx + 6]} />
                         </div>
                     ))}
                 </div>
@@ -365,7 +365,7 @@ export class GobanThemePicker extends React.PureComponent<
                                     }}
                                     onClick={this.selectTheme["board"][theme.theme_name]}
                                 >
-                                    <PersistentElement elt={this.canvases.board[idx + 5]} />
+                                    <PersistentElement elt={this.canvases.board[idx + 6]} />
                                 </div>
                             ))}
 
@@ -396,7 +396,7 @@ export class GobanThemePicker extends React.PureComponent<
                                     style={theme.styles}
                                     onClick={this.selectTheme["white"][theme.theme_name]}
                                 >
-                                    <PersistentElement elt={this.canvases.white[idx + 5]} />
+                                    <PersistentElement elt={this.canvases.white[idx + 6]} />
                                 </div>
                             ))}
 
@@ -428,7 +428,7 @@ export class GobanThemePicker extends React.PureComponent<
                                     style={theme.styles}
                                     onClick={this.selectTheme["white"][theme.theme_name]}
                                 >
-                                    <PersistentElement elt={this.canvases.white[idx + 6]} />
+                                    <PersistentElement elt={this.canvases.white[idx + 7]} />
                                 </div>
                             ))}
                             <div className="custom-url-selection">
@@ -458,7 +458,7 @@ export class GobanThemePicker extends React.PureComponent<
                                     style={theme.styles}
                                     onClick={this.selectTheme["black"][theme.theme_name]}
                                 >
-                                    <PersistentElement elt={this.canvases.black[idx + 5]} />
+                                    <PersistentElement elt={this.canvases.black[idx + 6]} />
                                 </div>
                             ))}
                             <div>
@@ -489,7 +489,7 @@ export class GobanThemePicker extends React.PureComponent<
                                     style={theme.styles}
                                     onClick={this.selectTheme["black"][theme.theme_name]}
                                 >
-                                    <PersistentElement elt={this.canvases.black[idx + 6]} />
+                                    <PersistentElement elt={this.canvases.black[idx + 7]} />
                                 </div>
                             ))}
 

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -234,7 +234,7 @@ export class GobanThemePicker extends React.PureComponent<
                             style={theme.styles}
                             onClick={this.selectTheme["board"][theme.theme_name]}
                         >
-                            <PersistentElement elt={this.canvases.board[idx]} />
+                            <PersistentElement elt={this.canvases.board[idx + 5]} />
                         </div>
                     ))}
                 </div>

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -296,7 +296,10 @@ export class GobanThemePicker extends React.PureComponent<
                                     title={_(theme.theme_name)}
                                     className={
                                         "selector" +
-                                        (this.state.board === theme.theme_name ? " active" : "")
+                                        // The board customisation selectors work together
+                                        (["Plain", "Custom"].includes(this.state.board)
+                                            ? " active"
+                                            : "")
                                     }
                                     style={{
                                         ...theme.styles,
@@ -346,7 +349,10 @@ export class GobanThemePicker extends React.PureComponent<
                                     title={_(theme.theme_name)}
                                     className={
                                         "selector" +
-                                        (this.state.board === theme.theme_name ? " active" : "")
+                                        // The board customisation selectors work together
+                                        (["Plain", "Custom"].includes(this.state.board)
+                                            ? " active"
+                                            : "")
                                     }
                                     style={{
                                         ...theme.styles,

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -38,6 +38,8 @@ interface GobanThemePickerState {
     whiteCustom: string;
     blackCustom: string;
     urlCustom: string;
+    black_stone_url: string;
+    white_stone_url: string;
 }
 export class GobanThemePicker extends React.PureComponent<
     GobanThemePickerProperties,
@@ -61,6 +63,8 @@ export class GobanThemePicker extends React.PureComponent<
             whiteCustom: this.getCustom("white"),
             blackCustom: this.getCustom("black"),
             urlCustom: this.getCustom("url"),
+            black_stone_url: this.getCustom("black_stone_url"),
+            white_stone_url: this.getCustom("white_stone_url"),
         };
 
         for (const k in GoThemesSorted) {
@@ -128,7 +132,15 @@ export class GobanThemePicker extends React.PureComponent<
 
     render() {
         const inputStyle = { height: `${this.state.size}px`, width: `${this.state.size * 1.5}px` };
-        const { boardCustom, lineCustom, whiteCustom, blackCustom, urlCustom } = this.state;
+        const {
+            boardCustom,
+            lineCustom,
+            whiteCustom,
+            blackCustom,
+            urlCustom,
+            white_stone_url,
+            black_stone_url,
+        } = this.state;
 
         return (
             <div className="GobanThemePicker">
@@ -231,6 +243,21 @@ export class GobanThemePicker extends React.PureComponent<
                             </button>
                         </div>
                     )}
+                    {this.state.white === "Custom" && (
+                        <div>
+                            <input
+                                className="customUrlSelector"
+                                type="text"
+                                value={white_stone_url}
+                                placeholder={pgettext(
+                                    "A URL pointing to a custom white stone image",
+                                    "Custom white stone URL",
+                                )}
+                                onFocus={(e) => e.target.select()}
+                                onChange={this.setCustom.bind(this, "white_stone_url")}
+                            />
+                        </div>
+                    )}
                 </div>
 
                 <div className="theme-set">
@@ -262,6 +289,21 @@ export class GobanThemePicker extends React.PureComponent<
                             >
                                 <i className="fa fa-undo" />
                             </button>
+                        </div>
+                    )}
+                    {this.state.black === "Custom" && (
+                        <div>
+                            <input
+                                className="customUrlSelector"
+                                type="text"
+                                value={black_stone_url}
+                                placeholder={pgettext(
+                                    "A URL pointing to a custom black stone image",
+                                    "Custom black stone URL",
+                                )}
+                                onFocus={(e) => e.target.select()}
+                                onChange={this.setCustom.bind(this, "black_stone_url")}
+                            />
                         </div>
                     )}
                 </div>

--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -112,7 +112,8 @@ export function configure_goban() {
         plainBoardColor: (): string => data.get("custom.board", ""),
         plainBoardLineColor: (): string => data.get("custom.line", ""),
         plainBoardUrl: (): string => data.get("custom.url", ""),
-
+        customBlackStoneUrl: (): string => data.get("custom.black_stone_url", ""),
+        customWhiteStoneUrl: (): string => data.get("custom.white_stone_url", ""),
         addCoordinatesToChatInput: (coordinates: string): void => {
             const chat_input = $(".chat-input");
 

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -113,7 +113,9 @@ export interface CustomGobanThemeSchema {
     white: string;
     board: string;
     line: string;
-    url: string;
+    url: string; // this is a board image url
+    black_stone_url: string;
+    white_stone_url: string;
 }
 
 type SoundSchema = {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -49,6 +49,8 @@ export const defaults = {
     "goban-theme-black": null as null | string,
     "goban-theme-board": null as null | string,
     "goban-theme-white": null as null | string,
+    "goban-theme-black_stone_url": null as null | string,
+    "goban-theme-white_stone_url": null as null | string,
     "hide-ranks": false,
     "label-positioning": "all" as LabelPosition,
     "label-positioning-puzzles": "all" as LabelPosition,


### PR DESCRIPTION
Fixes #2481

## Proposed Changes

 - Add the ability to supply a URL when the Goban stone theme "Custom" is selected.

Needs: https://github.com/online-go/goban/pull/145  , which adds this theme for stones.

![Screenshot 2024-01-14 at 9 36 13 pm (3)](https://github.com/online-go/online-go.com/assets/61894/cf35427a-ded8-4aff-a2c4-c0310ffe90fd)

