### PR TITLE
add warning-fg color to ogs.styl

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -167,6 +167,7 @@ light.chart-line                        = #184A6B
 light.error-boundary-bg                 = lighten(light.reject, 50%)
 light.error-boundary-fg                 = darken(light.reject, 50%)
 light.warning-bg                        = #FFAE2C
+light.warning-fg                        = #0051d3 // generated to contrast with warning-bg
 light.supporter-error-bg                = hsl(23, 100, 90);
 light.supporter-error-border            = hsl(23, 100, 80);
 
@@ -316,6 +317,7 @@ dark.chart-line                         = #329BE0
 dark.error-boundary-bg                  = darken(light.reject, 50%)
 dark.error-boundary-fg                  = lighten(light.reject, 50%)
 dark.warning-bg                         = #925A00
+dark.warning-fg                         = #6da5ff // generated to contrast with warning-bg
 dark.supporter-error-bg                 = hsl(23, 100, 10);
 dark.supporter-error-border             = hsl(23, 100, 30);
 

--- a/src/views/Game/PlayControls.styl
+++ b/src/views/Game/PlayControls.styl
@@ -133,7 +133,7 @@
         bottom: 0.5em;
         */
     }
-    
+
     .stalling-score-estimate {
         margin: 0.5rem;
         font-size: 1.0rem;
@@ -141,7 +141,7 @@
         text-wrap: balance;
         text-wrap-mode: balance;
     }
-    
+
     .needs-sealing {
         margin: 1.0rem;
         padding: 1.0rem;
@@ -176,13 +176,13 @@
             }
         }
     }
-    
+
     .score-square {
         display: inline-block;
         width: 0.7rem;
         height: 0.7rem;
         border: 0.3rem solid #f00;
-        
+
         &.black {
             background-color: black;
             border-color: #555;
@@ -192,12 +192,12 @@
             border-color: #AAA;
         }
     }
-    
+
     .btn-group {
         vertical-align: middle;
         display: inline-flex;
     }
-    
+
     .removal {
         color: red;
     }


### PR DESCRIPTION
Fixes  warnings being issued about undefined color

## Proposed Changes

  - I put the light and dark `warning-bg` into a "contrasting color generator" online, and created `warning-fg` with what it gave me
