### PR TITLE
Make move number URLs work for reviews and demos

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -217,8 +217,10 @@ export const routes = (
                 <Route path="/game/:game_id/:move_number" element={<Game />} />
                 <Route path="/game/:game_id" element={<Game />} />
                 <Route path="/review/view/:review_id" element={<Game />} />
+                <Route path="/review/:review_id/:move_number" element={<Game />} />
                 <Route path="/review/:review_id" element={<Game />} />
                 <Route path="/demo/view/:review_id" element={<Game />} />
+                <Route path="/demo/:review_id/:move_number" element={<Game />} />
                 <Route path="/demo/:review_id" element={<Game />} />
                 <Route path="/game/:game_id/embed" element={<GameEmbed />} />
                 <Route path="/review/:review_id/embed" element={<GameEmbed />} />

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1344,7 +1344,7 @@ export function Game(): JSX.Element | null {
         });
 
         if (params.move_number) {
-            goban.current.once("gamedata", () => {
+            goban.current.once(review_id ? "review.load-end" : "gamedata", () => {
                 nav_goto_move(parseInt(params.move_number as string));
             });
         }


### PR DESCRIPTION
Per this forum suggestion: <https://forums.online-go.com/t/clickable-move-numbers-in-chat/51503/5>

> Somewhat related, appending the move number to the url of a review doesn’t work to navigate there like it does in a game. Having to type that isn’t as convenient, but being a real url the plus is it is shareable externally.

Tested with <https://online-go.com/review/1254540/3> (well, via http://localhost:8080).