### PR TITLE
Show CM the current week's vote count

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -107,7 +107,7 @@ export function GobanBoardThemePicker(props: GobanThemePickerProperties): JSX.El
                         style={theme.styles}
                         onClick={selectTheme.current[theme.theme_name]}
                     >
-                        <PersistentElement elt={canvases.current[idx]} />
+                        {canvases.current[idx] && <PersistentElement elt={canvases.current[idx]} />}
                     </div>
                 ))}
             </div>
@@ -173,7 +173,7 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): JSX.E
                             style={theme.styles}
                             onClick={() => setBoard("Custom")}
                         >
-                            <PersistentElement elt={sample_canvas.current} />
+                            {sample_canvas && <PersistentElement elt={sample_canvas.current} />}
                         </div>
                     </div>
 
@@ -353,7 +353,9 @@ export function GobanWhiteThemePicker(props: GobanThemePickerProperties): JSX.El
                                 }}
                                 onClick={selectTheme.current[theme.theme_name]}
                             >
-                                <PersistentElement elt={canvases.current[idx]} />
+                                {canvases.current[idx] && (
+                                    <PersistentElement elt={canvases.current[idx]} />
+                                )}
                             </div>
                         ))}
                     </div>
@@ -550,7 +552,9 @@ export function GobanBlackThemePicker(props: GobanThemePickerProperties): JSX.El
                                 }}
                                 onClick={selectTheme.current[theme.theme_name]}
                             >
-                                <PersistentElement elt={canvases.current[idx]} />
+                                {canvases.current[idx] && (
+                                    <PersistentElement elt={canvases.current[idx]} />
+                                )}
                             </div>
                         ))}
                     </div>

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -656,7 +656,8 @@ export function getCurrentGameId() {
     return null;
 }
 
-// x is a  date, y is data for that date
+// x is a date, y is data for that date
+// sets y for the last date in the data array to null
 export function dropCurrentPeriod(data: { x: string; y: number | null }[]) {
     const newData = [...data];
     if (newData.length > 0) {

--- a/src/views/User/VoteActivityGraph.tsx
+++ b/src/views/User/VoteActivityGraph.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useState } from "react";
 
 import { get } from "requests";
 import * as data from "data";
-import { ResponsiveLine } from "@nivo/line";
+import { ResponsiveLine, Serie } from "@nivo/line"; // cspell:ignore Serie
 import { dropCurrentPeriod } from "misc";
 
 interface VoteCountPerDay {
@@ -49,6 +49,7 @@ const VoteActivityGraph = ({ vote_data }: VoteActivityGraphProps) => {
             [key: string]: number;
         } = {};
 
+        // Note: The vote_data.counts array is sorted by date in the backend
         vote_data.counts.forEach((day) => {
             const weekStart = startOfWeek(new Date(day.date)).toISOString().slice(0, 10); // Format as YYYY-MM-DD
             if (!aggregatedByWeek[weekStart]) {
@@ -65,10 +66,17 @@ const VoteActivityGraph = ({ vote_data }: VoteActivityGraphProps) => {
                 y: count, // y-axis will use the aggregated count
             }));
 
+        const completed_weeks = dropCurrentPeriod(data);
+        const current_week = data.pop();
+
         return [
             {
-                id: "votes",
-                data: dropCurrentPeriod(data),
+                id: "weekly_votes",
+                data: completed_weeks,
+            },
+            {
+                id: "current_week",
+                data: [current_week],
             },
         ];
     }, [vote_data]);
@@ -88,13 +96,19 @@ const VoteActivityGraph = ({ vote_data }: VoteActivityGraphProps) => {
         return <div>No activity yet</div>;
     }
 
+    const line_colors = {
+        weekly_votes: "rgba(230,183,151, 1)", // matches default in pie charts
+        current_week: "rgba(55, 200, 67, 1)", // visually matches nearby green on the page
+    };
+
     return (
         <div className="vote-activity-graph">
             <ResponsiveLine
-                data={chart_data}
+                data={chart_data as Serie[]}
                 animate
                 curve="monotoneX"
-                enablePoints={false}
+                enablePoints={true}
+                colors={({ id }) => line_colors[id as keyof typeof line_colors]}
                 enableSlices="x"
                 axisBottom={{
                     format: "%d %b %g",


### PR DESCRIPTION
Fixes disappointment at the end of the week when the final number comes in lower than hoped for.

## Proposed Changes

  - Put a dot on the weekly vote count graph showing the current week so CM can see how they are doing.
  