### PR TITLE
Fix PaginatedTable numbering

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -113,7 +113,9 @@
                 width: 2rem;
                 text-align: right;
                 border: 0;
+                margin-left: 0.25rem;
                 margin-right: 0.5rem;
+                outline: none;
                 //border-bottom: 1px solid;
                 //background-color: transparent;
                 //themed color fg
@@ -128,7 +130,7 @@
                 //font-size: 0.7em;
                 min-width: 0.8rem;
                 text-align: right;
-                margin-right: 0.5rem;
+                margin-right: 1rem;
             }
 
             .fa {

--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -104,15 +104,16 @@
         margin-top: 1rem;
 
         .left {
-            display: inline-block;
+            display: flex;
             flex:1;
+            align-items: center;
             input {
                 //font-size: 0.7em;
                 padding: 0;
                 width: 2rem;
-                text-align: left;
+                text-align: right;
                 border: 0;
-                margin-left: 0.5rem;
+                margin-right: 0.5rem;
                 //border-bottom: 1px solid;
                 //background-color: transparent;
                 //themed color fg

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -89,7 +89,7 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
     const [page_input_text, _setPageInputText]: [string, (s: string) => void] = React.useState(
         (props.startingPage || 1).toString(),
     );
-    const [num_pages, setNumPages]: [number, (x: number) => void] = React.useState(0);
+    const [num_pages, setNumPages]: [number, (x: number) => void] = React.useState(1);
     const [page_size, _setPageSize]: [number, (x: number) => void] = React.useState(
         data.get(`paginated-table.${table_name}.page_size`, props.pageSize || 10),
     );
@@ -164,7 +164,7 @@ function _PaginatedTable<RawEntryT = any, GroomedEntryT = RawEntryT>(
                     setLoadAgainRefresh(load_again_refresh + 1);
                 }
                 setRows(new_rows);
-                setNumPages(Math.ceil(res.count / page_size));
+                setNumPages(Math.ceil(res.count / page_size) || 1);
                 if (page > Math.ceil(res.count / page_size)) {
                     const new_page = Math.max(1, Math.ceil(res.count / page_size));
                     _setPage(new_page);


### PR DESCRIPTION
Fix pagination numbering on PaginatedTable component when user has played 0 games.

Before my change:
Pagination would display "1 / 0"

After my change:
Pagination displays "1 / 1"

This change also fixes the misaligned page numbering.