### PR TITLE
Show challenger colour from own perspective

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1942,11 +1942,8 @@ export function challenge_text_description(challenge: ChallengeDetails) {
     if (c.challenger_color !== "automatic") {
         let your_color = "";
 
-        if (
-            data.get("user") &&
-            ((c as any)?.challenger?.id !== data.get("user").id ||
-                (c as any)?.user?.id !== data.get("user").id)
-        ) {
+        const challenger_id = (c as any)?.challenger?.id || (c as any)?.user?.id;
+        if (challenger_id && challenger_id !== data.get("user")?.id) {
             if (c.challenger_color === "black") {
                 your_color = _("white");
             } else if (c.challenger_color === "white") {


### PR DESCRIPTION
When a challenge's challenger is looking at their challenge, show their own perspective.  Continue showing the (prospective) opponent's perspective for anyone else that looks.

The code here was already trying to have this effect, but it was subtly wrong because it would flip colours if either `challenge.challenger` or `challenge.user` (presumably an old spelling of `challenge.challenger`, but maybe still set in some circumstances?) did not match the current user's `id`. Since `challenge.user` is (almost?) never set, this condition would erroneously be true for all challenges.

Specifically, this fixes the challenge text for:

- Preferred settings
- Challenger's view of challenge list that's waiting for a response
- Challenger's view of open invitations

It does not change:

- Challenger's view for games in the "seek graph".  This code is independent, never tried to flip colours, and the display is greyed out for challengers. Maybe we should change it, but seems a bit less confusing.
- Prospective opponents' view of the challenges.
