### PR TITLE
Add close button to network status pop-up

### DIFF
--- a/src/components/NetworkStatus/NetworkStatus.styl
+++ b/src/components/NetworkStatus/NetworkStatus.styl
@@ -24,6 +24,7 @@
     font-weight: bold;
     padding-right: 1rem;
     border-radius: 0.3rem;
+    cursor: pointer;
 
     // if we're not on the game page, we make this more discreet...
     &.non-game {
@@ -38,7 +39,6 @@
         }
     }
 
-
     .icon {
         position: relative;
         display: inline-flex;
@@ -48,14 +48,9 @@
         justify-content: center;
     }
 
-    .icon.close {
-        cursor: pointer;
-    }
-
     .icon.no-wifi {
         margin-right: 1rem;
     }
-
 
     @keyframes fadeInOut {
         0% { opacity: 1; }

--- a/src/components/NetworkStatus/NetworkStatus.styl
+++ b/src/components/NetworkStatus/NetworkStatus.styl
@@ -39,23 +39,20 @@
     }
 
 
-    .icon.close {
+    .icon {
         position: relative;
         display: inline-flex;
         width: 2rem;
         height: 2rem;
         align-items: center;
         justify-content: center;
+    }
+
+    .icon.close {
         cursor: pointer;
     }
 
     .icon.no-wifi {
-        position: relative;
-        display: inline-flex;
-        width: 2rem;
-        height: 2rem;
-        align-items: center;
-        justify-content: center;
         margin-right: 1rem;
     }
 

--- a/src/components/NetworkStatus/NetworkStatus.styl
+++ b/src/components/NetworkStatus/NetworkStatus.styl
@@ -38,7 +38,18 @@
         }
     }
 
-    .icon {
+
+    .icon.close {
+        position: relative;
+        display: inline-flex;
+        width: 2rem;
+        height: 2rem;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+    }
+
+    .icon.no-wifi {
         position: relative;
         display: inline-flex;
         width: 2rem;
@@ -47,6 +58,7 @@
         justify-content: center;
         margin-right: 1rem;
     }
+
 
     @keyframes fadeInOut {
         0% { opacity: 1; }

--- a/src/components/NetworkStatus/NetworkStatus.styl
+++ b/src/components/NetworkStatus/NetworkStatus.styl
@@ -12,7 +12,7 @@
     display: inline-flex;
     position: absolute;
     z-index: z.network-warning;
-    top: navbar-height;
+    top: 0.5em;
     right: 0;
     min-width: 10rem;
     height: 2.5rem;

--- a/src/components/NetworkStatus/NetworkStatus.tsx
+++ b/src/components/NetworkStatus/NetworkStatus.tsx
@@ -101,13 +101,13 @@ export function NetworkStatus(): JSX.Element | null {
     return (
         // We don't show this if they're 'connected' (see above, return null)
         <div className={"NetworkStatus" + (show_banner ? "" : " non-game")}>
-            {/* This funky little thing builds an icon that is intended to say "no wifi!",
-                by superimposing a large "ban" icon over a normal sized "wifi" icon. */}
             {show_banner && (
                 <span className="icon close">
                     <i className="fa fa-times-circle" onClick={() => setManuallyClosed(true)} />
                 </span>
             )}
+            {/* This funky little thing builds an icon that is intended to say "no wifi!",
+                by superimposing a large "ban" icon over a normal sized "wifi" icon. */}
             <span className="icon no-wifi">
                 <i className="fa fa-2x fa-ban" />
                 <i className="fa fa-wifi" />

--- a/src/components/NetworkStatus/NetworkStatus.tsx
+++ b/src/components/NetworkStatus/NetworkStatus.tsx
@@ -100,10 +100,13 @@ export function NetworkStatus(): JSX.Element | null {
 
     return (
         // We don't show this if they're 'connected' (see above, return null)
-        <div className={"NetworkStatus" + (show_banner ? "" : " non-game")}>
+        <div
+            className={"NetworkStatus" + (show_banner ? "" : " non-game")}
+            onClick={() => setManuallyClosed(true)}
+        >
             {show_banner && (
                 <span className="icon close">
-                    <i className="fa fa-times-circle" onClick={() => setManuallyClosed(true)} />
+                    <i className="fa fa-times-circle" />
                 </span>
             )}
             {/* This funky little thing builds an icon that is intended to say "no wifi!",


### PR DESCRIPTION
Fixes: [“Bad connection” notification banner obscures players’ time](https://forums.online-go.com/t/bad-connection-notification-banner-obscures-players-time/51970)

## Proposed Changes
  - Added a close button the the network status pop-up which relegates it back to the little icon above the profile
  - Until reloading, on multiple disconnects, the pop-up would only show the first time
![image](https://github.com/online-go/online-go.com/assets/31443269/86268cee-4c9b-4744-a70d-5982ac814ef0)
