### PR TITLE
Add pass to conditional planner

### DIFF
--- a/src/views/Game/ConditionalMoveTreeDisplay.tsx
+++ b/src/views/Game/ConditionalMoveTreeDisplay.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { GoConditionalMove } from "goban";
 import { useGoban } from "./goban_context";
 import { generateGobanHook } from "./GameHooks";
+import { _ } from "translate";
 
 interface ConditionalMoveTreeDisplayProps {
     tree: GoConditionalMove;
@@ -113,7 +114,11 @@ function MoveEntry({ color, conditional_path }: MoveEntryProps) {
     return (
         <span className={`entry ${selected ? "selected" : ""}`} onClick={cb}>
             <span className={`stone ${color}`}></span>
-            <span>{goban.engine.prettyCoords(mv.x, mv.y)}</span>
+            <span>
+                {goban.engine.prettyCoords(mv.x, mv.y) !== "pass"
+                    ? goban.engine.prettyCoords(mv.x, mv.y)
+                    : _("Pass")}
+            </span>
         </span>
     );
 }

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -132,6 +132,11 @@ goban-view-bar-width=400px
         .buttons {
             display: flex;
             justify-content: space-between;
+
+            button {
+                min-height: 2em;
+                height: auto;
+            }
         }
     }
 

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -522,6 +522,7 @@ export function PlayControls({
                         <button className="primary" onClick={acceptConditionalMoves}>
                             {_("Accept Conditional Moves")}
                         </button>
+                        <button onClick={() => goban.pass()}>{_("Pass")}</button>
                         <button onClick={goban_setMode_play}>{_("Cancel")}</button>
                     </div>
                     <div className="ctrl-conditional-tree">


### PR DESCRIPTION
Fixes #251 

## Proposed Changes
  - Add pass to the conditional move planner

Is there a nicer way to localise the pass message than the check I used? I considered having the prettyCoord function return undefined when given invalid moves instead of the string `pass`.

I'd also like some feedback on the UI here:
![sc](https://github.com/online-go/online-go.com/assets/31443269/de3019ce-c7bf-4ffa-b290-b99aa5744c25)

