### PR TITLE
Fix double-elimination graph for if-games

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -633,6 +633,7 @@ export function Tournament(): JSX.Element {
                         match: match,
                         second_bracket: false,
                         round: round_num,
+                        is_final: round.byes.length === 0 && round.matches.length === 1,
                     };
                     if (obj.black_src) {
                         obj.black_src.parent = obj;
@@ -875,7 +876,14 @@ export function Tournament(): JSX.Element {
                         }
                     }
 
-                    if (!obj.second_bracket) {
+                    if (
+                        obj.is_final &&
+                        ((obj.black_src && obj.black_src.second_bracket) ||
+                            (obj.white_src && obj.white_src.second_bracket))
+                    ) {
+                        // Draw finals for double-elimination in between the two brackets.
+                        obj.top = bracket_spacing;
+                    } else if (!obj.second_bracket) {
                         if (obj.bye_src) {
                             if (obj.bye_src.second_bracket === obj.second_bracket) {
                                 obj.top = obj.bye_src.top;
@@ -983,6 +991,7 @@ export function Tournament(): JSX.Element {
                 if (obj.black_src) {
                     drawLines(obj.black_src);
                     if (
+                        obj.is_final ||
                         !obj.second_bracket ||
                         obj.second_bracket === obj.black_src.second_bracket
                     ) {
@@ -1009,6 +1018,7 @@ export function Tournament(): JSX.Element {
                 if (obj.white_src) {
                     drawLines(obj.white_src);
                     if (
+                        obj.is_final ||
                         !obj.second_bracket ||
                         obj.second_bracket === obj.white_src.second_bracket
                     ) {


### PR DESCRIPTION
When there's an if-game in a double-elimination tournament, both players have lost a game and are notionally in the "second bracket".  Update the drawing code to do something reasonable for that case.

- Always draw finals "in the middle" if either player came from the second bracket.
- Always connect lines back to the source.

This handles any backend change to support this forum proposal: https://forums.online-go.com/t/update-to-double-elimination-tournament/50521