### PR TITLE
Update "mobile-web-app-capable" meta tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
       <meta http-equiv="Cache-control" content="no-cache">
       <meta http-equiv="Expires" content="-1">
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-      <meta name="apple-mobile-web-app-capable" content="yes">
+      <meta name="mobile-web-app-capable" content="yes">
       <meta name="format-detection" content="telephone=no">
       <meta name="application-name" content="Online-Go.com"/>
       <meta name="keywords" content="{{PAGE_KEYWORDS}}"/>


### PR DESCRIPTION
## Proposed Changes

`<meta name="apple-mobile-web-app-capable" content="yes">` is deprecated.

The meta tag we should use is:
`<meta name="mobile-web-app-capable" content="yes">`

This updates the meta tag to keep OGS up to date with the latest web standards!
