### PR TITLE
Clicking on `IncidentReportIndicator` takes CMs straight to `ReportCenter`

### DIFF
--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -50,17 +50,17 @@ export function IncidentReportTracker(): JSX.Element | null {
         registerTargetItem("first-report-button");
 
     function toggleList() {
-        if (user.is_moderator) {
+        if (user.is_moderator || user.moderator_powers) {
+            signalUsed("incident-report-indicator");
             navigate("/reports-center/");
         } else {
-            signalUsed("incident-report-indicator");
             setShowIncidentList(!show_incident_list);
         }
     }
 
     React.useEffect(() => {
         if (incident_report_indicator && user.moderator_powers) {
-            if (!prefer_hidden && normal_ct > 0) {
+            if (normal_ct > 0) {
                 triggerFlow("community-moderator-with-reports-intro");
             } else {
                 triggerFlow("community-moderator-no-reports-intro");

--- a/src/views/HelpFlows/CommunityModeratorIntro.tsx
+++ b/src/views/HelpFlows/CommunityModeratorIntro.tsx
@@ -62,15 +62,7 @@ export function CommunityModeratorIntro(): JSX.Element {
                     <div>
                         {pgettext(
                             "A help message describing the community moderator incident report indicator",
-                            "Incident report indicator - click it to see your report list",
-                        )}
-                    </div>
-                </HelpItem>
-                <HelpItem target="first-report-button" position={"centre-left"}>
-                    <div>
-                        {pgettext(
-                            "A help message describing the how to see a report",
-                            "Press the 'report button' to see a report",
+                            "Incident report indicator - click it to see the report list",
                         )}
                     </div>
                 </HelpItem>


### PR DESCRIPTION
adjust help flow accordingly

Fixes CMs complaining  about number of clicks to get to a report :)

## Proposed Changes

  - Don't show report list when `IncidentReportIndicator` is clicked, instead go to ReportCentre
  - Take report list help item out of the flow
  - Don't check "prefer hidden" for CM help, because they can't have selected "prefer hidden" at this point.
  
