### PR TITLE
Fix move number links in review/demo boards

### DIFF
--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -51,7 +51,7 @@ interface ChatLine {
         | protocol.GameChatReviewMessage
         | protocol.GameChatTranslatedMessage;
     date: number;
-    move_number: number;
+    move_number?: number;
     from?: number;
     moves?: string;
     channel: string;
@@ -475,7 +475,21 @@ export function GameChatLine(props: GameChatLineProperties): JSX.Element {
             game_control.emit("stopEstimatingScore");
             const line = props.line;
 
-            if ("move_number" in line) {
+            // In a demo/review, line.move_number is never set. For lines that
+            // link to a specific move, line.from is set, and line.moves is an
+            // empty string (which is falsy).
+            if ((line.from ?? -1) >= 0 && "moves" in line) {
+                if (goban.isAnalysisDisabled()) {
+                    goban.setMode("analyze");
+                }
+
+                goban.engine.followPath(line.from as number, line.moves);
+                goban.syncReviewMove();
+                goban.drawPenMarks(goban.engine.cur_move.pen_marks);
+                goban.redraw();
+                //last_move_number[type] = line.from;
+                //last_moves[type] = line.moves;
+            } else if ("move_number" in line) {
                 if (!goban.isAnalysisDisabled()) {
                     goban.setMode("analyze");
                 }
@@ -489,25 +503,11 @@ export function GameChatLine(props: GameChatLineProperties): JSX.Element {
 
                 goban.emit("update");
             }
-
-            if ((line.from ?? -1) >= 0 && line.moves) {
-                if (goban.isAnalysisDisabled()) {
-                    goban.setMode("analyze");
-                }
-
-                goban.engine.followPath(line.from as number, line.moves);
-                goban.syncReviewMove();
-                goban.drawPenMarks(goban.engine.cur_move.pen_marks);
-                goban.redraw();
-                //last_move_number[type] = line.from;
-                //last_moves[type] = line.moves;
-            }
         };
 
-        // It's unclear to me if we still need this "move_number" in (line as any) check,
-        // our typing says that field should always exist so the second case isn't necessary,
-        // but I'm not sure why we had it to begin with then, so I'm leaving it in place
-        // for the time being. - anoek 2023-01-02
+        // line.move_number is not set in review/demo gobans. The move number
+        // is only available in line.from, and line.moves is an empty string if
+        // there's no variation.
         move_number = (
             <LineText className="move-number" onClick={jumpToMove}>
                 Move{" "}

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -483,7 +483,7 @@ export function GameChatLine(props: GameChatLineProperties): JSX.Element {
                     goban.setMode("analyze");
                 }
 
-                goban.engine.followPath(line.from as number, line.moves);
+                goban.engine.followPath(line.from as number, line.moves as string);
                 goban.syncReviewMove();
                 goban.drawPenMarks(goban.engine.cur_move.pen_marks);
                 goban.redraw();
@@ -494,7 +494,7 @@ export function GameChatLine(props: GameChatLineProperties): JSX.Element {
                     goban.setMode("analyze");
                 }
 
-                goban.engine.followPath(line.move_number, "");
+                goban.engine.followPath(line.move_number as number, "");
                 goban.redraw();
 
                 if (goban.isAnalysisDisabled()) {


### PR DESCRIPTION
Fixes issue reported in the forums:
https://forums.online-go.com/t/clickable-move-numbers-in-chat/51503

> But with the normal game moves (red arrow), that doesn’t seem to work. It would be very handy if that would work the same way.
> 
> Thanks.
> 
> Example: [FMfirst vs. Holon 4](https://online-go.com/review/1254540)
> ![8be3627e2e3946c1b8945368558dcad19fdc86b4](https://github.com/online-go/online-go.com/assets/1334620/bf4db4be-b47b-42ee-a6d2-2fc77aa2a72a)
