### PR TITLE
"Final action" to the top of game timings

### DIFF
--- a/src/views/Game/GameTimings.styl
+++ b/src/views/Game/GameTimings.styl
@@ -48,4 +48,9 @@
     .span-4 {
         grid-column: span 4;
     }
+
+    .final-action-row {
+        grid-row: 2; // final action time at the top for easy viewing in escape cases
+        padding-bottom: 0.2rem;
+    }
 }

--- a/src/views/Game/GameTimings.tsx
+++ b/src/views/Game/GameTimings.tsx
@@ -240,9 +240,9 @@ export function GameTimings(props: GameTimingProperties): JSX.Element {
             <div>Totals:</div>
             <div>{moment.duration(black_elapsed).format()}</div>
             <div>{moment.duration(white_elapsed).format()}</div>
-            <div>{/* empty cell at end of row */}</div>
-            <div className="span-3">Final action:</div>
-            <div>
+            <div>{moment.duration(game_elapsed).format()}</div>
+            <div className="span-3 final-action-row">Final action:</div>
+            <div className="final-action-row">
                 {props.end_time &&
                     show_seconds_resolution(
                         moment
@@ -250,7 +250,6 @@ export function GameTimings(props: GameTimingProperties): JSX.Element {
                             .subtract(game_elapsed),
                     )}
             </div>
-            <div>{/* empty cell at end of row */}</div>
         </div>
     );
 }


### PR DESCRIPTION
Fixes  scrolling down to see if it was a grievous escape

## Proposed Changes

  - cssed the last row (final action) of game timing up to the top to reduce scrolling to find it


  
![Screenshot 2024-04-01 at 8 45 52 am (2)](https://github.com/online-go/online-go.com/assets/61894/58ee560a-7593-46e6-a145-8161b43e898f)


(somewhat less elegant layout, but more useful)
  