### PR TITLE
Redo reported game layout

### DIFF
--- a/src/views/ReportsCenter/ReportedGame.styl
+++ b/src/views/ReportsCenter/ReportedGame.styl
@@ -1,0 +1,53 @@
+
+.reported-game-container {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: stretch;
+    align-content: stretch;
+    flex-wrap: wrap;
+    max-width: reports_center_content_width;
+
+    .reported-game-info {
+        order: -1; // put this first so mobile layout is nice
+        .reported-turn {
+            padding: 0.25rem;
+        }
+    }
+
+    .reported-game-mini-goban {
+        .MiniGoban  {
+            justify-content: flex-start;
+        }
+    }
+
+    .col {
+        flex: 1;
+        flex-basis: 45%;
+        display: inline-flex;
+        min-width: 20rem;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: stretch;
+        align-content: stretch;
+        padding: 0.5rem;
+
+        .event {
+            padding-right: 0.3rem;
+        }
+    }
+
+    // We have horizontal less room than `GameLog` expects
+    .GameLog {
+        tr {
+            vertical-align: top;
+        }
+        td>div {
+            margin-bottom: 2em
+            span {
+                display: inline-block;
+            }
+        }
+    }
+}

--- a/src/views/ReportsCenter/ReportedGame.styl
+++ b/src/views/ReportsCenter/ReportedGame.styl
@@ -7,7 +7,10 @@
     justify-content: stretch;
     align-content: stretch;
     flex-wrap: wrap;
-    max-width: reports_center_content_width;
+
+    .reported-game h3 {
+        margin-bottom: 0;
+    }
 
     .reported-game-info {
         order: -1; // put this first so mobile layout is nice

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -16,14 +16,13 @@
  */
 
 import * as React from "react";
-import * as moment from "moment";
 import { useRefresh } from "hooks";
 import { _, pgettext } from "translate";
 import { Link } from "react-router-dom";
 import { MiniGoban } from "MiniGoban";
 import { alert } from "swal_config";
 import { post, get } from "requests";
-import { errorAlerter, showSecondsResolution } from "misc";
+import { errorAlerter } from "misc";
 import { doAnnul } from "moderation";
 
 import {
@@ -34,7 +33,6 @@ import {
     GobanContext,
     useCurrentMove,
     game_control,
-    GameLog,
 } from "Game";
 import { GobanRenderer } from "goban";
 import { Resizable } from "Resizable";
@@ -42,6 +40,7 @@ import { Resizable } from "Resizable";
 import { Player } from "Player";
 import { useUser } from "hooks";
 import { shortTimeControl } from "TimeControl";
+import { GameLog } from "../Game/GameLog";
 
 export function ReportedGame({
     game_id,
@@ -62,7 +61,6 @@ export function ReportedGame({
     const [game, setGame] = React.useState<rest_api.GameDetails | null>(null);
     const [_aiReviewUuid, setAiReviewUuid] = React.useState<string | null>(null);
     const [annulled, setAnnulled] = React.useState<boolean>(false);
-    const [finalActionTime, setFinalActionTime] = React.useState<moment.Duration | null>(null);
     const [timedOutPlayer, setTimedOutPlayer] = React.useState<number | null>(null);
 
     const user = useUser();
@@ -180,39 +178,30 @@ export function ReportedGame({
                             <div>White: {game && <Player user={game.white} />}</div>
                             <div>Game Phase: {goban.engine.phase}</div>
                             {(goban.engine.phase === "finished" || null) && (
-                                <>
-                                    <div>
-                                        {_("Game Outcome:") + ` ${winner} (`}
-                                        <Player user={goban!.engine.winner as number} />
-                                        {` ) ${pgettext(
-                                            "use like: they won 'by' this much",
-                                            "by",
-                                        )} `}
-                                        {goban.engine.outcome}
-                                        {annulled ? _(" annulled") : ""}
-                                    </div>
-                                    <div>
-                                        {_("The last event took: ") +
-                                            showSecondsResolution(finalActionTime)}
-                                    </div>
-
-                                    {timedOutPlayer && (
-                                        <div>
-                                            {_("Player timed out:")}
-                                            <Player user={timedOutPlayer} />
-                                            {timedOutPlayer === reported_by
-                                                ? pgettext(
-                                                      "A note of surprise telling a moderator that the person who timed out is the reporter",
-                                                      " (reporter!)",
-                                                  )
-                                                : pgettext(
-                                                      "A label next to a player name telling a moderator that a they are the one who was reported",
-                                                      " (the reported player)",
-                                                  )}
-                                        </div>
-                                    )}
-                                </>
+                                <div>
+                                    {_("Game Outcome:") + ` ${winner} (`}
+                                    <Player user={goban!.engine.winner as number} />
+                                    {` ) ${pgettext("use like: they won 'by' this much", "by")} `}
+                                    {goban.engine.outcome}
+                                    {annulled ? _(" annulled") : ""}
+                                </div>
                             )}
+                            {timedOutPlayer && (
+                                <div>
+                                    {_("Player timed out:")}
+                                    <Player user={timedOutPlayer} />
+                                    {timedOutPlayer === reported_by
+                                        ? pgettext(
+                                              "A note of surprise telling a moderator that the person who timed out is the reporter",
+                                              " (reporter!)",
+                                          )
+                                        : pgettext(
+                                              "A label next to a player name telling a moderator that a they are the one who was reported",
+                                              " (reported)",
+                                          )}
+                                </div>
+                            )}
+
                             {user.is_moderator && (
                                 <>
                                     {goban.engine.phase === "finished" ? (
@@ -260,6 +249,7 @@ export function ReportedGame({
                                         hidden={false}
                                     />
                                 )}
+
                             <Resizable
                                 id="move-tree-container"
                                 className="vertically-resizable"
@@ -283,7 +273,6 @@ export function ReportedGame({
                                 handicap={goban.engine.config.handicap as any}
                                 black_id={goban.engine.config.black_player_id as any}
                                 white_id={goban.engine.config.white_player_id as any}
-                                onFinalActionCalculated={setFinalActionTime}
                             />
 
                             <GameLog

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -112,65 +112,12 @@ reports_center_content_width=56rem
         font-weight: normal;
     }
 
-    .reported-game-container {
-        flex: 1;
-        display: flex;
-        flex-direction: row;
-        align-items: stretch;
-        justify-content: stretch;
-        align-content: stretch;
-        flex-wrap: wrap;
-        max-width: reports_center_content_width;
-
-        .reported-game-info {
-            order: -1; // put this first so mobile layout is nice
-            .reported-turn {
-                padding: 0.25rem;
-            }
-        }
-
-        .reported-game-mini-goban {
-            .MiniGoban  {
-                justify-content: flex-start;
-            }
-        }
-
-        .col {
-            flex: 1;
-            flex-basis: 45%;
-            display: inline-flex;
-            min-width: 20rem;
-            flex-direction: column;
-            align-items: stretch;
-            justify-content: stretch;
-            align-content: stretch;
-            padding: 0.5rem;
-
-            .event {
-                padding-right: 0.3rem;
-            }
-        }
-    }
-
     .progress {
         margin-bottom: 0.5rem;
     }
 
     .progress-bar.empty {
         themed background-color shade5
-    }
-
-    // We have horizontal less room than `GameLog` expects
-    .GameLog {
-        tr {
-            vertical-align: top;
-        }
-        td>div {
-            margin-bottom: 2em
-            span {
-                display: inline-block;
-            }
-        }
     }
 }
 

--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -187,9 +187,6 @@
         }
     }
 
-    .reported-game h3 {
-        margin-bottom: 0;
-    }
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Fixes GameLog thumbnails conflicting with chat box

## Proposed Changes

  -  Let the ReportGame pane get as wide as it wants
 
This is not the solution I really want - which is to redo `ReportedGame` using Grid, or some other solution, to enfore the pieces where we want to see them.

But ... after I did this I thought "gee, actually I like ReportedGame being wider"... and it solves the immediate problem.