### PR TITLE
Better canned message format

### DIFF
--- a/src/components/AccountWarning/AccountWarning.styl
+++ b/src/components/AccountWarning/AccountWarning.styl
@@ -25,6 +25,11 @@
     z-index: z.account-warning;
     background-color: rgba(0, 0, 0, 0.5);
 }
+
+.canned-message {
+    white-space: pre-line;
+}
+
 .AccountWarning {
     position: fixed;
     top: auto;
@@ -50,7 +55,6 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-
 
     .AutoTranslate {
         font-size: 1.5rem;
@@ -154,7 +158,4 @@
         cursor: pointer;
         margin-right: 1rem;
     }
-
-
-
 }

--- a/src/components/AccountWarning/AccountWarning.tsx
+++ b/src/components/AccountWarning/AccountWarning.tsx
@@ -95,7 +95,9 @@ function MessageTextRender(props: MessageTextRenderProps): JSX.Element {
     console.log("rendering", props);
     if (props.warning.message_id) {
         return (
-            <div>{CANNED_MESSAGES[props.warning.message_id](props.warning.interpolation_data)}</div>
+            <div className="canned-message">
+                {CANNED_MESSAGES[props.warning.message_id](props.warning.interpolation_data)}
+            </div>
         );
     } else {
         return (

--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -23,246 +23,263 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
     warn_beginner_score_cheat: (game_id) =>
         interpolate(
             _(`
-        It appears that you delayed the end of game #{{game_id}}, by clicking
-        on the board to change the score incorrectly.   This can frustrate your
-        opponent and prevent them from moving on to the next game.
+It appears that you delayed the end of game #{{game_id}}, by clicking \
+on the board to change the score incorrectly.   This can frustrate your \
+opponent and prevent them from moving on to the next game.
 
-        Since you are a new player, no action will be taken against
-        your account. We simply ask that you learn when to end a game.
+Since you are a new player, no action will be taken against \
+your account. We simply ask that you learn when to end a game.
 
-        Until you develop the experience to judge better, if your
-        opponent passes and there are no open borders between your
-        stones then you should also pass.
+Until you develop the experience to judge better, if your \
+opponent passes and there are no open borders between your \
+stones then you should also pass.
 
-        After passing, promptly accept the correct score.
+After passing, promptly accept the correct score.
 
-        If in doubt about this sort of situation. please ask for help in chat
-        or the forums.`),
+If in doubt about this sort of situation. please ask for help in chat \
+or the forums.`),
             { game_id },
         ),
     warn_score_cheat: (game_id) =>
         interpolate(
             _(`
-            We noticed that you incorrectly changed the score at the end of game #{{game_id}}.
+We noticed that you incorrectly changed the score at the end of game #{{game_id}}.
 
-            While this might be a genuine mistake, please review the game and be sure you understand the final score.
+While this might be a genuine mistake, please review the game and be sure you understand the final score.
 
-            In future, we hope that you will end your games properly by first closing all the borders of your territory and secondly by accepting the correct score immediately after passing. 
+In future, we hope that you will end your games properly by first closing all the borders of your territory \
+and secondly by accepting the correct score immediately after passing.
 
-            In case of a disagreement over what the correct score is, we ask you to contact a moderator.
+In case of a disagreement over what the correct score is, we ask you to contact a moderator.
 
-            Unfortunately, some users use this form of score manipulation to cheat, if this happens repeatedly we’ll have no alternative than to suspend your account.`),
+Unfortunately, some users use this form of score manipulation to cheat, if this happens repeatedly \
+we’ll have no alternative than to suspend your account.`),
             { game_id },
         ),
     ack_educated_beginner_score_cheat: (reported) =>
         interpolate(
             _(`
-            Thanks for the report about {{reported}}. It seems that person was a
-            complete beginner - we have tried to explain that games should
-            be ended correctly, to pass when their opponent passes, and to accept promptly,
-            trusting the auto-score.`),
+Thanks for the report about {{reported}}.
+
+It seems that person was a complete beginner - we have tried to explain that games should \
+be ended correctly, to pass when their opponent passes, and to accept promptly, \
+trusting the auto-score.`),
             { reported },
         ),
     ack_educated_beginner_score_cheat_and_annul: (reported) =>
         interpolate(
             _(`
-            Thanks for the report about {{reported}}. It seems that person was a
-            complete beginner - we have tried to explain that games should
-            be ended correctly, to pass when their opponent passes, and to accept promptly,
-            trusting the auto-score.   That incorrectly scored game has been annulled.`),
+Thanks for the report about {{reported}}. 
+
+It seems that person was a complete beginner - we have tried to explain that games should \
+be ended correctly, to pass when their opponent passes, and to accept promptly, \
+trusting the auto-score.
+
+That incorrectly scored game has been annulled.`),
             { reported },
         ),
     ack_warned_score_cheat: (reported) =>
         interpolate(
             _(`
-        Thank you for your report, {{reported}} has been given a formal warning about scoring properly.`),
+Thank you for your report, {{reported}} has been given a formal warning about scoring properly.`),
             { reported },
         ),
     ack_warned_score_cheat_and_annul: (reported) =>
         interpolate(
             _(`
-            Thank you for your report, {{reported}} has been given a formal warning about scoring properly, and that cheated game annulled.`),
+Thank you for your report, {{reported}} has been given a formal warning about scoring properly, \
+and that cheated game annulled.`),
             reported,
         ),
     no_score_cheating_evident: (reported) =>
         interpolate(
             _(`
-        Thank you for bringing the possible instance of score cheating by {{reported}} to
-        our attention. We looked into the report and couldn't see evidence of score cheating.
+Thank you for bringing the possible instance of score cheating by {{reported}} to \
+our attention. We looked into the report and couldn't see evidence of score cheating.
 
-        It may be that you need to report a different type of problem, or provide more explanation -
-        you are welcome to raise a new report if that is the case.
+It may be that you need to report a different type of problem, or provide more explanation - \
+you are welcome to raise a new report if that is the case.
 
-        Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
     warn_beginner_escaper: (game_id) =>
         interpolate(
             _(`
-        Hi, welcome to OGS!
+Hi, welcome to OGS!
 
-        Please consider resigning games rather than letting them time out, as this is fairer to your opponents than making them wait for your clock to run out. Thank you.
+Please consider resigning games rather than letting them time out, as this is fairer to your opponents \
+than making them wait for your clock to run out. Thank you.
         `),
             { game_id },
         ),
     warn_escaper: (game_id) =>
         interpolate(
             _(`
-        It has come to our attention that you abandoned game #{{game_id}} and allowed it to time out rather than resigning.
+It has come to our attention that you abandoned game #{{game_id}} and allowed it to time out rather than resigning.
 
-        Players are required to end their games properly, as letting them time out can cause opponents to wait unnecessarily,
-        and prevent them from moving on to the next game.
+Players are required to end their games properly, as letting them time out can cause opponents to wait unnecessarily, \
+and prevent them from moving on to the next game.
 
-        Please ensure that you end your games properly by accepting the correct score immediately after passing,
-        or by resigning if you feel the position is hopeless.
+Please ensure that you end your games properly by accepting the correct score immediately after passing, \
+or by resigning if you feel the position is hopeless.
 
-        This helps maintain a positive gaming environment for everyone involved.`),
+This helps maintain a positive gaming environment for everyone involved.`),
             { game_id },
         ),
     ack_educated_beginner_escaper: (reported) =>
         interpolate(
             _(`
-        Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.`),
+Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.`),
             { reported },
         ),
     ack_educated_beginner_escaper_and_annul: (reported) =>
         interpolate(
             _(`
-        Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.
-        That incorrectly scored game has been annulled.`),
+Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.
+
+That incorrectly scored game has been annulled.`),
             { reported },
         ),
     ack_warned_escaper: (reported) =>
         interpolate(
             _(`
-        Thank you for your report, {{reported}} has been given a formal warning about finishing games properly.`),
+Thank you for your report, {{reported}} has been given a formal warning about finishing games properly.`),
             { reported },
         ),
     ack_warned_escaper_and_annul: (reported) =>
         interpolate(
             _(`
-        Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, and that abandoned game annulled.`),
+Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, \
+and that abandoned game annulled.`),
             reported,
         ),
     no_escaping_evident: (reported) =>
         interpolate(
             _(`
-        Thank you for bringing the possible instance of {{reported}} abandoning the game to
-        our attention. We looked into the game and did not see them failing to finish the game properly.
+Thank you for bringing the possible instance of {{reported}} abandoning the game to \
+our attention. 
 
-        It may be that you need to report a different type of problem, or provide more explanation -
-        you are welcome to raise a new report if that is the case.
+We looked into the game and did not see them failing to finish the game properly.
 
-        Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+It may be that you need to report a different type of problem, or provide more explanation - \
+you are welcome to raise a new report if that is the case.
+
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
     not_escaping_cancel: (reported) =>
         interpolate(
             _(`
-            Thank you for bringing the possible instance of {{reported}} abandoning the game to
-            our attention. We looked into the game and see that they used "Cancel".
+Thank you for bringing the possible instance of {{reported}} abandoning the game \
+to our attention.
 
-            Players are allowed to "Cancel" a game during the first moves.
+We looked into the game and see that they used "Cancel".
 
-            If you think the person is abusing this feature, please file a report with more details.
+Players are allowed to "Cancel" a game during the first moves.
 
-            Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+If you think the person is abusing this feature, please file a report with more details.
+
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
     warn_beginner_staller: (game_id) =>
         interpolate(
             _(`
-        Hi, welcome to OGS!
+Hi, welcome to OGS!
 
-        It appears that you delayed the end of game #{{game_id}}, which can frustrate your opponent and prevent them from moving on to the next game.
+It appears that you delayed the end of game #{{game_id}}, which can frustrate your opponent and \
+prevent them from moving on to the next game.
 
-        Since you are a new player, no action will be taken against your account. We simply ask that you learn when to end a game.
+Since you are a new player, no action will be taken against your account. We simply ask that you \
+learn when to end a game.
 
-        Until you develop the experience to judge better, if your opponent passes and there are no open borders between your stones then you should also pass.
+Until you develop the experience to judge better, if your opponent passes and there are no open borders \
+between your stones then you should also pass.
 
-        After passing, promptly accept the correct score.
+After passing, promptly accept the correct score.
 
-        If in doubt about this sort of situation. please ask for help in chat or the forums.
+If in doubt about this sort of situation. please ask for help in chat or the forums.
         `),
             { game_id },
         ),
     warn_staller: (game_id) =>
         interpolate(
             _(`
-        It has come to our attention that you delayed the end of game #{{game_id}}, which can frustrate your opponent and
-        prevent them from moving on to their next game.
+It has come to our attention that you delayed the end of game #{{game_id}}, which can frustrate your \
+opponent and prevent them from moving on to their next game.
 
-        Players are required to end their games properly, as letting them time out can cause opponents to wait unnecessarily,
-        and prevent them from moving on to the next game.
+Players are required to end their games properly, as letting them time out can cause opponents to wait \
+unnecessarily, and prevent them from moving on to the next game.
 
-        Please ensure that you end your games properly by accepting the correct score immediately after passing,
-        or by resigning if you feel the position is hopeless.
+Please ensure that you end your games properly by accepting the correct score immediately after passing, \
+or by resigning if you feel the position is hopeless.
 
-        This helps maintain a positive gaming environment for everyone involved.`),
+This helps maintain a positive gaming environment for everyone involved.`),
             { game_id },
         ),
     ack_educated_beginner_staller: (reported) =>
         interpolate(
             _(`
-        Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.`),
+Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.`),
             { reported },
         ),
     ack_educated_beginner_staller_and_annul: (reported) =>
         interpolate(
             _(`
-        Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.
-        That incorrectly scored game has been annulled.`),
+Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.
+
+That incorrectly scored game has been annulled.`),
             { reported },
         ),
     ack_warned_staller: (reported) =>
         interpolate(
             _(`
-        Thank you for your report, {{reported}} has been given a formal warning about finishing games properly.`),
+Thank you for your report, {{reported}} has been given a formal warning about finishing games properly.`),
             { reported },
         ),
     ack_warned_staller_and_annul: (reported) =>
         interpolate(
             _(`
-        Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, and that abandoned game annulled.`),
+Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, \
+and that abandoned game annulled.`),
             reported,
         ),
     no_stalling_evident: (reported) =>
         interpolate(
             _(`
-        Thank you for bringing the possible instance of stalling play by {{reported}} to
-        our attention. We looked into the report and don't see evidence of stalling.
+Thank you for bringing the possible instance of stalling play by {{reported}} to \
+our attention. We looked into the report and don't see evidence of stalling.
 
-        It may be that you need to report a different type of problem, or provide more explanation -
-        you are welcome to raise a new report if that is the case.
+It may be that you need to report a different type of problem, or provide more explanation - \
+you are welcome to raise a new report if that is the case.
 
-        Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
     report_type_changed: (change) =>
         interpolate(
             _(
                 `
-        Thanks for your recent report.   We've had to change the 'report type':
+Thanks for your recent report.   We've had to change the 'report type':
 
-            {{change}}.
+    {{change}}.
 
-        It makes it easier and quicker to process reports if they are raised with the
-        correct type - if you could help with that we'd appreciate it.
+It makes it easier and quicker to process reports if they are raised with the
+correct type - if you could help with that we'd appreciate it.
 
-        If this change seems wrong, we'd welcome feedback about that - please contact a moderator to let them know.
+If this change seems wrong, we'd welcome feedback about that - please contact a moderator to let them know.
         `,
             ),
             { change },
         ),
     bot_owner_notified: (bot) =>
         interpolate(
-            _(
-                `
-            Thanks for your recent report about {{bot}}.
-    
-            We've notified the owner of that bot.
-            `,
-            ),
+            _(`
+Thanks for your recent report about {{bot}}.
+
+We've notified the owner of that bot.
+            `),
             { bot },
         ),
 };

--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -156,6 +156,19 @@ export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
         Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
+    not_escaping_cancel: (reported) =>
+        interpolate(
+            _(`
+            Thank you for bringing the possible instance of {{reported}} abandoning the game to
+            our attention. We looked into the game and see that they used "Cancel".
+
+            Players are allowed to "Cancel" a game during the first moves.
+
+            If you think the person is abusing this feature, please file a report with more details.
+
+            Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+            { reported },
+        ),
     warn_beginner_staller: (game_id) =>
         interpolate(
             _(`

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -34,6 +34,7 @@ declare namespace rest_api {
             | "ack_warned_escaper"
             | "ack_warned_escaper_and_annul"
             | "no_escaping_evident"
+            | "not_escaping_cancel"
             | "warn_beginner_staller"
             | "warn_staller"
             | "ack_educated_beginner_staller"

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -71,6 +71,10 @@ const ACTION_PROMPTS = {
         "Label for a moderator to select this option",
         "No escaping evident - inform the reporter.",
     ),
+    not_escaping_cancel: pgettext(
+        "Label for a moderator to select this option",
+        "Not escaping, they used 'cancel'.",
+    ),
     annul_stalled: pgettext(
         "Label for a moderator to select this option",
         "Wrong result due to stalling - annul game, warn the staller.",


### PR DESCRIPTION
Fixes canned messages collapsing into one blob of text

## Proposed Changes

  - Format canned messages with `white-space: pre-line`, and adjust the input text to suit.
  
  
Note: this is on top of/inclusive of https://github.com/online-go/online-go.com/pull/2689  so that the new message in that PR gets this treatment as well.