### PR TITLE
Remove redundant board size from ladder list

### DIFF
--- a/src/views/LadderList/LadderList.tsx
+++ b/src/views/LadderList/LadderList.tsx
@@ -136,9 +136,7 @@ export function LadderList(): JSX.Element {
                             ) : (
                                 <i className="fa fa-list-ol"></i>
                             )}
-                            <Link to={`/ladder/${ladder.id}`}>
-                                {ladder.name} {ladder.board_size + "x" + ladder.board_size}
-                            </Link>
+                            <Link to={`/ladder/${ladder.id}`}>{ladder.name}</Link>
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
The board size is included in every ladder name.  Stop including it redundantly in the link from the ladder list.
