### PR TITLE
Defer warning till end of live game

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -18,6 +18,7 @@
 import * as React from "react";
 import * as data from "data";
 import { DataSchema } from "./data_schema";
+import { GobanCore } from "goban";
 
 /**
  * React Hook that gives the value for a given key.  This should be preferred
@@ -63,4 +64,8 @@ export function useUser(): rest_api.UserConfig {
 export function useRefresh(): () => void {
     const [, refresh] = React.useState(0);
     return React.useCallback(() => refresh(() => Math.random()), [refresh]);
+}
+
+export function useMainGoban(): GobanCore | null {
+    return (window as any)["global_goban"];
 }


### PR DESCRIPTION
Fixes players having to wait the dismiss-delay during a live game.

## Proposed Changes

  - Have AccountWarning check if they're on the Game page, and if so then wait till a live game is not in progress to show the warning, by polling `gobal_goban`.
  

