### PR TITLE
Disable mod action selector if report is escalated

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -475,7 +475,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                                 void report_manager.vote(report.id, action, note);
                                 next();
                             }}
-                            enable={report.state === "pending"}
+                            enable={report.state === "pending" && !report.escalated}
                             // clear the selection for subsequent reports
                             key={report.id}
                         />


### PR DESCRIPTION
Fixes one case at least where CMs might thing they are being asked to vote again

## Proposed Changes

  - Tell them that the report is already  handled if it is escalated
  