### PR TITLE
Display the `reported_game_move` in ViewReport

### DIFF
--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -57,6 +57,7 @@ export interface Report {
     reporting_user: any;
     reported_user: any;
     reported_game: number;
+    reported_game_move?: number;
     reported_review: number;
     reported_conversation: ReportedConversation;
     url: string;

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -43,7 +43,13 @@ import { socket } from "sockets";
 import { Player } from "Player";
 import { useUser } from "hooks";
 
-export function ReportedGame({ game_id }: { game_id: number }): JSX.Element | null {
+export function ReportedGame({
+    game_id,
+    reported_at,
+}: {
+    game_id: number;
+    reported_at: number | undefined;
+}): JSX.Element | null {
     const [goban, setGoban] = React.useState<Goban | null>(null);
     const [selectedChatLog, setSelectedChatLog] = React.useState<ChatMode>("main");
     const refresh = useRefresh();
@@ -149,6 +155,7 @@ export function ReportedGame({ game_id }: { game_id: number }): JSX.Element | nu
             </h3>
             <div className="reported-game-container">
                 <div className="col">
+                    {reported_at && <div>{_("Reported on turn:") + ` ${reported_at}`}</div>}
                     <MiniGoban
                         id={game_id}
                         noLink={true}

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -606,7 +606,12 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     )}
                 </>
             )}
-            {report.reported_game && <ReportedGame game_id={report.reported_game} />}
+            {report.reported_game && (
+                <ReportedGame
+                    game_id={report.reported_game}
+                    reported_at={report.reported_game_move}
+                />
+            )}
             {report.report_type === "appeal" && <AppealView user_id={report.reported_user.id} />}
             {report.reported_review && (
                 <span>


### PR DESCRIPTION
...  if the server provide…

Fixes CMs being unsure when escaping/stalling was reported

## Proposed Changes
 
 - show `reported_game_move` if it is suppled

Needs https://github.com/online-go/ogs/pull/1902 to actually display anything