### PR TITLE
Add "Copy SGF" Button to Game Dock

### DIFF
--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -129,6 +129,31 @@ export function GameDock({
         ? api1(`reviews/${review_id}/sgf`)
         : null;
 
+    // Function to copy SGF content to clipboard
+    const copySGFToClipboard = () => {
+        fetch(sgf_url)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+                return response.text();
+            })
+            .then((sgfData) => {
+                navigator.clipboard
+                    .writeText(sgfData)
+                    .then(() => {
+                        toast(<div>{_("SGF content copied to clipboard!")}</div>, 2000);
+                    })
+                    .catch((err) => {
+                        console.error("Failed to copy text to clipboard", err);
+                    });
+            })
+            .catch((error) => {
+                console.error("Fetch error:", error);
+                toast(<div>{_("Failed to fetch SGF data.")}</div>, 2000);
+            });
+    };
+
     const openACL = () => {
         if (game_id) {
             openACLModal({ game_id: game_id });
@@ -494,6 +519,24 @@ export function GameDock({
                     }
                 >
                     <i className="fa fa-download"></i> {_("Download SGF")}
+                </a>
+            )}
+            {sgf_download_enabled ? (
+                <Tooltip tooltipRequired={tooltipRequired} title={_("Copy SGF")}>
+                    <a onClick={copySGFToClipboard}>
+                        <i className="fa fa-clipboard"></i> {_("Copy SGF")}
+                    </a>
+                </Tooltip>
+            ) : (
+                <a
+                    className="disabled"
+                    onClick={() =>
+                        void alert.fire(
+                            _("SGF copying for this game is disabled until the game is complete."),
+                        )
+                    }
+                >
+                    <i className="fa fa-clipboard"></i> {_("Copy SGF")}
                 </a>
             )}
             {sgf_download_enabled && sgf_with_ai_review_url && (


### PR DESCRIPTION
## Proposed Changes
This pull request adds a new "Copy SGF" button to the Game Dock (side panel of the game page), enhancing the user experience by allowing users to copy the SGF content of a game directly to the clipboard. Below are the key changes and features implemented:

## New Functionality:
1. Added a new button labeled "Copy SGF" to the side panel dock.
2. Implemented functionality to fetch SGF content and copy it to the user's clipboard using the existing sgf_url.
3. Utilized the existing notification system to alert users when the SGF content is successfully copied.

## Component Update:
1. Modified the GameDock.tsx component to include the new "Copy SGF" button.

## Images:
![new_button_image](https://github.com/online-go/online-go.com/assets/87700093/65acc1ce-b726-4199-8f05-90d0d0830de6)
![notification-example](https://github.com/online-go/online-go.com/assets/87700093/69ff8832-5fd1-4ec5-bc29-476a4a8c0e85)
