### PR TITLE
WIP: Allow tournaments to be cloned

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -262,8 +262,8 @@ export const routes = (
                     element={<Tournament />}
                 />
                 <Route path="/tournament/clone/:src_tournament_id" element={<Tournament />} />
-                <Route key="current" path="/tournament/:tournament_id" element={<Tournament />} />
-                <Route key="current" path="/tournaments/:tournament_id" element={<Tournament />} />
+                <Route path="/tournament/:tournament_id" element={<Tournament />} />
+                <Route path="/tournaments/:tournament_id" element={<Tournament />} />
                 <Route path="/tournaments" element={<TournamentListMainView />} />
                 <Route path="/tournaments/" element={<TournamentListMainView />} />
                 <Route

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -257,8 +257,13 @@ export const routes = (
                 <Route path="/groupadmin/:group_id/*" element={<Group />} />
                 <Route path="/tournament/new/:group_id" element={<Tournament />} />
                 <Route path="/tournament/new" element={<Tournament />} />
-                <Route path="/tournament/:tournament_id" element={<Tournament />} />
-                <Route path="/tournaments/:tournament_id" element={<Tournament />} />
+                <Route
+                    path="/tournament/clone/:src_tournament_id/:group_id"
+                    element={<Tournament />}
+                />
+                <Route path="/tournament/clone/:src_tournament_id" element={<Tournament />} />
+                <Route key="current" path="/tournament/:tournament_id" element={<Tournament />} />
+                <Route key="current" path="/tournaments/:tournament_id" element={<Tournament />} />
                 <Route path="/tournaments" element={<TournamentListMainView />} />
                 <Route path="/tournaments/" element={<TournamentListMainView />} />
                 <Route

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -132,7 +132,11 @@ interface TournamentInterface {
 //class _Tournament extends React.PureComponent<TournamentProperties, TournamentState> {
 export function Tournament(): JSX.Element {
     const user = useUser();
-    const params = useParams<{ tournament_id: string; group_id: string }>();
+    const params = useParams<{
+        tournament_id: string;
+        group_id: string;
+        src_tournament_id: string;
+    }>();
     const tournament_id = parseInt(params.tournament_id ?? "0");
     const new_tournament_group_id = parseInt(params.group_id ?? "0");
     const clone_src_tournament_id = parseInt(params.src_tournament_id ?? "0");
@@ -285,7 +289,7 @@ export function Tournament(): JSX.Element {
             abort_requests();
             setExtraActionCallback(null);
         };
-    }, [tournament_id]);
+    }, [tournament_id, clone_src_tournament_id]);
 
     const abort_requests = () => {
         abort_requests_in_flight(`tournaments/${tournament_id}`);


### PR DESCRIPTION
Tournaments are super error-prone to create, because there are a lot of settings to get right. It should be easy to clone a previous tournament as a basis for a new one.

This enhancement allows tournaments to be cloned by adding routes:

- `/tournament/clone/7` clones tournament 7 without a group
- `/tournament/clone/7/37` clones tournament 7 into group 37

This works if you manually navigate to the URLs.  It behaves like a new tournament, loads tournament 7, and copies everything in.

But, the shiny new "Clone Tournament" button doesn't work.  We need a fresh instance of the `<Tournament/>` component, but it's reusing the existing one.

I'm not sure what right way to fix this is. Draft for now.