### PR TITLE
Reformatting automatch finder box

### DIFF
--- a/src/components/AutomatchSettings/AutomatchSettings.tsx
+++ b/src/components/AutomatchSettings/AutomatchSettings.tsx
@@ -162,6 +162,8 @@ export class AutomatchSettings extends Modal<
         switch (this.state.tab) {
             case "blitz":
                 return dup(this.state.blitz_settings);
+            case "rapid":
+                return dup(this.state.rapid_settings);
             case "live":
                 return dup(this.state.live_settings);
             case "correspondence":
@@ -175,6 +177,10 @@ export class AutomatchSettings extends Modal<
             case "blitz":
                 data.set("automatch.blitz", settings);
                 this.setState({ blitz_settings: settings });
+                break;
+            case "rapid":
+                data.set("automatch.rapid", settings);
+                this.setState({ rapid_settings: settings });
                 break;
             case "live":
                 data.set("automatch.live", settings);
@@ -260,6 +266,12 @@ export class AutomatchSettings extends Modal<
                             onClick={() => this.setTab("blitz")}
                         >
                             {_("Blitz")}
+                        </button>
+                        <button
+                            className={this.state.tab === "rapid" ? "primary active sm" : "sm"}
+                            onClick={() => this.setTab("rapid")}
+                        >
+                            {_("Rapid")}
                         </button>
                         <button
                             className={this.state.tab === "live" ? "primary active sm" : "sm"}

--- a/src/components/AutomatchSettings/AutomatchSettings.tsx
+++ b/src/components/AutomatchSettings/AutomatchSettings.tsx
@@ -32,6 +32,7 @@ export type AutomatchPreferences = AutomatchPreferencesBase & { size_options: Si
 interface AutomatchSettingsState {
     tab: Speed;
     blitz_settings: AutomatchPreferences;
+    rapid_settings: AutomatchPreferences;
     live_settings: AutomatchPreferences;
     correspondence_settings: AutomatchPreferences;
 }
@@ -53,6 +54,25 @@ const default_blitz: AutomatchPreferences = {
     handicap: {
         condition: "no-preference",
         value: "disabled",
+    },
+};
+const default_rapid: AutomatchPreferences = {
+    upper_rank_diff: 3,
+    lower_rank_diff: 3,
+    size_options: ["19x19"],
+    rules: {
+        condition: "no-preference",
+        value: "japanese",
+    },
+    time_control: {
+        condition: "no-preference",
+        value: {
+            system: "byoyomi",
+        },
+    },
+    handicap: {
+        condition: "no-preference",
+        value: "enabled",
     },
 };
 const default_live: AutomatchPreferences = {
@@ -104,10 +124,12 @@ const ConditionSelect = (props: { value: any; onChange: (x: any) => void }) => (
     </div>
 );
 
-export function getAutomatchSettings(speed: "blitz" | "live" | "correspondence") {
+export function getAutomatchSettings(speed: "blitz" | "live" | "rapid" | "correspondence") {
     switch (speed) {
         case "blitz":
             return dup(data.get("automatch.blitz", default_blitz));
+        case "rapid":
+            return dup(data.get("automatch.rapid", default_rapid));
         case "live":
             return dup(data.get("automatch.live", default_live));
         case "correspondence":
@@ -125,6 +147,7 @@ export class AutomatchSettings extends Modal<
         this.state = {
             tab: data.get("automatch.last-tab", "live") as Speed,
             blitz_settings: data.get("automatch.blitz", default_blitz),
+            rapid_settings: data.get("automatch.rapid", default_rapid),
             live_settings: data.get("automatch.live", default_live),
             correspondence_settings: data.get("automatch.correspondence", default_correspondence),
         };

--- a/src/components/TimeControl/TimeControl.ts
+++ b/src/components/TimeControl/TimeControl.ts
@@ -16,7 +16,7 @@
  */
 
 export namespace TimeControlTypes {
-    export type TimeControlSpeed = "blitz" | "live" | "correspondence";
+    export type TimeControlSpeed = "blitz" | "rapid" | "live" | "correspondence";
     export type TimeControlSystem =
         | "fischer"
         | "byoyomi"

--- a/src/components/TimeControl/util.ts
+++ b/src/components/TimeControl/util.ts
@@ -650,6 +650,27 @@ export const time_options: TimeOptionsMap = {
             total_time: gen(45, 300),
         },
     },
+    rapid: {
+        fischer: {
+            initial_time: gen(5, 300),
+            time_increment: gen(1, 10),
+            max_time: gen(5, 300),
+        },
+        simple: {
+            per_move: gen(3, 9),
+        },
+        canadian: {
+            main_time: [zero].concat(gen(0, 300)),
+            period_time: gen(5, 30),
+        },
+        byoyomi: {
+            main_time: [zero].concat(gen(0, 300)),
+            period_time: gen(3, 30),
+        },
+        absolute: {
+            total_time: gen(45, 300),
+        },
+    },
     live: {
         fischer: {
             initial_time: gen(30, 3600 * 4),
@@ -698,6 +719,41 @@ type TimeControlDefaults = { [K in TimeControlSystem]: Omit<Reify<K>, "speed" | 
 type DefaultTimeSettingsMap = { [K in TimeControlSpeed]: TimeControlDefaults };
 export const default_time_settings: DefaultTimeSettingsMap = {
     blitz: {
+        fischer: {
+            initial_time: 30,
+            time_increment: 10,
+            max_time: 60,
+            pause_on_weekends: false,
+        },
+        byoyomi: {
+            main_time: 30,
+            period_time: 5,
+            periods: 5,
+            periods_min: 1,
+            periods_max: 300,
+            pause_on_weekends: false,
+        },
+        canadian: {
+            main_time: 30,
+            period_time: 30,
+            stones_per_period: 5,
+            stones_per_period_min: 1,
+            stones_per_period_max: 50,
+            pause_on_weekends: false,
+        },
+        simple: {
+            per_move: 5,
+            pause_on_weekends: false,
+        },
+        absolute: {
+            total_time: 300,
+            pause_on_weekends: false,
+        },
+        none: {
+            pause_on_weekends: false,
+        },
+    },
+    rapid: {
         fischer: {
             initial_time: 30,
             time_increment: 10,

--- a/src/lib/automatch_manager.tsx
+++ b/src/lib/automatch_manager.tsx
@@ -157,9 +157,8 @@ class AutomatchManager extends TypedEventEmitter<Events> {
 
         /* live game? track it, and pop up our searching toast */
         if (
-            preferences.size_speed_options.filter(
-                (opt) => opt.speed === "blitz" || opt.speed === "live",
-            ).length
+            preferences.size_speed_options.filter((opt) => opt.speed in ["blitz", "rapid", "live"])
+                .length
         ) {
             this.last_find_match_uuid = preferences.uuid;
             if (this.active_toast) {

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -20,7 +20,7 @@
  * all the possible keys as well as the associated value types.
  */
 
-import { GroupList, ActiveTournamentList, Size, RuleSet } from "./types";
+import { GroupList, ActiveTournamentList, Size, Speed, RuleSet } from "./types";
 import { Announcement } from "src/components/Announcements";
 import { ValidSound, ValidSoundGroup } from "./sfx";
 import { defaults as defaultPreferences, ValidPreference } from "./preferences";
@@ -159,6 +159,7 @@ interface PMSchema {
 type AutomatchSchema = {
     "last-tab": TimeControlSpeed;
     size_options: Size[];
+    speed_option: Speed;
 } & {
     [speed_key in TimeControlSpeed]: AutomatchPreferences;
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,7 +83,7 @@ export interface ActiveTournament {
 
 export type ActiveTournamentList = Array<ActiveTournament>;
 
-export type Speed = "blitz" | "live" | "correspondence";
+export type Speed = "blitz" | "rapid" | "live" | "correspondence";
 export type Size = "9x9" | "13x13" | "19x19";
 export type AutomatchCondition = "required" | "preferred" | "no-preference";
 export type RuleSet = "japanese" | "chinese" | "aga" | "korean" | "nz" | "ing";

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -61,11 +61,45 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+    }
 
-        .btn-group {
+    .automatch-content {
+
+        .btn-group {            
+            width: 100%;
             display: flex;
+            flex-direction: row;
             flex-wrap: nowrap;
+            justify-content: space-between;
+            border-radius: 10px;
+
+            button {
+                font-weight: bold;
+
+                width: 100%;
+                height: 75%;
+                min-height: 2rem
+                padding: 0.5rem;
+            }
+
+            button::before {
+                content: none;
+            }
         }
+    }
+
+    .automatch-speed-name {
+        font-size: large;
+        margin-bottom: 0.3rem;
+    }
+
+    .automatch-play {
+        font-size: xx-large;
+        font-weight: bold;
+        width: 100%
+        margin-left: 0;
+        margin-right: 0;
+        border-radius: 5px;
     }
 
     .rengo-management-row {
@@ -161,10 +195,9 @@
             font-size: 1.1rem;
             font-weight: bold;
             flex-grow: 1;
-            flex-basis: 13rem;
-            max-width: 13rem;
+            flex-basis: 48%;
             height: 4rem;
-            margin: 0.5rem;
+            margin: 0.2rem;
             white-space: nowrap;
             display: flex;
             align-items: center;
@@ -227,38 +260,6 @@
         font-size: 1rem;
         padding: .5rem;
         padding-left: 3rem;
-    }
-
-    .custom-game-row {
-        display: flex;
-        justify-content: space-around;
-        align-content: stretch
-        width: 100%;
-
-        button {
-            font-size: 1.1rem;
-            font-weight: bold;
-            flex-grow: 1;
-            width: 100%;
-            max-width: 13rem;
-            margin: 0.5rem;
-            height: 4rem;
-
-            .fa {
-                margin: 0.2rem;
-            }
-        }
-    }
-
-    .custom-game-header {
-        display: flex;
-        justify-content: space-around;
-        align-content: stretch
-        width: 100%;
-        justify-content: space-between;
-        align-items: left;
-        font-size: 1.3rem;
-        margin-top: 1rem;
     }
 
     .showall-selector {

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -191,8 +191,11 @@
         display: flex;
         justify-content: space-around;
         align-content: stretch
-        width: 100%;
+        width: auto;
         flex-wrap: wrap;
+
+        padding-left: 0.3rem;
+        padding-right: 0.3rem;
 
         button {
             font-size: 1.1rem;

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -65,13 +65,14 @@
 
     .automatch-content {
 
-        .btn-group {            
-            width: 100%;
+        .btn-group {    
+            height: max-content;        
+            width: auto;
             display: flex;
             flex-direction: row;
             flex-wrap: nowrap;
             justify-content: space-between;
-            border-radius: 10px;
+            padding: 0.25rem 0.5rem 0.25rem 0.5rem;
 
             button {
                 font-weight: bold;
@@ -79,11 +80,22 @@
                 width: 100%;
                 height: 75%;
                 min-height: 2rem
-                padding: 0.5rem;
+                padding: 0.5rem; 
             }
-
+            
             button::before {
                 content: none;
+            }
+
+            .automatch-play {
+                padding-top: 1rem;
+                padding-bottom: 1rem;
+
+                margin-top: 0.5rem;
+                margin-bottom: 0.2rem;
+
+                font-size: xx-large;
+                font-weight: bold;
             }
         }
     }
@@ -91,15 +103,6 @@
     .automatch-speed-name {
         font-size: large;
         margin-bottom: 0.3rem;
-    }
-
-    .automatch-play {
-        font-size: xx-large;
-        font-weight: bold;
-        width: 100%
-        margin-left: 0;
-        margin-right: 0;
-        border-radius: 5px;
     }
 
     .rengo-management-row {
@@ -197,7 +200,7 @@
             flex-grow: 1;
             flex-basis: 48%;
             height: 4rem;
-            margin: 0.2rem;
+            margin: 0.3rem;
             white-space: nowrap;
             display: flex;
             align-items: center;

--- a/src/views/Play/Play.styl
+++ b/src/views/Play/Play.styl
@@ -88,8 +88,8 @@
             }
 
             .automatch-play {
-                padding-top: 1rem;
-                padding-bottom: 1rem;
+                padding-top: 1.5rem;
+                padding-bottom: 1.5rem;
 
                 margin-top: 0.5rem;
                 margin-bottom: 0.2rem;

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -887,9 +887,11 @@ export class Play extends React.Component<{}, PlayState> {
                                     </div>
                                 </button>
                             </div>
-                            <button className="primary automatch-play" onClick={this.findMatch}>
-                                {_("Play")}
-                            </button>
+                            <div className="btn-group">
+                                <button className="primary automatch-play" onClick={this.findMatch}>
+                                    {_("Play")}
+                                </button>
+                            </div>
                         </div>
                         <hr className="solid" />
                         <div className="automatch-special-game">

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -558,6 +558,8 @@ function getSpeedClass(speed: Speed) {
             return "speed-icon ogs-turtle";
         case "live":
             return "speed-icon fa fa-clock-o";
+        case "rapid":
+            return "speed-icon fa fa-wind";
         case "blitz":
             return "speed-icon fa fa-bolt";
     }


### PR DESCRIPTION
[Based on this forum mock-up](https://forums.online-go.com/t/revisiting-automatch-time-settings-data-backed-proposal-for-new-automatch-settings-on-ogs/52303/22?u=elforo)
This PR depends on [these changes in the goban repo](https://github.com/online-go/goban/pull/170)

## Proposed Changes

  - Expand front-end for a potential `rapid` automatch speed
  - Enable functionality for dynamic-ish speed displays (the text under 'Blitz', 'Rapid', 'Live'). This could change depending on byo-yomi/fischer options in the settings menu
  - Add a (current disabled) 'Play a Friend' button. I haven't gotten round to the functionality yet, but I'll work on that soon.

![sc](https://github.com/online-go/online-go.com/assets/31443269/527fcbe3-3973-4806-af18-cd20ccb34697)

Feedback is very much appreciated, even on small styling issues :sweat_smile:
Also I've probably missed out something obvious in adding the `rapid` time setting, so I would appreciate a double-check!