### PR TITLE
Provide a preference to control the "last move opacity".

### DIFF
--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -23,6 +23,8 @@ import { GobanCanvas, GobanCanvasConfig } from "goban";
 import { goban_view_mode } from "Game/util";
 //import { generateGobanHook } from "Game/GameHooks";
 
+import { usePreference } from "preferences";
+
 interface GobanContainerProps {
     goban?: GobanCanvas;
     /** callback that is called when the goban detects a resize. */
@@ -41,6 +43,7 @@ export function GobanContainer({
 }: GobanContainerProps): JSX.Element {
     const ref_goban_container = React.useRef<HTMLDivElement>(null);
     const resize_debounce = React.useRef<NodeJS.Timeout | null>(null);
+    const [last_move_opacity] = usePreference("last-move-opacity");
 
     // Since goban is a GobanCanvas, we know goban.config is a GobanCanvasConfig
     const goban_div = (goban?.config as GobanCanvasConfig | undefined)?.board_div;
@@ -91,6 +94,7 @@ export function GobanContainer({
                 }
             }
 
+            goban.setLastMoveOpacity(last_move_opacity);
             if (no_debounce) {
                 // Debouncing is necessary because setting the square size can be an expensive operation.
                 goban.setSquareSizeBasedOnDisplayWidth(

--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -28,6 +28,7 @@ import { Clock } from "Clock";
 import { fetch } from "player_cache";
 import { getGameResultText } from "misc";
 import { PlayerCacheEntry } from "player_cache";
+import { usePreference } from "preferences";
 
 export interface MiniGobanProps {
     id?: number;
@@ -78,6 +79,7 @@ export function MiniGoban(props: MiniGobanProps): JSX.Element {
     const [in_stone_removal_phase, setInStoneRemovalPhase] = React.useState(false);
     const [finished, setFinished] = React.useState(false);
     const [game_name, setGameName] = React.useState("");
+    const [last_move_opacity] = usePreference("last-move-opacity");
 
     React.useEffect(() => {
         goban.current = new Goban(
@@ -94,6 +96,7 @@ export function MiniGoban(props: MiniGobanProps): JSX.Element {
                 square_size: "auto",
                 width: props.width || (props.json ? props.json.width : 19),
                 height: props.height || (props.json ? props.json.height : 19),
+                last_move_opacity: last_move_opacity,
             },
             props.json,
         );

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -40,6 +40,7 @@ export const defaults = {
     "dock-delay": 0, // seconds.
     "double-click-submit-correspondence": false,
     "double-click-submit-live": false,
+    "last-move-opacity": 1.0,
     "variation-stone-transparency": 0.6,
     "variation-move-count": 10,
     "visual-undo-request-indicator": true,

--- a/src/views/Settings/GamePreferences.tsx
+++ b/src/views/Settings/GamePreferences.tsx
@@ -54,6 +54,7 @@ export function GamePreferences(): JSX.Element {
     const [autoplay_delay, _setAutoplayDelay]: [number, (x: number) => void] = React.useState(
         preferences.get("autoplay-delay") / 1000,
     );
+    const [last_move_opacity, _setLastMoveOpacity] = usePreference("last-move-opacity");
     const [variation_stone_transparency, _setVariationStoneTransparency] = usePreference(
         "variation-stone-transparency",
     );
@@ -115,6 +116,13 @@ export function GamePreferences(): JSX.Element {
     }
     function setCorrSubmitMode(value: string) {
         setSubmitMode("correspondence", value);
+    }
+    function setLastMoveOpacity(ev: React.ChangeEvent<HTMLInputElement>) {
+        const value = parseFloat(ev.target.value);
+
+        if (value >= 0.0 && value <= 1.0) {
+            _setLastMoveOpacity(value);
+        }
     }
     function setVariationStoneTransparency(ev: React.ChangeEvent<HTMLInputElement>) {
         const value = parseFloat(ev.target.value);
@@ -296,6 +304,26 @@ export function GamePreferences(): JSX.Element {
                 )}
             >
                 <Toggle checked={zen_mode_by_default} onChange={toggleZenMode} />
+            </PreferenceLine>
+
+            <PreferenceLine
+                title={_("Last move opacity")}
+                description={_(
+                    "Choose the level of opacity for the 'last move' mark on stones. 0.0 is transparent and 1.0 is opaque.",
+                )}
+            >
+                <input
+                    type="range"
+                    step="0.1"
+                    min="0.0"
+                    max="1.0"
+                    onChange={setLastMoveOpacity}
+                    value={last_move_opacity}
+                />
+                <span>
+                    &nbsp;
+                    {last_move_opacity}
+                </span>
             </PreferenceLine>
 
             <PreferenceLine


### PR DESCRIPTION
Fixes folk having a big circle messing up their custom stone images.

We've also been requested to do this in the past for folk who think it's cheating or distracting to know which stone was played last.

## Proposed Changes

  - Add a "game" preference for last move opacity
  - Pass this into goban
    - In Minigoban, it goes in with the config of the  goban
    - In GobanContainer it gets set when we draw the goban by calling setLastMoveOpacity
       -  That's because it seemed to complicated and "all over the place" to try to set it via config for GobanContainer applications

Needs:  https://github.com/online-go/goban/pull/150  
