### PR TITLE
Show the ruleset and handicap stones in the black player card

### DIFF
--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -284,6 +284,10 @@ export function PlayerCard({
     const their_turn = player_to_move === player.id;
     const highlight_their_turn = their_turn ? `their-turn` : "";
 
+    // Only show the rules for black, since white has komi showing here.
+    const rules =
+        color === "black" ? rulesString(engine.config.rules, engine.config.handicap) : null;
+
     const show_points =
         (engine.phase === "finished" || engine.phase === "stone removal") &&
         goban.mode !== "analyze" &&
@@ -352,13 +356,18 @@ export function PlayerCard({
                         })}
                     </div>
                 )}
-                <NumCapturesText
-                    score={score}
-                    color={color}
-                    zen_mode={zen_mode}
-                    hidden={show_points && !estimating_score}
-                />
-                {!show_points && <div className="komi">{komiString(score.komi)}</div>}
+                {!show_points && (
+                    <NumCapturesText
+                        score={score}
+                        color={color}
+                        zen_mode={zen_mode}
+                        hidden={show_points && !estimating_score}
+                    />
+                )}
+                {rules && <div className="rules">{rules}</div>}
+                {!show_points && !!score.komi && (
+                    <div className="komi">{komiString(score.komi)}</div>
+                )}
                 <div id={`${color}-score-details`} className="score-details">
                     <ScorePopup goban={goban} color={color} show={show_score_breakdown} />
                 </div>
@@ -428,6 +437,56 @@ function komiString(komi: number) {
     return komi > 0 ? `+ ${abs_komi}` : `- ${abs_komi}`;
 }
 
+function rulesString(rules: string | null, handicap_stones: number) {
+    const stones = handicap_stones ? stonesString(handicap_stones) : "";
+    let code: string;
+    switch (rules.toLowerCase()) {
+        default:
+        case "japanese":
+            code = "JP";
+            break;
+        case "nz":
+            code = "NZ";
+            break;
+        case "aga":
+            code = "AGA";
+            break;
+        case "ing":
+        case "ing sst": // Old spelling.
+            code = "Ing";
+            break;
+        case "chinese":
+            code = "CN";
+            break;
+        case "korean":
+            code = "KR";
+            break;
+    }
+    if (!code) {
+        return stones;
+    }
+    return code + " " + stones;
+}
+
+function stonesString(handicap_stones: number) {
+    if (handicap_stones <= 0) {
+        return "";
+    }
+    const one = 0x2460;
+    const twenty_one = 0x3251;
+    const thirty_six = 0x32b1;
+    if (handicap_stones <= 20) {
+        return String.fromCodePoint(one + handicap_stones - 1);
+    }
+    if (handicap_stones <= 35) {
+        return String.fromCodePoint(twenty_one + handicap_stones - 21);
+    }
+    if (handicap_stones <= 50) {
+        return String.fromCodePoint(thirty_six + handicap_stones - 36);
+    }
+    return "(" + handicap_stones + ")";
+}
+
 function useAutoResignExpiration(goban: GobanCore, color: "black" | "white") {
     const [auto_resign_expiration, setAutoResignExpiration] = React.useState<Date | null>(null);
     React.useEffect(() => {
@@ -482,7 +541,7 @@ function ScorePopup({ show, goban, color }: ScorePopupProps) {
     let first_points = 0;
     return (
         <div className="score_breakdown">
-            {color === "black" && !!goban.engine.handicap && (
+            {!!goban.engine.handicap && (
                 <div>
                     <span>{_("Handicap")}</span>
                     <div>{goban.engine.handicap}</div>

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -356,7 +356,7 @@ export function PlayerCard({
                         })}
                     </div>
                 )}
-                {!show_points && (
+                {(!show_points || estimating_score) && (
                     <NumCapturesText
                         score={score}
                         color={color}

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -541,7 +541,7 @@ function ScorePopup({ show, goban, color }: ScorePopupProps) {
     let first_points = 0;
     return (
         <div className="score_breakdown">
-            {!!goban.engine.handicap && (
+            {color === "black" && !!goban.engine.handicap && (
                 <div>
                     <span>{_("Handicap")}</span>
                     <div>{goban.engine.handicap}</div>

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -437,10 +437,10 @@ function komiString(komi: number) {
     return komi > 0 ? `+ ${abs_komi}` : `- ${abs_komi}`;
 }
 
-function rulesString(rules: string | null, handicap_stones: number) {
+function rulesString(rules: string | null | undefined, handicap_stones: number | undefined) {
     const stones = handicap_stones ? stonesString(handicap_stones) : "";
     let code: string;
-    switch (rules.toLowerCase()) {
+    switch (rules?.toLowerCase()) {
         default:
         case "japanese":
             code = "JP";

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -95,6 +95,11 @@
             text-align: right;
             font-weight: bold;
         }
+        .rules {
+            flex-grow: 0;
+            text-align: right;
+            font-weight: bold;
+        }
         .captures, .points {
             font-weight: bold;
             position: relative;
@@ -176,6 +181,7 @@
                 color: light[color-attr]!important
             }
         }
+
     }
 
     .black.player-container {
@@ -196,6 +202,13 @@
             .Player.{class-attr} {
                 color: dark[color-attr]!important
             }
+        }
+
+        a.rules-link:hover,
+        a.rules-link:link,
+        a.rules-link:visited,
+        a.rules-link:active {
+            themed color player-black-fg
         }
     }
 
@@ -378,7 +391,7 @@
         font-size: font-size-small;
     }
     .player-container {
-        .captures, .points, .komi {
+        .captures, .points, .komi, .rules {
             font-size: font-size-small;
         }
         padding-bottom: 0;
@@ -540,6 +553,7 @@ body.light .MainGobanView.zen .player-icons {
         .player-name-container,
         .player-name-plain,
         .score-details,
+        .rules,
         .komi {
             display: none;
         }

--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -203,13 +203,6 @@
                 color: dark[color-attr]!important
             }
         }
-
-        a.rules-link:hover,
-        a.rules-link:link,
-        a.rules-link:visited,
-        a.rules-link:active {
-            themed color player-black-fg
-        }
     }
 
     .player-container.shortgame.offline {

--- a/src/views/docs/RulesMatrix.tsx
+++ b/src/views/docs/RulesMatrix.tsx
@@ -24,11 +24,11 @@ export const RulesMatrix = () => (
                 <tr>
                     <th></th>
                     <th>AGA</th>
-                    <th>Japanese</th>
-                    <th>Chinese</th>
-                    <th>Korean</th>
-                    <th>Ing's SST Rules</th>
-                    <th>New Zealand</th>
+                    <th>Japanese (JP)</th>
+                    <th>Chinese (CN)</th>
+                    <th>Korean (KR)</th>
+                    <th>Ing's SST Rules (Ing)</th>
+                    <th>New Zealand (NZ)</th>
                 </tr>
 
                 <tr>


### PR DESCRIPTION
Now, the ruleset and handicap are directly shown in the black player card (except in Zen mode), in the same spot where the white player card has komi.

- The ruleset uses the two-letter country code for any rules named after a country, and "Ing" and "AGA" for the Ing and AGA rules.
- The rules matrix document now includes the the short code in parentheses.
- The handicap uses the unicode for a circled number up to 50. After that, it uses parentheses (such as "(51)"), which is the old way to circle numbers on a typewriter.  I think this won't come up in practice.

Things considered and not implemented (but could be tried again in the future).

- Link to the rules matrix.  I tried this out, but I was worried someone might accidentally abandon a game when trying to pop out the scoring panel.
- Using `pgettext()` to allow translation of the codes.  I wasn't sure if this was useful, but could implement if reviewer thinks it'd be better.
- Draw circle using CSS `border-radius` instead of the Unicode.  The existing choice is more compact and works nicely for all handicaps up to 50.
- Also show the long name of the rules in the pop-out scoring panel.  It seemed cluttered.

I'll post some examples of how this looks in a moment.

