### PR TITLE
Add link to selected AI Player profile page in Challenge dialog.

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -969,7 +969,7 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                                     target="_blank"
                                     title={_("Selected AI profile")}
                                 >
-                                    <i className="fa fa-link" />
+                                    <i className="fa fa-external-link" />
                                 </a>
                             </div>
                         </div>

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -38,7 +38,7 @@ import {
 } from "TimeControl";
 import { sfx } from "sfx";
 import { notification_manager, NotificationManagerEvents } from "Notifications/NotificationManager";
-import { one_bot, bots, bot_count, bots_list } from "bots";
+import { one_bot, bot_count, bots_list } from "bots";
 import { goban_view_mode } from "Game/util";
 import {
     Goban,
@@ -963,13 +963,13 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                                         </option>
                                     ))}
                                 </select>
-                            </div>
-                            <div>
-                                <a href={`/user/view/${this.state.conf.bot_id}`}>
-                                    <PlayerIcon id={this.state.conf.bot_id} size={16} />{" "}
-                                    {interpolate(_("{{who}}'s profile"), {
-                                        who: bots()[this.state.conf.bot_id].username,
-                                    })}
+                                &nbsp;
+                                <a
+                                    href={`/user/view/${this.state.conf.bot_id}`}
+                                    target="_blank"
+                                    title={_("Selected AI profile")}
+                                >
+                                    <i className="fa fa-link" />
                                 </a>
                             </div>
                         </div>

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -967,7 +967,9 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                             <div>
                                 <a href={`/user/view/${this.state.conf.bot_id}`}>
                                     <PlayerIcon id={this.state.conf.bot_id} size={16} />{" "}
-                                    {bots()[this.state.conf.bot_id].username}'s profile
+                                    {interpolate(_("{{who}}'s profile"), {
+                                        who: bots()[this.state.conf.bot_id].username,
+                                    })}
                                 </a>
                             </div>
                         </div>

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -38,7 +38,7 @@ import {
 } from "TimeControl";
 import { sfx } from "sfx";
 import { notification_manager, NotificationManagerEvents } from "Notifications/NotificationManager";
-import { one_bot, bot_count, bots_list } from "bots";
+import { one_bot, bots, bot_count, bots_list } from "bots";
 import { goban_view_mode } from "Game/util";
 import {
     Goban,
@@ -949,19 +949,27 @@ export class ChallengeModal extends Modal<Events, ChallengeModalProperties, any>
                         <label className="control-label" htmlFor="engine">
                             {pgettext("Computer opponent", "AI Player")}
                         </label>
-                        <div className="controls">
-                            <select
-                                id="challenge-ai"
-                                value={this.state.conf.bot_id}
-                                onChange={this.update_conf_bot_id}
-                                required={true}
-                            >
-                                {bots_list().map((bot, idx) => (
-                                    <option key={idx} value={bot.id}>
-                                        {bot.username} ({rankString(getUserRating(bot).rank)})
-                                    </option>
-                                ))}
-                            </select>
+                        <div>
+                            <div className="controls">
+                                <select
+                                    id="challenge-ai"
+                                    value={this.state.conf.bot_id}
+                                    onChange={this.update_conf_bot_id}
+                                    required={true}
+                                >
+                                    {bots_list().map((bot, idx) => (
+                                        <option key={idx} value={bot.id}>
+                                            {bot.username} ({rankString(getUserRating(bot).rank)})
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div>
+                                <a href={`/user/view/${this.state.conf.bot_id}`}>
+                                    <PlayerIcon id={this.state.conf.bot_id} size={16} />{" "}
+                                    {bots()[this.state.conf.bot_id].username}'s profile
+                                </a>
+                            </div>
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
Addresses #2569

## Proposed Changes

In the challenge dialog, adds a link to a selected AI Opponent's profile page, using the PlayerIcon (if present) and username of the bot. 

![Screenshot 2024-02-08 at 7 06 06 AM](https://github.com/online-go/online-go.com/assets/182420/0f3b627d-525e-4a5f-8572-0fa65eedbf92)
