### PR TITLE
Add missing cleanup function from 9a3f6fec611f965a531939e38241adaeace2284a

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -818,6 +818,7 @@ export function Tournament(): JSX.Element {
 
     React.useEffect(() => {
         setExtraActionCallback(renderExtraPlayerActions);
+        return () => setExtraActionCallback(null);
     }, [tournament.director, tournament.started, tournament.ended]);
     const renderExtraPlayerActions = (player_id: number): any => {
         if (


### PR DESCRIPTION
Follow-up to #2607. I missed the cleanup function before. Couldn't find anything broken without it, but it should probably be there.