### PR TITLE
Allow groups to turn on handicaps for their ladders

### DIFF
--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -71,6 +71,7 @@ interface GroupInfo {
     has_active_tournaments?: boolean;
     has_finished_tournaments?: boolean;
     rules?: string;
+    handicap?: number;
 }
 
 // API: group/%id%/news
@@ -308,6 +309,11 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
     setRules = (ev: React.ChangeEvent<HTMLSelectElement>) => {
         this.setState({ group: Object.assign({}, this.state.group, { rules: ev.target.value }) });
     };
+    setHandicap = (ev: React.ChangeEvent<HTMLSelectElement>) => {
+        this.setState({
+            group: Object.assign({}, this.state.group, { handicap: Number(ev.target.value) }),
+        });
+    };
     setShortDescription = (ev: React.ChangeEvent<HTMLTextAreaElement>) => {
         this.setState({
             group: Object.assign({}, this.state.group, { short_description: ev.target.value }),
@@ -510,6 +516,25 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                 <option value="japanese">{_("Japanese")}</option>
                 <option value="korean">{_("Korean")}</option>
                 <option value="nz">{_("New Zealand")}</option>
+            </select>
+        );
+    }
+
+    renderHandicap() {
+        if (
+            !this.state.group_loaded ||
+            !this.state.group.is_member ||
+            !this.state.is_admin ||
+            !this.state.editing
+        ) {
+            return this.state.group?.handicap === -1 ? _("Automatic") : _("None");
+        }
+
+        const group = this.state.group;
+        return (
+            <select value={group.handicap} onChange={this.setHandicap}>
+                <option value="0">{_("None")}</option>
+                <option value="-1">{_("Automatic")}</option>
             </select>
         );
     }
@@ -1171,6 +1196,10 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                                     <tr>
                                         <th>{_("Rules")}</th>
                                         <td>{this.renderRules()}</td>
+                                    </tr>
+                                    <tr>
+                                        <th>{_("Handicap")}</th>
+                                        <td>{this.renderHandicap()}</td>
                                     </tr>
                                 </table>
                             </div>

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -44,6 +44,7 @@ interface LadderState {
         player_is_member_of_group: boolean;
         player_rank: number;
         rules?: string;
+        handicap?: number;
     };
     ladder_size: number;
     topVisibleEntry: number;
@@ -174,6 +175,14 @@ class _Ladder extends React.PureComponent<LadderProperties, LadderState> {
                                 <tr>
                                     <th>{_("Rules")}</th>
                                     <td>{rulesText(this.state.ladder?.rules ?? "japanese")}</td>
+                                </tr>
+                                <tr>
+                                    <th>{_("Handicap")}</th>
+                                    <td>
+                                        {this.state.ladder?.handicap === -1
+                                            ? _("Automatic")
+                                            : _("None")}
+                                    </td>
                                 </tr>
                             </table>
                         </div>

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -241,6 +241,7 @@ export function Tournament(): JSX.Element {
                 .then((group) => {
                     tournament_ref.current.group = group;
                     tournament_ref.current.rules = group?.rules ?? "japanese";
+                    tournament_ref.current.handicap = String(group?.handicap ?? 0);
                     refresh();
                 })
                 .catch(errorAlerter);


### PR DESCRIPTION
Add frontend support for handicaps in group ladders:

- Enable configuration on the group page.
- Show the setting on the ladder page.
- Turn on handicaps by default when creating new tournaments.

One slightly awkward thing is that the group page canonicalizes the type as a `number` (0 or -1) and tournament page uses a `string` ("0" or "-1"), depending on what the backend expects.  If you'd rather have consistency here, I can change the backend to expect a string for the group page and convert to a number in the backend.

Fixes #2553
Depends on https://github.com/online-go/ogs/pull/1933