### PR TITLE
Added a "None" option for board label lettering

### DIFF
--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -51,12 +51,14 @@ export function configure_goban() {
             };
         },
 
-        getCoordinateDisplaySystem: (): "A1" | "1-1" => {
+        getCoordinateDisplaySystem: (): "A1" | "1-1" | "none" => {
             switch (preferences.get("board-labeling")) {
                 case "A1":
                     return "A1";
                 case "1-1":
                     return "1-1";
+                case "none":
+                    return "none";
                 default:
                     // auto
                     switch (current_language) {

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -226,6 +226,7 @@ export function ThemePreferences(): JSX.Element | null {
                                 { value: "automatic", label: _("Automatic") },
                                 { value: "A1", label: "A1" },
                                 { value: "1-1", label: "1-1" },
+                                { value: "none", label: "None" },
                             ]}
                             onChange={setBoardLabeling}
                         />


### PR DESCRIPTION
Fixes #2802

## Proposed Changes

  - Add a `None` option for board label lettering. This provides the option of a cleaner looking board. 
