### PR TITLE
bugfix: don't set isLoading to true after fetching empty array of streams

### DIFF
--- a/src/views/GoTV/GoTV.tsx
+++ b/src/views/GoTV/GoTV.tsx
@@ -64,11 +64,7 @@ export const GoTV = () => {
         streamManager.on("update", updateStreams);
 
         const initialStreams = streamManager.getStreams();
-        if (initialStreams.length > 0) {
-            updateStreams(initialStreams);
-        } else {
-            setIsLoading(true);
-        }
+        updateStreams(initialStreams);
 
         const bodyClassList = document.body.classList;
         setIsLightTheme(bodyClassList.contains("light"));


### PR DESCRIPTION
Fixes bug introduced in most recent GoTV update where fetching an empty array of streams causes the loading message to display forever
