### PR TITLE
Update to match refactored/renamed CM outcome graphs

### DIFF
--- a/src/views/ReportsCenter/ReportsCenterHistory.styl
+++ b/src/views/ReportsCenter/ReportsCenterHistory.styl
@@ -34,17 +34,16 @@
         grid-template-columns: 1fr auto; /* Action column takes up the remaining space, count column is as narrow as needed */
 
         .action-votes {
-            display: contents; /* Makes item content align with the grid */
+            display: contents; /* Makes action and vote count be controlled by the grid */
 
             .action {
                 padding: 0.5em;
                 align-self: start; /* Align text to the top of the grid cell */
-                white-space: nowrap; /* Prevents text from wrapping */
+                white-space: nowrap;  /* we actally don't care about the overflow, it's fine to cut if off */
             }
             .vote-count {
                 padding: 0.5em;
                 align-self: start; /* Align text to the top of the grid cell */
-                white-space: nowrap; /* Prevents text from wrapping */
             }
         }
 


### PR DESCRIPTION
Fixes graph breakage that will be happen when https://github.com/online-go/ogs/pull/1991 goes in :)

## Proposed Changes
  -  Use the new route names.  
  -- I put backward compatible routes into 1991, but we also need:
  -  Tweak data decode to match updated structure
  
