### PR TITLE
Show the handicap rank difference in Game Information

### DIFF
--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -147,7 +147,14 @@ export function GameDock({
     };
 
     const showGameInfo = () => {
-        for (const k of ["komi", "rules", "handicap", "rengo", "rengo_teams"] as const) {
+        for (const k of [
+            "komi",
+            "rules",
+            "handicap",
+            "handicap_rank_difference",
+            "rengo",
+            "rengo_teams",
+        ] as const) {
             (goban.config as any)[k] = goban.engine.config[k];
         }
         openGameInfoModal(

--- a/src/views/Game/GameInfoModal.tsx
+++ b/src/views/Game/GameInfoModal.tsx
@@ -317,7 +317,18 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, {}> {
                             {config.width}x{config.height}
                         </dd>
                         <dt>{_("Handicap")}</dt>
-                        <dd>{handicapText(config.handicap ?? -1)}</dd>
+                        <dd>
+                            {handicapText(config.handicap ?? -1)}
+                            {config.handicap_rank_difference &&
+                                config.handicap_rank_difference !== config.handicap && (
+                                    <span>
+                                        {" "}
+                                        (
+                                        {_("Rank") + ": " + String(config.handicap_rank_difference)}
+                                        )
+                                    </span>
+                                )}
+                        </dd>
                         <dt>{_("Result")}</dt>
                         <dd>
                             {editable && config.review_id && !config.game_id ? (


### PR DESCRIPTION
In the "Game Information" modal, show the handicap rank difference if it's different from the handicap.

Depends on https://github.com/online-go/goban/pull/147, https://github.com/online-go/ogs-node/pull/58, and https://github.com/online-go/ogs/pull/1903.