### PR TITLE
Remove react-number-format dependency... we don't seem to use it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
         "react-dropzone": "^12.0.5",
         "react-dynamic-help": "^3.0.1",
         "react-linkify": "^1.0.0-alpha",
-        "react-number-format": "^3.0.2",
         "react-router-dom": "=6.3.0",
         "react-select": "^5.0.1",
         "react-split": "^2.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9214,13 +9214,6 @@ react-linkify@^1.0.0-alpha:
     linkify-it "^2.0.3"
     tlds "^1.199.0"
 
-react-number-format@^3.0.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-3.6.2.tgz#46fb692a88ed25808f0cb08fd12aeae4ae68295a"
-  integrity sha512-HsO11fH6WiugtJflrMQn3/Yhq2J4uEWLxrKCQbI1gSGAOwIhUsOGJJeP8Vci/U4A7xK5SjC95ngZU8//Nuz3Gg==
-  dependencies:
-    prop-types "^15.6.0"
-
 react-router-dom@=6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"


### PR DESCRIPTION
Fixes # yarn complaining about incorrect peer dependency

## Proposed Changes

  - Remove from package.json
  