### PR TITLE
Wrap the <input> in chat boxes in a form and provide hint

### DIFF
--- a/src/components/TabCompleteInput/TabCompleteInput.styl
+++ b/src/components/TabCompleteInput/TabCompleteInput.styl
@@ -17,5 +17,8 @@
 
 
 .TabCompleteInput {
-    // here
+    input {
+        width: 100%;
+        box-sizing: border-box;
+    }
 }

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -35,7 +35,8 @@ export const TabCompleteInput = React.forwardRef<HTMLInputElement, TabCompleteIn
         }, [(ref as any).current]);
 
         // The input is wrapped in a form so that it presents a send button
-        // properly on mobile.
+        // properly on mobile, avoiding Smart Go Next kind of problems:
+        // https://www.androidpolice.com/2017/10/10/samsung-internet-browser-will-get-smart-go-next-better-form-navigation-also-coming-chrome/.
         return (
             <form className="TabCompleteInput" onSubmit={(e) => e.preventDefault()}>
                 <input ref={ref} enterKeyHint="send" {...props} />

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 
-interface TabCompleteInputProperties {
+interface TabCompleteInputProperties extends React.HTMLProps<HTMLInputElement> {
     id?: string;
     placeholder?: string;
     disabled?: boolean;
@@ -25,15 +25,21 @@ interface TabCompleteInputProperties {
     className?: string;
     onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
     autoFocus?: boolean;
+    enterKeyHint?: "search" | "enter" | "done" | "go" | "next" | "previous" | "send" | undefined;
 }
 
-export const TabCompleteInput = React.forwardRef<
-    HTMLInputElement,
-    React.HTMLProps<HTMLInputElement>
->((props: TabCompleteInputProperties, ref): JSX.Element => {
-    React.useEffect(() => {
-        ($((ref as any).current) as any).nicknameTabComplete();
-    }, [(ref as any).current]);
+export const TabCompleteInput = React.forwardRef<HTMLInputElement, TabCompleteInputProperties>(
+    (props, ref): JSX.Element => {
+        React.useEffect(() => {
+            ($((ref as any).current) as any).nicknameTabComplete();
+        }, [(ref as any).current]);
 
-    return <input ref={ref} {...props} />;
-});
+        // The input is wrapped in a form so that it presents a send button
+        // properly on mobile.
+        return (
+            <form className="TabCompleteInput" onSubmit={(e) => e.preventDefault()}>
+                <input ref={ref} enterKeyHint="send" {...props} />
+            </form>
+        );
+    },
+);


### PR DESCRIPTION
 to try to ensure that phone browsers give users an enter button

Fixes ... hopefully... https://forums.online-go.com/t/unable-to-reply-to-group-chat/49861?u=greenasjade

## Proposed Changes

  - Wrap the `input` in a non-submit `form` to provide a hint to phone browsers that this input needs an enter button
