### PR TITLE
Made game log easier to understand (and fixed set-state-before-mounted).

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,9 +1,10 @@
 {
     "ignorePaths": [
         "src/views/GoTV/twitchLanguageCodes.ts"
-      ],
+    ],
     "words": [
         "abcdefghjklmnopqrstuvwxyz",
+        "AFAICT",
         "AILR",
         "aireview",
         "annulable",


### PR DESCRIPTION
Fixes confusion about what game log is saying

## Proposed Changes

  - Get rid of "color" field display in stone_removal_stone_set - not needed, can be confusing (color of what?)
  - Get rid of needs_sealing display
  - Use words that say what the "removed" flag means
  - Don't show stone_removal_stone_set events with no stones (unclear what these are)
  - Dont set log state till we're mounted
  