### PR TITLE
Fix ack_warned_score_cheat missing braces

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -69,7 +69,7 @@ trusting the auto-score.`),
     ack_educated_beginner_score_cheat_and_annul: (reported) =>
         interpolate(
             _(`
-Thanks for the report about {{reported}}. 
+Thanks for the report about {{reported}}.
 
 It seems that person was a complete beginner - we have tried to explain that games should \
 be ended correctly, to pass when their opponent passes, and to accept promptly, \
@@ -89,7 +89,7 @@ Thank you for your report, {{reported}} has been given a formal warning about sc
             _(`
 Thank you for your report, {{reported}} has been given a formal warning about scoring properly, \
 and that cheated game annulled.`),
-            reported,
+            { reported },
         ),
     no_score_cheating_evident: (reported) =>
         interpolate(

--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -152,7 +152,7 @@ Thank you for your report, {{reported}} has been given a formal warning about fi
             _(`
 Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, \
 and that abandoned game annulled.`),
-            reported,
+            { reported },
         ),
     no_escaping_evident: (reported) =>
         interpolate(
@@ -243,7 +243,7 @@ Thank you for your report, {{reported}} has been given a formal warning about fi
             _(`
 Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, \
 and that abandoned game annulled.`),
-            reported,
+            { reported },
         ),
     no_stalling_evident: (reported) =>
         interpolate(


### PR DESCRIPTION
Fixes ack_warned_score_cheat message not interpolating username

## Proposed Changes

  - Add missing braces
  
  
