### PR TITLE
Delay reloading tournament when saving edits

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -148,7 +148,7 @@ export function Tournament(): JSX.Element {
         document.createElementNS("http://www.w3.org/2000/svg", "svg"),
     );
 
-    const [edit_save_state, setEditSaveState] = React.useState("none" as EditSaveState);
+    const [edit_save_state, setEditSaveState] = React.useState<EditSaveState>("none");
     const [, _refresh] = React.useState(0);
     const refresh = () => _refresh(Math.random());
     const [loading, setLoading] = React.useState(true);
@@ -1287,15 +1287,15 @@ export function Tournament(): JSX.Element {
         //tournament.round_start_times = round_start_times;
 
         if (tournament.id) {
-            setEditSaveState("saving" as EditSaveState);
+            setEditSaveState("saving");
             put(`tournaments/${tournament.id}`, tournament)
                 .then(() => {
-                    setEditSaveState("none" as EditSaveState);
+                    setEditSaveState("none");
                     resolve();
                 })
                 .catch((err: any) => {
                     const should_reload = edit_save_state === "reload";
-                    setEditSaveState("none" as EditSaveState);
+                    setEditSaveState("none");
                     setEditing(true);
                     errorAlerter(err);
                     if (should_reload) {

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1290,16 +1290,17 @@ export function Tournament(): JSX.Element {
             setEditSaveState("saving" as EditSaveState);
             put(`tournaments/${tournament.id}`, tournament)
                 .then(() => {
-                    resolve();
                     setEditSaveState("none" as EditSaveState);
+                    resolve();
                 })
                 .catch((err: any) => {
+                    const should_reload = edit_save_state === "reload";
+                    setEditSaveState("none" as EditSaveState);
                     setEditing(true);
                     errorAlerter(err);
-                    if (edit_save_state === "reload") {
+                    if (should_reload) {
                         resolve();
                     }
-                    setEditSaveState("none" as EditSaveState);
                 });
         } else {
             post("tournaments/", tournament)


### PR DESCRIPTION
If the tournament director clicks "Save Tournament" after making edits, when they're accepted by the server, the server will send a PUSH notification on the tournament channel asking all clients to reload before sending back "success".

Delay this reloading action until we have a response from the "Save" request. Previously, the reload was aborting the about-to-succeed request, kicking the client back into edit mode.

Fixes #2571