### PR TITLE
Make the game timing table available to community moderators

### DIFF
--- a/src/views/Game/GameTimings.styl
+++ b/src/views/Game/GameTimings.styl
@@ -25,8 +25,8 @@
     display: grid;
     grid-template-columns: auto auto auto auto;
 
-    padding-left: 1em;
-
+    padding-left: 1rem;
+    margin-bottom: 0.75rem;
     font-size: smaller;
 
     .timings-header {

--- a/src/views/Game/GameTimings.tsx
+++ b/src/views/Game/GameTimings.tsx
@@ -21,6 +21,7 @@ import "moment-duration-format";
 import * as React from "react";
 
 import { AdHocPackedMove, GobanMovesArray } from "goban";
+import { useUser } from "hooks";
 
 interface GameTimingProperties {
     moves: GobanMovesArray;
@@ -33,6 +34,8 @@ interface GameTimingProperties {
 }
 
 export function GameTimings(props: GameTimingProperties): JSX.Element {
+    const user = useUser();
+
     const show_seconds_nicely = (duration: moment.Duration) =>
         duration < moment.duration(60 * 1000) ? (
             <span className="timing-seconds">
@@ -96,12 +99,14 @@ export function GameTimings(props: GameTimingProperties): JSX.Element {
         }
     }
 
+    const cm = user.moderator_powers !== 0; // community moderator
+
     return (
         <div className="GameTimings">
             <div className="timings-header">Game Timings</div>
             <div>Move</div>
-            <div>Black (blur)</div>
-            <div>White (blur)</div>
+            <div>Black {!cm && "(blur)"}</div>
+            <div>White {!cm && "(blur)"}</div>
             <div>Elapsed Time</div>
             {white_first_turn ? first_row : ""}
             {
@@ -213,12 +218,12 @@ export function GameTimings(props: GameTimingProperties): JSX.Element {
                                 <div>{idx * 2 + 1 + handicap_move_offset}</div>
                                 <div>
                                     {black_move_time}
-                                    {blurDurationFormat(black_blur)}
+                                    {!cm && blurDurationFormat(black_blur)}
                                     {black_download_sgf ? <i className="fa fa-download" /> : null}
                                 </div>
                                 <div>
                                     {white_move_time}
-                                    {blurDurationFormat(white_blur)}
+                                    {!cm && blurDurationFormat(white_blur)}
                                     {white_download_sgf ? <i className="fa fa-download" /> : null}
                                 </div>
                                 <div>

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -228,20 +228,18 @@ export function ReportedGame({ game_id }: { game_id: number }): JSX.Element | nu
                         </div>
 
                         <div className="col">
-                            {(user.is_moderator /* community moderators don't see this secret stuff :o */ ||
-                                null) && (
-                                <GameTimings
-                                    moves={goban.engine.config.moves as any}
-                                    start_time={goban.engine.config.start_time as any}
-                                    end_time={goban.engine.config.end_time as any}
-                                    free_handicap_placement={
-                                        goban.engine.config.free_handicap_placement as any
-                                    }
-                                    handicap={goban.engine.config.handicap as any}
-                                    black_id={goban.engine.config.black_player_id as any}
-                                    white_id={goban.engine.config.white_player_id as any}
-                                />
-                            )}
+                            <GameTimings
+                                moves={goban.engine.config.moves as any}
+                                start_time={goban.engine.config.start_time as any}
+                                end_time={goban.engine.config.end_time as any}
+                                free_handicap_placement={
+                                    goban.engine.config.free_handicap_placement as any
+                                }
+                                handicap={goban.engine.config.handicap as any}
+                                black_id={goban.engine.config.black_player_id as any}
+                                white_id={goban.engine.config.white_player_id as any}
+                            />
+
                             <GameLog goban={goban} />
                         </div>
 


### PR DESCRIPTION
Fixes Community Moderators not being able to sensibly judge escapes

## Proposed Changes

  - Make the GameTiming table with move timing actuals available in ViewReport for CMS 