### PR TITLE
Include opponent's name in turn notification

### DIFF
--- a/src/components/Notifications/NotificationManager.tsx
+++ b/src/components/Notifications/NotificationManager.tsx
@@ -30,6 +30,7 @@ import { sfx } from "sfx";
 import { ogs_has_focus, getCurrentGameId, shouldOpenNewTab } from "misc";
 import { lookingAtOurLiveGame } from "TimeControl/util";
 import { PlayerCacheEntry } from "src/lib/player_cache";
+import { GameListEntry } from "goban/lib/protocol";
 
 //declare let Notification: any;
 
@@ -342,7 +343,7 @@ export class NotificationManager {
         this.rebuildNotificationList();
     }
     connect() {
-        socket.on("active_game", (game) => {
+        socket.on("active_game", (game: GameListEntry) => {
             delete this.boards_to_move_on[game.id];
             if (game.phase === "finished") {
                 delete this.active_boards[game.id];
@@ -379,9 +380,15 @@ export class NotificationManager {
                         if (!game_turn_notifications_sent[game_notification_key]) {
                             emitNotification(
                                 _("Your Turn"),
-                                interpolate("It's your turn in game {{game_id}}", {
-                                    game_id: game.id,
-                                }),
+                                interpolate(
+                                    "It's your turn to play against {{opponent_username}}",
+                                    {
+                                        opponent_username:
+                                            data.get("user").id === game.black.id
+                                                ? game.white.username
+                                                : game.black.username,
+                                    },
+                                ),
                                 () => {
                                     if (window.location.pathname !== "/game/" + game.id) {
                                         browserHistory.push("/game/" + game.id);


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Change the format of the notification when it's your move in correspondence games to remove the game id and instead include the username of the opponent.

## Motivation
I feel that the game id does not have any use in the notification, whereas I think the opponents name would be more useful.

I am new to this codebase so any advice would be useful, specifically if there's an established method for finding the name of the opponent.

![Screenshot from 2024-06-03 09-47-38](https://github.com/online-go/online-go.com/assets/31443269/f771f398-a6fe-45ac-bd09-6f70468369ef)
