### PR TITLE
Add messages and type for "duplicate report" handling for CMs

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -260,6 +260,19 @@ you are welcome to raise a new report if that is the case.
 Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
             { reported },
         ),
+    warn_duplicate_report: (reported) =>
+        interpolate(
+            _(`
+Thanks for your additional report about {{reported}}.
+
+Please don't file multiple reports for the same thing - that creates a lot of work for us tidying up, \
+which could be time spent better on other reports.
+
+We appreciate hearing about problems, but one report is enough for each incident - more than that will slow us down.
+
+Thanks!`),
+            { reported },
+        ),
     report_type_changed: (change) =>
         interpolate(
             _(`

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -42,6 +42,7 @@ declare namespace rest_api {
             | "ack_warned_staller"
             | "ack_warned_staller_and_annul"
             | "no_stalling_evident"
+            | "warn_duplicate_report"
             | "report_type_changed"
             | "bot_owner_notified";
 

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -98,6 +98,10 @@ const ACTION_PROMPTS = {
         "Label for a moderator to select this option",
         "No stalling evident - inform the reporter.",
     ),
+    warn_duplicate_reporter: pgettext(
+        "Label for a moderator to select this option",
+        "Duplicate report - ask them not to do that.",
+    ),
     // Note: keep this last, so it's positioned above the "note to moderator" input field
     escalate: pgettext(
         "A label for a community moderator to select this option - send report to to full moderators",


### PR DESCRIPTION
Fixes CMs not being able to sensibly respond to duplicate reports

## Proposed Changes

  - Give CMs an option to ask reporters not to do that
      - The same message that moderators have available

(Won't actually do anything till https://github.com/online-go/ogs/pull/1972 is in, which will send them this option)