### PR TITLE
Filter the `UserHistory` table for warnings only for CMs 

### DIFF
--- a/src/views/ReportsCenter/UserHistory.tsx
+++ b/src/views/ReportsCenter/UserHistory.tsx
@@ -41,7 +41,9 @@ export function UserHistory({
             {user.is_moderator && (
                 <ModTools user_id={target_user.id} show_mod_log={true} collapse_same_users={true} />
             )}
-            {!user.is_moderator && !!user.moderator_powers && <ModLog user_id={target_user.id} />}
+            {!user.is_moderator && !!user.moderator_powers && (
+                <ModLog user_id={target_user.id} warnings_only={true} />
+            )}
         </>
     );
 }

--- a/src/views/User/ModLog.tsx
+++ b/src/views/User/ModLog.tsx
@@ -24,9 +24,12 @@ import { chat_markup } from "Chat";
 
 interface ModLogProps {
     user_id: number;
+    warnings_only?: boolean;
 }
 
 export function ModLog(props: ModLogProps): JSX.Element {
+    const groomFunction = (data: any[]) => data.filter((X) => !X.action.includes("ack"));
+
     return (
         <PaginatedTable
             className="moderator-log"
@@ -37,6 +40,7 @@ export function ModLog(props: ModLogProps): JSX.Element {
                 event: `modlog-${props.user_id}-updated`,
                 channel: "moderators",
             }}
+            {...(props.warnings_only && { groom: groomFunction })}
             columns={[
                 {
                     header: "",


### PR DESCRIPTION

Fixes CMs having to squint at a huge list, looking for warnings

## Proposed Changes

  - filter to "only warnings" in `UserHistory` for CMs
  
(Note, this could be done in the backend, it already filters some stuff, but since this is not "they must not see" but rather "they prefer not to see", I've put it in the front end)
