### PR TITLE
Add the game time control into ViewReport 

### DIFF
--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -42,6 +42,7 @@ import { Resizable } from "Resizable";
 import { socket } from "sockets";
 import { Player } from "Player";
 import { useUser } from "hooks";
+import { shortTimeControl } from "TimeControl";
 
 const TRUNCATED_GAME_LOG_LENGTH = 25;
 
@@ -171,7 +172,7 @@ export function ReportedGame({
                                     {game && <Player user={game.creator} />})
                                 </span>
                             </h3>
-                            <div>
+                            <div className="reported-turn">
                                 {_("Reported on turn:") + ` ${reported_at ?? _("not available")}`}
                             </div>
                             <div>Black: {game && <Player user={game.black} />}</div>
@@ -240,6 +241,11 @@ export function ReportedGame({
                                 className="vertically-resizable"
                                 ref={(ref) => ref?.div && goban.setMoveTreeContainer(ref.div)}
                             />
+                            {!!goban?.engine && (
+                                <div className="reported-game-timing">
+                                    {`Time control: ${shortTimeControl(goban.engine.time_control)}`}
+                                </div>
+                            )}
                         </div>
 
                         <div className="col">

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -124,6 +124,15 @@ reports_center_content_width=56rem
 
         .reported-game-info {
             order: -1; // put this first so mobile layout is nice
+            .reported-turn {
+                padding: 0.25rem;
+            }
+        }
+
+        .reported-game-mini-goban {
+            .MiniGoban  {
+                justify-content: flex-start;
+            }
         }
 
         .col {


### PR DESCRIPTION
(and slight layout tweak: MiniGoban at top of column)

Fixes wondering what the time settings for the reported game were

## Proposed Changes

  - Put `shortTimeControl` text in the GameInfo section
  - lay out reported game container's Manitoban with justify-content: flex-start
  
