### PR TITLE
Translation for settings switch for SVG renderer

### DIFF
--- a/src/views/Settings/GeneralPreferences.tsx
+++ b/src/views/Settings/GeneralPreferences.tsx
@@ -321,7 +321,7 @@ export function GeneralPreferences(props: SettingGroupPageProps): JSX.Element {
                 />
             </PreferenceLine>
 
-            <PreferenceLine title={"Enable SVG goban renderer"}>
+            <PreferenceLine title={_("Enable SVG goban renderer")}>
                 <Toggle
                     checked={enable_svg}
                     onChange={(tf) => {


### PR DESCRIPTION
Fixes untranslated label

## Proposed Changes

  - `_()`
  
Note: this may have been left untranslated due to being transitory?
