### PR TITLE
Shift key to select rows for annul queue

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -55,6 +55,7 @@ interface PaginatedTableProperties<RawEntryT, GroomedEntryT = RawEntryT> {
     onRowClick?: (
         row: GroomedEntryT,
         ev: React.MouseEvent | React.TouchEvent | React.PointerEvent,
+        rows: GroomedEntryT[],
     ) => any;
     debug?: boolean;
     pageSizeOptions?: Array<number>;
@@ -63,7 +64,7 @@ interface PaginatedTableProperties<RawEntryT, GroomedEntryT = RawEntryT> {
     hidePageControls?: boolean;
     /** If provided, the table will listen for this push event and refresh its data accordingly */
     uiPushProps?: { event: string; channel: string };
-    annulQueue?: any[];
+    highlightedRows?: any[];
 }
 
 export interface PaginatedTableRef {
@@ -355,40 +356,19 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
                                     {column_render(column, row)}
                                 </td>
                             ));
-                            if (props.annulQueue) {
-                                if (props.onRowClick) {
-                                    return (
-                                        <tr
-                                            key={row.id}
-                                            className={
-                                                props.annulQueue.includes(row) ? "queued" : ""
-                                            }
-                                            onMouseUp={(ev) =>
-                                                props.onRowClick && props.onRowClick(row, ev)
-                                            }
-                                        >
-                                            {cols}
-                                        </tr>
-                                    );
-                                } else {
-                                    return <tr key={row.id}>{cols}</tr>;
-                                }
-                            } else {
-                                if (props.onRowClick) {
-                                    return (
-                                        <tr
-                                            key={row.id}
-                                            onMouseUp={(ev) =>
-                                                props.onRowClick && props.onRowClick(row, ev)
-                                            }
-                                        >
-                                            {cols}
-                                        </tr>
-                                    );
-                                } else {
-                                    return <tr key={row.id}>{cols}</tr>;
-                                }
-                            }
+                            return (
+                                <tr
+                                    key={row.id}
+                                    className={
+                                        props.highlightedRows && props.highlightedRows.includes(row) ? "queued" : ""
+                                    }
+                                    onMouseUp={(ev) =>
+                                        props.onRowClick && props.onRowClick(row, ev, rows)
+                                    }
+                                >
+                                    {cols}
+                                </tr>
+                            );
                         })}
                         {blank_rows}
                     </tbody>

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -360,7 +360,9 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
                                 <tr
                                     key={row.id}
                                     className={
-                                        props.highlightedRows && props.highlightedRows.includes(row) ? "queued" : ""
+                                        props.highlightedRows && props.highlightedRows.includes(row)
+                                            ? "queued"
+                                            : ""
                                     }
                                     onMouseUp={(ev) =>
                                         props.onRowClick && props.onRowClick(row, ev, rows)

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -113,14 +113,12 @@ export function GameHistoryTable(props: GameHistoryProps) {
                 if (annulQueue.at(-1)) {
                     window.getSelection()?.removeAllRanges();
                     const indexes = [
-                        rows.findIndex(r => r.id === annulQueue.at(-1).id),
-                        rows.findIndex(r => r.id === row.id),
-                    ]
+                        rows.findIndex((r) => r.id === annulQueue.at(-1).id),
+                        rows.findIndex((r) => r.id === row.id),
+                    ];
                     const minIndex = Math.min(...indexes);
                     const maxIndex = Math.max(...indexes);
-                    setAnnulQueue(
-                        rows.slice(minIndex, maxIndex +1).filter(r => !r.annulled)
-                    );
+                    setAnnulQueue(rows.slice(minIndex, maxIndex + 1).filter((r) => !r.annulled));
                 }
             } else {
                 toggleQueued(row);

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -34,7 +34,7 @@ import { TimeControl } from "src/components/TimeControl";
 import { Speed } from "src/lib/types";
 import { usePreference } from "preferences";
 import { openAnnulQueueModal, AnnulQueueModal } from "AnnulQueueModal";
-import { useUser } from "src/lib/hooks";
+import { useUser } from "hooks";
 import { GameNameForList } from "GobanLineSummary";
 
 interface GameHistoryProps {

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -34,6 +34,7 @@ import { TimeControl } from "src/components/TimeControl";
 import { Speed } from "src/lib/types";
 import { usePreference } from "preferences";
 import { openAnnulQueueModal, AnnulQueueModal } from "AnnulQueueModal";
+import { useUser } from "src/lib/hooks";
 import { GameNameForList } from "GobanLineSummary";
 
 interface GameHistoryProps {
@@ -83,6 +84,8 @@ export function GameHistoryTable(props: GameHistoryProps) {
     const [selectModeActive, setSelectModeActive] = React.useState<boolean>(false);
     const [annulQueue, setAnnulQueue] = React.useState<any[]>([]);
     const [isAnnulQueueModalOpen, setIsAnnulQueueModalOpen] = React.useState(false);
+
+    const user = useUser();
 
     function getBoardSize(size_filter: string): number | undefined {
         switch (size_filter) {
@@ -246,7 +249,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             />
                         </div>
                         <div>
-                            {true ? (
+                            {user.is_moderator ? (
                                 <div className="btn-group">
                                     {annulQueue.length > 0 ? (
                                         <button

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -104,6 +104,10 @@ export function GameHistoryTable(props: GameHistoryProps) {
         ev: React.MouseEvent | React.TouchEvent | React.PointerEvent,
         rows: GroomedGame[],
     ) {
+        if (row.annulled) {
+            return;
+        }
+
         if (selectModeActive) {
             if (ev.shiftKey) {
                 if (annulQueue.at(-1)) {


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - As a moderator, holding shift will select a list of rows for the annul queue
       - Skips rows that are already annulled
       - Can select top to bottom and bottom to top
  - Also, removed ability to click already annulled game 


https://github.com/user-attachments/assets/4090732e-188c-4550-bd2d-9c4c8d5c59b7


