### PR TITLE
Make sure input for chat consumes the space required

### DIFF
--- a/src/components/TabCompleteInput/TabCompleteInput.styl
+++ b/src/components/TabCompleteInput/TabCompleteInput.styl
@@ -18,7 +18,8 @@
 
 .TabCompleteInput {
     input {
-        width: 100%;
+        width: 100% !important;
+        height: 100% !important;
         box-sizing: border-box;
     }
 }


### PR DESCRIPTION
Fixes #2602

## Proposed Changes

  - Use `!important` to override input css for height and width in `TabCompleteInput`
