### PR TITLE
Display only 120 days of CM voting graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
         "@types/sanitize-html": "^1.22.0",
         "array-move": "^2.2.1",
         "d3": "^7.6.1",
+        "date-fns": "^3.6.0",
         "eventemitter3": "^5.0.0",
         "howler": "^2.2.1",
         "jquery": "^3.6.0",

--- a/src/views/ReportsCenter/ReportsCenterCMInfo.tsx
+++ b/src/views/ReportsCenter/ReportsCenterCMInfo.tsx
@@ -16,7 +16,10 @@
  */
 
 import React, { useEffect } from "react";
+import { format, subDays, startOfWeek as startOfWeekDateFns } from "date-fns";
+
 import { get } from "requests";
+
 import * as data from "data";
 
 import { ResponsiveLine } from "@nivo/line";
@@ -188,7 +191,11 @@ const CMVoteActivityGraph = ({ vote_data }: VoteActivityGraphProps) => {
                     xFormat="time:%Y-%m-%d"
                     xScale={{
                         type: "time",
-                        min: "2023-12-31",
+                        min: format(
+                            startOfWeekDateFns(subDays(new Date(), 120), { weekStartsOn: 1 }),
+
+                            "yyyy-MM-dd",
+                        ),
                         format: "%Y-%m-%d",
                         useUTC: false,
                         precision: "day",
@@ -224,7 +231,11 @@ const CMVoteActivityGraph = ({ vote_data }: VoteActivityGraphProps) => {
                     xFormat="time:%Y-%m-%d"
                     xScale={{
                         type: "time",
-                        min: "2023-12-31",
+                        min: format(
+                            startOfWeekDateFns(subDays(new Date(), 120), { weekStartsOn: 1 }),
+
+                            "yyyy-MM-dd",
+                        ),
                         format: "%Y-%m-%d",
                         useUTC: false,
                         precision: "day",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4262,6 +4262,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"


### PR DESCRIPTION


Fixes  old (irrelevant) data, messed up axis

## Proposed Changes

  -  Show only 120 days of data (calculated properly) 
      - Prep for making it zoomable if we feel like it (back end supports it now) 
  