### PR TITLE
Wrap tournament steps when there are too many

### DIFF
--- a/src/components/Steps/Steps.styl
+++ b/src/components/Steps/Steps.styl
@@ -21,6 +21,7 @@ step-fg=#fff
 .Steps {
     display: flex;
     align-items: flex-start;
+    flex-wrap: wrap;
 }
 
 .StepContainer {


### PR DESCRIPTION
It's rare, but sometimes when you have a long tournament [like this one](https://online-go.com/tournament/95975) with many rounds, the page gets too wide from all of the rounds:

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/80c71e1d-8fc0-4cc1-888b-b3fb75e5e6b9">

This fixes that, and wraps the steps after they hit the container width:

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/753cc8b7-5650-45cf-a5bd-0eeae5b3e78f">
