### PR TITLE
Use "opacity" instead of "transparency" to refer to the opacity setting for variation stones

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -40,7 +40,7 @@ export const defaults = {
     "dock-delay": 0, // seconds.
     "double-click-submit-correspondence": false,
     "double-click-submit-live": false,
-    "variation-stone-transparency": 0.6,
+    "variation-stone-opacity": 0.6,
     "variation-move-count": 10,
     "visual-undo-request-indicator": true,
     "dynamic-title": true,

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1287,9 +1287,7 @@ export function Game(): JSX.Element | null {
                         "double-click-submit-correspondence",
                     );
                 }
-                goban.current.variation_stone_transparency = preferences.get(
-                    "variation-stone-transparency",
-                );
+                goban.current.variation_stone_opacity = preferences.get("variation-stone-opacity");
                 goban.current.visual_undo_request_indicator = preferences.get(
                     "visual-undo-request-indicator",
                 );

--- a/src/views/Settings/GamePreferences.tsx
+++ b/src/views/Settings/GamePreferences.tsx
@@ -54,9 +54,8 @@ export function GamePreferences(): JSX.Element {
     const [autoplay_delay, _setAutoplayDelay]: [number, (x: number) => void] = React.useState(
         preferences.get("autoplay-delay") / 1000,
     );
-    const [variation_stone_transparency, _setVariationStoneTransparency] = usePreference(
-        "variation-stone-transparency",
-    );
+    const [variation_stone_opacity, _setVariationStoneOpacity] =
+        usePreference("variation-stone-opacity");
     const [variation_move_count, _setVariationMoveCount] = usePreference("variation-move-count");
     const [visual_undo_request_indicator, setVisualUndoRequestIndicator] = usePreference(
         "visual-undo-request-indicator",
@@ -116,11 +115,11 @@ export function GamePreferences(): JSX.Element {
     function setCorrSubmitMode(value: string) {
         setSubmitMode("correspondence", value);
     }
-    function setVariationStoneTransparency(ev: React.ChangeEvent<HTMLInputElement>) {
+    function setVariationStoneOpacity(ev: React.ChangeEvent<HTMLInputElement>) {
         const value = parseFloat(ev.target.value);
 
         if (value >= 0.0 && value <= 1.0) {
-            _setVariationStoneTransparency(value);
+            _setVariationStoneOpacity(value);
         }
     }
     function setVariationMoveCount(ev: React.ChangeEvent<HTMLInputElement>) {
@@ -299,9 +298,9 @@ export function GamePreferences(): JSX.Element {
             </PreferenceLine>
 
             <PreferenceLine
-                title={_("Variation stone transparency")}
+                title={_("Variation stone opacity")}
                 description={_(
-                    "Choose the level of transparency for stones shown in variations. 0.0 is transparent and 1.0 is opaque.",
+                    "Choose the level of opacity for stones shown in variations. 0.0 is transparent and 1.0 is opaque.",
                 )}
             >
                 <input
@@ -309,12 +308,12 @@ export function GamePreferences(): JSX.Element {
                     step="0.1"
                     min="0.0"
                     max="1.0"
-                    onChange={setVariationStoneTransparency}
-                    value={variation_stone_transparency}
+                    onChange={setVariationStoneOpacity}
+                    value={variation_stone_opacity}
                 />
                 <span>
                     &nbsp;
-                    {variation_stone_transparency}
+                    {variation_stone_opacity}
                 </span>
             </PreferenceLine>
 


### PR DESCRIPTION
Fixes wrong terminology, confusing number in "variation stone opacity" setting

## Proposed Changes

  - say opacity instead of transparency

Full disclosure: this will cause people who changed this setting to have to change it again, they will lose their old value.

I wouldn't have worried about this, except I'm planning to add "Last Move Opacity"... seems like it should be consistent.
