### PR TITLE
Use flex order to swap the position of the goban and game info 

### DIFF
--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -156,7 +156,7 @@ export function ReportedGame({
                 Game: <Link to={`/game/${game_id}`}>#{game_id}</Link>
             </h3>
             <div className="reported-game-container">
-                <div className="col">
+                <div className="col reported-game-mini-goban">
                     <div>{_("Reported on turn:") + ` ${reported_at ?? _("not available")}`}</div>
                     <MiniGoban
                         id={game_id}
@@ -168,7 +168,7 @@ export function ReportedGame({
 
                 {goban && goban.engine && (
                     <GobanContext.Provider value={goban}>
-                        <div className="col">
+                        <div className="col reported-game-info">
                             <div>Creator: {game && <Player user={game.creator} />}</div>
                             <div>Black: {game && <Player user={game.black} />}</div>
                             <div>White: {game && <Player user={game.white} />}</div>

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -116,6 +116,10 @@ reports_center_content_width=56rem
         flex-wrap: wrap;
         max-width: reports_center_content_width;
 
+        .reported-game-info {
+            order: -1; // put this first so mobile layout is nice
+        }
+
         .col {
             flex: 1;
             flex-basis: 45%;


### PR DESCRIPTION
in ViewReport, so that game info appears first in mobile view.

Fixes having to scroll to see if someone escaped.

## Proposed Changes

  - Use flex order to swap the position of the goban and game info 
