### PR TITLE
Notification message for bot reports

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -241,4 +241,15 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
             ),
             { change },
         ),
+    bot_owner_notified: (bot) =>
+        interpolate(
+            _(
+                `
+            Thanks for your recent report about {{bot}}.
+    
+            We've notified the owner of that bot.
+            `,
+            ),
+            { bot },
+        ),
 };

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -41,7 +41,8 @@ declare namespace rest_api {
             | "ack_warned_staller"
             | "ack_warned_staller_and_annul"
             | "no_stalling_evident"
-            | "report_type_changed";
+            | "report_type_changed"
+            | "bot_owner_notified";
 
         type Severity = "warning" | "acknowledgement" | "info";
 


### PR DESCRIPTION

## Proposed Changes

  - Support (implement)  the `bot_owner_notified` canned message
  
