### PR TITLE
Game.styl: remove unnecessary 8px right margin on "center-col", so board can get larger

### DIFF
--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -317,7 +317,6 @@ goban-view-bar-width=400px
         flex-direction: column;
         align-items: stretch;
         width: 100%;
-        margin-right: 0.5rem;
     }
     &.portrait .center-col {
         .cancel-button {
@@ -326,7 +325,6 @@ goban-view-bar-width=400px
             position: relative;
             top: 25px;
         }
-        margin-right: unset;
     }
 
 


### PR DESCRIPTION
I did this before I noticed @benjaminpjones's https://github.com/online-go/online-go.com/pull/2582. My main goal was to fix mobile, but still I think we can get rid of the 8px margin under all circumstances.  The right-col already has its own left margin so I don't see why we should also have a right margin on center-col.

Before:

![image](https://github.com/online-go/online-go.com/assets/466760/ef4ed09d-df4c-45de-90ec-97605d4cbb62)

After:

![image](https://github.com/online-go/online-go.com/assets/466760/232768f1-93f9-4c10-878e-80f44fd90828)

Without the highlighting, so you can see it's not ridiculous:

![image](https://github.com/online-go/online-go.com/assets/466760/e83be801-8887-41ac-899e-b833925c3bb6)

A larger window size showing the closest the board ever gets to the stuff on the right:

![image](https://github.com/online-go/online-go.com/assets/466760/da009585-e860-42e1-8971-9f9a7e157ce7)

