### PR TITLE
Fix order of pgettext and interpolate for "Message {{who}}"

### DIFF
--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -546,9 +546,12 @@ function ChatInput({
 
     const placeholder = inputPlaceholderText
         ? inputPlaceholderText
-        : pgettext(
-              "This is the placeholder text for the chat input field in games, chat channels, and private messages",
-              interpolate("Message {{who}}", { who: channel_name || "..." }),
+        : interpolate(
+              pgettext(
+                  "This is the placeholder text for the chat input field in games, chat channels, and private messages",
+                  "Message {{who}}",
+              ),
+              { who: channel_name || "..." },
           );
 
     return (

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -393,9 +393,12 @@ class PrivateChat {
             if (this.user_id) {
                 this.input.attr(
                     "placeholder",
-                    pgettext(
-                        "This is the placeholder text for the chat input field in games, chat channels, and private messages",
-                        interpolate("Message {{who}}", { who: this.player.username }),
+                    interpolate(
+                        pgettext(
+                            "This is the placeholder text for the chat input field in games, chat channels, and private messages",
+                            "Message {{who}}",
+                        ),
+                        { who: this.player.username },
                     ),
                 );
                 this.input.removeAttr("disabled");

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -295,9 +295,12 @@ export function GameChat(props: GameChatProperties): JSX.Element {
                                     ? "Message players as a moderator"
                                     : selected_chat_log === "hidden"
                                       ? "Visible only to moderators"
-                                      : pgettext(
-                                            "This is the placeholder text for the chat input field in games, chat channels, and private messages",
-                                            interpolate("Message {{who}}", { who: "..." }),
+                                      : interpolate(
+                                            pgettext(
+                                                "This is the placeholder text for the chat input field in games, chat channels, and private messages",
+                                                "Message {{who}}",
+                                            ),
+                                            { who: "..." },
                                         )
                     }
                     onKeyPress={onKeyPress}


### PR DESCRIPTION
Invert pgettext and interpolate calls for the three instances of:

    "Message {{who}}"

... so that "message" can be translated in the suggested text in chats.

From the forums: https://forums.online-go.com/t/no-sgf-from-just-part-of-my-games-why/50453/17

FWIW, I manually tested that I still get the expected prompts in English in the three places in the interface.