### PR TITLE
Add "other" to the report types that `ReportTypeSelector` knows about.

### DIFF
--- a/src/views/ReportsCenter/ReportTypeSelector.tsx
+++ b/src/views/ReportsCenter/ReportTypeSelector.tsx
@@ -29,6 +29,7 @@ const REPORT_TYPE_SELECTIONS: ReportTypeSelection[] = [
     { value: "harassment", label: "Harassment" },
     { value: "sandbagging", label: "Sandbagging" },
     { value: "ai_use", label: "AI Use" },
+    { value: "other", label: "Other" },
 ];
 
 export interface ReportTypeSelection {


### PR DESCRIPTION
Fixes blank appearing in selector for Other reports

## Proposed Changes

  - Add "other" to supported selection types
  
  
