### PR TITLE
Move rules out of the black player card

### DIFF
--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -58,26 +58,6 @@ export function rulesText(rules: string) {
     return "[unknown]";
 }
 
-export function rulesCode(rules: string | null | undefined) {
-    switch (rules?.toLowerCase()) {
-        default:
-            return null;
-        case "japanese":
-            return pgettext("Rules short form (2-3 characters)", "JP");
-        case "nz":
-            return pgettext("Rules short form (2-3 characters)", "NZ");
-        case "aga":
-            return pgettext("Rules short form (2-3 characters)", "AGA");
-        case "ing":
-        case "ing sst": // Old spelling.
-            return pgettext("Rules short form (2-3 characters)", "Ing");
-        case "chinese":
-            return pgettext("Rules short form (2-3 characters)", "CN");
-        case "korean":
-            return pgettext("Rules short form (2-3 characters)", "KR");
-    }
-}
-
 // Create a deep copy of obj
 export function dup<T>(obj: T): T {
     let ret: T;

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -43,6 +43,20 @@
     }
 }
 
+.condensed-game-information {
+    display: flex;
+    font-size: 75%;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+
+    div {
+        flex-grow: 1;
+    }
+    .condensed-game-rules {
+        text-align: right;
+    }
+}
+
 .Game.wide {
     overflow: hidden;
 }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -26,7 +26,7 @@ import { popover } from "popover";
 import { post, get, abort_requests_in_flight } from "requests";
 import { KBShortcut } from "KBShortcut";
 import { UIPush } from "UIPush";
-import { errorAlerter, ignore } from "misc";
+import { errorAlerter, ignore, rulesText } from "misc";
 import {
     Goban,
     GobanCanvas,
@@ -786,6 +786,25 @@ export function Game(): JSX.Element | null {
             shareAnalysis();
             return false;
         }
+    };
+    const frag_game_information = () => {
+        const config = goban.current?.engine?.config;
+        if (!config) {
+            return null;
+        }
+        const rules = config?.rules ? rulesText(config.rules) : null;
+        return (
+            <div className="condensed-game-information">
+                {(config?.ranked || null) && (
+                    <div className="condensed-game-ranked">{_("Ranked")}</div>
+                )}
+                {rules && (
+                    <div className="condensed-game-rules">
+                        {_("Rules")}: {rules}
+                    </div>
+                )}
+            </div>
+        );
     };
     const frag_estimate_score = () => (
         <EstimateScore
@@ -1598,22 +1617,24 @@ export function Game(): JSX.Element | null {
 
                     <div className="center-col">
                         {(view_mode === "portrait" || null) && (
-                            <PlayerCards
-                                historical_black={historical_black}
-                                historical_white={historical_white}
-                                estimating_score={estimating_score}
-                                zen_mode={zen_mode}
-                                black_flags={black_flags}
-                                white_flags={white_flags}
-                                black_ai_suspected={bot_detection_results?.ai_suspected.includes(
-                                    historical_black?.id,
-                                )}
-                                white_ai_suspected={bot_detection_results?.ai_suspected.includes(
-                                    historical_white?.id,
-                                )}
-                            />
+                            <>
+                                <PlayerCards
+                                    historical_black={historical_black}
+                                    historical_white={historical_white}
+                                    estimating_score={estimating_score}
+                                    zen_mode={zen_mode}
+                                    black_flags={black_flags}
+                                    white_flags={white_flags}
+                                    black_ai_suspected={bot_detection_results?.ai_suspected.includes(
+                                        historical_black?.id,
+                                    )}
+                                    white_ai_suspected={bot_detection_results?.ai_suspected.includes(
+                                        historical_white?.id,
+                                    )}
+                                />
+                                {frag_game_information()}
+                            </>
                         )}
-
                         <GobanContainer goban={goban.current} onResize={onResize} />
 
                         {frag_below_board_controls()}
@@ -1663,20 +1684,23 @@ export function Game(): JSX.Element | null {
                         <div className={"right-col" + (experimental ? " experimental" : "")}>
                             {(zen_mode || null) && <div className="align-col-start"></div>}
                             {(view_mode === "square" || view_mode === "wide" || null) && (
-                                <PlayerCards
-                                    historical_black={historical_black}
-                                    historical_white={historical_white}
-                                    estimating_score={estimating_score}
-                                    zen_mode={zen_mode}
-                                    black_flags={black_flags}
-                                    white_flags={white_flags}
-                                    black_ai_suspected={bot_detection_results?.ai_suspected.includes(
-                                        historical_black?.id,
-                                    )}
-                                    white_ai_suspected={bot_detection_results?.ai_suspected.includes(
-                                        historical_white?.id,
-                                    )}
-                                />
+                                <>
+                                    <PlayerCards
+                                        historical_black={historical_black}
+                                        historical_white={historical_white}
+                                        estimating_score={estimating_score}
+                                        zen_mode={zen_mode}
+                                        black_flags={black_flags}
+                                        white_flags={white_flags}
+                                        black_ai_suspected={bot_detection_results?.ai_suspected.includes(
+                                            historical_black?.id,
+                                        )}
+                                        white_ai_suspected={bot_detection_results?.ai_suspected.includes(
+                                            historical_white?.id,
+                                        )}
+                                    />
+                                    {frag_game_information()}
+                                </>
                             )}
 
                             {(view_mode === "square" || view_mode === "wide" || null) &&

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -787,6 +787,18 @@ export function Game(): JSX.Element | null {
             return false;
         }
     };
+    const frag_rengo_header = () => {
+        if (!goban.current?.engine?.rengo) {
+            return null;
+        }
+        return (
+            <div className="rengo-header-block">
+                {((!goban.current?.review_id && show_title) || null) && (
+                    <div className="game-state">{title}</div>
+                )}
+            </div>
+        );
+    };
     const frag_game_information = () => {
         const config = goban.current?.engine?.config;
         if (!config) {
@@ -1633,6 +1645,7 @@ export function Game(): JSX.Element | null {
                                     )}
                                 />
                                 {frag_game_information()}
+                                {frag_rengo_header()}
                             </>
                         )}
                         <GobanContainer goban={goban.current} onResize={onResize} />
@@ -1700,6 +1713,7 @@ export function Game(): JSX.Element | null {
                                         )}
                                     />
                                     {frag_game_information()}
+                                    {frag_rengo_header()}
                                 </>
                             )}
 

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -800,6 +800,10 @@ export function Game(): JSX.Element | null {
         );
     };
     const frag_game_information = () => {
+        if (zen_mode) {
+            return null;
+        }
+
         const config = goban.current?.engine?.config;
         if (!config) {
             return null;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1633,7 +1633,7 @@ export function Game(): JSX.Element | null {
 
                     <div className="center-col">
                         {(view_mode === "portrait" || null) && (
-                            <>
+                            <div>
                                 <PlayerCards
                                     historical_black={historical_black}
                                     historical_white={historical_white}
@@ -1650,7 +1650,7 @@ export function Game(): JSX.Element | null {
                                 />
                                 {frag_game_information()}
                                 {frag_rengo_header()}
-                            </>
+                            </div>
                         )}
                         <GobanContainer goban={goban.current} onResize={onResize} />
 
@@ -1701,7 +1701,7 @@ export function Game(): JSX.Element | null {
                         <div className={"right-col" + (experimental ? " experimental" : "")}>
                             {(zen_mode || null) && <div className="align-col-start"></div>}
                             {(view_mode === "square" || view_mode === "wide" || null) && (
-                                <>
+                                <div>
                                     <PlayerCards
                                         historical_black={historical_black}
                                         historical_white={historical_white}
@@ -1718,7 +1718,7 @@ export function Game(): JSX.Element | null {
                                     />
                                     {frag_game_information()}
                                     {frag_rengo_header()}
-                                </>
+                                </div>
                             )}
 
                             {(view_mode === "square" || view_mode === "wide" || null) &&

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -811,9 +811,9 @@ export function Game(): JSX.Element | null {
         const rules = config?.rules ? rulesText(config.rules) : null;
         return (
             <div className="condensed-game-information">
-                {(config?.ranked || null) && (
-                    <div className="condensed-game-ranked">{_("Ranked")}</div>
-                )}
+                <div className="condensed-game-ranked">
+                    {config.ranked ? _("Ranked") : _("Unranked")}
+                </div>
                 {rules && (
                     <div className="condensed-game-rules">
                         {_("Rules")}: {rules}

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -29,7 +29,7 @@ import { Player } from "Player";
 import { lookup, fetch } from "player_cache";
 import { _, interpolate, ngettext } from "translate";
 import * as data from "data";
-import { generateGobanHook, usePlayerToMove, useShowTitle, useTitle } from "./GameHooks";
+import { generateGobanHook, usePlayerToMove } from "./GameHooks";
 import { get_network_latency, get_clock_drift } from "sockets";
 import { useGoban } from "./goban_context";
 import { usePreference } from "preferences";
@@ -61,15 +61,11 @@ export function PlayerCards({
     white_ai_suspected,
 }: PlayerCardsProps): JSX.Element {
     const goban = useGoban();
-    const engine = goban.engine;
 
     const orig_marks = React.useRef<string | null>(null);
     const showing_scores = React.useRef<boolean>(false);
 
     const [show_score_breakdown, set_show_score_breakdown] = React.useState(false);
-
-    const show_title = useShowTitle(goban);
-    const title = useTitle(goban);
 
     const popupScores = () => {
         if (goban.engine.cur_move) {
@@ -125,21 +121,6 @@ export function PlayerCards({
                     ai_suspected={white_ai_suspected}
                 />
             </div>
-            {(engine.rengo || null) && (
-                <div className="rengo-header-block">
-                    {
-                        /* Title logic doesn't really belong in PlayerCards, but it appears it was
-                        added here so that in vertical-mode, the "White/Black to Move" message shows
-                        up above the board, not below it.
-
-                        TODO: move title logic out of this component.
-                        */
-                        ((!goban.review_id && show_title && goban?.engine?.rengo) || null) && (
-                            <div className="game-state">{title}</div>
-                        )
-                    }
-                </div>
-            )}
         </div>
     );
 }

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -26,7 +26,6 @@ import { ChatPresenceIndicator } from "ChatPresenceIndicator";
 import { Clock } from "Clock";
 import { useUser } from "hooks";
 import { Player } from "Player";
-import { rulesText, rulesCode } from "misc";
 import { lookup, fetch } from "player_cache";
 import { _, interpolate, ngettext } from "translate";
 import * as data from "data";
@@ -361,7 +360,7 @@ export function PlayerCard({
                         hidden={show_points && !estimating_score}
                     />
                 )}
-                {color === "black" && rulesAndHandicap(engine.config.rules, engine.config.handicap)}
+                {color === "black" && handicapStones(engine.config.handicap)}
                 {!show_points && !!score.komi && (
                     <div className="komi">{komiString(score.komi)}</div>
                 )}
@@ -434,12 +433,10 @@ function komiString(komi: number) {
     return komi > 0 ? `+ ${abs_komi}` : `- ${abs_komi}`;
 }
 
-function rulesAndHandicap(rules: string | null | undefined, handicap_stones: number | undefined) {
+function handicapStones(handicap_stones: number | undefined) {
     const stones = handicap_stones ? stonesString(handicap_stones) : "";
     return (
-        <div className="rules">
-            {rules && <span title={_("Rules") + ": " + rulesText(rules)}>{rulesCode(rules)}</span>}
-            {rules && stones && " "}
+        <div className="handicap-stones">
             {stones && <span title={_("Handicap") + ": " + handicap_stones}>{stones}</span>}
         </div>
     );
@@ -518,22 +515,12 @@ function ScorePopup({ show, goban, color }: ScorePopupProps) {
     let first_points = 0;
     return (
         <div className="score_breakdown">
-            {color === "black" && goban.engine.config.rules && (
-                <>
-                    <div>
-                        <span>
-                            {_("Rules")}: {rulesText(goban.engine.config.rules)}
-                        </span>
-                        <div>{rulesCode(goban.engine.config.rules)}</div>
-                    </div>
-                    {!!goban.engine.handicap && (
-                        <div>
-                            <span>{_("Handicap")}</span>
-                            <div>{goban.engine.handicap}</div>
-                        </div>
-                    )}
+            {color === "black" && !!goban.engine.handicap && (
+                <div>
+                    <span>{_("Handicap")}</span>
+                    <div>{goban.engine.handicap}</div>
                     <hr />
-                </>
+                </div>
             )}
             {!!stones && (
                 <div>


### PR DESCRIPTION
In the black player card, the rules codes can be mistaken for initials of the black player.  Move them out, just below the player cards, into an area for condensed game information with small font.

- Rules, aligned right.
- Ranked games, "Ranked", aligned left.

This is an option for addressing [feedback from the forums](https://forums.online-go.com/t/the-ruleset-of-the-game-should-be-easier-to-see/39165).

Draft for discussion. I'll post screenshots in a moment.