### PR TITLE
Fix tournament result colours and elimination graph for draws

### DIFF
--- a/src/global_styl/global.styl
+++ b/src/global_styl/global.styl
@@ -591,6 +591,9 @@ display: inline-block;
 .result-won {
     themed-desaturate-and-lighten-darken background-color win 55% 30%
 }
+.result-tie {
+    themed-desaturate-and-lighten-darken background-color tie 55% 30%
+}
 .result-lost {
     themed-desaturate-and-lighten-darken background-color loss 55% 30%
 }

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -192,6 +192,7 @@ light.chat-system                       = #1CA760
 light.private-chat-user                 = #111111
 
 light.win                               = #73D355
+light.tie                               = #F3F3D5
 light.loss                              = #BC4B9A
 
 light.weak-win                          = lighten(light.win, 25%)
@@ -350,6 +351,7 @@ dark.private-chat-user                  = #eeeeee
 
 
 dark.win                                = desaturate(darken(light.win, 30%), 20%)
+dark.tie                                = desaturate(darken(light.tie, 80%), 20%)
 dark.loss                               = desaturate(darken(light.loss, 30%), 20%)
 
 dark.strong-win                         = lighten(dark.win, 25%)
@@ -430,6 +432,7 @@ for key, value in dark
 // And add the different stuff...
 
 accessible.win                                = #0072B2  // blue from https://www.nature.com/articles/nmeth.1618/figures/2
+accessible.tie                                = #CC79A7  // reddish purple from there ^^
 accessible.loss                               = #D55E00  // vermillion from there ^^
 
 // get rid of green indicator light, colors chosen for apparent "looks good" against the bg in this context

--- a/src/views/Tournament/Tournament.styl
+++ b/src/views/Tournament/Tournament.styl
@@ -185,6 +185,9 @@
     .win {
         @extend .result-won
     }
+    .tie {
+        @extend .result-tie
+    }
     .loss {
         @extend .result-lost
     }


### PR DESCRIPTION
Drawn games are recorded as "B+0.5,W+0.5", and were incorrectly being displayed as wins for black.

- Check the full string of match results instead of just the first character.
- Fix the elimination graph drawing to allow for both players to continue.
- Choose colours for "tie" so it looks different from a loss.
- For accessibility, use a previously-unused colour from the accessibility table that is dark (since light text will be put on top of it).

Fixes #2536
