### PR TITLE
Added support for "not escaping, cancelled" CM vote option

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -156,6 +156,19 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
         Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
+    not_escaping_cancel: (reported) =>
+        interpolate(
+            _(`
+            Thank you for bringing the possible instance of {{reported}} abandoning the game to
+            our attention. We looked into the game and see that they used "Cancel".
+
+            Players are allowed to "Cancel" a game during the first moves.
+
+            If you think the person is abusing this feature, please file a report with more details.
+
+            Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+            { reported },
+        ),
     warn_beginner_staller: (game_id) =>
         interpolate(
             _(`

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -34,6 +34,7 @@ declare namespace rest_api {
             | "ack_warned_escaper"
             | "ack_warned_escaper_and_annul"
             | "no_escaping_evident"
+            | "not_escaping_cancel"
             | "warn_beginner_staller"
             | "warn_staller"
             | "ack_educated_beginner_staller"

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -71,6 +71,10 @@ const ACTION_PROMPTS = {
         "Label for a moderator to select this option",
         "No escaping evident - inform the reporter.",
     ),
+    not_escaping_cancel: pgettext(
+        "Label for a moderator to select this option",
+        "Not escaping, they used 'cancel'.",
+    ),
     annul_stalled: pgettext(
         "Label for a moderator to select this option",
         "Wrong result due to stalling - annul game, warn the staller.",


### PR DESCRIPTION
Fixes CMs not being able to explain that cancel is OK

## Proposed Changes

  - Add a "not escaping, they cancelled" vote option
  
  
