### PR TITLE
Show CMs a list of related reports that they are allowed to see

### DIFF
--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -29,7 +29,8 @@ import { ignore, errorAlerter } from "misc";
 import { openReportedConversationModal } from "ReportedConversationModal";
 import { AutoTranslate } from "AutoTranslate";
 import { report_categories } from "Report";
-import { Report, report_manager } from "report_manager";
+import { report_manager } from "report_manager";
+import { Report } from "report_util";
 import { useRefresh, useUser } from "hooks";
 import * as DynamicHelp from "react-dynamic-help";
 

--- a/src/lib/report_util.ts
+++ b/src/lib/report_util.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ReportedConversation } from "Report";
+import { PlayerCacheEntry } from "player_cache";
+import { MODERATOR_POWERS } from "moderation";
+
+interface Vote {
+    voter_id: number;
+    action: string;
+}
+
+export interface Report {
+    // TBD put this into /models, in a suitable namespace?
+    // TBD: relationship between this and SeverToClient['incident-report']
+    id: number;
+    created: string;
+    updated: string;
+    state: string;
+    escalated: boolean;
+    source: string;
+    report_type: string;
+    reporting_user: any;
+    reported_user: any;
+    reported_game: number;
+    reported_game_move?: number;
+    reported_review: number;
+    reported_conversation: ReportedConversation;
+    url: string;
+    moderator: PlayerCacheEntry;
+    cleared_by_user: boolean;
+    was_helpful: boolean;
+    reporter_note: string;
+    reporter_note_translation: {
+        source_language: string;
+        target_language: string;
+        source_text: string;
+        target_text: string;
+    };
+    moderator_note: string;
+    system_note: string;
+    detected_ai_games: Array<Object>;
+
+    automod_to_moderator?: string; // Suggestions from "automod"
+    automod_to_reporter?: string;
+    automod_to_reported?: string;
+
+    available_actions: Array<string>; // community moderator actions
+    voters: Vote[]; // votes from community moderators on this report
+    community_mod_note: string;
+
+    unclaim: () => void;
+    claim: () => void;
+    steal: () => void;
+    bad_report: () => void;
+    good_report: () => void;
+    cancel: () => void;
+    set_note: () => void;
+}
+
+export function community_mod_can_handle(user: rest_api.UserConfig, report: Report): boolean {
+    // Community moderators only get to see reports that they have the power for and
+    // that they have not yet voted on, and are not escalated
+    const has_handle_score_cheat =
+        (user.moderator_powers & MODERATOR_POWERS.HANDLE_SCORE_CHEAT) > 0;
+    const has_handle_escaping = (user.moderator_powers & MODERATOR_POWERS.HANDLE_ESCAPING) > 0;
+    const has_handle_stalling = (user.moderator_powers & MODERATOR_POWERS.HANDLE_STALLING) > 0;
+
+    const report_type = report.report_type;
+
+    if (
+        !user.is_moderator &&
+        user.moderator_powers &&
+        ((!(report_type === "score_cheating" && has_handle_score_cheat) &&
+            !(report_type === "escaping" && has_handle_escaping) &&
+            !(report_type === "stalling" && has_handle_stalling)) ||
+            report.voters?.some((vote) => vote.voter_id === user.id) ||
+            report.escalated)
+    ) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -21,7 +21,8 @@ import * as ReactSelect from "react-select";
 import Select from "react-select";
 import { useUser } from "hooks";
 import { report_categories } from "Report";
-import { report_manager, Report } from "report_manager";
+import { report_manager } from "report_manager";
+import { Report } from "report_util";
 import { AutoTranslate } from "AutoTranslate";
 import { _, pgettext } from "translate";
 import { Player } from "Player";
@@ -484,24 +485,24 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                 )}
             </div>
 
-            {user.is_moderator && (
-                <>
-                    <div className="actions">
-                        <div className="related-reports">
-                            {related.length > 0 && (
-                                <>
-                                    <h4>{_("Related Reports")}</h4>
-                                    <ul>
-                                        {related.map((r) => (
-                                            <li key={r.report.id}>
-                                                <Link to={`/reports-center/all/${r.report.id}`}>
-                                                    {R(r.report.id)}: {r.relationship}
-                                                </Link>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </>
-                            )}
+            <div className="actions">
+                <div className="related-reports">
+                    {related.length > 0 && (
+                        <>
+                            <h4>{_("Related Reports")}</h4>
+                            <ul>
+                                {related.map((r) => (
+                                    <li key={r.report.id}>
+                                        <Link to={`/reports-center/all/${r.report.id}`}>
+                                            {R(r.report.id)}: {r.relationship}
+                                        </Link>
+                                    </li>
+                                ))}
+                            </ul>
+                        </>
+                    )}
+                    {user.is_moderator && (
+                        <>
                             {report.voters?.length > 0 && (
                                 <div className="voters">
                                     <h4>{_("Voters:")}</h4>
@@ -520,51 +521,53 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                                     <div className="Card">{report.community_mod_note}</div>
                                 </div>
                             )}
-                        </div>
+                        </>
+                    )}
+                </div>
+                {user.is_moderator && (
+                    <div className="actions-right">
+                        {reportState !== "resolved" && report.detected_ai_games?.length > 0 ? (
+                            <button onClick={() => openAnnulQueueModal(setIsAnnulQueueModalOpen)}>
+                                Inspect & Annul Games
+                            </button>
+                        ) : null}
+                        {reportState !== "resolved" && claimed_by_me && (
+                            <button
+                                className="success"
+                                onClick={() => {
+                                    void report_manager.good_report(report.id);
+                                    next();
+                                }}
+                            >
+                                Close as good report
+                            </button>
+                        )}
 
-                        <div className="actions-right">
-                            {reportState !== "resolved" && report.detected_ai_games?.length > 0 ? (
-                                <button
-                                    onClick={() => openAnnulQueueModal(setIsAnnulQueueModalOpen)}
-                                >
-                                    Inspect & Annul Games
-                                </button>
-                            ) : null}
-                            {reportState !== "resolved" && claimed_by_me && (
-                                <button
-                                    className="success"
-                                    onClick={() => {
-                                        void report_manager.good_report(report.id);
-                                        next();
-                                    }}
-                                >
-                                    Close as good report
-                                </button>
-                            )}
+                        {reportState !== "resolved" && claimed_by_me && (
+                            <button
+                                className="reject"
+                                onClick={() => {
+                                    void report_manager.bad_report(report.id);
+                                    next();
+                                }}
+                            >
+                                Close as bad report
+                            </button>
+                        )}
 
-                            {reportState !== "resolved" && claimed_by_me && (
-                                <button
-                                    className="reject"
-                                    onClick={() => {
-                                        void report_manager.bad_report(report.id);
-                                        next();
-                                    }}
-                                >
-                                    Close as bad report
-                                </button>
-                            )}
-
-                            {reportState === "resolved" && (
-                                <button
-                                    className="default"
-                                    onClick={() => void report_manager.reopen(report.id)}
-                                >
-                                    Re-open
-                                </button>
-                            )}
-                        </div>
+                        {reportState === "resolved" && (
+                            <button
+                                className="default"
+                                onClick={() => void report_manager.reopen(report.id)}
+                            >
+                                Re-open
+                            </button>
+                        )}
                     </div>
-
+                )}
+            </div>
+            {user.is_moderator && (
+                <>
                     <hr />
                     <div className="automod-analysis">
                         <b>Automod Analysis:</b>{" "}
@@ -598,7 +601,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                         )}
                     </div>
                     <hr />
-                    {(user.is_moderator || null) && <UserHistory user={report.reported_user} />}
+                    <UserHistory user={report.reported_user} />
                     <hr />
                     {(report.url || null) && (
                         <a href={report.url} target="_blank">


### PR DESCRIPTION
Fixes CMs not having good insight into duplicate reports

## Proposed Changes

  - Show the 'related reports" list to CMs (filtered by "can they see that type")
  