### PR TITLE
Show number of rounds in Swiss tournament

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -984,6 +984,7 @@ export function Tournament(): JSX.Element {
     const has_fixed_number_of_rounds =
         tournament.tournament_type === "mcmahon" ||
         tournament.tournament_type === "s_mcmahon" ||
+        (tournament.tournament_type === "swiss" && tournament.started) ||
         tournament.tournament_type === "opengotha" ||
         null;
 


### PR DESCRIPTION
Once a Swiss tournament starts, it has a fixed number of rounds.  Show them. This addresses one of the [forum complaints][1] about Swiss tournaments.

[1]: https://forums.online-go.com/t/how-many-rounds-should-a-swiss-tournament-have/51168

