### PR TITLE
Support for CMs voting for suspend

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -294,7 +294,23 @@ moderator to let them know.
 Thanks for your recent report about {{bot}}.
 
 We've notified the owner of that bot.
-            `),
+`),
             { bot },
+        ),
+    ack_suspended: (reported) =>
+        interpolate(
+            _(`
+Thank you for your report.  {{reported}} is a repeat offender, their account has been suspended.
+`),
+            { reported },
+        ),
+
+    ack_suspended_and_annul: (reported) =>
+        interpolate(
+            _(`
+Thank you for your report.  {{reported}} is a repeat offender, their has been suspended. \
+The reported game has been annulled.
+`),
+            { reported },
         ),
 };

--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -381,6 +381,19 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                             onRetractOffer={this.retractOffer}
                             onRemovePower={this.removePower}
                         />
+                        <ModerationOfferControl
+                            ability={pgettext(
+                                "Label for a button to let a community moderator vote for suspension",
+                                "Vote for Suspension",
+                            )}
+                            ability_mask={MODERATOR_POWERS.SUSPEND}
+                            currently_offered={this.state.offered_moderator_powers}
+                            moderator_powers={this.state.moderator_powers}
+                            previously_rejected={this.state.mod_powers_rejected}
+                            onMakeOffer={this.makeOffer}
+                            onRetractOffer={this.retractOffer}
+                            onRemovePower={this.removePower}
+                        />
                     </div>
                 )}
                 <div className="buttons">

--- a/src/lib/moderation.tsx
+++ b/src/lib/moderation.tsx
@@ -31,6 +31,7 @@ export enum MODERATOR_POWERS {
     HANDLE_SCORE_CHEAT = 0b001,
     HANDLE_ESCAPING = 0b010,
     HANDLE_STALLING = 0b100,
+    SUSPEND = 0b1000,
 }
 
 export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
@@ -47,6 +48,7 @@ export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
         "A label for a moderator power",
         "Handle Stalling Reports",
     ),
+    [MODERATOR_POWERS.SUSPEND]: pgettext("A label for a moderator power", "Vote for Suspension"),
 };
 
 export function doAnnul(

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -44,7 +44,9 @@ declare namespace rest_api {
             | "no_stalling_evident"
             | "warn_duplicate_report"
             | "report_type_changed"
-            | "bot_owner_notified";
+            | "bot_owner_notified"
+            | "ack_suspended"
+            | "ack_suspended_and_annul";
 
         type Severity = "warning" | "acknowledgement" | "info";
 

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -102,6 +102,14 @@ const ACTION_PROMPTS = {
         "Label for a moderator to select this option",
         "Duplicate report - ask them not to do that.",
     ),
+
+    suspend_user: pgettext("Label for a moderator to select this option", "Suspend the user."),
+
+    suspend_user_and_annul: pgettext(
+        "Label for a moderator to select this option",
+        "Suspend user and annul game.",
+    ),
+
     // Note: keep this last, so it's positioned above the "note to moderator" input field
     escalate: pgettext(
         "A label for a community moderator to select this option - send report to to full moderators",

--- a/src/views/Settings/ModeratorPreferences.tsx
+++ b/src/views/Settings/ModeratorPreferences.tsx
@@ -56,6 +56,14 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
             _setReportQuota(ev.target.value as any);
         }
     }
+
+    // At the moment we want moderators do non-CM reports
+    React.useEffect(() => {
+        if (show_cm_reports) {
+            setShowCMReports(false);
+        }
+    }, [show_cm_reports, setShowCMReports]);
+
     if (!user.is_moderator && !user.moderator_powers) {
         return null;
     }
@@ -89,8 +97,11 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): JSX.Element
                         <Toggle checked={hide_claimed_reports} onChange={setHideClaimedReports} />
                     </PreferenceLine>
                     <PreferenceLine title="Show un-escalated reports">
-                        <Toggle checked={show_cm_reports} onChange={setShowCMReports} />
-                        <span>This will include for you reports that CMs can still vote on</span>
+                        <Toggle checked={false} onChange={() => {}} />
+                        <span>
+                            This would include for you reports that CMs can still vote on, but is
+                            not currently available.
+                        </span>
                     </PreferenceLine>
                     <PreferenceLine title="Join games anonymously">
                         <Toggle


### PR DESCRIPTION
Fixes Community Moderation being reliant on full moderators to process escalated reports that need user-suspension action.

## Proposed Changes

  - CMs can get vote-to-suspend power
  - CMs with vote-to-suspend can  vote to suspend users when the report about the user is escalated
  - Full moderators no longer get "CM-class" reports in their queues
     - if they want to see a CM-class report they need to access it via History or URL (likely from Mod Log)

 
Needs:  https://github.com/online-go/ogs-node/pull/66
Needs: https://github.com/online-go/ogs/pull/2003
