### PR TITLE
Indicate absolute time using '/*' and improve clock sorting

### DIFF
--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -115,6 +115,12 @@ export function Clock({
                         {prettyTime(player_clock.main_time)}
                     </span>
                 )}
+                {time_control.system === "absolute" && (
+                    <>
+                        <span className="periods-delimiter">/</span>
+                        <span className="period-moves boxed">*</span>
+                    </>
+                )}
 
                 {time_control.system === "byoyomi" && (
                     <div className="byo-yomi-container">


### PR DESCRIPTION
Borrow from the syntax for Canadian time to call out absolute time.

- Canadian time says "3 Days/10" when there are 10 moves to make in 3 days.
- With this, absoluate time says "3 Days/*".

Addresses this forum thread asking for an indication in the game list of which games are using absolute time:
https://forums.online-go.com/t/suggestion-sort-games-with-absolute-time-settings-to-appear-at-the-top-of-ones-list-of-games-when-sorting-by-time-remaining/50649

EDIT: also improved sorting; details at https://github.com/online-go/online-go.com/pull/2557#issuecomment-1925863507.