### PR TITLE
Avoid computing rounds until everything is loaded

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -197,8 +197,8 @@ export function Tournament(): JSX.Element {
 
     const use_elimination_trees = is_elimination(tournament.tournament_type);
     const rounds = React.useMemo<any[]>(
-        () => computeRounds(raw_rounds, players, tournament.tournament_type),
-        [tournament.tournament_type, raw_rounds, players],
+        () => (loading ? [] : computeRounds(raw_rounds, players, tournament.tournament_type)),
+        [tournament.tournament_type, raw_rounds, players, loading],
     );
     const sorted_players = React.useMemo<any[]>(
         () =>


### PR DESCRIPTION
Fix [sentry issues](https://github.com/online-go/online-go.com/pull/2577#issuecomment-1940383513) by delaying computation of rounds until everything is loaded.

