### PR TITLE
Fix copy/paste bug in tournament grids

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1087,9 +1087,9 @@ export function Tournament(): JSX.Element {
                             : "?"
                     : "?";
                 result_map[m.white + "x" + m.black] = m.result
-                    ? m.result === "B+1"
+                    ? m.result === "W+1"
                         ? "win"
-                        : m.result === "W+1"
+                        : m.result === "B+1"
                           ? "loss"
                           : m.result === "B+0.5,W+0.5"
                             ? "tie"
@@ -1105,9 +1105,9 @@ export function Tournament(): JSX.Element {
                             : "no-result"
                     : "?";
                 color_map[m.white + "x" + m.black] = m.result
-                    ? m.result === "B+1"
+                    ? m.result === "W+1"
                         ? "win"
-                        : m.result === "W+1"
+                        : m.result === "B+1"
                           ? "loss"
                           : m.result === "B+0.5,W+0.5"
                             ? "tie"


### PR DESCRIPTION
Fix a copy/paste bug introduced by 0d496f86840cb25b3411013438ba2d976c17296a, which caused half of the tournament grid to show the results backwards.

|    |   P1  |   P2  |   P3  |
|----|-------|-------|-------|
| P1 |       | wrong | wrong |
| P2 | right |       | wrong |
| P3 | right | right |       |

Fixes #2539
