### PR TITLE
Show minimum players to start tournaments

### DIFF
--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -387,7 +387,10 @@ export function TournamentList(props: TournamentListProperties) {
                     {
                         header: _("Players"),
                         className: "nobr",
-                        render: (tournament) => tournament.player_count,
+                        render: (tournament) =>
+                            tournament.started
+                                ? tournament.player_count
+                                : `${tournament.player_count}/${tournament.players_start}`,
                     },
                     {
                         header: _("Ranks"),


### PR DESCRIPTION
Only affects display of tournaments that haven't started.

Maybe would be better to only show the minimum if it hasn't been reached...