### PR TITLE
Only show custom komi in challenge descriptions

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1935,7 +1935,7 @@ export function challenge_text_description(challenge: ChallengeDetails) {
     details_html +=
         ", " +
         interpolate(_("%s handicap"), [g.handicap < 0 ? _("auto") : g.handicap]) +
-        (g.komi == null || typeof g.komi === "object"
+        (g?.komi_auto !== "custom" || g.komi == null || typeof g.komi === "object"
             ? ""
             : ", " + interpolate(_("{{komi}} komi"), { komi: g.komi })) +
         (g.disable_analysis ? ", " + _("analysis disabled") : "");


### PR DESCRIPTION
The `komi` field is inaccurate (and ignored) when `komi_auto !== "custom"`.  It might be nice to show the automatic komi, but right now that would be hard to do so consistently, since for small boards it depends on handicap tables that are server side.

For now, just stop showing komi at all unless `komi_auto === "custom"`.

Fixes #2527.

