### PR TITLE
POC - Add tooltip to modal, Modal provider (for computer challenge, language picker, game fork)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,5 @@
 {
+    "[ruby]": {
+        "editor.formatOnSave": false
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,2 @@
 {
-    "[ruby]": {
-        "editor.formatOnSave": false
-    }
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,6 +25,9 @@ module.exports = {
         "src",
         "node_modules"
     ],
+    "moduleNameMapper": {
+        '^@/(.*)': '<rootDir>/src/$1',
+    },
     "setupFiles": ["./setup-jest.js"],
-    "setupFilesAfterEnv": ["jest-chain"],
+    "setupFilesAfterEnv": ["jest-chain", "@testing-library/jest-dom"],
 }

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
         "sanitize-html": "^2.12.1",
         "sweetalert2": "^11.4.17",
         "ts-md5": "^1.3.1",
+        "ts-node": "^10.9.2",
         "valid-url": "^1.0.9",
         "whatwg-fetch": "^3.0.0"
     },

--- a/src/components/ChallengeModal/ChallengeModal.test.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.test.tsx
@@ -20,7 +20,8 @@ import * as React from "react";
 
 import * as ChallengeModal from "./ChallengeModal";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { ModalConsumer, ModalProvider, ModalTypes } from "../Modal/ModalProvider";
+import { ModalProvider } from "../Modal/ModalProvider";
+import { ModalContext, ModalTypes } from "../Modal/ModalContext";
 import * as DynamicHelp from "react-dynamic-help";
 
 jest.mock("./../Modal", () => {
@@ -37,12 +38,12 @@ describe("ChallengeModal", () => {
 
         render(
             <ModalProvider>
-                <ModalConsumer>
+                <ModalContext.Consumer>
                     {({ showModal }) => {
                         showModal(ModalTypes.Challenge);
                         return null;
                     }}
-                </ModalConsumer>
+                </ModalContext.Consumer>
             </ModalProvider>,
         );
 
@@ -71,12 +72,12 @@ describe("ChallengeModal", () => {
         render(
             <DynamicHelp.Api.Provider value={DynamicHelpProviderValue}>
                 <ModalProvider>
-                    <ModalConsumer>
+                    <ModalContext.Consumer>
                         {({ showModal }) => {
                             showModal(ModalTypes.Challenge);
                             return null;
                         }}
-                    </ModalConsumer>
+                    </ModalContext.Consumer>
                 </ModalProvider>
             </DynamicHelp.Api.Provider>,
         );

--- a/src/components/ChallengeModal/ChallengeModal.test.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* cspell: words groupadmin cotsen */
+import * as React from "react";
+
+import * as ChallengeModal from "./ChallengeModal";
+import * as Modal from "./../Modal";
+import { render } from "@testing-library/react";
+import { ModalConsumer, ModalProvider, ModalTypes } from "../Modal/ModalProvider";
+
+jest.mock("./../Modal", () => {
+    return {
+        ...jest.requireActual("./../Modal"),
+    };
+});
+
+describe("ChallengeModal", () => {
+    it("should do a computer challenge via provider", () => {
+        const challengeModalSpy = jest
+            .spyOn(ChallengeModal, "ChallengeModal")
+            .mockImplementation(jest.fn());
+
+        render(
+            <ModalProvider>
+                <ModalConsumer>
+                    {({ showModal }) => {
+                        showModal(ModalTypes.Challenge);
+                        return <div />;
+                    }}
+                </ModalConsumer>
+            </ModalProvider>,
+        );
+        expect(challengeModalSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                game_record_mode: true,
+                mode: "open",
+            }),
+            {},
+        );
+    });
+
+    it("should do a computer challenge via modal", () => {
+        const modalSpy = jest.spyOn(Modal, "openModal").mockReturnValue(true);
+        ChallengeModal.challengeComputer();
+        expect(modalSpy).toHaveBeenCalledWith(
+            <ChallengeModal.ChallengeModal initialState={null} mode="computer" />,
+        );
+    });
+});

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 
 import * as data from "@/lib/data";
 import * as player_cache from "@/lib/player_cache";
+import * as DynamicHelp from "react-dynamic-help";
 
 import { OgsResizeDetector } from "@/components/OgsResizeDetector";
 import { browserHistory } from "@/lib/ogsHistory";
@@ -64,7 +65,7 @@ import {
 
 export type ChallengeDetails = rest_api.ChallengeDetails;
 
-type ChallengeModes = "open" | "computer" | "player" | "demo";
+export type ChallengeModes = "open" | "computer" | "player" | "demo";
 
 interface Events {}
 
@@ -1778,7 +1779,22 @@ export class ChallengeModalBody extends React.Component<
                                 &nbsp; {player_username}
                             </span>
                         )}
-                        {mode === "computer" && <span>{_("Computer")}</span>}
+                        {mode === "computer" && (
+                            <DynamicHelp.Api.Consumer>
+                                {(value) => {
+                                    const { ref: modalHelpIntro } =
+                                        value.registerTargetItem("modal-help-intro");
+                                    return (
+                                        <span
+                                            ref={modalHelpIntro}
+                                            onClick={() => value.triggerFlow("modal-help")}
+                                        >
+                                            {_("Computer")}
+                                        </span>
+                                    );
+                                }}
+                            </DynamicHelp.Api.Consumer>
+                        )}
                     </h2>
                 </div>
                 <div className="body">

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -62,7 +62,6 @@ import {
     saveTimeControlSettings,
     updateSystem,
 } from "@/components/TimeControl/TimeControlUpdates";
-import { ModalConsumer } from "../Modal/ModalProvider";
 
 export type ChallengeDetails = rest_api.ChallengeDetails;
 
@@ -1976,9 +1975,6 @@ export function createDemoBoard(
             tournamentRecordRoundId={tournament_record_round_id}
         />,
     );
-}
-export function challengeComputer() {
-    return challenge(undefined, null, true);
 }
 export function challengeRematch(
     goban: GobanRenderer,

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -62,6 +62,7 @@ import {
     saveTimeControlSettings,
     updateSystem,
 } from "@/components/TimeControl/TimeControlUpdates";
+import { ModalConsumer } from "../Modal/ModalProvider";
 
 export type ChallengeDetails = rest_api.ChallengeDetails;
 

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -18,7 +18,6 @@ import * as React from "react";
 
 import * as data from "@/lib/data";
 import * as player_cache from "@/lib/player_cache";
-import * as DynamicHelp from "react-dynamic-help";
 
 import { OgsResizeDetector } from "@/components/OgsResizeDetector";
 import { browserHistory } from "@/lib/ogsHistory";
@@ -62,6 +61,7 @@ import {
     saveTimeControlSettings,
     updateSystem,
 } from "@/components/TimeControl/TimeControlUpdates";
+import { ActivateTooltip } from "@/views/HelpFlows/ModalHelp";
 
 export type ChallengeDetails = rest_api.ChallengeDetails;
 
@@ -1780,20 +1780,9 @@ export class ChallengeModalBody extends React.Component<
                             </span>
                         )}
                         {mode === "computer" && (
-                            <DynamicHelp.Api.Consumer>
-                                {(value) => {
-                                    const { ref: modalHelpIntro } =
-                                        value.registerTargetItem("modal-help-intro");
-                                    return (
-                                        <span
-                                            ref={modalHelpIntro}
-                                            onClick={() => value.triggerFlow("modal-help")}
-                                        >
-                                            {_("Computer")}
-                                        </span>
-                                    );
-                                }}
-                            </DynamicHelp.Api.Consumer>
+                            <ActivateTooltip flow="modal-help" item="intro">
+                                <span>{_("Computer")}</span>
+                            </ActivateTooltip>
                         )}
                     </h2>
                 </div>

--- a/src/components/ChallengeModal/ForkModal.tsx
+++ b/src/components/ChallengeModal/ForkModal.tsx
@@ -18,94 +18,69 @@
 import * as React from "react";
 import * as data from "@/lib/data";
 import { _ } from "@/lib/translate";
-import { Modal, openModal } from "@/components/Modal";
 import { GobanRenderer } from "goban";
 import { PlayerAutocomplete } from "@/components/PlayerAutocomplete";
 import { MiniGoban } from "@/components/MiniGoban";
 import { challenge } from "@/components/ChallengeModal";
 import { PlayerCacheEntry } from "@/lib/player_cache";
-
-interface Events {}
+import { ModalContext } from "../Modal/ModalProvider";
 
 interface ForkModalProperties {
     goban: GobanRenderer;
 }
 
-export class ForkModal extends Modal<Events, ForkModalProperties, any> {
-    constructor(props: ForkModalProperties) {
-        super(props);
+export const ForkModal = ({ goban }: ForkModalProperties) => {
+    const [currPlayer, setCurrPlayer] = React.useState(null as PlayerCacheEntry | null);
+    const { hideModal } = React.useContext(ModalContext);
 
-        const goban = this.props.goban;
-        this.state = {
-            player: null,
-            fork_preview: {
-                //"moves": goban.engine.cur_move.getMoveStringToThisPoint(),
-                //"initial_state": goban.engine.initial_state,
-                //"initial_player": goban.engine.config.initial_player,
-                moves: [],
-                initial_state: goban.engine.computeInitialStateForForkedGame(),
-                initial_player: goban.engine.colorToMove(),
-                width: goban.engine.width,
-                height: goban.engine.height,
-                rules: goban.engine.rules,
-                handicap: goban.engine.handicap,
-                komi: goban.engine.komi,
-                move_number: goban.engine.getMoveNumber(),
-                game_name: goban.engine.name,
-            },
-        };
-    }
-
-    openChallengeModal = () => {
-        this.close();
-        challenge(this.state.player.id, this.state.fork_preview);
+    const forkPreview = {
+        moves: [],
+        initial_state: goban.engine.computeInitialStateForForkedGame(),
+        initial_player: goban.engine.colorToMove(),
+        width: goban.engine.width,
+        height: goban.engine.height,
+        rules: goban.engine.rules,
+        handicap: goban.engine.handicap,
+        komi: goban.engine.komi,
+        move_number: goban.engine.getMoveNumber(),
+        game_name: goban.engine.name,
     };
 
-    setPlayer = (player: PlayerCacheEntry | null) => {
-        this.setState({ player: player });
+    const openChallengeModal = () => {
+        hideModal();
+        if (currPlayer) {
+            challenge(currPlayer.id, forkPreview);
+        }
     };
 
-    render() {
-        return (
-            <div className="Modal ForkModal">
-                <div className="header space-around">
-                    <h2>{_("Player to challenge")}:</h2>{" "}
-                    <PlayerAutocomplete onComplete={this.setPlayer} />
-                </div>
-                <div className="body space-around">
-                    <MiniGoban
-                        game_id={0}
-                        black={undefined}
-                        white={undefined}
-                        json={this.state.fork_preview}
-                        noLink
-                    />
-                </div>
-                <div className="buttons">
-                    <button onClick={this.close}>{_("Cancel")}</button>
-                    <button
-                        className="primary"
-                        disabled={
-                            this.state.player == null ||
-                            this.state.player.id === data.get("user").id
-                        }
-                        onClick={this.openChallengeModal}
-                    >
-                        {_("Game settings")} &rarr;
-                    </button>
-                </div>
+    const setPlayer = (player: PlayerCacheEntry | null) => {
+        setCurrPlayer(player);
+    };
+
+    return (
+        <div className="Modal ForkModal">
+            <div className="header space-around">
+                <h2>{_("Player to challenge")}:</h2> <PlayerAutocomplete onComplete={setPlayer} />
             </div>
-        );
-    }
-}
-
-export function openForkModal(goban: GobanRenderer) {
-    return openModal(<ForkModal goban={goban} />);
-}
-export function challengeFromBoardPosition(goban: GobanRenderer) {
-    if (!goban) {
-        return;
-    }
-
-    openForkModal(goban);
-}
+            <div className="body space-around">
+                <MiniGoban
+                    game_id={0}
+                    black={undefined}
+                    white={undefined}
+                    json={forkPreview}
+                    noLink
+                />
+            </div>
+            <div className="buttons">
+                <button onClick={hideModal}>{_("Cancel")}</button>
+                <button
+                    className="primary"
+                    disabled={currPlayer == null || currPlayer.id === data.get("user").id}
+                    onClick={openChallengeModal}
+                >
+                    {_("Game settings")} &rarr;
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/src/components/ChallengeModal/ForkModal.tsx
+++ b/src/components/ChallengeModal/ForkModal.tsx
@@ -23,7 +23,7 @@ import { PlayerAutocomplete } from "@/components/PlayerAutocomplete";
 import { MiniGoban } from "@/components/MiniGoban";
 import { challenge } from "@/components/ChallengeModal";
 import { PlayerCacheEntry } from "@/lib/player_cache";
-import { ModalContext } from "../Modal/ModalProvider";
+import { ModalContext } from "../Modal/ModalContext";
 
 interface ForkModalProperties {
     goban: GobanRenderer;

--- a/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/src/components/LanguagePicker/LanguagePicker.tsx
@@ -17,19 +17,8 @@
 
 import * as React from "react";
 import { _, setCurrentLanguage, current_language, languages } from "@/lib/translate";
-import { Modal, openModal } from "@/components/Modal";
 import * as preferences from "@/lib/preferences";
-
-interface Events {}
-
-interface LanguagePickerProperties {}
-
-let language_modal: JSX.Element | null = null;
-
-function openLanguageModal() {
-    language_modal = <LanguagePickerModal />;
-    openModal(language_modal);
-}
+import { ModalConsumer, ModalContext, ModalTypes } from "../Modal/ModalProvider";
 
 function language_sorter(a: string, b: string) {
     if (a === "auto") {
@@ -48,64 +37,63 @@ function language_sorter(a: string, b: string) {
 }
 
 export const LanguagePicker = () => (
-    <span className="LanguagePicker fakelink" onClick={openLanguageModal}>
-        <i className="fa fa-language" />
-        {languages[current_language]}
-    </span>
+    <ModalConsumer>
+        {(value) => (
+            <span
+                className="LanguagePicker fakelink"
+                onClick={() => value.showModal(ModalTypes.LanguagePicker)}
+            >
+                <i className="fa fa-language" />
+                {languages[current_language]}
+            </span>
+        )}
+    </ModalConsumer>
 );
 
-class LanguagePickerModal extends Modal<Events, LanguagePickerProperties, any> {
-    constructor(props: LanguagePickerProperties) {
-        super(props);
-        this.state = {
-            selected_language: current_language,
-        };
-    }
+export const LanguagePickerModal = () => {
+    const { hideModal } = React.useContext(ModalContext);
 
-    setLanguage(language_code: string) {
+    const setLanguage = (language_code: string) => {
         preferences.set("language", language_code);
         setCurrentLanguage(language_code);
-        this.close();
         window.location.reload();
-    }
+    };
 
-    render() {
-        const auto = preferences.get("language") === "auto";
-        function computeClass(lc: string) {
-            let ret = "";
-            if (auto) {
-                if (lc === "auto") {
-                    ret += "selected";
-                } else if (lc === current_language) {
-                    ret += "auto";
-                }
-            } else {
-                if (lc === current_language) {
-                    ret += "selected";
-                }
+    const auto = preferences.get("language") === "auto";
+    function computeClass(lc: string) {
+        let ret = "";
+        if (auto) {
+            if (lc === "auto") {
+                ret += "selected";
+            } else if (lc === current_language) {
+                ret += "auto";
             }
-            return ret;
+        } else {
+            if (lc === current_language) {
+                ret += "selected";
+            }
         }
-
-        return (
-            <div className="Modal LanguagePickerModal">
-                <div className="body">
-                    {Object.keys(languages)
-                        .sort(language_sorter)
-                        .map((lc, idx) => (
-                            <span
-                                key={idx}
-                                className={computeClass(lc) + " fakelink language-option"}
-                                onClick={() => this.setLanguage(lc)}
-                            >
-                                {languages[lc]}
-                            </span>
-                        ))}
-                </div>
-                <div className="footer">
-                    <button onClick={this.close}>{_("Cancel")}</button>
-                </div>
-            </div>
-        );
+        return ret;
     }
-}
+
+    return (
+        <div className="Modal LanguagePickerModal">
+            <div className="body">
+                {Object.keys(languages)
+                    .sort(language_sorter)
+                    .map((lc, idx) => (
+                        <span
+                            key={idx}
+                            className={computeClass(lc) + " fakelink language-option"}
+                            onClick={() => setLanguage(lc)}
+                        >
+                            {languages[lc]}
+                        </span>
+                    ))}
+            </div>
+            <div className="footer">
+                <button onClick={hideModal}>{_("Cancel")}</button>
+            </div>
+        </div>
+    );
+};

--- a/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/src/components/LanguagePicker/LanguagePicker.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import { _, setCurrentLanguage, current_language, languages } from "@/lib/translate";
 import * as preferences from "@/lib/preferences";
-import { ModalConsumer, ModalContext, ModalTypes } from "../Modal/ModalProvider";
+import { ModalContext, ModalTypes } from "../Modal/ModalContext";
 
 function language_sorter(a: string, b: string) {
     if (a === "auto") {
@@ -37,17 +37,17 @@ function language_sorter(a: string, b: string) {
 }
 
 export const LanguagePicker = () => (
-    <ModalConsumer>
-        {(value) => (
+    <ModalContext.Consumer>
+        {({ showModal }) => (
             <span
                 className="LanguagePicker fakelink"
-                onClick={() => value.showModal(ModalTypes.LanguagePicker)}
+                onClick={() => showModal(ModalTypes.LanguagePicker)}
             >
                 <i className="fa fa-language" />
                 {languages[current_language]}
             </span>
         )}
-    </ModalConsumer>
+    </ModalContext.Consumer>
 );
 
 export const LanguagePickerModal = () => {

--- a/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/src/components/LanguagePicker/LanguagePicker.tsx
@@ -36,19 +36,19 @@ function language_sorter(a: string, b: string) {
     return 0;
 }
 
-export const LanguagePicker = () => (
-    <ModalContext.Consumer>
-        {({ showModal }) => (
-            <span
-                className="LanguagePicker fakelink"
-                onClick={() => showModal(ModalTypes.LanguagePicker)}
-            >
-                <i className="fa fa-language" />
-                {languages[current_language]}
-            </span>
-        )}
-    </ModalContext.Consumer>
-);
+export const LanguagePicker = () => {
+    const { showModal } = React.useContext(ModalContext);
+
+    return (
+        <span
+            className="LanguagePicker fakelink"
+            onClick={() => showModal(ModalTypes.LanguagePicker)}
+        >
+            <i className="fa fa-language" />
+            {languages[current_language]}
+        </span>
+    );
+};
 
 export const LanguagePickerModal = () => {
     const { hideModal } = React.useContext(ModalContext);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -27,7 +27,7 @@ type ModalProps<P> = P & { fastDismiss?: boolean };
 export type ModalConstructorInput<P> = ModalProps<P> | Readonly<ModalProps<P>>;
 export class Modal<Events, P, S> extends TypedEventEmitterPureComponent<
     Events & { close: never; open: never },
-    P & { fastDismiss?: boolean },
+    P & { fastDismiss?: boolean; onClose?: () => void },
     S
 > {
     constructor(props: ModalConstructorInput<P>) {
@@ -39,6 +39,7 @@ export class Modal<Events, P, S> extends TypedEventEmitterPureComponent<
     }
 
     close = () => {
+        this.props.onClose && this.props.onClose();
         this.emit("close");
     };
     bindContainer(container: HTMLElement) {

--- a/src/components/Modal/ModalContext.tsx
+++ b/src/components/Modal/ModalContext.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createContext } from "react";
+
+export enum ModalTypes {
+    Challenge = "challenge",
+    LanguagePicker = "languagePicker",
+    Fork = "fork",
+}
+
+type ModalContextProps = {
+    showModal: (type: ModalTypes, props?: any) => void;
+    hideModal: () => void;
+};
+
+const defaultModalContext: ModalContextProps = {
+    showModal: () => {},
+    hideModal: () => {},
+};
+
+export const ModalContext = createContext<ModalContextProps>(defaultModalContext);

--- a/src/components/Modal/ModalProvider.tsx
+++ b/src/components/Modal/ModalProvider.tsx
@@ -20,9 +20,11 @@ import * as React from "react";
 
 import { ChallengeModal, ChallengeModes } from "../ChallengeModal";
 import { createPortal } from "react-dom";
+import { deepEqual } from "@/lib/misc";
 
 type ModalProviderType = {
     showModal: (types: ModalTypes) => void;
+    hideModal: () => void;
 };
 
 export enum ModalTypes {
@@ -39,7 +41,8 @@ interface Modals {
 
 type Property<T, K extends keyof T> = T[K];
 
-const { Provider, Consumer } = React.createContext({} as ModalProviderType);
+export const ModalContext = React.createContext({} as ModalProviderType);
+const { Provider, Consumer } = ModalContext;
 
 export const ModalConsumer = Consumer;
 
@@ -49,22 +52,27 @@ export const ModalProvider = ({ children }: React.PropsWithChildren): JSX.Elemen
 
     function showModal() {
         setModal(true);
-        setProps({
-            mode: "computer",
+
+        const payload = {
+            mode: "computer" as ChallengeModes,
             initialState: null,
             playerId: undefined,
-        });
+        };
+
+        if (!deepEqual(props, payload)) {
+            setProps(payload);
+        }
     }
 
-    const hideModal = () => {
+    function hideModal() {
         setModal(false);
-    };
+    }
     return (
-        <Provider value={{ showModal }}>
+        <Provider value={{ showModal, hideModal }}>
             {modal &&
                 createPortal(
                     <div className="Modal-container">
-                        <ChallengeModal {...props} onClose={hideModal} />
+                        <ChallengeModal {...props} />
                     </div>,
                     document.body,
                 )}

--- a/src/components/Modal/ModalProvider.tsx
+++ b/src/components/Modal/ModalProvider.tsx
@@ -21,15 +21,18 @@ import * as React from "react";
 import { ChallengeModal, ChallengeModes } from "../ChallengeModal";
 import { createPortal } from "react-dom";
 import { LanguagePickerModal } from "../LanguagePicker";
+import { ForkModal } from "../ChallengeModal/ForkModal";
+import { GobanRenderer } from "goban";
 
 type ModalProviderType = {
-    showModal: (type: ModalTypes) => void;
+    showModal: (type: ModalTypes, props?: ModalTypesProps) => void;
     hideModal: () => void;
 };
 
 export enum ModalTypes {
     Challenge = "challenge",
     LanguagePicker = "languagePicker",
+    Fork = "fork",
 }
 
 interface Modals {
@@ -37,6 +40,9 @@ interface Modals {
         mode: ChallengeModes;
         playerId?: number;
         initialState: any;
+    };
+    fork: {
+        goban: GobanRenderer;
     };
 }
 
@@ -53,7 +59,7 @@ export const ModalProvider = ({ children }: React.PropsWithChildren): JSX.Elemen
     const [modalType, setModalType] = React.useState(null as ModalTypes | null);
     const [modalProps, setModalProps] = React.useState({} as ModalTypesProps);
 
-    const showModal = (type: ModalTypes) => {
+    const showModal = (type: ModalTypes, props?: ModalTypesProps) => {
         setModalType(type);
 
         switch (type) {
@@ -62,6 +68,11 @@ export const ModalProvider = ({ children }: React.PropsWithChildren): JSX.Elemen
                     mode: "computer" as ChallengeModes,
                     initialState: null,
                     playerId: undefined,
+                });
+                break;
+            case ModalTypes.Fork:
+                setModalProps({
+                    goban: (props as Modals["fork"]).goban,
                 });
                 break;
             default:
@@ -99,6 +110,9 @@ export const ModalProvider = ({ children }: React.PropsWithChildren): JSX.Elemen
                             />
                         )}
                         {modalType === ModalTypes.LanguagePicker && <LanguagePickerModal />}
+                        {modalType === ModalTypes.Fork && (
+                            <ForkModal {...(modalProps as Modals["fork"])} />
+                        )}
                     </div>,
                     document.body,
                 )}

--- a/src/components/Modal/ModalProvider.tsx
+++ b/src/components/Modal/ModalProvider.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* cspell: words groupadmin cotsen */
+import * as React from "react";
+
+import { ChallengeModal, ChallengeModes } from "../ChallengeModal";
+import { createPortal } from "react-dom";
+
+type ModalProviderType = {
+    showModal: (types: ModalTypes) => void;
+};
+
+export enum ModalTypes {
+    Challenge = "challenge",
+}
+
+interface Modals {
+    challenge: {
+        mode: ChallengeModes;
+        playerId?: number;
+        initialState: any;
+    };
+}
+
+type Property<T, K extends keyof T> = T[K];
+
+const { Provider, Consumer } = React.createContext({} as ModalProviderType);
+
+export const ModalConsumer = Consumer;
+
+export const ModalProvider = ({ children }: React.PropsWithChildren): JSX.Element => {
+    const [modal, setModal] = React.useState(false);
+    const [props, setProps] = React.useState({} as Property<Modals, ModalTypes>);
+
+    function showModal() {
+        setModal(true);
+        setProps({
+            mode: "computer",
+            initialState: null,
+            playerId: undefined,
+        });
+    }
+
+    const hideModal = () => {
+        setModal(false);
+    };
+    return (
+        <Provider value={{ showModal }}>
+            {modal &&
+                createPortal(
+                    <div className="Modal-container">
+                        <ChallengeModal {...props} onClose={hideModal} />
+                    </div>,
+                    document.body,
+                )}
+            {children}
+        </Provider>
+    );
+};

--- a/src/components/Modal/ModalRegistry.ts
+++ b/src/components/Modal/ModalRegistry.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { ForkModal } from "../ChallengeModal/ForkModal";
+import { ChallengeModal } from "../ChallengeModal/ChallengeModal";
+import { LanguagePickerModal } from "../LanguagePicker/LanguagePicker";
+import { ModalTypes } from "./ModalContext";
+
+interface ModalRegistry {
+    [key: string]: React.ComponentType<any>;
+}
+
+export const modalRegistry: ModalRegistry = {
+    [ModalTypes.Fork]: ForkModal,
+    [ModalTypes.Challenge]: ChallengeModal,
+    [ModalTypes.LanguagePicker]: LanguagePickerModal,
+};
+
+export const registerModal = (modalType: string, component: React.ComponentType<any>) => {
+    modalRegistry[modalType] = component;
+};
+
+export const unregisterModal = (modalType: string) => {
+    delete modalRegistry[modalType];
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -328,7 +328,7 @@ const react_root = ReactDOM.createRoot(document.getElementById("main-content") a
 react_root.render(
     <React.StrictMode>
         <OgsHelpProvider>
-            {routes}
+            <ModalProvider>{routes}</ModalProvider>
             <HelpFlows />
         </OgsHelpProvider>
     </React.StrictMode>,
@@ -339,4 +339,5 @@ window.preferences = preferences;
 window.player_cache = player_cache;
 
 import * as requests from "@/lib/requests";
+import { ModalProvider } from "./components/Modal/ModalProvider";
 window.requests = requests;

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -30,7 +30,6 @@ import { openGameLinkModal } from "./GameLinkModal";
 import { openGameLogModal } from "./GameLogModal";
 import { sfx } from "@/lib/sfx";
 import { alert } from "@/lib/swal_config";
-import { challengeFromBoardPosition } from "@/components/ChallengeModal/ForkModal";
 import { errorAlerter } from "@/lib/misc";
 import { doAnnul } from "@/lib/moderation";
 import { openReport } from "@/components/Report";
@@ -39,6 +38,7 @@ import { openGameInfoModal } from "./GameInfoModal";
 import { useUserIsParticipant } from "./GameHooks";
 import { useGoban } from "./goban_context";
 import { Tooltip } from "../../components/Tooltip";
+import { ModalConsumer, ModalTypes } from "@/components/Modal/ModalProvider";
 
 interface DockProps {
     annulled: boolean;
@@ -139,11 +139,6 @@ export function GameDock({
         }
     };
 
-    const fork = () => {
-        if (!user.anonymous && !engine.rengo && !goban.isAnalysisDisabled()) {
-            challengeFromBoardPosition(goban);
-        }
-    };
     const showLinkModal = () => {
         openGameLinkModal(goban);
     };
@@ -446,16 +441,34 @@ export function GameDock({
                 </a>
             </Tooltip>
             <Tooltip tooltipRequired={tooltipRequired} title={_("Fork game")}>
-                <a
-                    onClick={fork}
-                    className={
-                        user.anonymous || engine.rengo || goban.isAnalysisDisabled()
-                            ? "disabled"
-                            : ""
-                    }
-                >
-                    <i className="fa fa-code-fork"></i> {_("Fork game")}
-                </a>
+                <ModalConsumer>
+                    {({ showModal }) => (
+                        <a
+                            onClick={() => {
+                                if (
+                                    !user.anonymous &&
+                                    !engine.rengo &&
+                                    !goban.isAnalysisDisabled()
+                                ) {
+                                    if (!goban) {
+                                        return;
+                                    }
+
+                                    return showModal(ModalTypes.Fork, {
+                                        goban,
+                                    });
+                                }
+                            }}
+                            className={
+                                user.anonymous || engine.rengo || goban.isAnalysisDisabled()
+                                    ? "disabled"
+                                    : ""
+                            }
+                        >
+                            <i className="fa fa-code-fork"></i> {_("Fork game")}
+                        </a>
+                    )}
+                </ModalConsumer>
             </Tooltip>
             <Tooltip tooltipRequired={tooltipRequired} title={_("Call moderator")}>
                 <a onClick={alertModerator} className={user.anonymous ? "disabled" : ""}>

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -39,6 +39,22 @@ import { useUserIsParticipant } from "./GameHooks";
 import { useGoban } from "./goban_context";
 import { Tooltip } from "../../components/Tooltip";
 import { ModalContext, ModalTypes } from "@/components/Modal/ModalContext";
+import { GobanEngine, GobanRenderer } from "goban";
+
+const handleForkGameClick = (
+    showModal: (type: ModalTypes, props?: any) => void,
+    user: rest_api.UserConfig,
+    engine: GobanEngine,
+    goban: GobanRenderer,
+) => {
+    if (!user.anonymous && !engine.rengo && !goban.isAnalysisDisabled()) {
+        if (!goban) {
+            return;
+        }
+
+        showModal(ModalTypes.Fork, { goban });
+    }
+};
 
 interface DockProps {
     annulled: boolean;
@@ -92,6 +108,7 @@ export function GameDock({
     const phase = engine.phase;
 
     const user = useUser();
+    const { showModal } = React.useContext(ModalContext);
 
     const tooltipRequired = preferences.get("dock-delay") === MAX_DOCK_DELAY;
 
@@ -441,34 +458,16 @@ export function GameDock({
                 </a>
             </Tooltip>
             <Tooltip tooltipRequired={tooltipRequired} title={_("Fork game")}>
-                <ModalContext.Consumer>
-                    {({ showModal }) => (
-                        <a
-                            onClick={() => {
-                                if (
-                                    !user.anonymous &&
-                                    !engine.rengo &&
-                                    !goban.isAnalysisDisabled()
-                                ) {
-                                    if (!goban) {
-                                        return;
-                                    }
-
-                                    return showModal(ModalTypes.Fork, {
-                                        goban,
-                                    });
-                                }
-                            }}
-                            className={
-                                user.anonymous || engine.rengo || goban.isAnalysisDisabled()
-                                    ? "disabled"
-                                    : ""
-                            }
-                        >
-                            <i className="fa fa-code-fork"></i> {_("Fork game")}
-                        </a>
-                    )}
-                </ModalContext.Consumer>
+                <a
+                    onClick={() => handleForkGameClick(showModal, user, engine, goban)}
+                    className={
+                        user.anonymous || engine.rengo || goban.isAnalysisDisabled()
+                            ? "disabled"
+                            : ""
+                    }
+                >
+                    <i className="fa fa-code-fork"></i> {_("Fork game")}
+                </a>
             </Tooltip>
             <Tooltip tooltipRequired={tooltipRequired} title={_("Call moderator")}>
                 <a onClick={alertModerator} className={user.anonymous ? "disabled" : ""}>

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -38,7 +38,7 @@ import { openGameInfoModal } from "./GameInfoModal";
 import { useUserIsParticipant } from "./GameHooks";
 import { useGoban } from "./goban_context";
 import { Tooltip } from "../../components/Tooltip";
-import { ModalConsumer, ModalTypes } from "@/components/Modal/ModalProvider";
+import { ModalContext, ModalTypes } from "@/components/Modal/ModalContext";
 
 interface DockProps {
     annulled: boolean;
@@ -441,7 +441,7 @@ export function GameDock({
                 </a>
             </Tooltip>
             <Tooltip tooltipRequired={tooltipRequired} title={_("Fork game")}>
-                <ModalConsumer>
+                <ModalContext.Consumer>
                     {({ showModal }) => (
                         <a
                             onClick={() => {
@@ -468,7 +468,7 @@ export function GameDock({
                             <i className="fa fa-code-fork"></i> {_("Fork game")}
                         </a>
                     )}
-                </ModalConsumer>
+                </ModalContext.Consumer>
             </Tooltip>
             <Tooltip tooltipRequired={tooltipRequired} title={_("Call moderator")}>
                 <a onClick={alertModerator} className={user.anonymous ? "disabled" : ""}>

--- a/src/views/HelpFlows/HelpFlows.tsx
+++ b/src/views/HelpFlows/HelpFlows.tsx
@@ -29,6 +29,7 @@ import { UndoRequestReceivedIntro } from "./UndoIntro";
 import { CommunityModeratorIntro } from "./CommunityModeratorIntro";
 import { OJEIntro } from "./OJEIntro";
 import { GameLogHelp } from "./GameLogHelp";
+import { ModalHelp } from "./ModalHelp";
 
 /**
  * This component is a handy wrapper for all the Help Flows, and reset on login/logout
@@ -80,7 +81,7 @@ export function HelpFlows(): JSX.Element {
             <GuestUserIntro />
 
             <GuestUserIntroRengo />
-
+            <ModalHelp />
             <OOLUserIntro />
             <OOLSpectatorIntro />
 

--- a/src/views/HelpFlows/ModalHelp.tsx
+++ b/src/views/HelpFlows/ModalHelp.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* cspell: words groupadmin cotsen */
+
+import * as React from "react";
+
+import { HelpFlow, HelpItem } from "react-dynamic-help";
+
+export function ModalHelp(): JSX.Element {
+    return (
+        <HelpFlow debug={true} id="modal-help" showInitially={true}>
+            <HelpItem target="modal-help-intro" position="bottom-left">
+                <div>test</div>
+            </HelpItem>
+        </HelpFlow>
+    );
+}

--- a/src/views/HelpFlows/ModalHelp.tsx
+++ b/src/views/HelpFlows/ModalHelp.tsx
@@ -20,6 +20,7 @@
 import * as React from "react";
 
 import { HelpFlow, HelpItem } from "react-dynamic-help";
+import * as DynamicHelp from "react-dynamic-help";
 
 export function ModalHelp(): JSX.Element {
     return (
@@ -30,3 +31,19 @@ export function ModalHelp(): JSX.Element {
         </HelpFlow>
     );
 }
+
+interface ActivateTooltipProps {
+    children: React.ReactNode;
+    flow: string;
+    item: string;
+}
+
+export const ActivateTooltip = ({ children, flow, item }: ActivateTooltipProps) => (
+    <DynamicHelp.Api.Consumer>
+        {(value) => {
+            const { ref: modalHelpIntro } = value.registerTargetItem(`${flow}-${item}`);
+            value.triggerFlow(flow);
+            return <div ref={modalHelpIntro}>{children}</div>;
+        }}
+    </DynamicHelp.Api.Consumer>
+);

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -61,6 +61,14 @@ import { ModalContext, ModalTypes } from "@/components/Modal/ModalContext";
 
 const CHALLENGE_LIST_FREEZE_PERIOD = 1000; // Freeze challenge list for this period while they move their mouse on it
 
+const handleComputerChallengeClick = (showModal: (type: ModalTypes, props?: any) => void) => {
+    if (bot_count() === 0) {
+        void alert.fire(_("Sorry, all bots seem to be offline, please try again later."));
+        return;
+    }
+    showModal(ModalTypes.Challenge);
+};
+
 interface PlayState {
     live_list: Array<Challenge>;
     correspondence_list: Array<Challenge>;
@@ -822,30 +830,18 @@ export class Play extends React.Component<{}, PlayState> {
                         </div>
                         <div className="automatch-row">
                             <ModalContext.Consumer>
-                                {({ showModal }) => {
-                                    return (
-                                        <button
-                                            className="primary"
-                                            onClick={() => {
-                                                if (bot_count() === 0) {
-                                                    void alert.fire(
-                                                        _(
-                                                            "Sorry, all bots seem to be offline, please try again later.",
-                                                        ),
-                                                    );
-                                                    return;
-                                                }
-                                                showModal(ModalTypes.Challenge);
-                                            }}
-                                            disabled={anon || warned}
-                                        >
-                                            <div className="play-button-text-root">
-                                                <i className="fa fa-desktop" /> {_("Computer")}
-                                                <span className="time-per-move"></span>
-                                            </div>
-                                        </button>
-                                    );
-                                }}
+                                {({ showModal }) => (
+                                    <button
+                                        className="primary"
+                                        onClick={() => handleComputerChallengeClick(showModal)}
+                                        disabled={anon || warned}
+                                    >
+                                        <div className="play-button-text-root">
+                                            <i className="fa fa-desktop" /> {_("Computer")}
+                                            <span className="time-per-move"></span>
+                                        </div>
+                                    </button>
+                                )}
                             </ModalContext.Consumer>
                             <button
                                 className="primary"

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -35,7 +35,7 @@ import {
     timeControlSystemText,
     usedForCheating,
 } from "@/components/TimeControl";
-import { challenge, challengeComputer } from "@/components/ChallengeModal";
+import { challenge } from "@/components/ChallengeModal";
 import { openGameAcceptModal } from "@/components/GameAcceptModal";
 import { errorAlerter, rulesText, dup, uuid, ignore } from "@/lib/misc";
 import { Player } from "@/components/Player";
@@ -378,14 +378,6 @@ export class Play extends React.Component<{}, PlayState> {
             automatch_manager.cancel(automatch_manager.active_live_automatcher.uuid);
         }
         this.forceUpdate();
-    };
-
-    newComputerGame = () => {
-        if (bot_count() === 0) {
-            void alert.fire(_("Sorry, all bots seem to be offline, please try again later."));
-            return;
-        }
-        challengeComputer();
     };
 
     newCustomGame = () => {
@@ -834,7 +826,17 @@ export class Play extends React.Component<{}, PlayState> {
                                     return (
                                         <button
                                             className="primary"
-                                            onClick={() => showModal(ModalTypes.Challenge)}
+                                            onClick={() => {
+                                                if (bot_count() === 0) {
+                                                    void alert.fire(
+                                                        _(
+                                                            "Sorry, all bots seem to be offline, please try again later.",
+                                                        ),
+                                                    );
+                                                    return;
+                                                }
+                                                showModal(ModalTypes.Challenge);
+                                            }}
                                             disabled={anon || warned}
                                         >
                                             <div className="play-button-text-root">

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -57,7 +57,7 @@ import {
     ChallengeFilterKey,
     shouldDisplayChallenge,
 } from "@/lib/challenge_utils";
-import { ModalConsumer, ModalTypes } from "../../components/Modal/ModalProvider";
+import { ModalContext, ModalTypes } from "@/components/Modal/ModalContext";
 
 const CHALLENGE_LIST_FREEZE_PERIOD = 1000; // Freeze challenge list for this period while they move their mouse on it
 
@@ -821,7 +821,7 @@ export class Play extends React.Component<{}, PlayState> {
                             </button>
                         </div>
                         <div className="automatch-row">
-                            <ModalConsumer>
+                            <ModalContext.Consumer>
                                 {({ showModal }) => {
                                     return (
                                         <button
@@ -846,7 +846,7 @@ export class Play extends React.Component<{}, PlayState> {
                                         </button>
                                     );
                                 }}
-                            </ModalConsumer>
+                            </ModalContext.Consumer>
                             <button
                                 className="primary"
                                 onClick={() => this.findMatch("correspondence")}

--- a/src/views/Play/Play.tsx
+++ b/src/views/Play/Play.tsx
@@ -57,6 +57,7 @@ import {
     ChallengeFilterKey,
     shouldDisplayChallenge,
 } from "@/lib/challenge_utils";
+import { ModalConsumer, ModalTypes } from "../../components/Modal/ModalProvider";
 
 const CHALLENGE_LIST_FREEZE_PERIOD = 1000; // Freeze challenge list for this period while they move their mouse on it
 
@@ -828,16 +829,22 @@ export class Play extends React.Component<{}, PlayState> {
                             </button>
                         </div>
                         <div className="automatch-row">
-                            <button
-                                className="primary"
-                                onClick={this.newComputerGame}
-                                disabled={anon || warned}
-                            >
-                                <div className="play-button-text-root">
-                                    <i className="fa fa-desktop" /> {_("Computer")}
-                                    <span className="time-per-move"></span>
-                                </div>
-                            </button>
+                            <ModalConsumer>
+                                {({ showModal }) => {
+                                    return (
+                                        <button
+                                            className="primary"
+                                            onClick={() => showModal(ModalTypes.Challenge)}
+                                            disabled={anon || warned}
+                                        >
+                                            <div className="play-button-text-root">
+                                                <i className="fa fa-desktop" /> {_("Computer")}
+                                                <span className="time-per-move"></span>
+                                            </div>
+                                        </button>
+                                    );
+                                }}
+                            </ModalConsumer>
                             <button
                                 className="primary"
                                 onClick={() => this.findMatch("correspondence")}


### PR DESCRIPTION
Fixes #

https://github.com/user-attachments/assets/611d3cdc-0b2a-4419-a74b-1ac3d95eccf6

## Background
- We had been unable to add tooltips on modals because modals were never a nested component under the main tree containing the DynamicHelp provider.
- Feel free to try this out by following the video!

## Proposed Changes
  - Infrastructure: add the modal provider as a component under the OGSHelpProvider to consumer tooltip information.
  - ActivateTooltip - React component to make it easy to trigger tooltips anywhere. Happy to update if I'm not handling all cases.
  - Modal Context
  - Modal Provider - A context for modals to be rendered at the top of the tree, right under the DynamicHelp functionality. CURRENTLY used only for creating a computer challenge
  - Modal Registry - This will include the list of modals that will use this logic - currently there's only three. Other modals can be added to the registry over time, or can use the register and unregister functions to do this dynamically.
  - ForkModal and LanguagePickerModal switched to functional components to better utilize useContext.
  - Backwards compatibility with other existing modals.
 
