### PR TITLE
Update setExtraActionCallback whenever the tournament changes

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -308,7 +308,6 @@ export function Tournament(): JSX.Element {
         setInviteResult(null);
         setUserToInvite(null);
 
-        setExtraActionCallback(renderExtraPlayerActions);
         if (tournament_id) {
             resolve();
         } else if (ref_tournament_to_clone.current?.id) {
@@ -328,7 +327,6 @@ export function Tournament(): JSX.Element {
 
         return () => {
             abort_requests();
-            setExtraActionCallback(null);
         };
     }, [tournament_id]);
 
@@ -818,6 +816,9 @@ export function Tournament(): JSX.Element {
         close_all_popovers();
     };
 
+    React.useEffect(() => {
+        setExtraActionCallback(renderExtraPlayerActions);
+    }, [tournament.director, tournament.started, tournament.ended]);
     const renderExtraPlayerActions = (player_id: number): any => {
         if (
             !(


### PR DESCRIPTION
After f0a617aa009781d1fcbb7074df04e0ac7b68edb2, tournament is immutable state (new copy on changes), not a mutable ref, so the renderExtraPlayerActions callback wasn't being kept up-to-date when the tournament changed.  Split it out to its own `useEffect` that updates when the relevant tournament fields do.

Tested:

- Director of started tournament (disqualify and adjust points)
- Director of not-started tournament (kick)
- Non-director (no actions)
- Switching between them via the search box, which reuses the same component

Fixes #2606
