### PR TITLE
Keep absolute time indication with main time

### DIFF
--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -115,8 +115,7 @@ export function Clock({
                         {prettyTime(player_clock.main_time)}
                         {time_control.system === "absolute" && (
                             <>
-                                <span className="periods-delimiter">/</span>
-                                <span className="period-moves boxed">*</span>
+                                <span className="absolute-time">+0</span>
                             </>
                         )}
                     </span>

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -113,13 +113,13 @@ export function Clock({
                         className={"main-time boxed " + (need_small_main_time_font ? " small" : "")}
                     >
                         {prettyTime(player_clock.main_time)}
+                        {time_control.system === "absolute" && (
+                            <>
+                                <span className="periods-delimiter">/</span>
+                                <span className="period-moves boxed">*</span>
+                            </>
+                        )}
                     </span>
-                )}
-                {time_control.system === "absolute" && (
-                    <>
-                        <span className="periods-delimiter">/</span>
-                        <span className="period-moves boxed">*</span>
-                    </>
                 )}
 
                 {time_control.system === "byoyomi" && (


### PR DESCRIPTION
Encourage CSS layout to keep the `/*` absolute time indication with the main time by putting it in the same `<span>`.  When the main time has a line break, this prevents creating an extra one just for the `/*`.

I.e., instead of:

    6 Days 23
        Hours
           /*

We get:

    6 Days 23
      Hours/*

EDIT: after feedback in the forums, seems `+0` is more intuitive:

    6 Days 23
      Hours+0