### PR TITLE
Add support for switching between the new SVG based goban renderer and the old canvas renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "express": "^4.19.2",
         "express-http-proxy": "^2.0.0",
         "fork-ts-checker-webpack-plugin": "^9.0.0",
-        "goban": "=0.7.40",
+        "goban": "=0.7.41",
         "gulp": "^5.0.0",
         "gulp-clean-css": "^4.3.0",
         "gulp-eslint-new": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "express": "^4.19.2",
         "express-http-proxy": "^2.0.0",
         "fork-ts-checker-webpack-plugin": "^9.0.0",
-        "goban": "=0.7.41",
+        "goban": "=0.7.42",
         "gulp": "^5.0.0",
         "gulp-clean-css": "^4.3.0",
         "gulp-eslint-new": "^2.0.0",

--- a/src/components/AnnulQueueModal/AnnulQueueModal.tsx
+++ b/src/components/AnnulQueueModal/AnnulQueueModal.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import { _ } from "translate";
 import { MiniGoban } from "MiniGoban";
-import { Goban } from "goban";
+import { GobanRenderer } from "goban";
 import { AIReview, GameTimings, ChatMode, GameChat, GobanContext } from "Game";
 import { Player } from "Player";
 import { Resizable } from "Resizable";
@@ -45,9 +45,9 @@ export function AnnulQueueModal({
 }: AnnulQueueModalProps) {
     // Declare state variables
     const [selectedGameIndex, setSelectedGameIndex] = React.useState(0);
-    const [goban, setGoban] = React.useState<Goban | null>(null);
+    const [goban, setGoban] = React.useState<GobanRenderer | null>(null);
     const [selectedChatLog, setSelectedChatLog] = React.useState<ChatMode>("main");
-    const onGobanCreated = React.useCallback((goban: Goban) => {
+    const onGobanCreated = React.useCallback((goban: GobanRenderer) => {
         setGoban(goban);
     }, []);
     const [, setAiReviewUuid] = React.useState<string | null>(null);

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -41,7 +41,7 @@ import { notification_manager, NotificationManagerEvents } from "Notifications/N
 import { one_bot, bot_count, bots_list } from "bots";
 import { goban_view_mode } from "Game/util";
 import {
-    Goban,
+    GobanRenderer,
     GoEngineConfig,
     GoEngineInitialState,
     GoEnginePlayerEntry,
@@ -1889,7 +1889,7 @@ export function challengeComputer() {
     return challenge(undefined, null, true);
 }
 export function challengeRematch(
-    goban: Goban,
+    goban: GobanRenderer,
     opponent: GoEnginePlayerEntry,
     original_game_meta: GoEngineConfig & { pause_on_weekends?: boolean },
 ) {

--- a/src/components/ChallengeModal/ForkModal.tsx
+++ b/src/components/ChallengeModal/ForkModal.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import * as data from "data";
 import { _ } from "translate";
 import { Modal, openModal } from "Modal";
-import { Goban } from "goban";
+import { GobanRenderer } from "goban";
 import { PlayerAutocomplete } from "PlayerAutocomplete";
 import { MiniGoban } from "MiniGoban";
 import { challenge } from "ChallengeModal";
@@ -28,7 +28,7 @@ import { PlayerCacheEntry } from "src/lib/player_cache";
 interface Events {}
 
 interface ForkModalProperties {
-    goban: Goban;
+    goban: GobanRenderer;
 }
 
 export class ForkModal extends Modal<Events, ForkModalProperties, any> {
@@ -99,10 +99,10 @@ export class ForkModal extends Modal<Events, ForkModalProperties, any> {
     }
 }
 
-export function openForkModal(goban: Goban) {
+export function openForkModal(goban: GobanRenderer) {
     return openModal(<ForkModal goban={goban} />);
 }
-export function challengeFromBoardPosition(goban: Goban) {
+export function challengeFromBoardPosition(goban: GobanRenderer) {
     if (!goban) {
         return;
     }

--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -30,7 +30,7 @@ import {
     AdHocPlayerClock,
     AdHocPauseControl,
     AdHocPackedMove,
-    Goban,
+    GobanRenderer,
 } from "goban";
 
 interface UserType {
@@ -43,7 +43,7 @@ interface GameType {
     name: string;
     black: UserType;
     white: UserType;
-    goban?: Goban;
+    goban?: GobanRenderer;
     json?: {
         clock: AdHocClock;
         moves: AdHocPackedMove[];
@@ -373,7 +373,7 @@ export class GameList extends React.PureComponent<GameListProps, GameListState> 
                     currentSort={this.state.sort_order}
                     player={this.props.player}
                     lineSummaryMode={this.props.lineSummaryMode}
-                    onGobanCreated={(game: GameType, goban: Goban) =>
+                    onGobanCreated={(game: GameType, goban: GobanRenderer) =>
                         this.onGobanCreated(game, goban)
                     }
                 ></LineSummaryTable>
@@ -382,14 +382,14 @@ export class GameList extends React.PureComponent<GameListProps, GameListState> 
             return MiniGobanList(
                 games,
                 !!this.props.namesByGobans,
-                (game: GameType, goban: Goban) => this.onGobanCreated(game, goban),
+                (game: GameType, goban: GobanRenderer) => this.onGobanCreated(game, goban),
                 this.props?.player,
                 this.props.miniGobanProps,
             );
         }
     }
 
-    onGobanCreated(game: GameType, goban: Goban) {
+    onGobanCreated(game: GameType, goban: GobanRenderer) {
         // Save a pointer into the goban to use when sorting.
         game.goban = goban;
 
@@ -419,7 +419,7 @@ interface LineSummaryTableProps extends GameListProps {
     disableSort: boolean;
     currentSort: SortOrder | DescendingSortOrder;
     onSort: (sortBy: SortOrder) => void;
-    onGobanCreated: (game: GameType, goban: Goban) => void;
+    onGobanCreated: (game: GameType, goban: GobanRenderer) => void;
 }
 
 function LineSummaryTable({
@@ -523,7 +523,7 @@ function LineSummaryTable({
 function MiniGobanList(
     games: GameType[],
     withNames: boolean,
-    onGobanCreated: (game: GameType, goban: Goban) => void,
+    onGobanCreated: (game: GameType, goban: GobanRenderer) => void,
     player?: { id: number },
     miniGobanProps?: MiniGobanProps,
 ): JSX.Element {

--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import { PersistentElement } from "PersistentElement";
 import { OgsResizeDetector } from "OgsResizeDetector";
-import { GobanCanvas, GobanCanvasConfig } from "goban";
+import { GobanRenderer, GobanRendererConfig } from "goban";
 // Pull this out its own util
 import { goban_view_mode } from "Game/util";
 //import { generateGobanHook } from "Game/GameHooks";
@@ -26,7 +26,7 @@ import { goban_view_mode } from "Game/util";
 import { usePreference } from "preferences";
 
 interface GobanContainerProps {
-    goban?: GobanCanvas;
+    goban?: GobanRenderer;
     /** callback that is called when the goban detects a resize. */
     onResize?: () => void;
     /** Additional props to pass to the PersistentElement that wraps the goban_div */
@@ -45,8 +45,7 @@ export function GobanContainer({
     const resize_debounce = React.useRef<NodeJS.Timeout | null>(null);
     const [last_move_opacity] = usePreference("last-move-opacity");
 
-    // Since goban is a GobanCanvas, we know goban.config is a GobanCanvasConfig
-    const goban_div = (goban?.config as GobanCanvasConfig | undefined)?.board_div;
+    const goban_div = (goban?.config as GobanRendererConfig | undefined)?.board_div;
 
     const recenterGoban = () => {
         if (!ref_goban_container.current || !goban || !goban_div) {
@@ -112,7 +111,7 @@ export function GobanContainer({
         [goban, goban_div, onResizeCb],
     );
 
-    // Trigger resize on new Goban and subsequent "load" events
+    // Trigger resize on createGoban and subsequent "load" events
     //generateGobanHook(() => onResize(/* no_debounce */ true, /* do_cb */ false))(goban || null);
 
     if (!goban || !goban_div) {

--- a/src/components/GobanLineSummary/GobanLineSummary.tsx
+++ b/src/components/GobanLineSummary/GobanLineSummary.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import { interpolate } from "translate";
-import { Goban } from "goban";
+import { createGoban, GobanRenderer } from "goban";
 import * as data from "data";
 import { rankString } from "rank_utils";
 import { Player } from "Player";
@@ -41,7 +41,7 @@ interface GobanLineSummaryProps {
     black: UserType;
     white: UserType;
     player?: { id: number };
-    gobanRef?: (goban: Goban) => void;
+    gobanRef?: (goban: GobanRenderer) => void;
     width?: number;
     height?: number;
     rengo_teams?: {
@@ -62,7 +62,7 @@ export class GobanLineSummary extends React.Component<
     GobanLineSummaryProps,
     GobanLineSummaryState
 > {
-    goban!: Goban;
+    goban!: GobanRenderer;
 
     constructor(props: GobanLineSummaryProps) {
         super(props);
@@ -100,7 +100,7 @@ export class GobanLineSummary extends React.Component<
          */
 
         requestAnimationFrame(() => {
-            this.goban = new Goban({
+            this.goban = createGoban({
                 board_div: undefined,
                 draw_top_labels: false,
                 draw_bottom_labels: false,

--- a/src/components/MiniGoban/MiniGoban.tsx
+++ b/src/components/MiniGoban/MiniGoban.tsx
@@ -20,7 +20,7 @@ import { Link } from "react-router-dom";
 import { npgettext, interpolate } from "translate";
 import * as moment from "moment";
 import * as preferences from "preferences";
-import { Goban } from "goban";
+import { GobanRenderer, createGoban } from "goban";
 import * as data from "data";
 import { PersistentElement } from "PersistentElement";
 import { getUserRating, PROVISIONAL_RATING_CUTOFF } from "rank_utils";
@@ -51,7 +51,7 @@ export interface MiniGobanProps {
     openLinksInNewTab?: boolean;
     noText?: boolean;
     title?: boolean;
-    onGobanCreated?: (goban: Goban) => void;
+    onGobanCreated?: (goban: GobanRenderer) => void;
     chat?: boolean;
 }
 
@@ -63,7 +63,7 @@ export function MiniGoban(props: MiniGobanProps): JSX.Element {
             return ret;
         })(),
     );
-    const goban = React.useRef<Goban>();
+    const goban = React.useRef<GobanRenderer>();
 
     const [white_points, setWhitePoints] = React.useState("");
     const [black_points, setBlackPoints] = React.useState("");
@@ -83,7 +83,7 @@ export function MiniGoban(props: MiniGobanProps): JSX.Element {
     const [last_move_opacity] = usePreference("last-move-opacity");
 
     React.useEffect(() => {
-        goban.current = new Goban(
+        goban.current = createGoban(
             {
                 board_div: goban_div.current,
                 draw_top_labels: false,

--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { computeAverageMoveTime, Goban, JGOFTimeControl } from "goban";
+import { computeAverageMoveTime, GobanRenderer, JGOFTimeControl } from "goban";
 import { _, pgettext, ngettext, interpolate } from "translate";
 import { TimeControl, TimeControlTypes } from "./TimeControl";
 
@@ -454,7 +454,7 @@ export function usedForCheating(_time_control: ValidTimeControlFormats) {
 
 export function lookingAtOurLiveGame(): boolean {
     // Is the current page looking at a game we are live playing in...
-    const goban = (window as any)["global_goban"] as Goban;
+    const goban = (window as any)["global_goban"] as GobanRenderer;
     if (!goban) {
         return false;
     }

--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -34,8 +34,8 @@ data.setDefault("custom.line", "#000000");
 data.setDefault("custom.url", "");
 
 export function configure_goban() {
-    data.watch("experiments.v6", () => {
-        const v = data.get("experiments.v6");
+    data.watch("experiments.svg", () => {
+        const v = data.get("experiments.svg");
         if (v === "enabled") {
             setGobanRenderer("svg");
         }

--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -20,10 +20,10 @@ import * as data from "data";
 import * as Sentry from "@sentry/browser";
 import { get_clock_drift, get_network_latency, socket } from "sockets";
 import { current_language } from "translate";
-import { Goban, GobanCore, GoEngine, GoThemes } from "goban";
+import { GobanCore, GoEngine, GoThemes, setGobanRenderer } from "goban";
 import { sfx } from "sfx";
 
-(window as any)["Goban"] = Goban;
+//(window as any)["Goban"] = Goban;
 (window as any)["GoThemes"] = GoThemes;
 (window as any)["GoEngine"] = GoEngine;
 
@@ -34,7 +34,14 @@ data.setDefault("custom.line", "#000000");
 data.setDefault("custom.url", "");
 
 export function configure_goban() {
-    Goban.setHooks({
+    data.watch("experiments.v6", () => {
+        const v = data.get("experiments.v6");
+        if (v === "enabled") {
+            setGobanRenderer("svg");
+        }
+    });
+
+    GobanCore.setHooks({
         defaultConfig: () => {
             return {
                 server_socket: socket,

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -223,17 +223,18 @@ export function getSelectedThemes(): { board: string; black: string; white: stri
     const default_plain = $(window).width() * (window.devicePixelRatio || 1) <= 768;
 
     let board = get("goban-theme-board") || (default_plain ? "Plain" : "Kaya");
-    let white = get("goban-theme-white") || (default_plain ? "Plain" : "Shell");
-    let black = get("goban-theme-black") || (default_plain ? "Plain" : "Slate");
+    let white = get("goban-theme-white") || (default_plain ? "Plain" : "Plain");
+    let black = get("goban-theme-black") || (default_plain ? "Plain" : "Plain");
 
     if (!(board in GoThemes["board"])) {
         board = default_plain ? "Plain" : "Kaya";
     }
     if (!(white in GoThemes["white"])) {
-        white = default_plain ? "Plain" : "Shell";
+        white = default_plain ? "Plain" : "Plain";
     }
     if (!(black in GoThemes["black"])) {
-        black = default_plain ? "Plain" : "Slate";
+        console.log("Theme ", black, "didn't exist, so resetting");
+        black = default_plain ? "Plain" : "Plain";
     }
 
     return {

--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -16,7 +16,7 @@
  */
 
 import Debug from "debug";
-import { GobanSocket, protocol, Goban, JGOFTimeControl } from "goban";
+import { GobanSocket, protocol, GobanRenderer, JGOFTimeControl } from "goban";
 import { lookingAtOurLiveGame } from "TimeControl/util";
 
 const debug = new Debug("sockets");
@@ -95,7 +95,7 @@ socket.on("latency", (latency, drift) => {
     // If they are playing a live game at the moment, work out what timing they would like
     // us to make sure that they have...
     if (lookingAtOurLiveGame()) {
-        const goban = (window as any)["global_goban"] as Goban;
+        const goban = (window as any)["global_goban"] as GobanRenderer;
         const time_control = goban.engine.time_control as JGOFTimeControl;
         switch (time_control.system) {
             case "fischer":

--- a/src/views/Game/AIDemoReview.tsx
+++ b/src/views/Game/AIDemoReview.tsx
@@ -22,7 +22,7 @@ import { Toggle } from "Toggle";
 import { uuid } from "misc";
 import * as preferences from "preferences";
 import { usePreference } from "preferences";
-import { JGOFNumericPlayerColor, ColoredCircle, MoveTree, Goban } from "goban";
+import { JGOFNumericPlayerColor, ColoredCircle, MoveTree, GobanRenderer } from "goban";
 import { useUser } from "hooks";
 
 const cached_data: { [review_id: number]: { [board_string: string]: any } } = {};
@@ -36,7 +36,7 @@ export function AIDemoReview({
     goban,
     controller,
 }: {
-    goban: Goban;
+    goban: GobanRenderer;
     controller: number;
 }): JSX.Element | null {
     const user = useUser();
@@ -324,7 +324,7 @@ function stringifyBoardState(move: MoveTree): string {
     return move.state.board.reduce((a, b) => a + b.reduce((a, b) => a + b, ""), "");
 }
 
-function clearAnalysis(goban: Goban) {
+function clearAnalysis(goban: GobanRenderer) {
     goban.setMarks({}, true); /* draw the remaining AI sequence as ghost marks, if any */
     goban.setHeatmap(undefined, true);
     goban.setColoredCircles([], false);
@@ -334,7 +334,7 @@ function computePrediction(data: any): any {
     return { score: data.analysis.score, win_rate: data.analysis.win_rate };
 }
 
-function renderAnalysis(goban: Goban, data: any) {
+function renderAnalysis(goban: GobanRenderer, data: any) {
     if (!preferences.get("ai-review-enabled")) {
         return;
     }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -28,9 +28,9 @@ import { KBShortcut } from "KBShortcut";
 import { UIPush } from "UIPush";
 import { errorAlerter, ignore, rulesText } from "misc";
 import {
-    Goban,
-    GobanCanvas,
-    GobanCanvasConfig,
+    createGoban,
+    GobanRenderer,
+    GobanRendererConfig,
     GoMath,
     MoveTree,
     AudioClockEvent,
@@ -99,7 +99,7 @@ export function Game(): JSX.Element | null {
     const copied_node = React.useRef<MoveTree>();
     const white_username = React.useRef<string>("White");
     const black_username = React.useRef<string>("Black");
-    const goban = React.useRef<Goban | null>(null);
+    const goban = React.useRef<GobanRenderer | null>(null);
     const return_url_debounce = React.useRef<boolean>(false);
     const last_phase = React.useRef<string>("");
     const page_loaded_time = React.useRef<number>(Date.now()); // when we first created this view
@@ -1041,7 +1041,7 @@ export function Game(): JSX.Element | null {
     const setMoveTreeContainer = (resizable: Resizable): void => {
         ref_move_tree_container.current = resizable ? resizable.div ?? undefined : undefined;
         if (goban.current && ref_move_tree_container.current) {
-            (goban.current as GobanCanvas).setMoveTreeContainer(ref_move_tree_container.current);
+            (goban.current as GobanRenderer).setMoveTreeContainer(ref_move_tree_container.current);
         }
     };
 
@@ -1073,7 +1073,7 @@ export function Game(): JSX.Element | null {
         document.addEventListener("keypress", setLabelHandler);
 
         const label_position = preferences.get("label-positioning");
-        const opts: GobanCanvasConfig = {
+        const opts: GobanRendererConfig = {
             board_div: goban_div.current,
             move_tree_container: ref_move_tree_container.current,
             interactive: true,
@@ -1107,7 +1107,7 @@ export function Game(): JSX.Element | null {
                 goban.current?.review_controller_id === data.get("user").id;
         }
 
-        goban.current = new Goban(opts);
+        goban.current = createGoban(opts);
 
         onResize(true);
         (window as any)["global_goban"] = goban.current;
@@ -1772,7 +1772,7 @@ export function Game(): JSX.Element | null {
     );
 }
 
-function bindAudioEvents(goban: Goban): void {
+function bindAudioEvents(goban: GobanRenderer): void {
     // called by init
     const user = data.get("user");
 

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -24,7 +24,7 @@ import { Link } from "react-router-dom";
 import { _, pgettext, interpolate, current_language } from "translate";
 import { Player } from "Player";
 import { profanity_filter } from "profanity_filter";
-import { Goban, GobanCore, protocol } from "goban";
+import { GobanRenderer, GobanCore, protocol } from "goban";
 import { ChatUserList, ChatUserCount } from "ChatUserList";
 import { TabCompleteInput } from "TabCompleteInput";
 import { chat_markup } from "components/Chat";
@@ -329,7 +329,7 @@ export function GameChat(props: GameChatProperties): JSX.Element {
 
 interface QuickChatProperties {
     selected_chat_log: ChatMode;
-    goban: Goban;
+    goban: GobanRenderer;
     onSend: () => void;
 }
 

--- a/src/views/Game/GameDock.test.tsx
+++ b/src/views/Game/GameDock.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import * as React from "react";
 import { GameDock } from "./GameDock";
-import { Goban } from "goban";
+import { createGoban } from "goban";
 import { GobanContext } from "./goban_context";
 import { BrowserRouter as Router } from "react-router-dom";
 import * as data from "data";
@@ -59,7 +59,7 @@ const BASE_PROPS = {
 
 test("providing both Game ID and Review ID cause SGF buttons to link to review SGFs", () => {
     data.set("user", TEST_USER);
-    const goban = new Goban({ game_id: 123456, review_id: 123 });
+    const goban = createGoban({ game_id: 123456, review_id: 123 });
 
     render(
         <Router>

--- a/src/views/Game/GameLinkModal.tsx
+++ b/src/views/Game/GameLinkModal.tsx
@@ -18,13 +18,13 @@
 import * as React from "react";
 import { pgettext, _ } from "translate";
 import { openModal, Modal } from "Modal";
-import { Goban } from "goban";
+import { GobanRenderer } from "goban";
 import { Player } from "Player";
 
 interface Events {}
 
 interface GameLinkModalProperties {
-    goban: Goban;
+    goban: GobanRenderer;
 }
 
 export class GameLinkModal extends Modal<Events, GameLinkModalProperties, {}> {
@@ -97,7 +97,7 @@ export class GameLinkModal extends Modal<Events, GameLinkModalProperties, {}> {
     }
 }
 
-function AnimatedPngCreator({ goban }: { goban: Goban }): JSX.Element {
+function AnimatedPngCreator({ goban }: { goban: GobanRenderer }): JSX.Element {
     const engine = goban.engine;
     const MAX_MOVES = 30;
     const NUM_MOVES = engine?.last_official_move.move_number || 1;
@@ -198,7 +198,7 @@ function AnimatedPngCreator({ goban }: { goban: Goban }): JSX.Element {
     );
 }
 
-export function openGameLinkModal(goban: Goban): void {
+export function openGameLinkModal(goban: GobanRenderer): void {
     openModal(<GameLinkModal goban={goban} fastDismiss />);
 }
 

--- a/src/views/Game/PlayButtons.test.tsx
+++ b/src/views/Game/PlayButtons.test.tsx
@@ -1,4 +1,4 @@
-import { AdHocPackedMove, Goban } from "goban";
+import { AdHocPackedMove, createGoban, GobanRenderer } from "goban";
 import { CancelButton, PlayButtons } from "./PlayButtons";
 import { act, cleanup, fireEvent, render, screen /* waitFor */ } from "@testing-library/react";
 import * as React from "react";
@@ -66,7 +66,7 @@ afterEach(() => {
 
 describe("CancelButton", () => {
     test('says "Cancel game" in the first 6 moves.', () => {
-        const goban = new Goban(LESS_THAN_SIX_MOVES);
+        const goban = createGoban(LESS_THAN_SIX_MOVES);
 
         render(
             <GobanContext.Provider value={goban}>
@@ -79,7 +79,7 @@ describe("CancelButton", () => {
     });
 
     test('says "Resign" after 6 moves', () => {
-        const goban = new Goban(MORE_THAN_SIX_MOVES);
+        const goban = createGoban(MORE_THAN_SIX_MOVES);
 
         render(
             <GobanContext.Provider value={goban}>
@@ -92,7 +92,7 @@ describe("CancelButton", () => {
     });
 
     test('changes to "Resign" on the 6th move.', () => {
-        const goban = new Goban({
+        const goban = createGoban({
             // 5 moves
             moves: [
                 [16, 3, 9136.12],
@@ -129,7 +129,7 @@ describe("CancelButton", () => {
     uncomment this test after upgrading...
 
     test("allows user to cancel before 6 moves.", async () => {
-        const goban = new Goban(LESS_THAN_SIX_MOVES);
+        const goban = createGoban(LESS_THAN_SIX_MOVES);
         const cancel_spy = spyOn(goban, "cancelGame");
 
         render(
@@ -148,7 +148,7 @@ describe("CancelButton", () => {
     });
 
     test("allows user to resign after 6 moves.", async () => {
-        const goban = new Goban(MORE_THAN_SIX_MOVES);
+        const goban = createGoban(MORE_THAN_SIX_MOVES);
         const resign_spy = spyOn(goban, "resign");
 
         render(
@@ -167,7 +167,7 @@ describe("CancelButton", () => {
     });
 
     test("allows user to abandon in casual rengo.", async () => {
-        const goban = new Goban({
+        const goban = createGoban({
             ...MORE_THAN_SIX_MOVES,
             rengo: true,
             rengo_teams: {
@@ -197,7 +197,7 @@ describe("CancelButton", () => {
     });
 
     test("allows user to change their mind", async () => {
-        const goban = new Goban(MORE_THAN_SIX_MOVES);
+        const goban = createGoban(MORE_THAN_SIX_MOVES);
         const resign_spy = spyOn(goban, "resign");
 
         render(
@@ -218,7 +218,7 @@ describe("CancelButton", () => {
     */
 });
 
-function WrapTest(props: { goban: Goban; children: any }): JSX.Element {
+function WrapTest(props: { goban: GobanRenderer; children: any }): JSX.Element {
     return (
         <OgsHelpProvider>
             <GobanContext.Provider value={props.goban}>{props.children}</GobanContext.Provider>
@@ -228,7 +228,7 @@ function WrapTest(props: { goban: Goban; children: any }): JSX.Element {
 
 describe("PlayButtons", () => {
     test("normal game when it's my opponent's turn.", () => {
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -257,7 +257,7 @@ describe("PlayButtons", () => {
     });
 
     test("normal game when it's my turn.", () => {
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -287,7 +287,7 @@ describe("PlayButtons", () => {
     });
 
     test('shows "Accept Undo" when opponent requested an undo.', () => {
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -317,7 +317,7 @@ describe("PlayButtons", () => {
     });
 
     test('shows "Accept undo" if undo was requested after initial render', () => {
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -350,7 +350,7 @@ describe("PlayButtons", () => {
     });
 
     test('shows "Submit Move" when user staged a move.', () => {
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -387,7 +387,7 @@ describe("PlayButtons", () => {
     });
 
     test("Don't show undo for rengo", () => {
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -417,7 +417,7 @@ describe("PlayButtons", () => {
     });
 
     test("Don't show undo on the first move", () => {
-        const goban = new Goban({
+        const goban = createGoban({
             players: {
                 black: { id: LOGGED_IN_USER.id, username: LOGGED_IN_USER.username },
                 white: { id: 456, username: "test_user2" },
@@ -441,7 +441,7 @@ describe("PlayButtons", () => {
     });
 
     test("Don't show undo if analyzing the game", () => {
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -470,7 +470,7 @@ describe("PlayButtons", () => {
 
     test("Don't show accept undo if analyzing the game", () => {
         console.log("test started");
-        const goban = new Goban({
+        const goban = createGoban({
             moves: [
                 [16, 3, 9136.12], // B
                 [3, 2, 1897.853], // W
@@ -502,7 +502,7 @@ describe("PlayButtons", () => {
     });
 
     test("forked game where it's the first move, white to play, my move.", () => {
-        const goban = new Goban({
+        const goban = createGoban({
             initial_player: "white",
             players: {
                 black: { id: 456, username: "test_user2" },

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -1,4 +1,4 @@
-import { Goban, GoConditionalMove } from "goban";
+import { createGoban, GobanRenderer, GoConditionalMove } from "goban";
 import { PlayControls } from "./PlayControls";
 import { render, screen } from "@testing-library/react";
 import * as React from "react";
@@ -77,7 +77,7 @@ const PLAY_CONTROLS_DEFAULTS = {
     },
 } as const;
 
-function WrapTest(props: { goban: Goban; children: any }): JSX.Element {
+function WrapTest(props: { goban: GobanRenderer; children: any }): JSX.Element {
     return (
         <OgsHelpProvider>
             <Router>
@@ -88,7 +88,7 @@ function WrapTest(props: { goban: Goban; children: any }): JSX.Element {
 }
 
 test("No moves have been played", () => {
-    const goban = new Goban({
+    const goban = createGoban({
         game_id: 1234,
         // TEST_USER must be a member of the game in order for cancel to show up.
         players: {
@@ -112,7 +112,7 @@ test("No moves have been played", () => {
 });
 
 test("Don't render play buttons if user is not a player", () => {
-    const goban = new Goban({ game_id: 1234 });
+    const goban = createGoban({ game_id: 1234 });
     data.set("user", TEST_USER);
 
     render(
@@ -129,7 +129,7 @@ test("Don't render play buttons if user is not a player", () => {
 });
 
 test("Renders undo if it is not the players turn", () => {
-    const goban = new Goban({
+    const goban = createGoban({
         game_id: 1234,
         // Need to play at least one move before Undo button shows up
         moves: [
@@ -157,7 +157,7 @@ test("Renders undo if it is not the players turn", () => {
 });
 
 test("Renders accept undo if undo requested", () => {
-    const goban = new Goban({
+    const goban = createGoban({
         game_id: 1234,
         // Need to play at least one move before Undo button shows up
         moves: [
@@ -187,7 +187,7 @@ test("Renders accept undo if undo requested", () => {
 });
 
 test("Renders Pass if it is the user's turn", () => {
-    const goban = new Goban({
+    const goban = createGoban({
         game_id: 1234,
         moves: [
             [15, 15, 5241],
@@ -233,7 +233,7 @@ function makeConditionalMoveTree() {
 }
 
 test("Renders conditional moves", () => {
-    const goban = new Goban({
+    const goban = createGoban({
         game_id: 1234,
         moves: [],
         players: {
@@ -256,10 +256,10 @@ test("Renders conditional moves", () => {
 });
 
 test("Unsubscribe from all events on unmount", () => {
-    const goban = new Goban({ game_id: 1234 });
+    const goban = createGoban({ game_id: 1234 });
     data.set("user", TEST_USER);
 
-    const getListenerCounts = (emitter: Goban) =>
+    const getListenerCounts = (emitter: GobanRenderer) =>
         Object.fromEntries(emitter.eventNames().map((key) => [key, emitter.listenerCount(key)]));
 
     // Goban may set up listeners on itself
@@ -276,7 +276,7 @@ test("Unsubscribe from all events on unmount", () => {
 });
 
 test("Pause buttons show up", () => {
-    const goban = new Goban({
+    const goban = createGoban({
         game_id: 1234,
         // TEST_USER must be a member of the game in order for cancel to show up.
         players: {

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -21,7 +21,7 @@ import * as DynamicHelp from "react-dynamic-help";
 import * as data from "data";
 import {
     ConditionalMoveTree,
-    Goban,
+    GobanRenderer,
     GobanCore,
     GoConditionalMove,
     GobanModes,
@@ -826,7 +826,7 @@ export function AnalyzeButtonBar({
 }
 
 export function copyBranch(
-    goban: Goban,
+    goban: GobanRenderer,
     copied_node: React.MutableRefObject<MoveTree | undefined>,
     mode: GobanModes,
 ) {
@@ -847,7 +847,7 @@ export function copyBranch(
     toast(<div>{_("Branch copied")}</div>, 1000);
 }
 export function pasteBranch(
-    goban: Goban,
+    goban: GobanRenderer,
     copied_node: React.MutableRefObject<MoveTree | undefined>,
     mode: GobanModes,
 ) {
@@ -893,7 +893,7 @@ export function pasteBranch(
     }
 }
 
-export function deleteBranch(goban: Goban, mode: GobanModes) {
+export function deleteBranch(goban: GobanRenderer, mode: GobanModes) {
     if (mode !== "analyze") {
         return;
     }
@@ -1247,7 +1247,7 @@ function diffToConditionalMove(moves: string): GoConditionalMove {
 
 // Copies branch to conditional move planner (only copies up to the selected
 // move). Should only be called in analyze mode.
-function automateBranch(goban: Goban): void {
+function automateBranch(goban: GobanRenderer): void {
     if (goban.engine.phase === "finished") {
         return;
     }

--- a/src/views/Game/PlayerCards.test.tsx
+++ b/src/views/Game/PlayerCards.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import * as React from "react";
 import { PlayerCard } from "./PlayerCards";
-import { Goban } from "goban";
+import { createGoban } from "goban";
 import { GobanContext } from "./goban_context";
 import { BrowserRouter as Router } from "react-router-dom";
 import * as data from "data";
@@ -53,7 +53,7 @@ test("make sure komi is displayed for white", () => {
     data.set("preferences.moderator.hide-flags", false);
     data.set("preferences.moderator.hide-player-card-mod-controls", false);
 
-    const goban = new Goban({ game_id: 123456, komi: 5 });
+    const goban = createGoban({ game_id: 123456, komi: 5 });
 
     const props = { goban: goban, ...BASE_PROPS };
 
@@ -74,7 +74,7 @@ test("make sure komi is not displayed for black", () => {
     data.set("preferences.moderator.hide-flags", false);
     data.set("preferences.moderator.hide-player-card-mod-controls", false);
 
-    const goban = new Goban({ game_id: 123456, komi: 5 });
+    const goban = createGoban({ game_id: 123456, komi: 5 });
 
     const props = { goban: goban, ...BASE_PROPS, color: "black" as const };
 

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import { get } from "requests";
 
-import { Goban, GobanCore, PlayerScore, JGOFPlayerSummary } from "goban";
+import { GobanRenderer, GobanCore, PlayerScore, JGOFPlayerSummary } from "goban";
 import { icon_size_url } from "PlayerIcon";
 import { CountDown } from "./CountDown";
 import { Flag } from "Flag";
@@ -181,7 +181,7 @@ const useScore = generateGobanHook(
 );
 interface PlayerCardProps {
     color: "black" | "white";
-    goban: Goban;
+    goban: GobanRenderer;
     historical: PlayerType | null;
     estimating_score: boolean;
     show_score_breakdown: boolean;

--- a/src/views/Game/goban_context.ts
+++ b/src/views/Game/goban_context.ts
@@ -16,16 +16,16 @@
  */
 
 import * as React from "react";
-import { Goban } from "goban";
+import { GobanRenderer } from "goban";
 
-export const GobanContext = React.createContext<Goban | null>(null);
+export const GobanContext = React.createContext<GobanRenderer | null>(null);
 
 /**
  * A React hook that provides the goban.
  *
  * Throws if a goban is not set.
  */
-export function useGoban(): Goban {
+export function useGoban(): GobanRenderer {
     const goban = React.useContext(GobanContext);
 
     if (goban === null) {

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -29,7 +29,7 @@ import * as data from "data";
 import { _, interpolate, pgettext, npgettext } from "translate";
 import { get, put, post } from "requests";
 import { KBShortcut } from "KBShortcut";
-import { Goban, GoMath, GobanConfig, JGOFMove } from "goban";
+import { GobanRenderer, GoMath, GobanRendererConfig, JGOFMove, createGoban } from "goban";
 import { AutoTranslate } from "AutoTranslate";
 import { Markdown } from "Markdown";
 import { chat_manager } from "chat_manager";
@@ -194,7 +194,7 @@ interface JosekiState {
 }
 
 class _Joseki extends React.Component<JosekiProps, JosekiState> {
-    goban!: Goban;
+    goban!: GobanRenderer;
     goban_div: HTMLDivElement;
     goban_opts: any = {};
     goban_container!: HTMLDivElement;
@@ -322,7 +322,7 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
             this.goban.destroy();
         }
 
-        const opts: GobanConfig = {
+        const opts: GobanRendererConfig = {
             board_div: this.goban_div,
             interactive: true,
             mode: "puzzle",
@@ -335,7 +335,7 @@ class _Joseki extends React.Component<JosekiProps, JosekiState> {
             opts["moves"] = initial_position as any;
         }
         this.goban_opts = opts;
-        this.goban = new Goban(opts);
+        this.goban = createGoban(opts);
         this.goban.setMode("puzzle");
         this.goban.on("update", () => this.onBoardUpdate());
         (window as any)["global_goban"] = this.goban;

--- a/src/views/LearningHub/InstructionalGoban.tsx
+++ b/src/views/LearningHub/InstructionalGoban.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import { Goban } from "goban";
+import { createGoban, GobanRenderer } from "goban";
 import { sfx } from "sfx";
 import { PersistentElement } from "PersistentElement";
 
@@ -31,7 +31,7 @@ interface InstructionalGobanProps {
 
 export class InstructionalGoban extends React.Component<InstructionalGobanProps> {
     goban_div: HTMLDivElement;
-    goban?: Goban;
+    goban?: GobanRenderer;
 
     constructor(props: InstructionalGobanProps) {
         super(props);
@@ -61,7 +61,7 @@ export class InstructionalGoban extends React.Component<InstructionalGobanProps>
     }
 
     initialize() {
-        this.goban = new Goban(
+        this.goban = createGoban(
             {
                 board_div: this.goban_div,
                 initial_player: "black",

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -25,7 +25,7 @@ import { KBShortcut } from "KBShortcut";
 import { goban_view_mode, goban_view_squashed } from "Game";
 import { errorAlerter, errorLogger, ignore } from "misc";
 import { longRankString, rankList } from "rank_utils";
-import { Goban, GobanCanvas, GobanCanvasConfig, PuzzlePlacementSetting } from "goban";
+import { createGoban, GobanRenderer, GobanRendererConfig, PuzzlePlacementSetting } from "goban";
 import { Markdown } from "Markdown";
 import { Player } from "Player";
 import { StarRating } from "StarRating";
@@ -100,7 +100,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
     ref_hint_button: React.RefObject<HTMLButtonElement>;
     ref_toggle_coordinates_button?: React.RefObject<HTMLButtonElement>;
 
-    goban!: Goban;
+    goban!: GobanRenderer;
     goban_div: HTMLDivElement;
     goban_opts: any = {};
     solve_time_start: number = Date.now();
@@ -276,7 +276,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
     }
 
     reset(editing?: boolean) {
-        const opts: GobanCanvasConfig = this.editor.reset(
+        const opts: GobanRendererConfig = this.editor.reset(
             this.goban_div,
             !!editing,
             this.replacementSettingFunction.bind(this),
@@ -285,7 +285,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
         opts.move_tree_container = this.ref_move_tree_container;
         this.goban_opts = opts;
 
-        this.goban = new Goban(opts);
+        this.goban = createGoban(opts);
         this.goban.setMode("puzzle");
         (window as any)["global_goban"] = this.goban;
         this.goban.on("update", () => this.onUpdate());
@@ -647,7 +647,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
     setMoveTreeContainer = (resizable: Resizable): void => {
         this.ref_move_tree_container = resizable?.div ? resizable.div : undefined;
         if (this.goban && this.ref_move_tree_container) {
-            (this.goban as GobanCanvas).setMoveTreeContainer(this.ref_move_tree_container);
+            (this.goban as GobanRenderer).setMoveTreeContainer(this.ref_move_tree_container);
         }
     };
     toggleCoordinates = () => {

--- a/src/views/Puzzle/PuzzleEditing.ts
+++ b/src/views/Puzzle/PuzzleEditing.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GobanCanvasConfig, GoMath, PuzzleConfig, PuzzlePlacementSetting } from "goban";
+import { GobanRendererConfig, GoMath, PuzzleConfig, PuzzlePlacementSetting } from "goban";
 import { errorAlerter, dup } from "misc";
 import { PuzzleTransform } from "./PuzzleTransform";
 import { _Puzzle } from "./Puzzle";
@@ -214,7 +214,7 @@ export class PuzzleEditor {
         goban_div: HTMLDivElement,
         editing: boolean,
         replacementSettingsFunction: () => PuzzlePlacementSetting,
-    ): GobanCanvasConfig {
+    ): GobanRendererConfig {
         const puzzle = (this.puzzle_config = dup(this.orig_puzzle_config));
 
         if (!puzzle) {
@@ -237,7 +237,7 @@ export class PuzzleEditor {
             goban_div.removeChild(goban_div.firstChild);
         }
 
-        const opts: GobanCanvasConfig = Object.assign(
+        const opts: GobanRendererConfig = Object.assign(
             {
                 board_div: goban_div,
                 interactive: true,

--- a/src/views/Puzzle/PuzzleNavigation.ts
+++ b/src/views/Puzzle/PuzzleNavigation.ts
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Goban } from "goban";
+import { GobanRenderer } from "goban";
 
 export class PuzzleNavigation {
-    _goban!: Goban;
+    _goban!: GobanRenderer;
 
-    set goban(newValue: Goban) {
+    set goban(newValue: GobanRenderer) {
         this._goban = newValue;
     }
 

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -37,7 +37,7 @@ import {
     LogEntry,
     LogData,
 } from "Game";
-import { Goban } from "goban";
+import { GobanRenderer } from "goban";
 import { Resizable } from "Resizable";
 import { socket } from "sockets";
 import { Player } from "Player";
@@ -53,10 +53,10 @@ export function ReportedGame({
     game_id: number;
     reported_at: number | undefined;
 }): JSX.Element | null {
-    const [goban, setGoban] = React.useState<Goban | null>(null);
+    const [goban, setGoban] = React.useState<GobanRenderer | null>(null);
     const [selectedChatLog, setSelectedChatLog] = React.useState<ChatMode>("main");
     const refresh = useRefresh();
-    const onGobanCreated = React.useCallback((goban: Goban) => {
+    const onGobanCreated = React.useCallback((goban: GobanRenderer) => {
         setGoban(goban);
     }, []);
     const cur_move = useCurrentMove(goban);
@@ -279,7 +279,7 @@ export function ReportedGame({
     );
 }
 
-function GameLog({ goban }: { goban: Goban }): JSX.Element {
+function GameLog({ goban }: { goban: GobanRenderer }): JSX.Element {
     const [log, setLog] = React.useState<LogEntry[]>([]);
     const game_id = goban.engine.game_id;
 

--- a/src/views/ReportsCenter/ScoringEventThumbnail.tsx
+++ b/src/views/ReportsCenter/ScoringEventThumbnail.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GoMath, Goban, GobanConfig } from "goban";
+import { GoMath, GobanRenderer, GobanRendererConfig, createGoban } from "goban";
 import React from "react";
 import { PersistentElement } from "../../components/PersistentElement";
 
@@ -25,7 +25,7 @@ export function ScoringEventThumbnail({
     move_number,
     removal_string,
 }: {
-    config: GobanConfig;
+    config: GobanRendererConfig;
     move_number: number | undefined;
     removal_string: string | undefined;
 }) {
@@ -36,10 +36,10 @@ export function ScoringEventThumbnail({
             return ret;
         })(),
     );
-    const goban = React.useRef<Goban>();
+    const goban = React.useRef<GobanRenderer>();
 
     React.useEffect(() => {
-        goban.current = new Goban({
+        goban.current = createGoban({
             ...config,
             board_div: goban_div.current,
             server_socket: undefined,

--- a/src/views/Settings/GeneralPreferences.tsx
+++ b/src/views/Settings/GeneralPreferences.tsx
@@ -71,6 +71,9 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
     const [enable_v6, setEnableV6]: [boolean, (x: boolean) => void] = React.useState(
         data.get("experiments.v6") === "enabled",
     );
+    const [enable_svg, setEnableSVG]: [boolean, (x: boolean) => void] = React.useState(
+        data.get("experiments.svg") === "enabled",
+    );
     const [show_slow_internet_warning, setShowSlowInternetWarning] = usePreference(
         "show-slow-internet-warning",
     );
@@ -314,6 +317,16 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
                     onChange={(tf) => {
                         data.set("experiments.v6", tf ? "enabled" : undefined);
                         setEnableV6(tf);
+                    }}
+                />
+            </PreferenceLine>
+
+            <PreferenceLine title={"Enable SVG goban renderer"}>
+                <Toggle
+                    checked={enable_svg}
+                    onChange={(tf) => {
+                        data.set("experiments.svg", tf ? "enabled" : undefined);
+                        setEnableSVG(tf);
                     }}
                 />
             </PreferenceLine>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,10 +5939,10 @@ glogg@^2.2.0:
   dependencies:
     sparkles "^2.1.0"
 
-goban@=0.7.41:
-  version "0.7.41"
-  resolved "https://registry.yarnpkg.com/goban/-/goban-0.7.41.tgz#227acc1239501075d0a31e99df7c2a39c6abe96c"
-  integrity sha512-1Lkw120Mio0YB0+rLPo111saVq4eSvWKNyrkk0tSo3lPJY+rHA7h5IlVUiRQZzfGTqF3kPBTqCP8SSAPRYqxjg==
+goban@=0.7.42:
+  version "0.7.42"
+  resolved "https://registry.yarnpkg.com/goban/-/goban-0.7.42.tgz#2b2272d4f53033cb416ee97f6152c9e5914e946a"
+  integrity sha512-l2cmpuZQovzlGll1f9vldiZbnfQue1/gsch4AQP2cbi9l59vJVyI2NJ9l1SBhwfbAHgycDpBbgssxTtwsK7RJA==
   dependencies:
     eventemitter3 "^5.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,10 +5939,10 @@ glogg@^2.2.0:
   dependencies:
     sparkles "^2.1.0"
 
-goban@=0.7.40:
-  version "0.7.40"
-  resolved "https://registry.yarnpkg.com/goban/-/goban-0.7.40.tgz#9d5b62c637b7071ca661a2b30333de4de4e62f54"
-  integrity sha512-vCqo2LHTVDpLu/aXF1hbXVrGUv4UTWjdLRmLYskO5yFo3raRWHGFI6ngpUY39Dy6MTPblJk6aWukTxulfJ5WrQ==
+goban@=0.7.41:
+  version "0.7.41"
+  resolved "https://registry.yarnpkg.com/goban/-/goban-0.7.41.tgz#227acc1239501075d0a31e99df7c2a39c6abe96c"
+  integrity sha512-1Lkw120Mio0YB0+rLPo111saVq4eSvWKNyrkk0tSo3lPJY+rHA7h5IlVUiRQZzfGTqF3kPBTqCP8SSAPRYqxjg==
   dependencies:
     eventemitter3 "^5.0.0"
 


### PR DESCRIPTION
This adds support for using the new `GobanSVG` renderer if the `Enable experimental interface changes` toggle is switched on.

This will be mergeable once https://github.com/online-go/goban/pull/159 is merged.