### PR TITLE
Get rid of leftover RDH elements...

### DIFF
--- a/src/components/IncidentReportTracker/IncidentReportCard.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportCard.tsx
@@ -50,17 +50,9 @@ function getReportType(report: Report): string {
 
 interface IncidentReportCardProps {
     report: Report;
-    index: number;
-    first_report_button: React.RefObject<HTMLDivElement>;
-    reportButtonClicked: (id: number) => void;
 }
 
-export function IncidentReportCard({
-    report,
-    index,
-    first_report_button,
-    reportButtonClicked,
-}: IncidentReportCardProps): JSX.Element {
+export function IncidentReportCard({ report }: IncidentReportCardProps): JSX.Element {
     const user = useUser();
     const [reporterNote, setReporterNote] = React.useState(report.reporter_note || "");
     const [isEditing, setIsEditing] = React.useState(false);
@@ -88,8 +80,8 @@ export function IncidentReportCard({
     return (
         <div className="incident" key={report.id}>
             <div className="report-header">
-                <div className="report-id" ref={index === 0 ? first_report_button : null}>
-                    <button onClick={() => reportButtonClicked(report.id)} className="small">
+                <div className="report-id">
+                    <button className="small inactive">
                         {"R" + report.id.toString().slice(-3)}
                     </button>
                 </div>

--- a/src/components/IncidentReportTracker/IncidentReportTracker.styl
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.styl
@@ -56,6 +56,11 @@
             display: flex;
             margin-top: auto;
             padding-right: 1 em;
+            // this is just for appearance, it no longer has a function
+            button {
+                cursor: default;
+                pointer-events: none;
+            }
         }
         .unclaimed {
             font-style: italic;
@@ -69,18 +74,6 @@
         display: flex;
         justify-content: space-between;
         padding-top: 0.7rem;
-    }
-
-    // Attempt to make this line up with the player name to the right.
-    // Still doesn't work properly, not sure why
-    .reported-user {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-    }
-
-    .reported-user-label {
-        margin-right: 1rem;
     }
 
     #conversation {
@@ -102,12 +95,7 @@
             margin: 0.5em 0 0 0;
         }
 
-        .note-container {
-            display: flex;
-            flex-direction: column;
-        }
         .notes {
-            flex-grow: 1;
             user-select: text;
 
             .source-to-target-languages {
@@ -118,11 +106,6 @@
             .translated {
                 font-style: italic;
             }
-        }
-
-        .edit-notes {
-            display: flex;
-            flex-direction: column;
         }
     }
 }

--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -48,8 +48,6 @@ export function IncidentReportTracker(): JSX.Element | null {
     const { ref: hidden_incident_report_indicator } = registerTargetItem(
         "hidden-incident-report-indicator",
     );
-    const { ref: first_report_button, used: reportButtonUsed } =
-        registerTargetItem("first-report-button");
 
     function toggleList() {
         if (user.is_moderator || user.moderator_powers) {
@@ -181,11 +179,6 @@ export function IncidentReportTracker(): JSX.Element | null {
         };
     }, []);
 
-    const reportButtonClicked = (report_id: number) => {
-        reportButtonUsed();
-        navigate(`/reports-center/all/${report_id}`);
-    };
-
     if (!user) {
         // Can happen when deleting your account, apparently.
         return null;
@@ -240,13 +233,7 @@ export function IncidentReportTracker(): JSX.Element | null {
                             </div>
                         )}
                         {filtered_reports.map((report: Report, index) => (
-                            <IncidentReportCard
-                                key={index}
-                                report={report}
-                                index={index}
-                                first_report_button={first_report_button}
-                                reportButtonClicked={reportButtonClicked}
-                            />
+                            <IncidentReportCard key={index} report={report} />
                         ))}
                     </div>
                 </div>


### PR DESCRIPTION
… lingering from "incident list removal for moderators"

Fixes # spurious error message when someone clicks non-functional button

## Proposed Changes

  - Make the button unclickable, and get rid of unused elements
     - left the button as button-shaped, for continuity of presentation
 
