### PR TITLE
vote handling sequence bugfix

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -472,8 +472,9 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                                 /* community moderators don't claim reports */
                             }}
                             submit={(action, note) => {
-                                void report_manager.vote(report.id, action, note);
-                                next();
+                                void report_manager
+                                    .vote(report.id, action, note)
+                                    .then(() => next());
                             }}
                             enable={report.state === "pending" && !report.escalated}
                             // clear the selection for subsequent reports


### PR DESCRIPTION
Fixes staying on the last report after voting on it (should say "All Done")

Also might fix the "reappearing report" bug 🫣  🐞

## Proposed Changes

  - Don't call "next" until the processing of the voted report is handled
  - Disallow "escalated" reports available in the CM's `reports` list
  
