### PR TITLE
Filter system reports out of the "outstanding report count".

### DIFF
--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -157,7 +157,9 @@ export function IncidentReportTracker(): JSX.Element | null {
         }
 
         function updateUser() {
-            updateCt(report_manager.getEligibleReports().length);
+            updateCt(
+                report_manager.getEligibleReports().filter((r) => r.report_type !== "troll").length,
+            );
         }
 
         data.watch("user", updateUser);


### PR DESCRIPTION
Fixes the daunting number being even higher than effectively it is

## Proposed Changes

  - Don't show system generated reports (which most moderators won't look at) in the report count
  