### PR TITLE
Be less certain about whether the game can be scored or not in sealing warning

### DIFF
--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -469,7 +469,7 @@ export function PlayControls({
                     {need_to_seal && (
                         <div className="needs-sealing">
                             {_(
-                                "The highlighted locations need to be sealed before the game can be scored correctly",
+                                "The highlighted locations may need to be sealed before the game can be scored correctly",
                             )}
                             <div className="needs-sealing-coordinates">
                                 <span className="needs-sealing-box" />


### PR DESCRIPTION
Fixes users feeling like they can't accept the score

## Proposed Changes

  - "need to be" -> "may need to be"
 