### PR TITLE
Implement ability to change report type.

### DIFF
--- a/src/components/AccountWarning/AccountWarning.tsx
+++ b/src/components/AccountWarning/AccountWarning.tsx
@@ -74,6 +74,7 @@ export function AccountWarning() {
     const Renderers = {
         warning: WarningModal,
         acknowledgement: AckModal,
+        info: AckModal,
     };
 
     const MessageRenderer = Renderers[warning.severity];

--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -225,4 +225,20 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
         Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
+    report_type_changed: (change) =>
+        interpolate(
+            _(
+                `
+        Thanks for your recent report.   We've had to change the 'report type':
+
+            {{change}}.
+
+        It makes it easier and quicker to process reports if they are raised with the
+        correct type - if you could help with that we'd appreciate it.
+
+        If this change seems wrong, we'd welcome feedback about that - please contact a moderator to let them know.
+        `,
+            ),
+            { change },
+        ),
 };

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -25,7 +25,21 @@ import { post } from "requests";
 import { alert } from "swal_config";
 import { setIgnore } from "BlockPlayer";
 import { useUser } from "hooks";
-import { ReportType } from "moderation";
+
+export type ReportType =
+    | "all" // not a type, just useful for the enumeration
+    // These need to match those defined in the IncidentReport model on the back end
+    | "stalling"
+    | "inappropriate_content"
+    | "score_cheating"
+    | "harassment"
+    | "ai_use"
+    | "sandbagging"
+    | "escaping"
+    | "appeal"
+    | "other"
+    | "warning" // for moderators only
+    | "troll"; // system generated, for moderators only
 
 export interface ReportDescription {
     type: ReportType;

--- a/src/lib/moderation.tsx
+++ b/src/lib/moderation.tsx
@@ -25,23 +25,7 @@ import { toast } from "toast";
 
 import { pgettext } from "translate";
 
-export type ReportType =
-    | "all" // not a type, just useful for the enumeration
-    // These need to match those defined in the IncidentReport model on the back end
-    | "stalling"
-    | "inappropriate_content"
-    | "score_cheating"
-    | "harassment"
-    | "ai_use"
-    | "sandbagging"
-    | "escaping"
-    | "appeal"
-    | "other"
-    | "warning" // for moderators only
-    | "troll"; // system generated, for moderators only
-
 // Must match back-end MODERATOR_POWER definition
-
 export enum MODERATOR_POWERS {
     NONE = 0,
     HANDLE_SCORE_CHEAT = 0b001,

--- a/src/lib/report_util.ts
+++ b/src/lib/report_util.ts
@@ -17,7 +17,8 @@
 
 import { ReportedConversation } from "Report";
 import { PlayerCacheEntry } from "player_cache";
-import { MODERATOR_POWERS, ReportType } from "moderation";
+import { MODERATOR_POWERS } from "moderation";
+import { ReportType } from "Report";
 
 interface Vote {
     voter_id: number;
@@ -32,6 +33,7 @@ export interface Report {
     updated: string;
     state: string;
     escalated: boolean;
+    retyped: boolean;
     source: string;
     report_type: ReportType;
     reporting_user: any;

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -40,9 +40,10 @@ declare namespace rest_api {
             | "ack_educated_beginner_staller_and_annul"
             | "ack_warned_staller"
             | "ack_warned_staller_and_annul"
-            | "no_stalling_evident";
+            | "no_stalling_evident"
+            | "report_type_changed";
 
-        type Severity = "warning" | "acknowledgement";
+        type Severity = "warning" | "acknowledgement" | "info";
 
         type InterpolatedMessage = (data: any) => string;
 

--- a/src/views/ReportsCenter/ReportTypeSelector.tsx
+++ b/src/views/ReportsCenter/ReportTypeSelector.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import Select, { SingleValue, components } from "react-select";
+
+import { ReportType } from "Report";
+
+const REPORT_TYPE_SELECTIONS: ReportTypeSelection[] = [
+    { value: "escaping", label: "Stopped Playing" },
+    { value: "stalling", label: "Stalling" },
+    { value: "score_cheating", label: "Score Cheating" },
+    { value: "inappropriate_content", label: "Inappropriate Content" },
+    { value: "harassment", label: "Harassment" },
+    { value: "sandbagging", label: "Sandbagging" },
+    { value: "ai_use", label: "AI Use" },
+];
+
+export interface ReportTypeSelection {
+    value: ReportType;
+    label: string;
+}
+
+interface ReportTypeSelectorProps {
+    current_type: ReportType | undefined;
+    lock: boolean;
+    onUpdate: (new_value: ReportType) => void;
+}
+
+export function ReportTypeSelector(props: ReportTypeSelectorProps) {
+    const onTypeChange = (e: SingleValue<ReportTypeSelection>) => {
+        if (e) {
+            props.onUpdate(e.value);
+        }
+    };
+
+    const current_selection = REPORT_TYPE_SELECTIONS.filter(
+        (selection) => selection.value === props.current_type,
+    );
+    return (
+        <Select
+            isDisabled={props.lock}
+            className="report-type-selector"
+            classNamePrefix="ogs-react-select"
+            value={current_selection}
+            options={REPORT_TYPE_SELECTIONS}
+            onChange={onTypeChange}
+            getOptionLabel={(o) => o.label}
+            getOptionValue={(o) => o.value}
+            components={{
+                Option: ({ innerRef, innerProps, isFocused, isSelected, data }) => (
+                    <div
+                        ref={innerRef}
+                        {...innerProps}
+                        className={(isFocused ? "focused " : "") + (isSelected ? "selected" : "")}
+                    >
+                        {data.label}
+                    </div>
+                ),
+                DropdownIndicator: props.lock
+                    ? (props) => (
+                          <components.DropdownIndicator {...props}>
+                              <i className="fa fa-lock" style={{ color: "gray" }}></i>
+                          </components.DropdownIndicator>
+                      )
+                    : components.DropdownIndicator,
+            }}
+        />
+    );
+}

--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -12,7 +12,7 @@
         visibility: hidden;
     }
 
-    h3.users {
+    .users-header {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -22,11 +22,22 @@
             white-space: nowrap;
         }
 
+        .reported-user {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: left;
+            > span {
+                margin-left: 0.5rem;
+            }
+
+        }
+
         .reporting-user {
             float: right;
             font-size: 0.8rem;
             font-weight: 400;
-        }
+       }
     }
 
     .view-report-header {

--- a/src/views/User/ActivityCard.tsx
+++ b/src/views/User/ActivityCard.tsx
@@ -22,7 +22,7 @@ import { Card } from "material";
 import * as data from "data";
 import UserVoteActionSummary from "./UserVoteActionSummary";
 import UserVoteActivityGraph from "./VoteActivityGraph";
-import { ReportType } from "moderation";
+import { ReportType } from "Report";
 import { COMMUNITY_MODERATION_REPORT_TYPES, community_mod_has_power } from "report_util";
 
 /** Activity card doesn't care about that many user traits */

--- a/src/views/User/UserVoteActionSummary.tsx
+++ b/src/views/User/UserVoteActionSummary.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from "react";
 import { get } from "requests";
 import * as data from "data";
 import { ResponsivePie } from "@nivo/pie";
-import { ReportType } from "moderation";
+import { ReportType } from "Report";
 
 interface VoteSummaryData {
     report_type: string;


### PR DESCRIPTION
Fixes CM escalating because the report is of the wrong type so they don't have suitable voting options

## Proposed Changes

  - Make the `Report Type` selectable on ViewReport, send a `retype` POST if they decide to change it
  -- Disable this if the report has already been retyped
  - Provide info message to reporter for use when this happens.
   

Needs https://github.com/online-go/ogs/pull/1951 - otherwise "retype" will 404.