### PR TITLE
Modified rankString() so as to produce more understandable decimal ra…

### DIFF
--- a/src/lib/rank_utils.test.ts
+++ b/src/lib/rank_utils.test.ts
@@ -152,7 +152,7 @@ test("getUserRating", () => {
             professional: false,
             provisional: false,
             rank: 23,
-            rank_deviation_labels: ["8.1k", "6.2k"],
+            rank_deviation_labels: ["8.2k", "6.2k"],
             rank_label: "7k",
             rating: 1465,
             unset: false,

--- a/src/lib/rank_utils.test.ts
+++ b/src/lib/rank_utils.test.ts
@@ -147,12 +147,12 @@ test("getUserRating", () => {
             bounded_rank: 23,
             bounded_rank_label: "7k",
             deviation: 62,
-            partial_bounded_rank_label: "6.3k",
-            partial_rank_label: "6.3k",
+            partial_bounded_rank_label: "7.2k",
+            partial_rank_label: "7.2k",
             professional: false,
             provisional: false,
             rank: 23,
-            rank_deviation_labels: ["7.3k", "5.3k"],
+            rank_deviation_labels: ["8.1k", "6.2k"],
             rank_label: "7k",
             rating: 1465,
             unset: false,
@@ -166,12 +166,12 @@ test("getUserRating", () => {
             bounded_rank: 23,
             bounded_rank_label: "7k",
             deviation: 64,
-            partial_bounded_rank_label: "6.1k",
-            partial_rank_label: "6.1k",
+            partial_bounded_rank_label: "7.0k",
+            partial_rank_label: "7.0k",
             professional: false,
             provisional: false,
             rank: 23,
-            rank_deviation_labels: ["7.1k", "5.1k"],
+            rank_deviation_labels: ["8.0k", "6.0k"],
             rank_label: "7k",
             rating: 1480,
             unset: false,
@@ -185,12 +185,12 @@ test("getUserRating", () => {
             bounded_rank: 24,
             bounded_rank_label: "6k",
             deviation: 350,
-            partial_bounded_rank_label: "5.7k",
-            partial_rank_label: "5.7k",
+            partial_bounded_rank_label: "6.6k",
+            partial_rank_label: "6.6k",
             professional: false,
             provisional: true,
             rank: 24,
-            rank_deviation_labels: ["11.9k", "0.9k"],
+            rank_deviation_labels: ["12.8k", "1.8k"],
             rank_label: "6k",
             rating: 1500,
             unset: true,
@@ -231,7 +231,7 @@ test("rankString", () => {
 
     // User passed in
     expect(rankString(user)).toBe("7k");
-    expect(rankString(user, true)).toBe("7.0k"); // bug? I would expect this to be "6.3k"
+    expect(rankString(user, true)).toBe("7.9k"); // bug? I would expect this to be "6.3k" (now "7.2k")
     expect(rankString(provisional_user)).toBe("?");
 
     // Professional user

--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -42,8 +42,8 @@ export interface Rating {
     partial_bounded_rank_label: string;
 }
 
-export const MinRank = 5;
-export const MaxRank = 38;
+export const MinRank = 5.01;
+export const MaxRank = 38.99;
 export const PROVISIONAL_RATING_CUTOFF = 160;
 
 const MIN_RATING = 100;
@@ -245,21 +245,15 @@ export function rankString(
         return "?";
     }
 
-    if (r < 30) {
-        if (with_tenths) {
-            (r as any) = (Math.ceil((30 - r) * 10) / 10).toFixed(1);
-        } else {
-            r = Math.ceil(30 - r);
-        }
-        return interpolate(pgettext("Kyu", "%sk"), [r]);
+    let is_kyu = (r < 30);
+    r = 1 + Math.abs(r - 30);
+    r = Math.floor(r * 10) / 10;
+    let r_str = r.toFixed(1);
+    if (!with_tenths) {
+        r_str = r_str.split('.')[0];
+        // n.b. Working in string space to avoid any floating point conversion inconsistencies.
     }
-
-    if (with_tenths) {
-        (r as any) = (Math.floor((r - 29) * 10) / 10).toFixed(1);
-    } else {
-        r = Math.floor(r - 29);
-    }
-    return interpolate(pgettext("Dan", "%sd"), [r]);
+    return interpolate(is_kyu ? pgettext("Kyu", "%sk") : pgettext("Dan", "%sd"),[r_str]);
 }
 
 /**

--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -247,7 +247,7 @@ export function rankString(
 
     if (r < 30) {
         if (with_tenths) {
-            (r as any) = (Math.ceil((30 - r) * 10) / 10).toFixed(1);
+            (r as any) = (Math.ceil((30 - r + 0.9) * 10) / 10).toFixed(1);
         } else {
             r = Math.ceil(30 - r);
         }

--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -42,8 +42,8 @@ export interface Rating {
     partial_bounded_rank_label: string;
 }
 
-export const MinRank = 5.01;
-export const MaxRank = 38.99;
+export const MinRank = 5;
+export const MaxRank = 38;
 export const PROVISIONAL_RATING_CUTOFF = 160;
 
 const MIN_RATING = 100;
@@ -245,15 +245,21 @@ export function rankString(
         return "?";
     }
 
-    const is_kyu = r < 30;
-    r = 1 + Math.abs(r - 30);
-    r = Math.floor(r * 10) / 10;
-    let r_str = r.toFixed(1);
-    if (!with_tenths) {
-        r_str = r_str.split(".")[0];
-        // n.b. Working in string space to avoid any floating point conversion inconsistencies.
+    if (r < 30) {
+        if (with_tenths) {
+            (r as any) = (Math.ceil((30 - r) * 10) / 10).toFixed(1);
+        } else {
+            r = Math.ceil(30 - r);
+        }
+        return interpolate(pgettext("Kyu", "%sk"), [r]);
     }
-    return interpolate(is_kyu ? pgettext("Kyu", "%sk") : pgettext("Dan", "%sd"), [r_str]);
+
+    if (with_tenths) {
+        (r as any) = (Math.floor((r - 29) * 10) / 10).toFixed(1);
+    } else {
+        r = Math.floor(r - 29);
+    }
+    return interpolate(pgettext("Dan", "%sd"), [r]);
 }
 
 /**

--- a/src/lib/rank_utils.ts
+++ b/src/lib/rank_utils.ts
@@ -245,15 +245,15 @@ export function rankString(
         return "?";
     }
 
-    let is_kyu = (r < 30);
+    const is_kyu = r < 30;
     r = 1 + Math.abs(r - 30);
     r = Math.floor(r * 10) / 10;
     let r_str = r.toFixed(1);
     if (!with_tenths) {
-        r_str = r_str.split('.')[0];
+        r_str = r_str.split(".")[0];
         // n.b. Working in string space to avoid any floating point conversion inconsistencies.
     }
-    return interpolate(is_kyu ? pgettext("Kyu", "%sk") : pgettext("Dan", "%sd"),[r_str]);
+    return interpolate(is_kyu ? pgettext("Kyu", "%sk") : pgettext("Dan", "%sd"), [r_str]);
 }
 
 /**


### PR DESCRIPTION
Note: This is small code-wise but cosmetically impacts many/most users.

Background discussion for this proposal is at https://forums.online-go.com/t/what-rating-value-can-be-considered-the-middle-of-the-rank/47569. My TL:DR is that for kyus the currently displayed decimal ranks (e.g., 3.2k) are very confusing and that a more understandable system would be welcome.

The main point is that the decimal rank should always transparently match the integer rank. The decimal rank of a 3k player should be between 3.0k and 3.9k (with 3.0k being the strong end of 3k and the closest to becoming 2.9k/2k).

This is not the case in the current system, hence the confusion. A weak 3k is 3.0k but a strong 3k is actually displayed as 2.1k, and perhaps even more confusingly a strong 1k is displayed as 0.1k. The 3.2k above indicates a 4-kyu player. The issue is with kyu ranks only: dan ranks already have a custom adjustment so that's it's not possible to be say 0.4d. Essentially, the proposed commit applies this already present custom adjustment to kyu ranks also.

Now, those ranks are not wrong per se, as there's no standard, and there may be room to apply the "it's not a bug, it's a feature" logic. Though I find it hard to justify adjusting the dan ranks but not the kyu ones. And obvisouly, I believe the proposed change would be worth it despite the initial impact on users.

~~As for the changes themselves: the core of the commit is to avoid the `floor()`/`ceil()` shenanigans and the related issues in by inserting the expression `1 + abs(r - 30)` where `r` is the OGS rank (where 0 is the minimal possible go rank of 30k, and 30 is the boundary between kyu and dan, so that between 29 and 30 is 1k and between 30 and 31 is 1d). This is all in `rankString()` in `rank_utils.ts`~~

The commit doesn't affect integer ranks.