### PR TITLE
Show headers even if they can't be used for sorting

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -262,7 +262,7 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
         setOrderBy(new_order_by);
     }
 
-    function getHeader(order: string[], header: string): JSX.Element {
+    function getHeader(order: string[] | undefined, header: string): JSX.Element {
         let el: JSX.Element;
         if (order && order.length > 0) {
             let clsName = "";
@@ -343,7 +343,7 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
                                             : null
                                     }
                                 >
-                                    {column.orderBy ? getHeader(column.orderBy, column.header) : ""}
+                                    {getHeader(column.orderBy, column.header)}
                                 </th>
                             ))}
                         </tr>


### PR DESCRIPTION
Headers that couldn't be used for sorting got dropped in 4e677869059e414c3c7c368d4f2997f2ac7c7f92. Put them back.