### PR TITLE
They want the handicap numbers in the centre

### DIFF
--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -398,10 +398,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             },
                             {
                                 header: pgettext("Handicap abbreviation", "HC"),
-                                className: (X) =>
-                                    "handicap" +
-                                    (X && X.handicap !== "-" ? "-present" : "") +
-                                    (X && X.annulled ? " annulled" : ""),
+                                className: (X) => "handicap" + (X && X.annulled ? " annulled" : ""),
                                 render: (X) => X.handicap,
                             },
                             {

--- a/src/views/User/User.styl
+++ b/src/views/User/User.styl
@@ -497,7 +497,7 @@
         }
 
         .handicap {
-            padding-right: 0.5em;
+            text-align: center;
         }
 
         .game_name {
@@ -536,14 +536,6 @@
 
         th {
             padding-right: 0.5em;
-        }
-
-        .handicap { // note that this is the "no handicap" case for this column
-            text-align: center;
-        }
-        .handicap-present { // this is for an actual number
-            text-align: right;
-            padding-right: 0.4rem;  // get the number away from the next column
         }
     }
 


### PR DESCRIPTION
Fixes people complaining about handicap numbers looking odd right aligned

## Proposed Changes

  - Put handicap number in the centre instead of right aligned.
  - Also got rid of 0.5rem padding - not clear what value that's adding, esp with centre aligned content.
