### PR TITLE
Provide `isDesktop` hook, use it to turn of RDH on not-desktop

### DIFF
--- a/src/components/OgsHelpProvider/OgsHelpProvider.tsx
+++ b/src/components/OgsHelpProvider/OgsHelpProvider.tsx
@@ -24,6 +24,7 @@ import * as data from "data";
 
 import { HelpProvider, HelpPopupDictionary } from "react-dynamic-help";
 import * as DynamicHelp from "react-dynamic-help";
+import { useIsDesktop, useUser } from "hooks";
 
 const helpPopupDictionary: HelpPopupDictionary = {
     "Skip this topic": pgettext("A button to dismiss a help popup topic", "Skip this topic"),
@@ -39,10 +40,13 @@ type OgsHelpProviderProps = {
  */
 
 export function OgsHelpProvider(props: OgsHelpProviderProps): JSX.Element {
+    // RDH needs work to support mobile layouts
+    const isDesktop = useIsDesktop();
+
     const [storageLoaded, setStorageLoaded] = React.useState(false);
 
     const debugDynamicHelp = data.get("debug-dynamic-help", false);
-    const user = data.get("config.user");
+    const user = useUser();
 
     // Make help system use our server-based storage, to achieve logged-in-user-specific help state.
 
@@ -82,7 +86,7 @@ export function OgsHelpProvider(props: OgsHelpProviderProps): JSX.Element {
         <HelpProvider
             dictionary={helpPopupDictionary}
             storageApi={dynamicHelpStorage}
-            storageReady={storageLoaded}
+            storageReady={storageLoaded && isDesktop} // hack to turn it off for mobile
             debug={debugDynamicHelp}
         >
             {props.children}

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -69,3 +69,19 @@ export function useRefresh(): () => void {
 export function useMainGoban(): Goban | null {
     return (window as any)["global_goban"];
 }
+
+export const useIsDesktop = () => {
+    const [isDesktop, setIsDesktop] = React.useState(true);
+
+    React.useEffect(() => {
+        const mediaQuery = window.matchMedia("(min-width: 850px)");
+        const handleResize = () => setIsDesktop(mediaQuery.matches);
+
+        handleResize(); // Check on mount
+        mediaQuery.addEventListener("change", handleResize); // Listen for changes
+
+        return () => mediaQuery.removeEventListener("change", handleResize);
+    }, []);
+
+    return isDesktop;
+};


### PR DESCRIPTION
Fixes likely (now) and certain (upcoming) layout issues when RDH fires in mobile phone layout

## Proposed Changes

  - Use `window.watchMedia` to see if we are wider than 850px for isDesktop hook
  - Use `isDesktop` hook to disable RDH if we're not on a desktop (by telling it that we're not ready)
  
I recently discovered an RDH popup-positioning bug that's ugly on mobile phone layout.

I'm working on the fix for that, likely "quick fix" ... once I can remember how to rebuild RDH 🥴

(The bug occurs when the target element is off the bottom of the screen ... not something that actually happens for the original flows, since RDH was mostly used for top right menu stuff initially)
