### PR TITLE
Defend against GameLog being used in a context without help

### DIFF
--- a/src/views/Game/GameLog.tsx
+++ b/src/views/Game/GameLog.tsx
@@ -44,7 +44,13 @@ export function GameLog({
     const [shouldDisplayFullLog, setShouldDisplayFullLog] = React.useState(false);
 
     const { registerTargetItem } = React.useContext(DynamicHelp.Api);
-    const { ref: autoscoreRef } = registerTargetItem("autoscore-game-log-entry");
+    const { ref: autoscoreRef } = {
+        // this chicanery defends against registerTargetItem being null due to this component _not_ being
+        // wrapped in OGSHelpProvider, which happens when it is in a Modal.
+        // TBD: make Modals be inside OGSHelpProvider, so they can have help.
+        ref: null,
+        ...registerTargetItem?.("autoscore-game-log-entry"),
+    };
 
     const game_id = goban_config.game_id as number;
 

--- a/src/views/Game/GameLog.tsx
+++ b/src/views/Game/GameLog.tsx
@@ -44,14 +44,10 @@ export function GameLog({
     const [shouldDisplayFullLog, setShouldDisplayFullLog] = React.useState(false);
 
     const { registerTargetItem } = React.useContext(DynamicHelp.Api);
-    const { ref: autoscoreRef } = {
-        // this chicanery defends against registerTargetItem being null due to this component _not_ being
-        // wrapped in OGSHelpProvider, which happens when it is in a Modal.
-        // TBD: make Modals be inside OGSHelpProvider, so they can have help.
-        ref: null,
-        ...registerTargetItem?.("autoscore-game-log-entry"),
-    };
 
+    // Defend against the case where we aren't wrapped in a help provider: in a Modal
+    // TBD: made Modals be able to use the help provider
+    const autoscoreRef = registerTargetItem?.("autoscore-game-log-entry")?.ref || null;
     const game_id = goban_config.game_id as number;
 
     let firstAutoscoringEntryRendered = false;


### PR DESCRIPTION
Fixes GameLog modal not working on Game page

## Proposed Changes

  - detect when registerTargetItem isn't available, which is the case in an OGS Modal
  