### PR TITLE
Change escaping title to "Stopped Playing", 

### DIFF
--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -54,10 +54,10 @@ interface ReportProperties {
 export const report_categories: ReportDescription[] = [
     {
         type: "escaping",
-        title: pgettext("Report user for escaping", "Escaping"),
+        title: pgettext("Report user for escaping", "Stopped Playing"),
         description: pgettext(
-            "Report user for escaping",
-            "User left the game without concluding it properly.",
+            "Report user for not finishing the game properly",
+            "User left the game or stopped playing without concluding it properly.",
         ),
         game_id_required: true,
     },
@@ -78,6 +78,7 @@ export const report_categories: ReportDescription[] = [
             "User is playing time wasting moves, or passing and resuming needlessly, delaying completion of the game.",
         ),
         game_id_required: true,
+        min_description_length: 20,
     },
     {
         type: "inappropriate_content",

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -54,7 +54,7 @@ interface ReportProperties {
 export const report_categories: ReportDescription[] = [
     {
         type: "escaping",
-        title: pgettext("Report user for escaping", "Stopped Playing"),
+        title: pgettext("Report user for escaping from the game", "Stopped Playing"),
         description: pgettext(
             "Report user for not finishing the game properly",
             "User left the game or stopped playing without concluding it properly.",


### PR DESCRIPTION
and require an explanation for "stalling"

... here's a novel idea:  let's make the title for "my opponent stopped playing" say "stopped playing" 

Fixes ongoing stream of escaping reported as stalling (which is a hassle for CM's, because they can only vote for stalling outcomes in this case).

## Proposed Changes
 - Change wording of "escaping" to "Stopped Playing"
 - Require a description for stalling (so folk have to be more sure that this is what they want to report, and they hopefully tell us where to look)
