### PR TITLE
Optimize vertical space in view report

### DIFF
--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -156,7 +156,7 @@ export function ReportedGame({
                 Game: <Link to={`/game/${game_id}`}>#{game_id}</Link>
             </h3>
             <div className="reported-game-container">
-                <div className="col">
+                <div className="col reported-game-mini-goban">
                     <div>{_("Reported on turn:") + ` ${reported_at ?? _("not available")}`}</div>
                     <MiniGoban
                         id={game_id}
@@ -168,7 +168,7 @@ export function ReportedGame({
 
                 {goban && goban.engine && (
                     <GobanContext.Provider value={goban}>
-                        <div className="col">
+                        <div className="col reported-game-info">
                             <div>Creator: {game && <Player user={game.creator} />}</div>
                             <div>Black: {game && <Player user={game.black} />}</div>
                             <div>White: {game && <Player user={game.white} />}</div>

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -152,12 +152,8 @@ export function ReportedGame({
 
     return (
         <div className="reported-game">
-            <h3>
-                Game: <Link to={`/game/${game_id}`}>#{game_id}</Link>
-            </h3>
             <div className="reported-game-container">
                 <div className="col reported-game-mini-goban">
-                    <div>{_("Reported on turn:") + ` ${reported_at ?? _("not available")}`}</div>
                     <MiniGoban
                         id={game_id}
                         noLink={true}
@@ -165,11 +161,19 @@ export function ReportedGame({
                         chat={true}
                     />
                 </div>
-
                 {goban && goban.engine && (
                     <GobanContext.Provider value={goban}>
                         <div className="col reported-game-info">
-                            <div>Creator: {game && <Player user={game.creator} />}</div>
+                            <h3>
+                                Game: <Link to={`/game/${game_id}`}>#{game_id}</Link>
+                                <span className="created-note">
+                                    (created by:
+                                    {game && <Player user={game.creator} />})
+                                </span>
+                            </h3>
+                            <div>
+                                {_("Reported on turn:") + ` ${reported_at ?? _("not available")}`}
+                            </div>
                             <div>Black: {game && <Player user={game.black} />}</div>
                             <div>White: {game && <Player user={game.white} />}</div>
                             <div>Game Phase: {goban.engine.phase}</div>

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -116,6 +116,10 @@ reports_center_content_width=56rem
         flex-wrap: wrap;
         max-width: reports_center_content_width;
 
+        .reported-game-info {
+            order: -1; // put this first so mobile layout is nice
+        }
+
         .col {
             flex: 1;
             flex-basis: 45%;

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -106,6 +106,12 @@ reports_center_content_width=56rem
         margin-top: 0;
     }
 
+    .created-note {
+        margin-left: 1rem;
+        font-size: smaller;
+        font-weight: normal;
+    }
+
     .reported-game-container {
         flex: 1;
         display: flex;


### PR DESCRIPTION
Fixes  extra scrolling by mods and CMs

## Proposed Changes

  - Put "created by" alongside "Game heading"
  - Put "reported on turn" into game info, which is less tall than the goban so has space for it
 
** This PR is on top of #2616.   It doesn't _have to be_, but they operate on the same code, so it's easier to manage if it is.
