### PR TITLE
Trophy icon tooltip to include tournament name

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -73,6 +73,7 @@ import { GobanContext } from "./goban_context";
 import { is_valid_url } from "url_validation";
 import { disableTouchAction, enableTouchAction } from "./touch_actions";
 import { BotDetectionResults } from "./BotDetectionResults";
+import { ActiveTournament } from "src/lib/types";
 
 export function Game(): JSX.Element | null {
     const params = useParams<"game_id" | "review_id" | "move_number">();
@@ -141,6 +142,7 @@ export function Game(): JSX.Element | null {
 
     const title = useTitle(goban.current);
     const cur_move = useCurrentMove(goban.current);
+    const [tournament, set_tournament] = React.useState<ActiveTournament>();
 
     const [mode, set_mode] = React.useState<GobanModes>("play");
     const [score_estimate_winner, set_score_estimate_winner] = React.useState<string>();
@@ -1447,6 +1449,18 @@ export function Game(): JSX.Element | null {
                     ladder_id.current = game.ladder;
                     tournament_id.current = game.tournament ?? undefined;
 
+                    if (game.tournament) {
+                        get(`tournaments/${game.tournament}`)
+                            .then((t: ActiveTournament) => {
+                                console.log(t);
+                                set_tournament(t);
+                            })
+                            .catch((e) => {
+                                console.warn(`Could not get tournament information`);
+                                console.warn(e.name, e);
+                            });
+                    }
+
                     set_annulled(game.annulled);
                     set_annulment_reason(game.annulment_reason);
                     set_historical_black(game.historical_ratings.black);
@@ -1685,6 +1699,7 @@ export function Game(): JSX.Element | null {
                                 annulled={annulled}
                                 selected_ai_review_uuid={selected_ai_review_uuid}
                                 tournament_id={tournament_id.current}
+                                tournament_name={tournament?.name}
                                 ladder_id={ladder_id.current}
                                 ai_review_enabled={ai_review_enabled}
                                 historical_black={historical_black}
@@ -1752,6 +1767,7 @@ export function Game(): JSX.Element | null {
                                 annulled={annulled}
                                 selected_ai_review_uuid={selected_ai_review_uuid}
                                 tournament_id={tournament_id.current}
+                                tournament_name={tournament?.name}
                                 ladder_id={ladder_id.current}
                                 ai_review_enabled={ai_review_enabled}
                                 historical_black={historical_black}

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -44,6 +44,7 @@ interface DockProps {
     annulled: boolean;
     selected_ai_review_uuid: string | null;
     tournament_id?: number;
+    tournament_name?: string;
     ladder_id?: number;
     ai_review_enabled: boolean;
     historical_black: rest_api.games.Player | null;
@@ -67,6 +68,7 @@ export function GameDock({
     annulled,
     selected_ai_review_uuid,
     tournament_id,
+    tournament_name,
     ladder_id,
     historical_black,
     historical_white,
@@ -322,8 +324,7 @@ export function GameDock({
         <Dock>
             {(tournament_id || null) && (
                 <Link className="plain" to={`/tournament/${tournament_id}`}>
-                    <i className="fa fa-trophy" title={_("This is a tournament game")} />{" "}
-                    {_("Tournament")}
+                    <i className="fa fa-trophy" title={_(`${tournament_name}`)} /> {_("Tournament")}
                 </Link>
             )}
             {(ladder_id || null) && (

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -324,7 +324,8 @@ export function GameDock({
         <Dock>
             {(tournament_id || null) && (
                 <Link className="plain" to={`/tournament/${tournament_id}`}>
-                    <i className="fa fa-trophy" title={_(`${tournament_name}`)} /> {_("Tournament")}
+                    <i className="fa fa-trophy" title={tournament_name ?? _("Tournament")} />{" "}
+                    {_("Tournament")}
                 </Link>
             )}
             {(ladder_id || null) && (


### PR DESCRIPTION
Fixes #2618 

## Proposed Changes
  - When the tournament is hovered over, it displays the name of the tournament instead of a generic phrase
  - This is done by getting the tournament info when the game loads


Potentially this could be also done with ladder games.
It would also be nice to cache the tournament info to avoid the request, but I'm not familiar enough with potential solutions.
