### PR TITLE
add an enter key hint to TabCompleteInput

### DIFF
--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -35,5 +35,5 @@ export const TabCompleteInput = React.forwardRef<
         ($((ref as any).current) as any).nicknameTabComplete();
     }, [(ref as any).current]);
 
-    return <input ref={ref} {...props} />;
+    return <input ref={ref} enterKeyHint="send" {...props} />;
 });


### PR DESCRIPTION
The minimal change suggested to fix https://forums.online-go.com/t/unable-to-reply-to-group-chat/49861?u=greenasjade

## Proposed Changes

  - add an `enterKeyHint` to the   `input` of `TabCompleteInput`
  
  This doesn't break group chat or game chat for me, at various screen widths, but I can't easily test whether it fixes group chat as requested (since installing an android simulator doesn't count as "easy" 😝 )