### PR TITLE
[ReportCenter] truncate the game log

### DIFF
--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -282,44 +282,58 @@ function GameLog({ goban }: { goban: Goban }): JSX.Element {
         [goban],
     );
 
+    const [shouldDisplayFullLog, setShouldDisplayFullLog] = React.useState(false);
+
     return (
         <>
             <h3>{_("Game Log")}</h3>
             {log.length > 0 ? (
-                <table className="game-log">
-                    <thead>
-                        <tr>
-                            <th>
-                                {pgettext("A heading: the time when something happened", "Time")}
-                            </th>
-                            <th>{pgettext("A heading: something that happened", "Event")}</th>
-                            <th>
-                                {pgettext(
-                                    "A heading: a column with game parameters in it",
-                                    "Parameters",
-                                )}
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {log.map((entry, idx) => (
-                            <tr key={entry.timestamp + ":" + idx} className="entry">
-                                <td className="timestamp">
-                                    {moment(entry.timestamp).format("L LTS")}
-                                </td>
-                                <td className="event">{entry.event.replace(/_/g, " ")}</td>
-                                <td className="data">
-                                    <LogData
-                                        config={goban.engine.config}
-                                        markCoords={markCoords}
-                                        event={entry.event}
-                                        data={entry.data}
-                                    />
-                                </td>
+                <>
+                    <table className="game-log">
+                        <thead>
+                            <tr>
+                                <th>
+                                    {pgettext(
+                                        "A heading: the time when something happened",
+                                        "Time",
+                                    )}
+                                </th>
+                                <th>{pgettext("A heading: something that happened", "Event")}</th>
+                                <th>
+                                    {pgettext(
+                                        "A heading: a column with game parameters in it",
+                                        "Parameters",
+                                    )}
+                                </th>
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            {log
+                                .filter((_, idx) => shouldDisplayFullLog || idx < 25)
+                                .map((entry, idx) => (
+                                    <tr key={entry.timestamp + ":" + idx} className="entry">
+                                        <td className="timestamp">
+                                            {moment(entry.timestamp).format("L LTS")}
+                                        </td>
+                                        <td className="event">{entry.event.replace(/_/g, " ")}</td>
+                                        <td className="data">
+                                            <LogData
+                                                config={goban.engine.config}
+                                                markCoords={markCoords}
+                                                event={entry.event}
+                                                data={entry.data}
+                                            />
+                                        </td>
+                                    </tr>
+                                ))}
+                        </tbody>
+                    </table>
+                    {!shouldDisplayFullLog && (
+                        <button onClick={() => setShouldDisplayFullLog(true)}>
+                            Show all ({log.length})
+                        </button>
+                    )}
+                </>
             ) : (
                 <div>{_("No game log entries")}</div>
             )}

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -330,7 +330,7 @@ function GameLog({ goban }: { goban: Goban }): JSX.Element {
                     </table>
                     {!shouldDisplayFullLog && (
                         <button onClick={() => setShouldDisplayFullLog(true)}>
-                            Show all ({log.length})
+                            {`${_("Show all")} (${log.length})`}
                         </button>
                     )}
                 </>


### PR DESCRIPTION
Conrad mentioned there are more frozen reports in the reports center.  And indeed here is an example: [R814](https://online-go.com/reports-center/all/134814).  The event log is a whopping 5000 entries!  IIUC, rendering is still the bottleneck, so this is a quick and dirty fix to truncate the rendered list until the user opts in to showing the full thing.

## Proposed Changes

  - Truncate event log to 25 events before rendering
  - Add "Show all" button

## Screenshot

<img width="573" alt="Screenshot 2024-01-21 at 4 20 34 PM" src="https://github.com/online-go/online-go.com/assets/25233703/848932c9-2c3b-49c0-bd5c-773b9a314c94">

## Alternative considered

In a perfect world, we would do proper paging, but I think that is overkill for the mod log - returns diminish greatly after the first few entries.  That said, I'm guessing 5000 is also an artificial limit set on the backend.  It might be reasonable to lower that cap as well since we don't expect mods to look at thousands of entries.


