### PR TITLE
Delete some dead code

### DIFF
--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -479,10 +479,6 @@ export function GameChatLine(props: GameChatLineProperties): JSX.Element {
             // link to a specific move, line.from is set, and line.moves is an
             // empty string (which is falsy).
             if ((line.from ?? -1) >= 0 && "moves" in line) {
-                if (goban.isAnalysisDisabled()) {
-                    goban.setMode("analyze");
-                }
-
                 goban.engine.followPath(line.from as number, line.moves as string);
                 goban.syncReviewMove();
                 goban.drawPenMarks(goban.engine.cur_move.pen_marks);


### PR DESCRIPTION
Delete code related to analysis being disabled from the review/demo code path.  Since 72f9c2b70a56a55a5e056f06908a5f2564baf122, finished games have always had analysis enabled.

Interestingly, this code looks like it was backwards, turning on analysis only when disabled???, but turning on analysis in reviews is probably meaningless anyway.

Noticed after moving it in 3dddbb68d3a43126a69a892a835000f165c32993.

Was about to tack this onto https://github.com/online-go/online-go.com/pull/2659 but you merged too quickly :).