### PR TITLE
Button for Random Next Puzzle

### DIFF
--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -907,28 +907,16 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
         const show_correct = this.state.show_correct;
 
         let next_id = 0;
+        const ids = this.state.puzzle_collection_summary
+            .map((p) => p.id)
+            .filter((id) => id !== puzzle.id);
         let random_id = 0;
-        let temp_id = 0;
+        if (ids.length > 0) {
+            random_id = ids[Math.floor(Math.random() * ids.length)];
+        }
         for (let i = 0; i < this.state.puzzle_collection_summary.length - 1; ++i) {
             if (this.state.puzzle_collection_summary[i].id === puzzle.id) {
                 next_id = this.state.puzzle_collection_summary[i + 1].id;
-            }
-        }
-        if (this.state.puzzle_collection_summary.length > 1) {
-            temp_id = Math.floor(Math.random() * this.state.puzzle_collection_summary.length);
-            random_id = this.state.puzzle_collection_summary[temp_id].id;
-            if (random_id === puzzle.id) {
-                if (temp_id === 0) {
-                    random_id = this.state.puzzle_collection_summary[1].id;
-                }
-                if (temp_id === this.state.puzzle_collection_summary.length - 1) {
-                    random_id =
-                        this.state.puzzle_collection_summary[
-                            this.state.puzzle_collection_summary.length - 2
-                        ].id;
-                } else {
-                    random_id = this.state.puzzle_collection_summary[temp_id - 1].id;
-                }
             }
         }
 

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -907,9 +907,28 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
         const show_correct = this.state.show_correct;
 
         let next_id = 0;
+        let random_id = 0;
+        let temp_id = 0;
         for (let i = 0; i < this.state.puzzle_collection_summary.length - 1; ++i) {
             if (this.state.puzzle_collection_summary[i].id === puzzle.id) {
                 next_id = this.state.puzzle_collection_summary[i + 1].id;
+            }
+        }
+        if (this.state.puzzle_collection_summary.length > 1) {
+            temp_id = Math.floor(Math.random() * this.state.puzzle_collection_summary.length);
+            random_id = this.state.puzzle_collection_summary[temp_id].id;
+            if (random_id === puzzle.id) {
+                if (temp_id === 0) {
+                    random_id = this.state.puzzle_collection_summary[1].id;
+                }
+                if (temp_id === this.state.puzzle_collection_summary.length - 1) {
+                    random_id =
+                        this.state.puzzle_collection_summary[
+                            this.state.puzzle_collection_summary.length - 2
+                        ].id;
+                } else {
+                    random_id = this.state.puzzle_collection_summary[temp_id - 1].id;
+                }
             }
         }
 
@@ -938,6 +957,15 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
 
                 {(show_correct || null) && (
                     <div className="actions">
+                        {(random_id !== 0 || null) && (
+                            <Link
+                                ref={this.next_link}
+                                to={`/puzzle/${random_id}`}
+                                className="btn danger"
+                            >
+                                {_("Random")}
+                            </Link>
+                        )}
                         {((next_id !== 0 && next_id !== puzzle.id) || null) && (
                             <Link
                                 ref={this.next_link}


### PR DESCRIPTION
Related to #1031 

Also requested in

https://forums.online-go.com/t/resource-for-making-custom-puzzles-with-randomised-order/50994?u=shinuito

## Proposed Changes

  - Add a yellow (resuing danger colour) "Random" button beside the next puzzle button, to jump to a random other puzzle in the same collection.
  - Doesn't show up if there's only one puzzle in the collection.
  - If the random puzzle id chosen is the current id, then go to either the puzzle preceding this one if available or the next one in case of it being the first puzzle. (Less likely when there's more puzzles in the collection anyway).
 
![image](https://github.com/online-go/online-go.com/assets/26803867/05dcfcd7-1a18-4291-8f94-765750e388cd)

![image](https://github.com/online-go/online-go.com/assets/26803867/f28ad5b2-be9e-466b-96b9-b30797a90b8e)

