### PR TITLE
Annotate `Players` based on role in a report

### DIFF
--- a/src/components/Player/Player.styl
+++ b/src/components/Player/Player.styl
@@ -40,6 +40,27 @@
         margin-left: 0.1rem;
     }
 
+    // On the ViewReport page, we support showing "reporter" and "reported"
+
+    #ViewReport & {
+        align-items: center;
+        &::after {
+            padding-left: 0.25rem;
+            width: 0.8rem;
+            font-family: 'FontAwesome';
+            font-size: 0.7rem;
+            content: "";
+        }
+        &.reported::after {
+            content: fa-exclamation-triangle-content;
+            themed color danger
+        }
+        &.reporter::after {
+            content: fa-bullhorn-content;
+            themed color supporter
+        }
+    }
+
     &.with-flare {
         align-items: baseline;  // if we have flare, then we don't have presence indicator, and it's better to line up the baselines (looks better in chat)
     }

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -73,6 +73,13 @@ export interface PlayerProperties {
     forceShowRank?: boolean;
 }
 
+type ViewReportContextType = {
+    reporter: player_cache.PlayerCacheEntry;
+    reported: player_cache.PlayerCacheEntry;
+};
+
+export const ViewReportContext = React.createContext<ViewReportContextType | null>(null);
+
 export function Player(props: PlayerProperties): JSX.Element {
     const user = data.get("user");
     const player_id: number =
@@ -98,6 +105,8 @@ export function Player(props: PlayerProperties): JSX.Element {
 
     const base = player || historical;
     const combined = base ? Object.assign({}, base, historical ? historical : {}) : null;
+
+    const viewReportContext = React.useContext(ViewReportContext);
 
     React.useEffect(() => {
         if (!props.disableCacheUpdate) {
@@ -281,6 +290,14 @@ export function Player(props: PlayerProperties): JSX.Element {
 
     if (combined.ui_class) {
         main_attrs.className += " " + combined.ui_class;
+    }
+
+    if (viewReportContext && viewReportContext.reported.id === player_id) {
+        main_attrs.className += " reported";
+    }
+
+    if (viewReportContext && viewReportContext.reporter.id === player_id) {
+        main_attrs.className += " reporter";
     }
 
     if (player_id < 0) {

--- a/src/global_styl/font-awesome-hacks.styl
+++ b/src/global_styl/font-awesome-hacks.styl
@@ -20,4 +20,6 @@ fa-circle-content="\f111";
 fa-wrench-content="\f0ad";
 fa-sort-asc-content="\f0de";
 fa-sort-desc-content="\f0dd";
+fa-bullhorn-content="\f0a1";
+fa-exclamation-triangle-content="\f071";
 fa-graduation-cap="\f19d";

--- a/src/views/ReportsCenter/ReportedGame.tsx
+++ b/src/views/ReportsCenter/ReportedGame.tsx
@@ -339,15 +339,8 @@ function GameOutcomeSummary({
                 <div>
                     {_("Player timed out:")}
                     <Player user={timedOutPlayer} />
-                    {timedOutPlayer === reported_by
-                        ? pgettext(
-                              "A note of surprise telling a moderator that the person who timed out is the reporter",
-                              " (reporter!)",
-                          )
-                        : pgettext(
-                              "A label next to a player name telling a moderator that a they are the one who was reported",
-                              " (the reported player)",
-                          )}
+                    {timedOutPlayer === reported_by && "!!"}
+                    {/* we are surprised if the reporter timed out */}
                 </div>
             )}
             {scoringAbandoned && <div>{_("Scoring abandoned by both players")}</div>}


### PR DESCRIPTION
Fixes moderators losing track of who reported and who is accused.

## Proposed Changes

  - Have `ViewReport` provide context to `Player` so that `Player` can annotate according to role in a report.
