### PR TITLE
Allow tournament administrators to clone tournaments

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -195,6 +195,10 @@ export function Tournament(): JSX.Element {
     const players_loaded = raw_players !== null;
     const loading = !rounds_loaded || !players_loaded || !tournament_loaded;
 
+    const new_tournament_group_loaded =
+        !new_tournament_group_id || new_tournament_group_id === (tournament.group?.id ?? 0);
+    const ready_to_edit = editing && new_tournament_group_loaded;
+
     const use_elimination_trees = is_elimination(tournament.tournament_type);
 
     const players: TournamentPlayers = raw_players === null ? {} : raw_players;
@@ -921,7 +925,7 @@ export function Tournament(): JSX.Element {
         tournament.tournament_type === "opengotha" ||
         null;
 
-    if (!tournament_loaded && !editing) {
+    if (!tournament_loaded && !ready_to_edit) {
         return <LoadingPage />;
     }
 


### PR DESCRIPTION
Add a "Clone Tournament" button to the tournament page that allows an existing tournament to be cloned.

- Button shows up for anyone that can administer the tournament.
- Takes the user to the "new tournament" page in the same group.
- All tournament settings are pre-loaded to match the source tournament.

This makes it easy to create new tournaments in a series, without the laborious and error-prone process of re-entering the settings.

Replaces #2573.

In case it's easier to look at them individually, there are three commits here, the first two of which are prep commits which would be nice to land even if this PR doesn't:
- d6ec4d5b7cbebbbf89642d545dd341497f622bb2 Remove extra state variables to track what has loaded
- b7b754175dcbcbb33d3b1f7cc1e0db5d5ef7c049 Delay editing new tournaments until the group has loaded
- 30251cbfbb24749f6fc32e13972232ab881627d9 Allow tournament administrators to clone tournaments
