### PR TITLE
Community moderation updates - Game Stalling handling

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -150,4 +150,71 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
         Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
+    warn_beginner_staller: (game_id) =>
+        interpolate(
+            _(`
+        Hi, welcome to OGS!
+
+        It appears that you delayed the end of game #{{game_id}}, which can frustrate your opponent and prevent them from moving on to the next game.
+
+        Since you are a new player, no action will be taken against your account. We simply ask that you learn when to end a game.
+
+        Until you develop the experience to judge better, if your opponent passes and there are no open borders between your stones then you should also pass.
+
+        After passing, promptly accept the correct score.
+
+        If in doubt about this sort of situation. please ask for help in chat or the forums.
+        `),
+            { game_id },
+        ),
+    warn_staller: (game_id) =>
+        interpolate(
+            _(`
+        It has come to our attention that you delayed the end of game #{{game_id}}, which can frustrate your opponent and
+        prevent them from moving on to their next game.
+
+        Players are required to end their games properly, as letting them time out can cause opponents to wait unnecessarily,
+        and prevent them from moving on to the next game.
+
+        Please ensure that you end your games properly by accepting the correct score immediately after passing,
+        or by resigning if you feel the position is hopeless.
+
+        This helps maintain a positive gaming environment for everyone involved.`),
+            { game_id },
+        ),
+    ack_educated_beginner_staller: (reported) =>
+        interpolate(
+            _(`
+        Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.`),
+            { reported },
+        ),
+    ack_educated_beginner_staller_and_annul: (reported) =>
+        interpolate(
+            _(`
+        Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.
+        That incorrectly scored game has been annulled.`),
+            { reported },
+        ),
+    ack_warned_staller: (reported) =>
+        interpolate(
+            _(`
+        Thank you for your report, {{reported}} has been given a formal warning about finishing games properly.`),
+            { reported },
+        ),
+    ack_warned_staller_and_annul: (reported) =>
+        interpolate(
+            _(`
+        Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, and that abandoned game annulled.`),
+            reported,
+        ),
+    no_stalling_evident: (reported) =>
+        interpolate(
+            _(`
+        Thank you for bringing the possible instance of stalling by {{reported}} to
+        our attention. We looked into the report and their actions seemed appropriate. If a pattern of
+        complaints emerges, we will investigate further.
+
+        Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+            { reported },
+        ),
 };

--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import * as data from "data";
 import { _, pgettext } from "translate";
 import { put, get, del } from "requests";
-import { MOD_POWER_HANDLE_SCORE_CHEAT, MOD_POWER_HANDLE_ESCAPING, errorAlerter } from "misc";
+import { MODERATOR_POWERS, errorAlerter } from "misc";
 import { proRankList } from "rank_utils";
 import { Modal, openModal } from "Modal";
 import { PlayerCacheEntry, lookup } from "player_cache";
@@ -340,7 +340,7 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                                 "Label for a button to let a community moderator handle score cheating",
                                 "Handle Score Cheat",
                             )}
-                            ability_mask={MOD_POWER_HANDLE_SCORE_CHEAT}
+                            ability_mask={MODERATOR_POWERS.HANDLE_SCORE_CHEAT}
                             currently_offered={this.state.offered_moderator_powers}
                             moderator_powers={this.state.moderator_powers}
                             previously_rejected={this.state.mod_powers_rejected}
@@ -353,7 +353,20 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                                 "Label for a button to let a community moderator handle escaping",
                                 "Handle Escaping",
                             )}
-                            ability_mask={MOD_POWER_HANDLE_ESCAPING}
+                            ability_mask={MODERATOR_POWERS.HANDLE_ESCAPING}
+                            currently_offered={this.state.offered_moderator_powers}
+                            moderator_powers={this.state.moderator_powers}
+                            previously_rejected={this.state.mod_powers_rejected}
+                            onMakeOffer={this.makeOffer}
+                            onRetractOffer={this.retractOffer}
+                            onRemovePower={this.removePower}
+                        />
+                        <ModerationOfferControl
+                            ability={pgettext(
+                                "Label for a button to let a community moderator handle stalling",
+                                "Handle Stalling",
+                            )}
+                            ability_mask={MODERATOR_POWERS.HANDLE_STALLING}
                             currently_offered={this.state.offered_moderator_powers}
                             moderator_powers={this.state.moderator_powers}
                             previously_rejected={this.state.mod_powers_rejected}

--- a/src/components/ModerationOffer/ModerationOffer.tsx
+++ b/src/components/ModerationOffer/ModerationOffer.tsx
@@ -22,6 +22,7 @@ import { openModerationOfferModal } from "./ModerationOfferModal";
 
 interface ModerationOfferProps {
     player_id: number;
+    current_moderator_powers: number;
     offered_moderator_powers: number;
     onAck?: () => void;
 }
@@ -34,6 +35,7 @@ export function ModerationOffer(props: ModerationOfferProps) {
                 onClick={() =>
                     openModerationOfferModal(
                         props.player_id,
+                        props.current_moderator_powers,
                         props.offered_moderator_powers,
                         props.onAck,
                     )

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -198,6 +198,8 @@ class NotificationEntry extends React.Component<NotificationEntryProps, any> {
     renderNotification(): JSX.Element | null {
         const notification = this.props.notification;
 
+        const user = data.get("user");
+
         switch (notification.type) {
             case "test":
                 return <div dangerouslySetInnerHTML={{ __html: notification.html }} />;
@@ -534,7 +536,8 @@ class NotificationEntry extends React.Component<NotificationEntryProps, any> {
             case "moderationOffer":
                 return (
                     <ModerationOffer
-                        player_id={notification.player_id}
+                        player_id={user.id}
+                        current_moderator_powers={user.moderator_powers}
                         offered_moderator_powers={notification.offered_moderator_powers}
                         onAck={this.del}
                     />

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -44,6 +44,7 @@ export type ReportType =
 export const CommunityModeratorReportTypes: ReadonlyArray<ReportType> = [
     "escaping",
     "score_cheating",
+    "stalling",
 ];
 
 export interface ReportDescription {

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -23,8 +23,29 @@ import { alert } from "swal_config";
 import React from "react";
 
 // Must match back-end MODERATOR_POWER
-export const MOD_POWER_HANDLE_SCORE_CHEAT = 0b01;
-export const MOD_POWER_HANDLE_ESCAPING = 0b10;
+
+export enum MODERATOR_POWERS {
+    NONE = 0,
+    HANDLE_SCORE_CHEAT = 0b001,
+    HANDLE_ESCAPING = 0b010,
+    HANDLE_STALLING = 0b100,
+}
+
+export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
+    [MODERATOR_POWERS.NONE]: pgettext("... as in 'moderators powers: None'", "None"),
+    [MODERATOR_POWERS.HANDLE_SCORE_CHEAT]: pgettext(
+        "A label for a moderator power",
+        "Handle Score Cheating Reports",
+    ),
+    [MODERATOR_POWERS.HANDLE_ESCAPING]: pgettext(
+        "A label for a moderator power",
+        "Handle Score Cheating Reports",
+    ),
+    [MODERATOR_POWERS.HANDLE_STALLING]: pgettext(
+        "A label for a moderator power",
+        "Handle Score Cheating Reports",
+    ),
+};
 
 export type Timeout = ReturnType<typeof setTimeout>;
 

--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -33,7 +33,7 @@ import { EventEmitter } from "eventemitter3";
 import { emitNotification } from "Notifications";
 import { browserHistory } from "ogsHistory";
 import { get, post } from "requests";
-import { MOD_POWER_HANDLE_SCORE_CHEAT, MOD_POWER_HANDLE_ESCAPING } from "./misc";
+import { MODERATOR_POWERS } from "./misc";
 
 export const DAILY_REPORT_GOAL = 10;
 
@@ -227,13 +227,19 @@ class ReportManager extends EventEmitter<Events> {
             // Community moderators only get to see reports that they have the power for and
             // that they have not yet voted on.
             const has_handle_score_cheat =
-                (user.moderator_powers & MOD_POWER_HANDLE_SCORE_CHEAT) > 0;
-            const has_handle_escaping = (user.moderator_powers & MOD_POWER_HANDLE_ESCAPING) > 0;
+                (user.moderator_powers & MODERATOR_POWERS.HANDLE_SCORE_CHEAT) > 0;
+            const has_handle_escaping =
+                (user.moderator_powers & MODERATOR_POWERS.HANDLE_ESCAPING) > 0;
+            const has_handle_stalling =
+                (user.moderator_powers & MODERATOR_POWERS.HANDLE_STALLING) > 0;
+
+            const report_type = report.report_type;
             if (
                 !user.is_moderator &&
                 user.moderator_powers &&
-                ((!(report.report_type === "score_cheating" && has_handle_score_cheat) &&
-                    !(report.report_type === "escaping" && has_handle_escaping)) ||
+                ((!(report_type === "score_cheating" && has_handle_score_cheat) &&
+                    !(report_type === "escaping" && has_handle_escaping) &&
+                    !(report_type === "stalling" && has_handle_stalling)) ||
                     report.voters?.some((vote) => vote.voter_id === user.id))
             ) {
                 return false;
@@ -245,8 +251,7 @@ class ReportManager extends EventEmitter<Events> {
                 if (
                     user.is_moderator &&
                     !(report.moderator?.id === user.id) && // maybe they already have it, so they need to see it
-                    (report.report_type === "score_cheating" ||
-                        report.report_type === "escaping") &&
+                    (report_type === "score_cheating" || report_type === "escaping") &&
                     !report.escalated
                 ) {
                     return false;

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -18,6 +18,7 @@
 
 declare namespace rest_api {
     namespace warnings {
+        // These must match voting handling in django moderation.py
         type WarningMessageId =
             | "warn_beginner_score_cheat"
             | "warn_score_cheat"
@@ -32,7 +33,14 @@ declare namespace rest_api {
             | "ack_educated_beginner_escaper_and_annul"
             | "ack_warned_escaper"
             | "ack_warned_escaper_and_annul"
-            | "no_escaping_evident";
+            | "no_escaping_evident"
+            | "warn_beginner_staller"
+            | "warn_staller"
+            | "ack_educated_beginner_staller"
+            | "ack_educated_beginner_staller_and_annul"
+            | "ack_warned_staller"
+            | "ack_warned_staller_and_annul"
+            | "no_stalling_evident";
 
         type Severity = "warning" | "acknowledgement";
 

--- a/src/views/Overview/EXV6Overview.tsx
+++ b/src/views/Overview/EXV6Overview.tsx
@@ -153,6 +153,7 @@ export class EXV6Overview extends React.Component<{}, OverviewState> {
                         {user && !!user.offered_moderator_powers && (
                             <ModerationOffer
                                 player_id={user.id}
+                                current_moderator_powers={user.moderator_powers}
                                 offered_moderator_powers={user.offered_moderator_powers}
                             />
                         )}

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -70,7 +70,27 @@ const ACTION_PROMPTS = {
         "Label for a moderator to select this option",
         "No escaping evident - inform the reporter.",
     ),
-    // Note: keep this last, so it's positioned above the "note to moderator" input
+    annul_stalled: pgettext(
+        "Label for a moderator to select this option",
+        "Wrong result due to stalling - annul and warn the staller.",
+    ),
+    warn_staller: pgettext(
+        "Label for a moderator to select this option",
+        "The accused stalled - warn them.",
+    ),
+    call_stalled_game_for_black: pgettext(
+        "Label for a moderator to select this option",
+        "White stalled - call the game for black, and warn white.",
+    ),
+    call_stalled_game_for_white: pgettext(
+        "Label for a moderator to select this option",
+        "Black stalled - call the game for white, and warn black.",
+    ),
+    no_stalling: pgettext(
+        "Label for a moderator to select this option",
+        "No stalling evident - inform the reporter.",
+    ),
+    // Note: keep this last, so it's positioned above the "note to moderator" input field
     escalate: pgettext(
         "A label for a community moderator to select this option - send report to to full moderators",
         "Escalate: send direct to moderators.",


### PR DESCRIPTION
... plus improved "offer/accept" and notification handling.

Fixes offer notifications not getting deleted when accepted.

## Proposed Changes

  - Provide option to offer Game Stalling reports to CMs
  - Improve offer/accept flow - CMs get told what new thing they're getting
  - Reload the page to see the new tools/reports  _after_ clearing the notification after accepting an offer


Needs https://github.com/online-go/ogs/pull/1919 - moderator/CM experience might be glitchy if they try to use the new stuff without the back end in place.
