### PR TITLE
[Reports Center] Some display improvements to the game log

### DIFF
--- a/src/views/Game/GameLogModal.tsx
+++ b/src/views/Game/GameLogModal.tsx
@@ -109,6 +109,16 @@ export class GameLogModal extends Modal<Events, GameLogModalProperties, { log: A
     }
 }
 
+// Fields that are only used to enhance the display of other fields,
+// or aren't used at all.
+const HIDDEN_LOG_FIELDS = [
+    // used with "stones"
+    "current_removal_string",
+    "move_number",
+    // isn't used
+    "strict_seki_mode",
+];
+
 export function LogData({
     config,
     event,
@@ -179,7 +189,7 @@ export function LogData({
                             />,
                         );
                     }
-                } else if (k === "current_removal_string" || k === "move_number") {
+                } else if (HIDDEN_LOG_FIELDS.includes(k)) {
                     // skip
                 } else {
                     ret.push(

--- a/src/views/Game/GameLogModal.tsx
+++ b/src/views/Game/GameLogModal.tsx
@@ -124,7 +124,7 @@ export function LogData({
         if (event === "game_created") {
             return;
         }
-        if (!data?.stones) {
+        if (!data?.hasOwnProperty("stones")) {
             return;
         }
 

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -140,6 +140,15 @@ reports_center_content_width=56rem
     .progress-bar.empty {
         themed background-color shade5
     }
+
+    .game-log {
+        tr {
+            vertical-align: top;
+        }
+        td>div {
+            margin-bottom: 2em
+        }
+    }
 }
 
 #ReportsCenterContainer {

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -147,6 +147,9 @@ reports_center_content_width=56rem
         }
         td>div {
             margin-bottom: 2em
+            span {
+                display: inline-block;
+            }
         }
     }
 }


### PR DESCRIPTION
There is feedback in the forums that the game logs are still hard to parse. @pdg137 provided good, specific suggestions in this post: https://forums.online-go.com/t/feedback-on-the-new-game-log/50372/2.  Additionally, here are more threads with some general confusion: https://forums.online-go.com/t/bug-log-shows-no-scoring-phase-images/50631, https://forums.online-go.com/t/questions-about-the-report-center-and-community-moderation/50645.

## Proposed Changes

  - Always show the board for "stones" events, even when it's `stones: ""`
  - Don't display `strict_seki_mode` - it doesn't provide signal to mods when the feature is turned off.
  - Layout adjustments
      - More space between log entries
      - Align cells to the top of the row
      - Put each field on its own line - abutting elements and wraparound is a little confusing.

<img width="729" alt="Screenshot 2024-02-03 at 5 10 42 PM" src="https://github.com/online-go/online-go.com/assets/25233703/efc60057-affa-4db5-91f1-76f640b8a92f">
