### PR TITLE
Give mods a pref to see unescalated reports

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -62,6 +62,7 @@ export const defaults = {
     "notify-on-incident-report": true,
     "hide-incident-reports": false,
     "hide-claimed-reports": false,
+    "show-cm-reports": false,
     "observed-games-page-size": 9,
     "observed-games-viewing": "live",
     "observed-games-filter": {},

--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -35,8 +35,6 @@ import { browserHistory } from "ogsHistory";
 import { get, post } from "requests";
 import { MODERATOR_POWERS } from "moderation";
 
-const DONT_OFFER_COMMUNITY_MODERATION_TYPES_TO_MODERATORS = true;
-
 interface Vote {
     voter_id: number;
     action: string;
@@ -253,8 +251,10 @@ class ReportManager extends EventEmitter<Events> {
                 return false;
             }
 
-            if (DONT_OFFER_COMMUNITY_MODERATION_TYPES_TO_MODERATORS) {
+            const show_cm_reports = preferences.get("show-cm-reports");
+            if (!show_cm_reports) {
                 // don't hand community moderation reports to full mods unless the report is escalated,
+                // or they've asked to show them explicitly in settings,
                 // because community moderators are supposed to do these!
                 if (
                     user.is_moderator &&

--- a/src/views/Settings/ModeratorPreferences.tsx
+++ b/src/views/Settings/ModeratorPreferences.tsx
@@ -30,6 +30,7 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
     );
     const [hide_incident_reports, setHideIncidentReports] = usePreference("hide-incident-reports");
     const [hide_claimed_reports, setHideClaimedReports] = usePreference("hide-claimed-reports");
+    const [show_cm_reports, setShowCMReports] = usePreference("show-cm-reports");
     const [join_games_anonymously, setJoinGamesAnonymously] = usePreference(
         "moderator.join-games-anonymously",
     );
@@ -86,6 +87,10 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
                     </PreferenceLine>
                     <PreferenceLine title="Hide claimed reports">
                         <Toggle checked={hide_claimed_reports} onChange={setHideClaimedReports} />
+                    </PreferenceLine>
+                    <PreferenceLine title="Show un-escalated reports">
+                        <Toggle checked={show_cm_reports} onChange={setShowCMReports} />
+                        <span>This will include for you reports that CMs can still vote on</span>
                     </PreferenceLine>
                     <PreferenceLine title="Join games anonymously">
                         <Toggle


### PR DESCRIPTION
Fixes  mods not being able to chose to help with reports that CMs are eligible for

## Proposed Changes

  - Give mods a preference that lets them see all CM reports, escalated or not.
  
