### PR TITLE
Add `/reload` route to fix the default view for social logins

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -193,12 +193,22 @@ function SettingsRedirect(): JSX.Element {
     return <Navigate to={`/settings/${last_settings_page}`} replace />;
 }
 
+function Reload(): JSX.Element | null {
+    if (window.location.hash && window.location.hash[1] === "/") {
+        window.location.pathname = window.location.hash.substring(1);
+    } else {
+        window.location.pathname = "/";
+    }
+    return null;
+}
+
 export const routes = (
     <Router history={browserHistory}>
         <Main>
             <Routes>
                 <Route path="/sign-in" element={<SignIn />} />
                 <Route path="/register" element={<Register />} />
+                <Route path="/reload" element={<Reload />} />
                 <Route path="/welcome/*" element={<ChallengeLinkLanding />} />
                 <Route path="/appeal/:player_id" element={<Appeal />} />
                 <Route path="/appeal" element={<Appeal />} />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -193,12 +193,17 @@ function SettingsRedirect(): JSX.Element {
     return <Navigate to={`/settings/${last_settings_page}`} replace />;
 }
 
-function Reload(): JSX.Element | null {
-    if (window.location.hash && window.location.hash[1] === "/") {
-        window.location.pathname = window.location.hash.substring(1);
-    } else {
-        window.location.pathname = "/";
-    }
+function WaitForUser(): JSX.Element | null {
+    data.watch("config.user", (user) => {
+        if (user.anonymous) {
+            return;
+        }
+        if (window.location.hash && window.location.hash[1] === "/") {
+            window.location.pathname = window.location.hash.substring(1);
+        } else {
+            window.location.pathname = "/";
+        }
+    });
     return null;
 }
 
@@ -208,7 +213,7 @@ export const routes = (
             <Routes>
                 <Route path="/sign-in" element={<SignIn />} />
                 <Route path="/register" element={<Register />} />
-                <Route path="/reload" element={<Reload />} />
+                <Route path="/wait-for-user" element={<WaitForUser />} />
                 <Route path="/welcome/*" element={<ChallengeLinkLanding />} />
                 <Route path="/appeal/:player_id" element={<Appeal />} />
                 <Route path="/appeal" element={<Appeal />} />

--- a/src/views/Register/Register.tsx
+++ b/src/views/Register/Register.tsx
@@ -200,7 +200,7 @@ export function Register(): JSX.Element {
                         }
                     </span>
 
-                    <SocialLoginButtons />
+                    <SocialLoginButtons next_url={"/reload"} />
                 </Card>
 
                 <div className="sign-in-option">

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -253,7 +253,9 @@ export function SignIn(): JSX.Element {
                         ) /* translators: username or password, or sign in with social authentication */
                     }
                 </span>
-                <SocialLoginButtons next_url={"/reload#" + window.location.hash.substring(1)} />
+                <SocialLoginButtons
+                    next_url={"/wait-for-user#" + window.location.hash.substring(1)}
+                />
             </Card>
 
             <div className="registration">

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -253,7 +253,7 @@ export function SignIn(): JSX.Element {
                         ) /* translators: username or password, or sign in with social authentication */
                     }
                 </span>
-                <SocialLoginButtons next_url={window.location.hash.substring(1)} />
+                <SocialLoginButtons next_url={"/reload#" + window.location.hash.substring(1)} />
             </Card>
 
             <div className="registration">


### PR DESCRIPTION
Before this commit: when social logins succeed after Register or SignIn views, they currently show the content from the ObserveGames view instead of from the Overview view. This is because `config.user.anonymous` is true when the Default component is loaded.

Username/password signins don't have this problem because they force a reload by explicitly setting `window.location.pathname`.

This is a speculative fix (I can't test the OAuth stuff), adding a `/reload` route that uses the same trick for social logins.