### PR TITLE
Fix display of 0 handicap rank difference in GameInfoModal

### DIFF
--- a/src/views/Game/GameInfoModal.tsx
+++ b/src/views/Game/GameInfoModal.tsx
@@ -319,7 +319,7 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, {}> {
                         <dt>{_("Handicap")}</dt>
                         <dd>
                             {handicapText(config.handicap ?? -1)}
-                            {config.handicap_rank_difference &&
+                            {!!config.handicap_rank_difference &&
                                 config.handicap_rank_difference !== config.handicap && (
                                     <span>
                                         {" "}


### PR DESCRIPTION
Without this, the handicap for new even games was being shown as `None0` instead of `None`.

Caused by 50d60910b6b32e145e7c01ccdfe983eb78809c08. Could have sworn I fixed this bug before push, but I guess it slipped through (or maybe it was a similar bug, another location...).