### PR TITLE
Add handicap to game history table

### DIFF
--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -398,8 +398,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             },
                             {
                                 header: _("Hd"),
-                                className: (X) =>
-                                    "handicap" + (X && X.annulled ? " annulled" : ""),
+                                className: (X) => "handicap" + (X && X.annulled ? " annulled" : ""),
                                 render: (X) => X.handicap,
                             },
                             {

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import { _ } from "translate";
+import { _, pgettext } from "translate";
 import { PlayerAutocomplete } from "PlayerAutocomplete";
 import { Card } from "material";
 import { PaginatedTable } from "PaginatedTable";
@@ -397,7 +397,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 render: (X) => `${X.width}x${X.height}`,
                             },
                             {
-                                header: _("Hd"),
+                                header: pgettext("Handicap abbreviation", "HC"),
                                 className: (X) => "handicap" + (X && X.annulled ? " annulled" : ""),
                                 render: (X) => X.handicap,
                             },

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -69,6 +69,7 @@ interface GroomedGame {
     result: JSX.Element;
     flags?: { [flag_key: string]: number | string | boolean };
     rengo_vs_text?: `${number} vs. ${number}`;
+    handicap: number;
 }
 
 export function GameHistoryTable(props: GameHistoryProps) {
@@ -189,6 +190,8 @@ export function GameHistoryTable(props: GameHistoryProps) {
             item.speed_icon_class = getSpeedClass(speed);
 
             item.name = r.name;
+
+            item.handicap = r.handicap;
 
             if (item.name && item.name.trim() === "") {
                 item.name = item.href;
@@ -392,6 +395,12 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 className: (X) =>
                                     "board_size" + (X && X.annulled ? " annulled" : ""),
                                 render: (X) => `${X.width}x${X.height}`,
+                            },
+                            {
+                                header: _("Hd"),
+                                className: (X) =>
+                                    "handicap" + (X && X.annulled ? " annulled" : ""),
+                                render: (X) => X.handicap,
                             },
                             {
                                 header: _("Name"),

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -492,13 +492,20 @@
           themed color strong-loss
         }
 
+        .board_size {
+            padding-right: 0.5em;
+        }
+
+        .handicap {
+            padding-right: 0.5em;
+        }
+
         .game_name {
             a {
                 color: unset;
             }
             max-width: 15rem;
             overflow: hidden;
-            padding-left: 0.5em;
             text-overflow: ellipsis;
         }
 
@@ -525,6 +532,10 @@
 
         .annulled {
             themed opacity annul-opacity;
+        }
+
+        th {
+            padding-right: 0.5em;
         }
     }
 


### PR DESCRIPTION
Fixes #2708

## Proposed Changes
<img width="712" alt="Screenshot 2024-06-08 at 2 49 28 PM" src="https://github.com/online-go/online-go.com/assets/1885776/cc2324c9-c596-4a7f-84c1-49167ae304a7">

  - Add a new column with the header "Hd" with each row containing the number of stones.
