### PR TITLE
Center the board on mobile.

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -326,6 +326,7 @@ goban-view-bar-width=400px
             position: relative;
             top: 25px;
         }
+        margin-right: unset;
     }
 
 


### PR DESCRIPTION
The margins were uneven (left: 0, right: .5rem).  It was introduced in https://github.com/online-go/online-go.com/pull/2355 to address display jitter on desktop, but I don't believe the change should have been applied to portrait layout as well.  The wider margin and un-centered board recently drew criticism in [the forums](https://forums.online-go.com/t/give-max-size-to-the-board/50375/6)

## Screenshots

Taken in Firefox's Responsive Design tool (device: Samsung S20, display width: 360px)

![Before and After](https://github.com/online-go/online-go.com/assets/25233703/b62fcecc-0460-4b19-849c-dfedbd860d6c)


