### PR TITLE
Let CMs submit dupe reports, and defend against list getting stuck open

### DIFF
--- a/src/components/IncidentReportTracker/IncidentReportTracker.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportTracker.tsx
@@ -34,9 +34,7 @@ import { IncidentReportCard } from "./IncidentReportCard";
 export function IncidentReportTracker(): JSX.Element | null {
     const user = useUser();
     const navigate = useNavigate();
-    const [show_incident_list, setShowIncidentList] = React.useState(
-        data.get("ui-state.show_incident_list"),
-    );
+    const [show_incident_list, setShowIncidentList] = React.useState<boolean | undefined>(false);
 
     const [normal_ct, setNormalCt] = React.useState(0);
     const [prefer_hidden] = usePreference("hide-incident-reports");
@@ -176,6 +174,7 @@ export function IncidentReportTracker(): JSX.Element | null {
             data.unwatch("user", updateUser);
             data.unwatch("preferences.moderator.report-quota", updateUser);
             data.unwatch("preferences.show-cm-reports", updateUser);
+            data.unwatch("ui-state.show_incident_list", setShowIncidentList);
         };
     }, []);
 
@@ -212,7 +211,7 @@ export function IncidentReportTracker(): JSX.Element | null {
                     <span className={`count ${normal_ct > 0 ? "active" : ""}`}>{normal_ct}</span>
                 </div>
             )}
-            {show_incident_list && (
+            {!!show_incident_list && (
                 <div className="IncidentReportTracker">
                     <div className="IncidentReportList-backdrop" onClick={toggleList}></div>
                     <div className="IncidentReportList-results">

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -27,6 +27,7 @@ import { alert } from "swal_config";
 import { setIgnore } from "BlockPlayer";
 import { useUser } from "hooks";
 import { get } from "requests";
+import { toast } from "toast";
 
 export type ReportType =
     | "all" // not a type, just useful for the enumeration
@@ -448,6 +449,7 @@ export function Report(props: ReportProperties): JSX.Element {
 }
 
 export function openReport(report: ReportProperties): void {
+    const user = data.get("user");
     const container = document.createElement("DIV");
     const game_id = parseInt(
         document.location.pathname.match(/game\/(view\/)?([0-9]+)/)?.[2] || "0",
@@ -470,8 +472,13 @@ export function openReport(report: ReportProperties): void {
     const already_reported = data.get("reported-games", []) as number[];
 
     if (report.reported_game_id && already_reported.includes(report.reported_game_id)) {
-        data.set("ui-state.show_incident_list", true);
-        return;
+        if (!user.is_moderator && !user.moderator_powers) {
+            toast(<div>{_("You have already reported this game.")}</div>);
+            data.set("ui-state.show_incident_list", true);
+            return;
+        } else {
+            toast(<div>{_("Note: You have already reported this game!")}</div>);
+        }
     }
 
     function onClose() {


### PR DESCRIPTION
Fixes IncidentReportList getting stuck open, and confusing experience for CMs who submit dupe reports.

## Proposed Changes

  - Reset "show list" on mount
  - Don't prevent CMs from submitting duplicate reports.
  
