### PR TITLE
Clarify "acknowledgement" severity warnings

### DIFF
--- a/src/views/User/ModLog.styl
+++ b/src/views/User/ModLog.styl
@@ -30,4 +30,11 @@
         white-space: pre-wrap;
         word-wrap: break-word;
     }
+
+    .acknowledgement-event {
+        themed background shade4;
+        color green;
+        font-size: smaller;
+        font-style: italic;
+    }
 }

--- a/src/views/User/ModLog.tsx
+++ b/src/views/User/ModLog.tsx
@@ -58,7 +58,12 @@ export function ModLog(props: ModLogProps): JSX.Element {
                     header: "",
                     className: "",
                     render: (X) => (
-                        <div>
+                        <div
+                            className={
+                                // "acknowledgements" are not warnings, so need de-emphasis
+                                X.action.includes("acknowledgement") ? "acknowledgement-event" : ""
+                            }
+                        >
                             <div className="action">
                                 {X.incident_report?.id ? (
                                     <Link to={`/reports-center/all/${X.incident_report.id}`}>


### PR DESCRIPTION
Attempt to be clearer in the mod log that "acknowledgement" means "we thanked this person for their report and they acked this".

Fixes moderators thinking that a person has been warned a lot, when in fact they have been thanked a lot.

## Proposed Changes

  - Change the styling of "acknowledgement" entries


Note: ideally the backend should not call these "warnings" either ... that word comes from the backend and is displayed confusingly.
