### PR TITLE
Prevent report dupes

### DIFF
--- a/src/components/AutoTranslate/AutoTranslate.styl
+++ b/src/components/AutoTranslate/AutoTranslate.styl
@@ -11,4 +11,11 @@
         text-align: right;
         themed background-color shade5
     }
+    .placeholder {
+        themed color fg;
+        font-style: italic;
+        font-size: smaller;
+        themed background-color bg
+        padding: 0.5em;
+    }
 }

--- a/src/components/AutoTranslate/AutoTranslate.tsx
+++ b/src/components/AutoTranslate/AutoTranslate.tsx
@@ -25,6 +25,7 @@ interface AutoTranslateProps {
     className?: string;
     markdown?: boolean;
     source_language?: string;
+    placeholder?: string;
 }
 
 interface Translation {
@@ -39,7 +40,15 @@ export function AutoTranslate({
     source_language,
     className,
     markdown,
+    placeholder,
 }: AutoTranslateProps): JSX.Element | null {
+    let showing_placeholder = false;
+
+    if (!source && placeholder) {
+        showing_placeholder = true;
+        source = placeholder;
+        markdown = false; // this is needed to ensure placeholder is formatted correctly
+    }
     const need_translation =
         source !== "" && (!source_language || source_language.toLowerCase() !== current_language);
 
@@ -76,14 +85,16 @@ export function AutoTranslate({
     // If we have a translation, then we show it in the primary formatting, followed by the original.
     // If we don't have a translation, then we show the original in primary formatting.
     return (
-        <div className={`AutoTranslate ${className || ""}`}>
+        <div className={`AutoTranslate ${className || ""} `}>
             {show_translation ? (
                 <>
-                    {markdown ? (
-                        <Markdown source={translation.target_text} />
-                    ) : (
-                        translation.target_text
-                    )}
+                    <div className={`primary ${showing_placeholder ? "placeholder" : ""}`}>
+                        {markdown ? (
+                            <Markdown source={translation.target_text} />
+                        ) : (
+                            translation.target_text
+                        )}
+                    </div>
                     <div className="language-map">
                         {pgettext(
                             "This label is placed on the original text of something that has been translated",
@@ -97,7 +108,9 @@ export function AutoTranslate({
             ) : markdown ? (
                 <Markdown source={source} />
             ) : (
-                source
+                <div className={`primary ${showing_placeholder ? "placeholder" : ""}`}>
+                    {source}
+                </div>
             )}
         </div>
     );

--- a/src/components/IncidentReportTracker/IncidentReportCard.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportCard.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This file contains the incident report tracking and management system
+ * which is used by our IncidentReportTracker widget and our ReportsCenter view.
+ */
+
+import * as React from "react";
+
+import * as moment from "moment";
+
+import { Link } from "react-router-dom";
+
+import { _ } from "translate";
+
+import { Player } from "Player";
+
+import { AutoTranslate } from "AutoTranslate";
+import { Report } from "report_util";
+import { useUser } from "hooks";
+import { report_categories } from "Report";
+import { openReportedConversationModal } from "ReportedConversationModal";
+
+function getReportType(report: Report): string {
+    if (report.report_type === "appeal") {
+        return "Ban Appeal";
+    }
+
+    const report_category = report_categories.filter((r) => r.type === report.report_type)[0];
+    const report_type_title = report_category?.title || "Other";
+    return report_type_title;
+}
+
+interface IncidentReportCardProps {
+    report: Report;
+    index: number;
+    first_report_button: React.RefObject<HTMLDivElement>;
+    reportButtonClicked: (id: number) => void;
+}
+
+export function IncidentReportCard({
+    report,
+    index,
+    first_report_button,
+    reportButtonClicked,
+}: IncidentReportCardProps): JSX.Element {
+    const user = useUser();
+    return (
+        <div className="incident" key={report.id}>
+            <div className="report-header">
+                <div className="report-id" ref={index === 0 ? first_report_button : null}>
+                    <button onClick={() => reportButtonClicked(report.id)} className="small">
+                        {"R" + report.id.toString().slice(-3)}
+                    </button>
+                </div>
+                {getReportType(report)}
+                {!report.moderator && user.is_moderator && (
+                    <button className="primary xs" onClick={report.claim}>
+                        {_("Claim")}
+                    </button>
+                )}
+                {user.is_moderator && report.moderator && <Player user={report.moderator} icon />}
+            </div>
+            {report.reporter_note && (
+                <h4 className="notes">
+                    {report.reporter_note_translation ? (
+                        <>
+                            {report.reporter_note_translation.source_text}
+                            {report.reporter_note_translation.target_language !==
+                                report.reporter_note_translation.source_language && (
+                                <>
+                                    <div className="source-to-target-languages">
+                                        {report.reporter_note_translation.source_language} =&gt;{" "}
+                                        {report.reporter_note_translation.target_language}
+                                    </div>
+                                    <div className="translated">
+                                        {report.reporter_note_translation.target_text}
+                                    </div>
+                                </>
+                            )}
+                        </>
+                    ) : (
+                        <AutoTranslate source={report.reporter_note} />
+                    )}
+                </h4>
+            )}
+
+            {report.system_note && <h4 className="notes">{report.system_note}</h4>}
+
+            <div className="notes">
+                <i>{user.is_moderator ? report.moderator_note || "" : ""}</i>
+            </div>
+
+            <div className="spread">
+                {report.url && (
+                    <a href={report.url} target="_blank">
+                        {report.url}
+                    </a>
+                )}
+
+                {report.reported_user && (
+                    <span>
+                        {_("Reported user")}: <Player user={report.reported_user} icon />
+                    </span>
+                )}
+                {report.reported_game && (
+                    <span>
+                        {_("Game")}:{" "}
+                        <Link to={`/game/${report.reported_game}`}>#{report.reported_game}</Link>
+                    </span>
+                )}
+                {report.reported_review && (
+                    <span>
+                        {_("Review")}:{" "}
+                        <Link to={`/review/${report.reported_review}`}>
+                            ##{report.reported_review}
+                        </Link>
+                    </span>
+                )}
+            </div>
+
+            {report.report_type === "appeal" && (
+                <h3>
+                    <Link to={`/appeal/${report.reported_user?.id}`}>View Appeal</Link>
+                </h3>
+            )}
+
+            {report.reported_conversation && (
+                <div
+                    className="spread"
+                    onClick={() => {
+                        openReportedConversationModal(
+                            report.reported_user?.id,
+                            report.reported_conversation,
+                        );
+                    }}
+                >
+                    <span id="conversation">{_("View Reported Conversation")}</span>
+                </div>
+            )}
+
+            <div className="spread">
+                {report.moderator && user.is_moderator && user.id !== report.moderator.id && (
+                    <button className="danger xs" onClick={report.steal}>
+                        {_("Steal")}
+                    </button>
+                )}
+                {!report.moderator &&
+                    report.reporting_user &&
+                    user.id === report.reporting_user.id && (
+                        <button className="reject xs" onClick={report.cancel}>
+                            {_("Cancel")}
+                        </button>
+                    )}
+                {report.moderator && user.is_moderator && user.id === report.moderator.id && (
+                    <>
+                        <button className="success xs" onClick={report.good_report}>
+                            {_("Good report")}
+                        </button>
+                        <button className="info xs" onClick={report.set_note}>
+                            {_("Note")}
+                        </button>
+                        <button className="danger xs" onClick={report.unclaim}>
+                            {_("Unclaim")}
+                        </button>
+                        <button className="reject xs" onClick={report.bad_report}>
+                            {_("Bad report")}
+                        </button>
+                    </>
+                )}
+            </div>
+            <div className="spread">
+                {report.reporting_user ? (
+                    <Player user={report.reporting_user} icon />
+                ) : (
+                    <span>{_("System")}</span>
+                )}
+                <i>{moment(report.created).fromNow()}</i>
+            </div>
+        </div>
+    );
+}

--- a/src/components/IncidentReportTracker/IncidentReportCard.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportCard.tsx
@@ -85,7 +85,6 @@ export function IncidentReportCard({
         }
     };
 
-    console.log(report.reporter_note_translation);
     return (
         <div className="incident" key={report.id}>
             <div className="report-header">

--- a/src/components/IncidentReportTracker/IncidentReportCard.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportCard.tsx
@@ -103,7 +103,11 @@ export function IncidentReportCard({
             </div>
             {isEditing ? (
                 <div className="edit-notes">
-                    <textarea value={reporterNote} onChange={handleNoteChange} />
+                    <textarea
+                        value={reporterNote}
+                        onChange={handleNoteChange}
+                        placeholder={_("Provide details here")}
+                    />
                     <div className="edit-buttons">
                         <button className="primary" onClick={handleNoteSubmit}>
                             {_("Update")}
@@ -112,33 +116,33 @@ export function IncidentReportCard({
                     </div>
                 </div>
             ) : (
-                report.reporter_note && (
-                    <div className="note-container">
-                        <h4 className="notes">
-                            {report.reporter_note_translation ? (
-                                <>
-                                    {report.reporter_note_translation.source_text}
-                                    {report.reporter_note_translation.target_language !==
-                                        report.reporter_note_translation.source_language && (
-                                        <>
-                                            <div className="source-to-target-languages">
-                                                {report.reporter_note_translation.source_language}{" "}
-                                                =&gt;
-                                                {report.reporter_note_translation.target_language}
-                                            </div>
-                                            <div className="translated">
-                                                {report.reporter_note_translation.target_text}
-                                            </div>
-                                        </>
-                                    )}
-                                </>
-                            ) : (
-                                <AutoTranslate source={report.reporter_note} />
-                            )}
-                        </h4>
-                        <i className="fa fa-pencil-square-o" onClick={() => setIsEditing(true)}></i>
-                    </div>
-                )
+                <div className="note-container">
+                    <h4 className="notes">
+                        {report.reporter_note_translation?.target_text ? (
+                            <>
+                                {report.reporter_note_translation.source_text}
+                                {report.reporter_note_translation.target_language !==
+                                    report.reporter_note_translation.source_language && (
+                                    <>
+                                        <div className="source-to-target-languages">
+                                            {report.reporter_note_translation.source_language} =&gt;
+                                            {report.reporter_note_translation.target_language}
+                                        </div>
+                                        <div className="translated">
+                                            {report.reporter_note_translation.target_text}
+                                        </div>
+                                    </>
+                                )}
+                            </>
+                        ) : (
+                            <AutoTranslate
+                                source={report.reporter_note}
+                                placeholder="Provide details here"
+                            />
+                        )}
+                    </h4>
+                    <i className="fa fa-pencil-square-o" onClick={() => setIsEditing(true)}></i>
+                </div>
             )}
 
             {report.system_note && <h4 className="notes">{report.system_note}</h4>}

--- a/src/components/IncidentReportTracker/IncidentReportTracker.styl
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.styl
@@ -71,6 +71,18 @@
         padding-top: 0.7rem;
     }
 
+    // Attempt to make this line up with the player name to the right.
+    // Still doesn't work properly, not sure why
+    .reported-user {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .reported-user-label {
+        margin-right: 1rem;
+    }
+
     #conversation {
         font-weight: bold;
 
@@ -90,7 +102,12 @@
             margin: 0.5em 0 0 0;
         }
 
+        .note-container {
+            display: flex;
+            flex-direction: column;
+        }
         .notes {
+            flex-grow: 1;
             user-select: text;
 
             .source-to-target-languages {
@@ -101,6 +118,11 @@
             .translated {
                 font-style: italic;
             }
+        }
+
+        .edit-notes {
+            display: flex;
+            flex-direction: column;
         }
     }
 }

--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -236,6 +236,7 @@ export function IncidentReportTracker(): JSX.Element | null {
                         )}
                         {filtered_reports.map((report: Report, index) => (
                             <IncidentReportCard
+                                key={index}
                                 report={report}
                                 index={index}
                                 first_report_button={first_report_button}

--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -34,7 +34,10 @@ import { IncidentReportCard } from "./IncidentReportCard";
 export function IncidentReportTracker(): JSX.Element | null {
     const user = useUser();
     const navigate = useNavigate();
-    const [show_incident_list, setShowIncidentList] = React.useState(false);
+    const [show_incident_list, setShowIncidentList] = React.useState(
+        data.get("ui-state.show_incident_list"),
+    );
+
     const [normal_ct, setNormalCt] = React.useState(0);
     const [prefer_hidden] = usePreference("hide-incident-reports");
     const [report_quota] = usePreference("moderator.report-quota");
@@ -53,7 +56,7 @@ export function IncidentReportTracker(): JSX.Element | null {
             signalUsed("incident-report-indicator");
             navigate("/reports-center/");
         } else {
-            setShowIncidentList(!show_incident_list);
+            data.set("ui-state.show_incident_list", !show_incident_list);
         }
     }
 
@@ -165,6 +168,8 @@ export function IncidentReportTracker(): JSX.Element | null {
         report_manager.on("incident-report", onReport);
         report_manager.on("active-count", updateCt);
         report_manager.on("update", refresh);
+
+        data.watch("ui-state.show_incident_list", setShowIncidentList);
 
         return () => {
             report_manager.off("incident-report", onReport);

--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -16,23 +16,20 @@
  */
 
 import * as React from "react";
-import * as moment from "moment";
 import * as preferences from "preferences";
 import * as data from "data";
 import { Link, useNavigate } from "react-router-dom";
 import { alert } from "swal_config";
-import { _, pgettext } from "translate";
+import { pgettext } from "translate";
 import { post } from "requests";
 import { usePreference } from "preferences";
-import { Player } from "Player";
+
 import { ignore, errorAlerter } from "misc";
-import { openReportedConversationModal } from "ReportedConversationModal";
-import { AutoTranslate } from "AutoTranslate";
-import { report_categories } from "Report";
 import { report_manager } from "report_manager";
 import { Report } from "report_util";
 import { useRefresh, useUser } from "hooks";
 import * as DynamicHelp from "react-dynamic-help";
+import { IncidentReportCard } from "./IncidentReportCard";
 
 export function IncidentReportTracker(): JSX.Element | null {
     const user = useUser();
@@ -192,16 +189,6 @@ export function IncidentReportTracker(): JSX.Element | null {
     const reports = report_manager.getEligibleReports();
     const hide_indicator = (reports.length === 0 && !user.is_moderator) || prefer_hidden;
 
-    function getReportType(report: Report): string {
-        if (report.report_type === "appeal") {
-            return "Ban Appeal";
-        }
-
-        const report_category = report_categories.filter((r) => r.type === report.report_type)[0];
-        const report_type_title = report_category?.title || "Other";
-        return report_type_title;
-    }
-
     const filtered_reports = reports.filter(
         (report) =>
             !preferences.get("hide-claimed-reports") ||
@@ -248,189 +235,12 @@ export function IncidentReportTracker(): JSX.Element | null {
                             </div>
                         )}
                         {filtered_reports.map((report: Report, index) => (
-                            <div className="incident" key={report.id}>
-                                <div className="report-header">
-                                    <div
-                                        className="report-id"
-                                        ref={index === 0 ? first_report_button : null}
-                                    >
-                                        <button
-                                            onClick={() => reportButtonClicked(report.id)}
-                                            className="small"
-                                        >
-                                            {"R" + report.id.toString().slice(-3)}
-                                        </button>
-                                    </div>
-                                    {getReportType(report)}
-                                    {((!report.moderator && user.is_moderator) || null) && (
-                                        <button className="primary xs" onClick={report.claim}>
-                                            {_("Claim")}
-                                        </button>
-                                    )}
-                                    {user.is_moderator && report.moderator && (
-                                        <Player user={report.moderator} icon />
-                                    )}
-                                </div>
-                                {(report.reporter_note || null) && (
-                                    <h4 className="notes">
-                                        {report.reporter_note_translation ? (
-                                            <>
-                                                {report.reporter_note_translation.source_text}
-                                                {(report.reporter_note_translation
-                                                    .target_language !==
-                                                    report.reporter_note_translation
-                                                        .source_language ||
-                                                    null) && (
-                                                    <>
-                                                        <div className="source-to-target-languages">
-                                                            {
-                                                                report.reporter_note_translation
-                                                                    .source_language
-                                                            }{" "}
-                                                            =&gt;{" "}
-                                                            {
-                                                                report.reporter_note_translation
-                                                                    .target_language
-                                                            }
-                                                        </div>
-                                                        <div className="translated">
-                                                            {
-                                                                report.reporter_note_translation
-                                                                    .target_text
-                                                            }
-                                                        </div>
-                                                    </>
-                                                )}
-                                            </>
-                                        ) : (
-                                            <AutoTranslate source={report.reporter_note} />
-                                        )}
-                                    </h4>
-                                )}
-
-                                {(report.system_note || null) && (
-                                    <h4 className="notes">{report.system_note}</h4>
-                                )}
-
-                                <div className="notes">
-                                    <i>{user.is_moderator ? report.moderator_note || "" : ""}</i>
-                                </div>
-
-                                <div className="spread">
-                                    {(report.url || null) && (
-                                        <a href={report.url} target="_blank">
-                                            {report.url}
-                                        </a>
-                                    )}
-
-                                    {(report.reported_user || null) && (
-                                        <span>
-                                            {_("Reported user")}:{" "}
-                                            <Player user={report.reported_user} icon />
-                                        </span>
-                                    )}
-                                    {(report.reported_game || null) && (
-                                        <span>
-                                            {_("Game")}:{" "}
-                                            <Link to={`/game/${report.reported_game}`}>
-                                                #{report.reported_game}
-                                            </Link>
-                                        </span>
-                                    )}
-                                    {(report.reported_review || null) && (
-                                        <span>
-                                            {_("Review")}:{" "}
-                                            <Link to={`/review/${report.reported_review}`}>
-                                                ##{report.reported_review}
-                                            </Link>
-                                        </span>
-                                    )}
-                                </div>
-
-                                {(report.report_type === "appeal" || null) && (
-                                    <h3>
-                                        <Link to={`/appeal/${report.reported_user.id}`}>
-                                            View Appeal
-                                        </Link>
-                                    </h3>
-                                )}
-
-                                {(report.reported_conversation || null) && (
-                                    <div
-                                        className="spread"
-                                        onClick={() => {
-                                            openReportedConversationModal(
-                                                report.reported_user?.id,
-                                                report.reported_conversation,
-                                            );
-                                        }}
-                                    >
-                                        <span id="conversation">
-                                            {_("View Reported Conversation")}
-                                        </span>
-                                    </div>
-                                )}
-
-                                <div className="spread">
-                                    {((report.moderator &&
-                                        user.is_moderator &&
-                                        user.id !== report.moderator.id) ||
-                                        null) && (
-                                        <button className="danger xs" onClick={report.steal}>
-                                            {_("Steal")}
-                                        </button>
-                                    )}
-                                    {((!report.moderator &&
-                                        report.reporting_user &&
-                                        user.id === report.reporting_user.id) ||
-                                        null) && (
-                                        <button className="reject xs" onClick={report.cancel}>
-                                            {_("Cancel")}
-                                        </button>
-                                    )}
-
-                                    {((report.moderator &&
-                                        user.is_moderator &&
-                                        user.id === report.moderator.id) ||
-                                        null) && (
-                                        <button className="success xs" onClick={report.good_report}>
-                                            {_("Good report")}
-                                        </button>
-                                    )}
-                                    {((report.moderator &&
-                                        user.is_moderator &&
-                                        user.id === report.moderator.id) ||
-                                        null) && (
-                                        <button className="info xs" onClick={report.set_note}>
-                                            {_("Note")}
-                                        </button>
-                                    )}
-                                    {((report.moderator &&
-                                        user.is_moderator &&
-                                        user.id === report.moderator.id) ||
-                                        null) && (
-                                        <button className="danger xs" onClick={report.unclaim}>
-                                            {_("Unclaim")}
-                                        </button>
-                                    )}
-                                    {((report.moderator &&
-                                        user.is_moderator &&
-                                        user.id === report.moderator.id) ||
-                                        null) && (
-                                        <button className="reject xs" onClick={report.bad_report}>
-                                            {_("Bad report")}
-                                        </button>
-                                    )}
-                                </div>
-                                <div className="spread">
-                                    {report.reporting_user ? (
-                                        <Player user={report.reporting_user} icon />
-                                    ) : (
-                                        <span>{_("System")}</span>
-                                    )}
-                                    <i>{moment(report.created).fromNow()}</i>
-                                </div>
-                            </div>
+                            <IncidentReportCard
+                                report={report}
+                                index={index}
+                                first_report_button={first_report_button}
+                                reportButtonClicked={reportButtonClicked}
+                            />
                         ))}
                     </div>
                 </div>

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -16,6 +16,7 @@
  */
 
 import * as React from "react";
+import * as data from "data";
 import * as ReactDOM from "react-dom/client";
 import * as player_cache from "player_cache";
 import { Card } from "material";
@@ -454,15 +455,23 @@ export function openReport(report: ReportProperties): void {
     const review_id = parseInt(
         document.location.pathname.match(/(review|demo\/view)\/([0-9]+)/)?.[2] || "0",
     );
-    container.className = "Report-container-container";
-    document.body.append(container);
-    const root = ReactDOM.createRoot(container);
 
     if (game_id && !("reported_game_id" in report)) {
         report["reported_game_id"] = game_id;
     }
     if (review_id && !("reported_review_id" in report)) {
         report["reported_review_id"] = review_id;
+    }
+
+    // Don't open the report creation dialog if they have already reported this game.
+    // Instead, open the incident report list to show them their current report, which they can edit.
+    // (arguably we might let them report the "other" player as well as the already reported one,
+    //  but that's a bit more complicated and not worth the effort for now.)
+    const already_reported = data.get("reported-games") as number[];
+    console.log("already_reported", already_reported, report.reported_game_id);
+    if (report.reported_game_id && already_reported.includes(report.reported_game_id)) {
+        data.set("ui-state.show_incident_list", true);
+        return;
     }
 
     function onClose() {
@@ -474,7 +483,9 @@ export function openReport(report: ReportProperties): void {
         }
     }
 
-    console.log("Preparing report: ", report);
+    container.className = "Report-container-container";
+    document.body.append(container);
+    const root = ReactDOM.createRoot(container);
 
     root.render(
         <React.StrictMode>

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -268,6 +268,8 @@ export interface DataSchema
     "help-system-enabled": boolean;
     "rdh-system-state": string;
     "ignored-reports": { [report_id: number]: number /* id -> expiration */ };
+    "reported-games": number[];
+    "ui-state.show_incident_list": boolean;
 
     // A challenge that the user accepted, but we didn't tell the server yet, because
     // we are busy getting them logged in first.

--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -51,6 +51,7 @@ let post_connect_notification_squelch = true;
 class ReportManager extends EventEmitter<Events> {
     active_incident_reports: { [id: string]: Report } = {};
     sorted_active_incident_reports: Report[] = [];
+    this_user_reported_games: number[] = [];
 
     constructor() {
         super();
@@ -114,10 +115,17 @@ class ReportManager extends EventEmitter<Events> {
             (user.moderator_powers && report.escalated)
         ) {
             delete this.active_incident_reports[report.id];
+            this.this_user_reported_games = this.this_user_reported_games.filter(
+                (game_id) => game_id !== report.reported_game,
+            );
         } else {
             this.active_incident_reports[report.id] = report;
+            if (report.reported_game && report.reporting_user?.id === user.id) {
+                this.this_user_reported_games.push(report.reported_game);
+            }
         }
-
+        data.set("reported-games", this.this_user_reported_games);
+        console.log("ReportManager: reported games", this.this_user_reported_games);
         this.emit("incident-report", report);
         this.update();
     }


### PR DESCRIPTION
Fixes CMs having hassles knowing how to vote to give sensible messages about duplicate reports

## Proposed Changes

  - Instead of opening the Report form, open the IncidentList, if the user already has opened a report on that game
  
* : built on top of #2752, because it doesn't really make sense to do this if they can't edit their reports.