### PR TITLE
Fix elimination graph to update on changes

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3177,14 +3177,13 @@ export function EliminationTree(props: EliminationTreeProps): JSX.Element | null
     );
 
     // Plan the graph.
-    const num_rounds = React.useMemo(() => rounds.length, [rounds]);
     const { all_objects, last_cur_bucket } = React.useMemo(
         () => createEliminationNodes(rounds),
         [rounds],
     );
     const svg_extents = React.useMemo(
-        () => layoutEliminationGraph(last_cur_bucket, all_objects, players, num_rounds),
-        [all_objects, last_cur_bucket, players, num_rounds],
+        () => layoutEliminationGraph(last_cur_bucket, all_objects, players, rounds.length),
+        [all_objects, last_cur_bucket, players, rounds.length],
     );
 
     // Draw the edges.
@@ -3194,7 +3193,7 @@ export function EliminationTree(props: EliminationTreeProps): JSX.Element | null
 
     // Render the graph.
     const num_players = React.useMemo(() => Object.keys(players).length, [players]);
-    if (num_rounds === 0 || num_players === 0) {
+    if (rounds.length === 0 || num_players === 0) {
         return null;
     }
     return (

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3171,48 +3171,48 @@ function createEliminationNodes(rounds: any[]) {
     organizeEliminationBrackets(all_objects, rounds.length, last_cur_bucket_arr.length);
     return { all_objects: all_objects, last_cur_bucket: last_cur_bucket };
 }
+function eliminationMouseOver(id: number) {
+    $(".elimination-player-hover").removeClass("elimination-player-hover");
+    $(".elimination-player-" + id).addClass("elimination-player-hover");
+}
+function eliminationMouseOut() {
+    $(".elimination-player-hover").removeClass("elimination-player-hover");
+}
+interface EliminationPlayerProps {
+    id: number;
+    user: TournamentPlayer;
+}
+export function EliminationBye(props: EliminationPlayerProps): JSX.Element {
+    return (
+        <div
+            className={`bye elimination-player-${props.id}`}
+            onMouseOver={() => eliminationMouseOver(props.id)}
+            onMouseOut={eliminationMouseOut}
+        >
+            <Player user={props.user} icon rank />
+        </div>
+    );
+}
 function renderEliminationNodes(
     container: HTMLDivElement,
     all_objects: any[],
     players: { [id: string]: TournamentPlayer },
 ) {
-    const bindHovers = (div: JQuery, id: number | object) => {
-        if (typeof id !== "number") {
-            try {
-                console.warn("ID = ", id);
-                for (const k in id) {
-                    console.warn("ID.", k, "=", (id as any)[k]);
-                }
-            } catch (e) {
-                // ignore error
-            }
-            console.error("Tournament bind hover called with non numeric id");
-        }
-
-        div.mouseover(() => {
-            $(".elimination-player-hover").removeClass("elimination-player-hover");
-            $(".elimination-player-" + id).addClass("elimination-player-hover");
-        });
-        div.mouseout(() => {
-            $(".elimination-player-hover").removeClass("elimination-player-hover");
-        });
+    const bindHovers = (div: JQuery, id: number) => {
+        div.mouseover(() => eliminationMouseOver(id));
+        div.mouseout(eliminationMouseOut);
     };
 
     for (const obj of all_objects) {
         if (obj.match === undefined) {
-            const bye = obj.player_id;
+            const bye = obj.player_id as number;
             const bye_div = $("<div>").addClass("bye-div");
-            const bye_entry = $("<div>")
-                .addClass("bye")
-                .addClass("elimination-player-" + bye);
-            const root = ReactDOM.createRoot(bye_entry[0]);
+            const root = ReactDOM.createRoot(bye_div[0]);
             root.render(
                 <React.StrictMode>
-                    <Player user={players[bye]} icon rank />
+                    <EliminationBye id={bye} user={players[bye]} />
                 </React.StrictMode>,
             );
-            bindHovers(bye_entry, bye);
-            bye_div.append(bye_entry);
             obj.div = bye_div;
             container.appendChild(bye_div[0]);
             continue;

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3277,7 +3277,7 @@ function EliminationNodes({
     return (
         <>
             {all_objects.map((obj) => {
-                const location = { top: obj.top, left: obj.left } as EliminationLocation;
+                const location: EliminationLocation = { top: obj.top, left: obj.left };
                 if (obj.match === undefined) {
                     const bye = obj.player_id as number;
                     return (

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3193,7 +3193,8 @@ export function EliminationTree(props: EliminationTreeProps): JSX.Element | null
     }, [svg_extents, last_cur_bucket]);
 
     // Render the graph.
-    if (num_rounds === 0 || Object.keys(players).length === 0) {
+    const num_players = React.useMemo(() => Object.keys(players).length, [players]);
+    if (num_rounds === 0 || num_players === 0) {
         return null;
     }
     return (

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3148,30 +3148,13 @@ interface EliminationLocation {
     left: number;
 }
 type EliminationNodeKind = "bye" | "black" | "white";
-interface EliminationNodeProps {
-    player: EliminationPlayer;
-    kind: EliminationNodeKind;
-    result_class?: string;
-    gameid?: any;
-}
-interface EliminationByeProps {
-    player: EliminationPlayer;
-    location: EliminationLocation;
-}
-interface EliminationMatchProps {
-    black: EliminationPlayer;
-    white: EliminationPlayer;
-    gameid: any;
-    result: any;
-    location: EliminationLocation;
-}
-interface EliminationTreeProps {
+export function EliminationTree({
+    rounds,
+    players,
+}: {
     rounds: any[];
-    players: { [id: string]: TournamentPlayer };
-}
-export function EliminationTree(props: EliminationTreeProps): JSX.Element | null {
-    const rounds = props.rounds;
-    const players = props.players;
+    players: TournamentPlayers;
+}): JSX.Element | null {
     const elimination_tree = React.useRef(
         document.createElementNS("http://www.w3.org/2000/svg", "svg"),
     );
@@ -3199,23 +3182,30 @@ export function EliminationTree(props: EliminationTreeProps): JSX.Element | null
     return (
         <div className="tournament-elimination-container">
             <svg ref={elimination_tree} />
-            {renderEliminationNodes(all_objects, players)}
+            <EliminationNodes all_objects={all_objects} players={players} />
         </div>
     );
 }
-export function EliminationNode(props: EliminationNodeProps): JSX.Element {
-    const player = props.player;
+export function EliminationNode({
+    player,
+    kind,
+    result_class,
+    gameid,
+}: {
+    player: EliminationPlayer;
+    kind: EliminationNodeKind;
+    result_class?: string;
+    gameid?: any;
+}): JSX.Element {
     return (
         <>
             <div
-                className={`${props.kind} ${props.result_class ?? ""} elimination-player-${
-                    player.id
-                }`}
+                className={`${kind} ${result_class ?? ""} elimination-player-${player.id}`}
                 onMouseOver={() => eliminationMouseOver(player.id)}
                 onMouseOut={eliminationMouseOut}
             >
-                {(props.gameid || null) && (
-                    <a className="elimination-game" href={`/game/view/${props.gameid}`}>
+                {(gameid || null) && (
+                    <a className="elimination-game" href={`/game/view/${gameid}`}>
                         <i className="ogs-goban"></i>
                     </a>
                 )}
@@ -3224,59 +3214,92 @@ export function EliminationNode(props: EliminationNodeProps): JSX.Element {
         </>
     );
 }
-export function EliminationBye(props: EliminationByeProps): JSX.Element {
+export function EliminationBye({
+    player,
+    location,
+}: {
+    player: EliminationPlayer;
+    location: EliminationLocation;
+}): JSX.Element {
     return (
-        <div className="bye-div" style={props.location}>
-            <EliminationNode player={props.player} kind="bye" />
+        <div className="bye-div" style={location}>
+            <EliminationNode player={player} kind="bye" />
         </div>
     );
 }
-export function EliminationMatch(props: EliminationMatchProps): JSX.Element {
+export function EliminationMatch({
+    black,
+    white,
+    gameid,
+    result,
+    location,
+}: {
+    black: EliminationPlayer;
+    white: EliminationPlayer;
+    gameid: any;
+    result: any;
+    location: EliminationLocation;
+}): JSX.Element {
     let black_result: string | undefined;
     let white_result: string | undefined;
-    if (props.result === "B+1") {
+    if (result === "B+1") {
         black_result = "win";
-    } else if (props.result === "W+1") {
+    } else if (result === "W+1") {
         white_result = "win";
-    } else if (props.result === "B+0.5,W+0.5") {
+    } else if (result === "B+0.5,W+0.5") {
         black_result = "tie";
         white_result = "tie";
     }
     return (
-        <div className="match-div" style={props.location}>
+        <div className="match-div" style={location}>
             <EliminationNode
-                player={props.black}
+                player={black}
                 kind="black"
                 result_class={black_result}
-                gameid={props.gameid}
+                gameid={gameid}
             />
             <EliminationNode
-                player={props.white}
+                player={white}
                 kind="white"
                 result_class={white_result}
-                gameid={props.gameid}
+                gameid={gameid}
             />
         </div>
     );
 }
-function renderEliminationNodes(all_objects: any[], players: { [id: string]: TournamentPlayer }) {
-    return all_objects.map((obj) => {
-        const location = { top: obj.top, left: obj.left } as EliminationLocation;
-        if (obj.match === undefined) {
-            const bye = obj.player_id as number;
-            return <EliminationBye player={{ id: bye, user: players[bye] }} location={location} />;
-        }
-        const match = obj.match;
-        return (
-            <EliminationMatch
-                black={{ id: match.black, user: players[match.black] }}
-                white={{ id: match.white, user: players[match.white] }}
-                gameid={match.gameid}
-                result={match.result}
-                location={location}
-            />
-        );
-    });
+function EliminationNodes({
+    all_objects,
+    players,
+}: {
+    all_objects: any[];
+    players: TournamentPlayers;
+}) {
+    return (
+        <>
+            {all_objects.map((obj) => {
+                const location = { top: obj.top, left: obj.left } as EliminationLocation;
+                if (obj.match === undefined) {
+                    const bye = obj.player_id as number;
+                    return (
+                        <EliminationBye
+                            player={{ id: bye, user: players[bye] }}
+                            location={location}
+                        />
+                    );
+                }
+                const match = obj.match;
+                return (
+                    <EliminationMatch
+                        black={{ id: match.black, user: players[match.black] }}
+                        white={{ id: match.white, user: players[match.white] }}
+                        gameid={match.gameid}
+                        result={match.result}
+                        location={location}
+                    />
+                );
+            })}
+        </>
+    );
 }
 function renderEliminationEdges(
     elimination_tree: SVGSVGElement,
@@ -3399,7 +3422,7 @@ function renderEliminationEdges(
 function layoutEliminationGraph(
     collection: any,
     all_objects: any[],
-    players: { [id: string]: TournamentPlayer },
+    players: TournamentPlayers,
     num_rounds: number,
 ) {
     const svg_extents = { x: 0, y: 0 };

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3182,6 +3182,10 @@ interface EliminationPlayer {
     id: number;
     user: TournamentPlayer;
 }
+interface EliminationLocation {
+    top: number;
+    left: number;
+}
 type EliminationNodeKind = "bye" | "black" | "white";
 interface EliminationNodeProps {
     player: EliminationPlayer;
@@ -3189,11 +3193,16 @@ interface EliminationNodeProps {
     result_class?: string;
     gameid?: any;
 }
+interface EliminationByeProps {
+    player: EliminationPlayer;
+    location: EliminationLocation;
+}
 interface EliminationMatchProps {
     black: EliminationPlayer;
     white: EliminationPlayer;
     gameid: any;
     result: any;
+    location: EliminationLocation;
 }
 export function EliminationNode(props: EliminationNodeProps): JSX.Element {
     const player = props.player;
@@ -3216,6 +3225,13 @@ export function EliminationNode(props: EliminationNodeProps): JSX.Element {
         </>
     );
 }
+export function EliminationBye(props: EliminationByeProps): JSX.Element {
+    return (
+        <div className="bye-div" style={props.location}>
+            <EliminationNode player={props.player} kind="bye" />
+        </div>
+    );
+}
 export function EliminationMatch(props: EliminationMatchProps): JSX.Element {
     let black_result: string | undefined;
     let white_result: string | undefined;
@@ -3228,7 +3244,7 @@ export function EliminationMatch(props: EliminationMatchProps): JSX.Element {
         white_result = "tie";
     }
     return (
-        <>
+        <div className="match-div" style={props.location}>
             <EliminationNode
                 player={props.black}
                 kind="black"
@@ -3241,7 +3257,7 @@ export function EliminationMatch(props: EliminationMatchProps): JSX.Element {
                 result_class={white_result}
                 gameid={props.gameid}
             />
-        </>
+        </div>
     );
 }
 function renderEliminationNodes(
@@ -3250,21 +3266,21 @@ function renderEliminationNodes(
     players: { [id: string]: TournamentPlayer },
 ) {
     for (const obj of all_objects) {
+        const location = { top: obj.top, left: obj.left } as EliminationLocation;
         if (obj.match === undefined) {
             const bye = obj.player_id as number;
-            const bye_div = $("<div>").addClass("bye-div");
+            const bye_div = $("<div>");
             const root = ReactDOM.createRoot(bye_div[0]);
             root.render(
                 <React.StrictMode>
-                    <EliminationNode player={{ id: bye, user: players[bye] }} kind="bye" />
+                    <EliminationBye player={{ id: bye, user: players[bye] }} location={location} />
                 </React.StrictMode>,
             );
-            obj.div = bye_div;
             container.appendChild(bye_div[0]);
             continue;
         }
         const match = obj.match;
-        const match_div = $("<div>").addClass("match-div");
+        const match_div = $("<div>");
         const root = ReactDOM.createRoot(match_div[0]);
         root.render(
             <React.StrictMode>
@@ -3273,19 +3289,11 @@ function renderEliminationNodes(
                     white={{ id: match.white, user: players[match.white] }}
                     gameid={match.gameid}
                     result={match.result}
+                    location={location}
                 />
             </React.StrictMode>,
         );
-
-        obj.div = match_div;
         container.appendChild(match_div[0]);
-    }
-
-    for (const obj of all_objects) {
-        obj.div.css({
-            top: obj.top,
-            left: obj.left,
-        });
     }
 }
 function renderEliminationEdges(


### PR DESCRIPTION
This series of commits:

- Splits the elimination graph out as a separate component
    - Also splits outs a number of its elements for convenience
- Converts it to use JSX for everything but the SVG rather than manipulate the DOM directly
- Memoizes the computations with dependencies
- Clears the SVG before drawing new lines

This makes it so that elimination graphs are drawn correctly when navigating between two tournaments (or when they update live).

Fixes #1416
