### PR TITLE
Display 'System' instead of NULL USER in mod log

### DIFF
--- a/src/views/Moderator/Moderator.tsx
+++ b/src/views/Moderator/Moderator.tsx
@@ -177,6 +177,13 @@ const greylist = [
 
 const greylist2 = [".xyz", ".life", ".website"];
 
+const setModeratorRender = (X: any) => {
+    if (!X.moderator) {
+        return "System";
+    }
+    return <Player user={X.moderator} />;
+};
+
 interface ModeratorState {
     newuserany_filter: string;
     playerusernameistartswith_filter: string;
@@ -382,7 +389,7 @@ export class Moderator extends React.PureComponent<{}, ModeratorState> {
                             {
                                 header: _("Moderator"),
                                 className: () => "moderator",
-                                render: (X) => <Player user={X.moderator} />,
+                                render: (X) => setModeratorRender(X),
                             },
 
                             {


### PR DESCRIPTION

## Proposed Changes

  -  Display "System" instead of a link to [NULL USER] for system generated actions in mod log


<img width="374" alt="Screenshot 2024-06-30 at 4 02 25 PM" src="https://github.com/online-go/online-go.com/assets/42720842/6e83ff38-6829-454b-8a15-4ea7d77b3323">

<img width="405" alt="Screenshot 2024-06-30 at 4 01 52 PM" src="https://github.com/online-go/online-go.com/assets/42720842/596661be-bcd2-44c0-a188-7c755e474fe2">
