### PR TITLE
Shorter clock strings: "6 Days 3 Hours" -> "6d 3h"

### DIFF
--- a/src/components/Clock/Clock.test.tsx
+++ b/src/components/Clock/Clock.test.tsx
@@ -1,4 +1,4 @@
-import { Clock } from "./Clock";
+import { Clock, prettyTime } from "./Clock";
 import * as React from "react";
 import { TestGoban } from "goban";
 import { act, render } from "@testing-library/react";
@@ -46,4 +46,21 @@ test("Byo-yomi with days and hours", () => {
     expect(container.querySelector(".main-time")).toHaveTextContent("2 Days 12 Hours");
     expect(container.querySelector(".period-time")).toHaveTextContent("7 Days");
     expect(container.querySelector(".byo-yomi-periods")).toHaveTextContent("(5)");
+});
+
+test("prettyTime", () => {
+    expect(prettyTime(0)).toBe("0.0");
+    expect(prettyTime(5000)).toBe("0:05");
+    expect(prettyTime(3.3e5)).toBe("5:30");
+    expect(prettyTime(5.4e6)).toBe("1h 30m");
+    expect(prettyTime(2.16e7)).toBe("6h 0m");
+    expect(prettyTime(1.296e8)).toBe("36h");
+    expect(prettyTime(2.16e8)).toBe("2 Days 12 Hours");
+    expect(prettyTime(2.592e8)).toBe("3 Days");
+});
+
+test("prettyTime bad input", () => {
+    expect(prettyTime(NaN)).toBe("0.0");
+    expect(prettyTime(-1)).toBe("0.0");
+    expect(prettyTime(Infinity)).toBe("Infinity Days");
 });

--- a/src/components/Clock/Clock.test.tsx
+++ b/src/components/Clock/Clock.test.tsx
@@ -1,0 +1,49 @@
+import { Clock } from "./Clock";
+import * as React from "react";
+import { TestGoban } from "goban";
+import { act, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+test("Byo-yomi with days and hours", () => {
+    const goban = new TestGoban({
+        time_control: {
+            system: "byoyomi",
+            speed: "correspondence",
+            main_time: 6.048e8,
+            periods: 5,
+            period_time: 6.048e8,
+            pause_on_weekends: false,
+        },
+    });
+
+    const black_clock = {
+        main_time: 0,
+        periods_left: 5,
+        period_time_left: 5.038e8, // 5 days 20hr
+    };
+    const white_clock = {
+        main_time: 2.16e8, // 2.5 days
+        periods_left: 5,
+        period_time_left: 6.048e8, // 7 days
+    };
+
+    const { container } = render(<Clock goban={goban} color="white" />);
+    act(() => {
+        // Very hacky way to emit the clock event, but I don't want to start any timers...
+        goban.emit("clock", {
+            current_player: "black",
+
+            /** Player ID of player to move */
+            current_player_id: "12345",
+            time_of_last_move: 1700000000,
+            black_clock,
+            white_clock,
+            black_move_transmitting: 0,
+            white_move_transmitting: 0,
+        });
+    });
+
+    expect(container.querySelector(".main-time")).toHaveTextContent("2 Days 12 Hours");
+    expect(container.querySelector(".period-time")).toHaveTextContent("7 Days");
+    expect(container.querySelector(".byo-yomi-periods")).toHaveTextContent("(5)");
+});

--- a/src/components/Clock/Clock.test.tsx
+++ b/src/components/Clock/Clock.test.tsx
@@ -43,7 +43,7 @@ test("Byo-yomi with days and hours", () => {
         });
     });
 
-    expect(container.querySelector(".main-time")).toHaveTextContent("2 Days 12 Hours");
+    expect(container.querySelector(".main-time")).toHaveTextContent("2d 12h");
     expect(container.querySelector(".period-time")).toHaveTextContent("7 Days");
     expect(container.querySelector(".byo-yomi-periods")).toHaveTextContent("(5)");
 });
@@ -55,7 +55,7 @@ test("prettyTime", () => {
     expect(prettyTime(5.4e6)).toBe("1h 30m");
     expect(prettyTime(2.16e7)).toBe("6h 0m");
     expect(prettyTime(1.296e8)).toBe("36h");
-    expect(prettyTime(2.16e8)).toBe("2 Days 12 Hours");
+    expect(prettyTime(2.16e8)).toBe("2d 12h");
     expect(prettyTime(2.592e8)).toBe("3 Days");
 });
 

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -245,11 +245,9 @@ export function prettyTime(ms: number): string {
         return "0.0";
     }
     if (days > 1) {
-        let ret = days + " " + ngettext("Day", "Days", days);
-        if (hours > 0) {
-            ret += " " + hours + " " + ngettext("Hour", "Hours", hours);
-        }
-        return ret;
+        return hours > 0
+            ? interpolate(pgettext("Game clock: Days and hours", "%sd %sh"), [days, hours])
+            : days + " " + ngettext("Day", "Days", days);
     }
     if (hours || days === 1) {
         return days === 0

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import * as data from "data";
 import { useEffect, useState } from "react";
-import { Goban, JGOFClockWithTransmitting, JGOFPlayerClock, JGOFTimeControl } from "goban";
+import { GobanCore, JGOFClockWithTransmitting, JGOFPlayerClock, JGOFTimeControl } from "goban";
 import { _, pgettext, interpolate, ngettext } from "translate";
 
 type clock_color = "black" | "white" | "stone-removal";
@@ -30,7 +30,7 @@ export function Clock({
     compact,
     lineSummary,
 }: {
-    goban: Goban;
+    goban: GobanCore;
     color: clock_color;
     className?: string;
     compact?: boolean;

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -231,7 +231,8 @@ function ClockPauseReason({
     return <span className="pause-text">{pause_text}</span>;
 }
 
-function prettyTime(ms: number): string {
+// exported for testing
+export function prettyTime(ms: number): string {
     //return shortDurationString(Math.round(ms / 1000));
 
     let seconds = Math.ceil((ms - 1) / 1000);

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -233,8 +233,6 @@ function ClockPauseReason({
 
 // exported for testing
 export function prettyTime(ms: number): string {
-    //return shortDurationString(Math.round(ms / 1000));
-
     let seconds = Math.ceil((ms - 1) / 1000);
     const days = Math.floor(seconds / 86400);
     seconds -= days * 86400;
@@ -243,25 +241,20 @@ export function prettyTime(ms: number): string {
     const minutes = Math.floor(seconds / 60);
     seconds -= minutes * 60;
 
-    let ret = "";
     if (ms <= 0 || isNaN(ms)) {
-        ret = "0.0";
-    } else if (days > 1) {
-        ret += days + " " + ngettext("Day", "Days", days);
-        if (hours > 0) {
-            ret += " " + (hours + (hours ? " " + ngettext("Hour", "Hours", hours) : ""));
-        }
-    } else if (hours || days === 1) {
-        ret =
-            days === 0
-                ? interpolate(pgettext("Game clock: Hours and minutes", "%sh %sm"), [
-                      hours,
-                      minutes,
-                  ])
-                : interpolate(pgettext("Game clock: hours", "%sh"), [hours + 24]);
-    } else {
-        ret = minutes + ":" + (seconds < 10 ? "0" : "") + seconds;
+        return "0.0";
     }
-
-    return ret;
+    if (days > 1) {
+        let ret = days + " " + ngettext("Day", "Days", days);
+        if (hours > 0) {
+            ret += " " + hours + " " + ngettext("Hour", "Hours", hours);
+        }
+        return ret;
+    }
+    if (hours || days === 1) {
+        return days === 0
+            ? interpolate(pgettext("Game clock: Hours and minutes", "%sh %sm"), [hours, minutes])
+            : interpolate(pgettext("Game clock: hours", "%sh"), [hours + 24]);
+    }
+    return minutes + ":" + (seconds < 10 ? "0" : "") + seconds;
 }


### PR DESCRIPTION
This is an attempt to prevent wraparound in narrow contexts, which can cause layout issues in the player cards on the Game page. See discussion/poll at [OGF: Should time control show days without hours?](https://forums.online-go.com/t/should-time-control-show-days-without-hours/51213)

To summarize, the "6d 3h" format the overwhelming preference (93%) in the multiple choice poll.  One user cited precision as a reason for choosing this over an option like "6 Days" that keeps long-form units, but drops hours.  Another user pointed out that the Sente Android app uses this format.

## Proposed Changes

I've broken this into four commits:

 - One basic component test (~66% coverage of the file)
 - In depth test of `prettyTime()` (100% coverage of the function)
 - Clean up `prettyTime()` a bit (no functional changes)
 - Change the output for `days > 1 && hours > 0`

## Screenshots

Notice, we get one line of vertical space back on both the player cards and the active games list.  This is critical for phone screens!

<img width="296" alt="Screenshot 2024-04-02 at 10 03 28 PM" src="https://github.com/online-go/online-go.com/assets/25233703/8eaa8455-4b0a-4dda-8aed-83974aefcc05">
<img width="289" alt="Screenshot 2024-04-02 at 10 05 21 PM" src="https://github.com/online-go/online-go.com/assets/25233703/a62da6c8-f358-4769-84c3-b1b5f8719842">
<img width="360" alt="Screenshot 2024-04-02 at 10 06 24 PM" src="https://github.com/online-go/online-go.com/assets/25233703/2ea3427a-d76a-4039-8c4a-d6077c3d9b51">
<img width="361" alt="Screenshot 2024-04-02 at 10 06 08 PM" src="https://github.com/online-go/online-go.com/assets/25233703/d853f21f-dea4-40c0-a422-be097723bbfd">