### PR TITLE
Change "Game Stalling" to "Playing Stalling Moves" 

### DIFF
--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -72,7 +72,7 @@ export const report_categories: ReportDescription[] = [
     },
     {
         type: "stalling",
-        title: pgettext("Report user for stalling in a game", "Game Stalling"),
+        title: pgettext("Report user for stalling in a game", "Playing Stalling Moves"),
         description: pgettext(
             "Report user for stalling in a game",
             "User is playing time wasting moves, or passing and resuming needlessly, delaying completion of the game.",


### PR DESCRIPTION
to try to reduce people reporting escaping as stalling.

This is a significant problem, because it presents CMs with a difficult choice of warning an escaper for stalling - a poor message - or escalating ... which increases the chances of the report falling through to full moderators.