### PR TITLE
Add support for CM new actions: final warnings for current CM report types

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -15,164 +15,98 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { _, interpolate, llm_pgettext } from "@/lib/translate";
+import { interpolate, llm_pgettext } from "@/lib/translate";
 
 // These are the "canned messages" that Community Moderators can vote for.
 
 export const CANNED_MESSAGES: rest_api.warnings.WarningMessages = {
-    warn_beginner_score_cheat: (game_id) =>
-        interpolate(
-            _(`
-It appears that you delayed the end of game #{{game_id}}, by clicking \
-on the board to change the score incorrectly.   This can frustrate your \
-opponent and prevent them from moving on to the next game.
-
-Since you are a new player, no action will be taken against \
-your account. We simply ask that you learn when to end a game.
-
-Until you develop the experience to judge better, if your \
-opponent passes and there are no open borders between your \
-stones then you should also pass.
-
-After passing, promptly accept the correct score.
-
-If in doubt about this sort of situation. please ask for help in chat \
-or the forums.`),
-            { game_id },
-        ),
-    warn_score_cheat: (game_id) =>
-        interpolate(
-            _(`
-We noticed that you incorrectly changed the score at the end of game #{{game_id}}.
-
-While this might be a genuine mistake, please review the game and be sure you understand the final score.
-
-In future, we hope that you will end your games properly by first closing all the borders of your territory \
-and secondly by accepting the correct score immediately after passing.
-
-In case of a disagreement over what the correct score is, we ask you to contact a moderator.
-
-Unfortunately, some users use this form of score manipulation to cheat, if this happens repeatedly \
-we’ll have no alternative than to suspend your account.`),
-            { game_id },
-        ),
-    ack_educated_beginner_score_cheat: (reported) =>
-        interpolate(
-            _(`
-Thanks for the report about {{reported}}.
-
-It seems that person was a complete beginner - we have tried to explain that games should \
-be ended correctly, to pass when their opponent passes, and to accept promptly, \
-trusting the auto-score.`),
-            { reported },
-        ),
-    ack_educated_beginner_score_cheat_and_annul: (reported) =>
-        interpolate(
-            _(`
-Thanks for the report about {{reported}}.
-
-It seems that person was a complete beginner - we have tried to explain that games should \
-be ended correctly, to pass when their opponent passes, and to accept promptly, \
-trusting the auto-score.
-
-That incorrectly scored game has been annulled.`),
-            { reported },
-        ),
-    ack_warned_score_cheat: (reported) =>
-        interpolate(
-            _(`
-Thank you for your report, {{reported}} has been given a formal warning about scoring properly.`),
-            { reported },
-        ),
-    ack_warned_score_cheat_and_annul: (reported) =>
-        interpolate(
-            _(`
-Thank you for your report, {{reported}} has been given a formal warning about scoring properly, \
-and that cheated game annulled.`),
-            { reported },
-        ),
-    no_score_cheating_evident: (reported) =>
-        interpolate(
-            _(`
-Thank you for bringing the possible instance of score cheating by {{reported}} to \
-our attention. We looked into the report and couldn't see evidence of score cheating.
-
-It may be that you need to report a different type of problem, or provide more explanation - \
-you are welcome to raise a new report if that is the case.
-
-Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
-            { reported },
-        ),
     warn_beginner_escaper: (game_id) =>
         interpolate(
-            _(`
+            llm_pgettext(
+                "Warning message to a user",
+                `
 Hi, welcome to OGS!
 
-Please consider resigning games rather than letting them time out, as this is fairer to your opponents \
-than making them wait for your clock to run out. Thank you.
-        `),
+Please consider resigning games rather than letting them time out, as this is fairer to your opponents than making them wait for your clock to run out. Thank you.
+        `,
+            ),
             { game_id },
         ),
     warn_escaper: (game_id) =>
         interpolate(
-            _(`
+            llm_pgettext(
+                "Warning message to a user",
+                `
 It has come to our attention that you abandoned game #{{game_id}} and allowed it to time out rather than resigning.
 
-Players are required to end their games properly, as letting them time out can cause opponents to wait unnecessarily, \
-and prevent them from moving on to the next game.
+Players are required to end their games properly, as letting them time out can cause opponents to wait unnecessarily, and prevent them from moving on to the next game.
 
-Please ensure that you end your games properly by accepting the correct score immediately after passing, \
-or by resigning if you feel the position is hopeless.
+Please ensure that you end your games properly by accepting the correct score immediately after passing, or by resigning if you feel the position is hopeless.
 
-This helps maintain a positive gaming environment for everyone involved.`),
+This helps maintain a positive gaming environment for everyone involved.`,
+            ),
             { game_id },
         ),
     ack_educated_beginner_escaper: (reported) =>
         interpolate(
-            _(`
-Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.`),
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thanks for the report about '{{reported}}', we've asked your newcomer opponent to be more respectful of people’s time.`,
+            ),
             { reported },
         ),
     ack_educated_beginner_escaper_and_annul: (reported) =>
         interpolate(
-            _(`
-Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thanks for the report about '{{reported}}', we've asked your newcomer opponent to be more respectful of people’s time.
 
-That incorrectly scored game has been annulled.`),
+That incorrectly scored game has been annulled.`,
+            ),
             { reported },
         ),
     ack_warned_escaper: (reported) =>
         interpolate(
-            _(`
-Thank you for your report, {{reported}} has been given a formal warning about finishing games properly.`),
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for your report, '{{reported}}' has been given a formal warning about finishing games properly.`,
+            ),
             { reported },
         ),
     ack_warned_escaper_and_annul: (reported) =>
         interpolate(
-            _(`
-Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, \
-and that abandoned game annulled.`),
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for your report, '{{reported}}' has been given a formal warning about finishing games properly, and that abandoned game annulled.`,
+            ),
             { reported },
         ),
     no_escaping_evident: (reported) =>
         interpolate(
-            _(`
-Thank you for bringing the possible instance of {{reported}} abandoning the game to
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for bringing the possible instance of '{{reported}}' abandoning the game to
 our attention.
 
 We looked into the game and did not see them failing to finish the game properly.
 
-It may be that you need to report a different type of problem, or provide more explanation -
-you are welcome to raise a new report if that is the case.
+It may be that you need to report a different type of problem, or provide more explanation - you are welcome to raise a new report if that is the case.
 
-Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
+            ),
             { reported },
         ),
     not_escaping_cancel: (reported) =>
         interpolate(
-            _(`
-Thank you for bringing the possible instance of {{reported}} abandoning the game \
-to our attention.
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for bringing the possible instance of '{{reported}}' abandoning the game to our attention.
 
 We looked into the game and see that they used "Cancel".
 
@@ -180,132 +114,398 @@ Players are allowed to "Cancel" a game during the first moves.
 
 If you think the person is abusing this feature, please file a report with more details.
 
-Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
+            ),
             { reported },
         ),
     warn_beginner_staller: (game_id) =>
         interpolate(
-            _(`
+            llm_pgettext(
+                "Warning message to a user",
+                `
 Hi, welcome to OGS!
 
-It appears that you delayed the end of game #{{game_id}}, which can frustrate your opponent and \
-prevent them from moving on to the next game.
+It appears that you delayed the end of game #{{game_id}}, which can frustrate your opponent and prevent them from moving on to the next game.
 
-Since you are a new player, no action will be taken against your account. We simply ask that you \
-learn when to end a game.
+Since you are a new player, no action will be taken against your account. We simply ask that you learn when to end a game.
 
-Until you develop the experience to judge better, if your opponent passes and there are no open borders \
-between your stones then you should also pass.
+Until you develop the experience to judge better, if your opponent passes and there are no open borders between your stones then you should also pass.
 
 After passing, promptly accept the correct score.
 
 If in doubt about this sort of situation. please ask for help in chat or the forums.
-        `),
+        `,
+            ),
             { game_id },
         ),
     warn_staller: (game_id) =>
         interpolate(
-            _(`
-It has come to our attention that you delayed the end of game #{{game_id}}, which can frustrate your \
-opponent and prevent them from moving on to their next game.
+            llm_pgettext(
+                "Warning message to a user",
+                `
+It has come to our attention that you delayed the end of game #{{game_id}}, which can frustrate your opponent and prevent them from moving on to their next game.
 
-Players are required to end their games properly, as letting them time out can cause opponents to wait \
-unnecessarily, and prevent them from moving on to the next game.
+Players are required to end their games properly, as letting them time out can cause opponents to wait unnecessarily, and prevent them from moving on to the next game.
 
-Please ensure that you end your games properly by accepting the correct score immediately after passing, \
-or by resigning if you feel the position is hopeless.
+Please ensure that you end your games properly by accepting the correct score immediately after passing, or by resigning if you feel the position is hopeless.
 
-This helps maintain a positive gaming environment for everyone involved.`),
+This helps maintain a positive gaming environment for everyone involved.`,
+            ),
             { game_id },
         ),
     ack_educated_beginner_staller: (reported) =>
         interpolate(
-            _(`
-Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.`),
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thanks for the report about '{{reported}}', we've asked your newcomer opponent to be more respectful of people’s time.`,
+            ),
             { reported },
         ),
     ack_educated_beginner_staller_and_annul: (reported) =>
         interpolate(
-            _(`
-Thanks for the report about {{reported}}, we've asked your newcomer opponent to be more respectful of people’s time.
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thanks for the report about '{{reported}}', we've asked your newcomer opponent to be more respectful of people’s time.
 
-That incorrectly scored game has been annulled.`),
+That incorrectly scored game has been annulled.`,
+            ),
             { reported },
         ),
     ack_warned_staller: (reported) =>
         interpolate(
-            _(`
-Thank you for your report, {{reported}} has been given a formal warning about finishing games properly.`),
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for your report, '{{reported}}' has been given a formal warning about finishing games properly.`,
+            ),
             { reported },
         ),
     ack_warned_staller_and_annul: (reported) =>
         interpolate(
-            _(`
-Thank you for your report, {{reported}} has been given a formal warning about finishing games properly, \
-and that abandoned game annulled.`),
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for your report, '{{reported}}' has been given a formal warning about finishing games properly, and that abandoned game annulled.`,
+            ),
             { reported },
         ),
     no_stalling_evident: (reported) =>
         interpolate(
-            _(`
-Thank you for bringing the possible instance of stalling play by {{reported}} to \
-our attention. We looked into the report and don't see evidence of stalling.
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for bringing the possible instance of stalling play by '{{reported}}' to our attention. We looked into the report and don't see evidence of stalling.
 
-Note that the correct way to signal the game has finished is to pass.  If you didn't pass, \
-then your opponent is entitled to keep playing.
+Note that the correct way to signal the game has finished is to pass.  If you didn't pass, then your opponent is entitled to keep playing.
 
-It may be that you need to report a different type of problem, or provide more explanation - \
-you are welcome to raise a new report if that is the case.
+It may be that you need to report a different type of problem, or provide more explanation - you are welcome to raise a new report if that is the case.
 
-Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`),
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
+            ),
             { reported },
         ),
-    warn_duplicate_report: (reported) =>
-        interpolate(
-            _(`
-Thanks for your additional report about {{reported}}.
-
-Please don't file multiple reports for the same thing - that creates a lot of work for us tidying up, \
-which could be time spent better on other reports.
-
-We appreciate hearing about problems, but one report is enough for each incident - more than that will slow us down.
-
-Thanks!`),
-            { reported },
-        ),
-    report_type_changed: (change) =>
-        interpolate(
-            _(`
-Thanks for your recent report.   We've had to change the 'report type':
-
-    {{change}}.
-
-It makes it easier and quicker to process reports if they are raised with the \
-correct type - if you could help with that we'd appreciate it.
-
-If this change seems wrong, we'd welcome feedback about that - please contact a \
-moderator to let them know.
-`),
-            { change },
-        ),
-    bot_owner_notified: (bot) =>
+    warn_beginner_score_cheat: (game_id) =>
         interpolate(
             llm_pgettext(
-                "Message to acknowledge a report of a bot",
+                "Warning message to a user",
                 `
-Thanks for your recent report about {{bot}}.
+It appears that you delayed the end of game #{{game_id}}, by clicking on the board to change the score incorrectly.   This can frustrate your opponent and prevent them from moving on to the next game.
 
-We've notified the owner of that bot.
+Since you are a new player, no action will be taken against your account. We simply ask that you learn when to end a game.
+
+Until you develop the experience to judge better, if your opponent passes and there are no open borders between your stones then you should also pass.
+
+After passing, promptly accept the correct score.
+
+If in doubt about this sort of situation. please ask for help in chat or the forums.`,
+            ),
+            { game_id },
+        ),
+    warn_score_cheat: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Warning message to a user",
+                `
+We noticed that you incorrectly changed the score at the end of game #{{game_id}}.
+
+While this might be a genuine mistake, please review the game and be sure you understand the final score.
+
+In future, we hope that you will end your games properly by first closing all the borders of your territory and secondly by accepting the correct score immediately after passing.
+
+In case of a disagreement over what the correct score is, we ask you to contact a moderator.
+
+Unfortunately, some users use this form of score manipulation to cheat, if this happens repeatedly we’ll have no alternative than to suspend your account.`,
+            ),
+            { game_id },
+        ),
+    ack_educated_beginner_score_cheat: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thanks for the report about '{{reported}}'.
+
+It seems that person was a complete beginner - we have tried to explain that games should be ended correctly, to pass when their opponent passes, and to accept promptly, trusting the auto-score.`,
+            ),
+            { reported },
+        ),
+    ack_educated_beginner_score_cheat_and_annul: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thanks for the report about '{{reported}}'.
+
+It seems that person was a complete beginner - we have tried to explain that games should be ended correctly, to pass when their opponent passes, and to accept promptly, trusting the auto-score.
+
+That incorrectly scored game has been annulled.`,
+            ),
+            { reported },
+        ),
+    ack_warned_score_cheat: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for your report, '{{reported}}' has been given a formal warning about scoring properly.`,
+            ),
+            { reported },
+        ),
+    ack_warned_score_cheat_and_annul: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for your report, '{{reported}}' has been given a formal warning about scoring properly, and that cheated game annulled.`,
+            ),
+            { reported },
+        ),
+    no_score_cheating_evident: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for bringing the possible instance of score cheating by '{{reported}}' to our attention. We looked into the report and couldn't see evidence of score cheating.
+
+It may be that you need to report a different type of problem, or provide more explanation - you are welcome to raise a new report if that is the case.
+
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
+            ),
+            { reported },
+        ),
+    final_warn_escaper: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Final warning message to a repeat escaper",
+                `
+Important: this is a final warning.
+
+It seems you failed to end game #{{game_id}} properly, and let it time out.
+
+If you continue to abandon games without finishing them properly your account will be suspended.
+
+We have previous explained that you need to resign if you feel the position is hopeless, or pass and accept the correct score then the game is over. 
+
+Please take care to do that each time, and ask for help if you are not clear what is the problem.
+
+Thanks.
 `,
             ),
-            { bot },
+            { game_id },
+        ),
+    final_warn_escaper_and_annul: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Final warning message to a repeat escaper and annul a game",
+                `
+Important: this is a final warning.
+
+It seems you failed to end game #{{game_id}} properly, and let it time out.
+
+The outcome was wrong as a result - we've annulled that game.
+
+If you continue to abandon games without finishing them properly your account will be suspended.
+
+We have previous explained that you need to resign if you feel the position is hopeless, or pass and accept the correct score then the game is over. 
+
+Please take care to do that each time, and ask for help if you are not clear what is the problem.
+
+Thanks.
+`,
+            ),
+            { game_id },
+        ),
+    final_warn_staller: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Final warning message to a repeat staller",
+                `
+Important: this is a final warning.
+
+It seems you delayed the end of game #{{game_id}}, which can frustrate your opponent and prevent them from moving on to the next game.
+
+If you continue to delay games without finishing them properly your account will be suspended.
+
+We've previously explained that you need to end games properly, by accepting the correct score immediately after passing, or by resigning if you feel the position is hopeless.
+
+Please take care to do that each time, and ask for help if you are not clear what is the problem.
+
+Thanks.
+`,
+            ),
+            { game_id },
+        ),
+    final_warn_staller_and_annul: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Final warning message to a repeat staller and annul a game",
+                `
+Important: this is a final warning.
+
+It seems you delayed the end of game #{{game_id}}, which can frustrate your opponent and prevent them from moving on to the next game.
+
+The outcome was wrong as a result - we've annulled that game.
+
+If you continue to delay games without finishing them properly your account will be suspended.
+
+We've previously explained that you need to end games properly, by accepting the correct score immediately after passing, or by resigning if you feel the position is hopeless.
+
+Please take care to do that each time, and ask for help if you are not clear what is the problem.
+
+Thanks.
+`,
+            ),
+            { game_id },
+        ),
+    final_warn_score_cheat: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Final warning message to a repeat score cheater",
+                `
+Important: this is a final warning.
+
+It seems you incorrectly changed the score at the end of game #{{game_id}}.
+
+If you continue to change the score incorrectly your account will be suspended.
+
+We've previously explained that you need to end games properly, by accepting the correct score immediately after passing, or by resigning if you feel the position is hopeless.
+
+Please take care to do that each time, and ask for help if you are not clear what is the problem.
+
+Thanks.
+`,
+            ),
+            { game_id },
+        ),
+    final_warn_score_cheat_and_annul: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Final warning message to a repeat score cheater and annul a game",
+                `
+Important: this is a final warning.
+
+It seems you incorrectly changed the score at the end of game #{{game_id}}.
+
+The outcome was wrong as a result - we've annulled that game.
+
+If you continue to change the score incorrectly your account will be suspended.
+
+We've previously explained that you need to end games properly, by accepting the correct score immediately after passing, or by resigning if you feel the position is hopeless.
+
+Please take care to do that each time, and ask for help if you are not clear what is the problem.
+
+Thanks.
+`,
+            ),
+            { game_id },
+        ),
+
+    ack_final_warn_escaper: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement to acknowledge a report of a repeat escaper",
+                `
+Thank you for your report.  '{{reported}}' has been given a final warning about abandoning games.
+
+If this continues, their account will be suspended.
+`,
+            ),
+            { reported },
+        ),
+    ack_final_warn_escaper_and_annul: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement to acknowledge a report of a repeat escaper and annul a game",
+                `
+Thank you for your report.  '{{reported}}' has been given a final warning about abandoning games.
+
+If this continues, their account will be suspended.
+
+That game has been annulled.
+`,
+            ),
+            { reported },
+        ),
+    ack_final_warn_staller: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Message to acknowledge a report of a repeat staller",
+                `
+Thank you for your report.  '{{reported}}' has been given a final warning about stalling.
+
+If this continues, their account will be suspended.
+`,
+            ),
+            { reported },
+        ),
+    ack_final_warn_staller_and_annul: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Message to acknowledge a report of a repeat staller and annul a game",
+                `
+Thank you for your report.  '{{reported}}' has been given a final warning about stalling.
+
+If this continues, their account will be suspended.
+
+That game has been annulled.
+`,
+            ),
+            { reported },
+        ),
+    ack_final_warn_score_cheat: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Message to acknowledge a report of a repeat score cheater",
+                `
+Thank you for your report.  '{{reported}}' has been given a final warning about cheating the score.
+
+If this continues, their account will be suspended.
+`,
+            ),
+            { reported },
+        ),
+    ack_final_warn_score_cheat_and_annul: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Message to acknowledge a report of a repeat score cheater and annul a game",
+                `
+Thank you for your report.  '{{reported}}' has been given a final warning about cheating the score.
+
+If this continues, their account will be suspended.
+
+That game has been annulled.
+`,
+            ),
+            { reported },
         ),
     ack_suspended: (reported) =>
         interpolate(
             llm_pgettext(
                 "Message to acknowledge a report of a repeat offender",
                 `
-Thank you for your report.  {{reported}} is a repeat offender, their account has been suspended.
+Thank you for your report.  '{{reported}}' is a repeat offender, their account has been suspended.
 `,
             ),
             { reported },
@@ -316,10 +516,54 @@ Thank you for your report.  {{reported}} is a repeat offender, their account has
             llm_pgettext(
                 "Message to acknowledge a report of a repeat offender and annul a game",
                 `
-Thank you for your report.  {{reported}} is a repeat offender, their has been suspended. \
+Thank you for your report.  '{{reported}}' is a repeat offender, their has been suspended.
+
 The reported game has been annulled.
 `,
             ),
             { reported },
+        ),
+    warn_duplicate_report: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Warning message to a user",
+                `
+Thanks for your additional report about '{{reported}}'.
+
+Please don't file multiple reports for the same thing - that creates a lot of work for us tidying up, which could be time spent better on other reports.
+
+We appreciate hearing about problems, but one report is enough for each incident - more than that will slow us down.
+
+Thanks!`,
+            ),
+            { reported },
+        ),
+    report_type_changed: (change) =>
+        interpolate(
+            llm_pgettext(
+                "Warning message to a user",
+                `
+Thanks for your recent report.   We've had to change the 'report type':
+
+    {{change}}.
+
+It makes it easier and quicker to process reports if they are raised with the correct type - if you could help with that we'd appreciate it.
+
+If this change seems wrong, we'd welcome feedback about that - please contact a moderator to let them know.
+    `,
+            ),
+            { change },
+        ),
+    bot_owner_notified: (bot) =>
+        interpolate(
+            llm_pgettext(
+                "Message to acknowledge a report of a bot",
+                `
+Thanks for your recent report about {{bot}}.
+
+We've notified the owner of that bot.
+    `,
+            ),
+            { bot },
         ),
 };

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -19,14 +19,8 @@
 declare namespace rest_api {
     namespace warnings {
         // These must match voting handling in django moderation.py
+        // Don't forget to also update ACTION_PROMPTS as needed: new messages usually mean new actions.
         type WarningMessageId =
-            | "warn_beginner_score_cheat"
-            | "warn_score_cheat"
-            | "ack_educated_beginner_score_cheat"
-            | "ack_educated_beginner_score_cheat_and_annul"
-            | "ack_warned_score_cheat"
-            | "ack_warned_score_cheat_and_annul"
-            | "no_score_cheating_evident"
             | "warn_beginner_escaper"
             | "warn_escaper"
             | "ack_educated_beginner_escaper"
@@ -42,11 +36,30 @@ declare namespace rest_api {
             | "ack_warned_staller"
             | "ack_warned_staller_and_annul"
             | "no_stalling_evident"
+            | "warn_beginner_score_cheat"
+            | "warn_score_cheat"
+            | "ack_educated_beginner_score_cheat"
+            | "ack_educated_beginner_score_cheat_and_annul"
+            | "ack_warned_score_cheat"
+            | "ack_warned_score_cheat_and_annul"
+            | "no_score_cheating_evident"
+            | "final_warn_escaper"
+            | "final_warn_escaper_and_annul"
+            | "final_warn_staller"
+            | "final_warn_staller_and_annul"
+            | "final_warn_score_cheat"
+            | "final_warn_score_cheat_and_annul"
+            | "ack_final_warn_escaper"
+            | "ack_final_warn_escaper_and_annul"
+            | "ack_final_warn_staller"
+            | "ack_final_warn_staller_and_annul"
+            | "ack_final_warn_score_cheat"
+            | "ack_final_warn_score_cheat_and_annul"
+            | "ack_suspended"
+            | "ack_suspended_and_annul"
             | "warn_duplicate_report"
             | "report_type_changed"
-            | "bot_owner_notified"
-            | "ack_suspended"
-            | "ack_suspended_and_annul";
+            | "bot_owner_notified";
 
         type Severity = "warning" | "acknowledgement" | "info";
 

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import { _, pgettext } from "@/lib/translate";
+import { _, llm_pgettext } from "@/lib/translate";
 
 import * as DynamicHelp from "react-dynamic-help";
 import { useUser } from "@/lib/hooks";
@@ -33,85 +33,111 @@ interface ModerationActionSelectorProps {
 
 // Translatable versions of the prompts for Community Moderators.
 // The set of keys (choices) here is determined by the server's VotableActions class.
+//
+// Don't forget to update rest_api.warnings.WarningMessageId as needed: new actions usually mean new messages.
 const ACTION_PROMPTS = {
-    annul_score_cheat: pgettext(
-        "Label for a moderator to select this option",
-        "Annul the game and warn the cheater.",
-    ),
-    warn_score_cheat: pgettext(
-        "Label for a moderator to select this option",
-        "The accused tried to cheat - warn the cheater.",
-    ),
-    no_score_cheat: pgettext(
-        "Label for a moderator to select this option",
-        "No cheating - inform the reporter.",
-    ),
-    call_score_cheat_for_black: pgettext(
-        "Label for a moderator to select this option",
-        "White is cheating - call the game for black, and warn white.",
-    ),
-    call_score_cheat_for_white: pgettext(
-        "Label for a moderator to select this option",
-        "Black is cheating - call the game for white, and warn black.",
-    ),
-    annul_escaped: pgettext(
+    annul_escaped: llm_pgettext(
         "Label for a moderator to select this option",
         "Wrong result due to escape - annul game, warn the escaper.",
     ),
-    warn_escaper: pgettext(
+    warn_escaper: llm_pgettext(
         "Label for a moderator to select this option",
         "The accused escaped - warn them.",
     ),
-    call_escaped_game_for_black: pgettext(
+    call_escaped_game_for_black: llm_pgettext(
         "Label for a moderator to select this option",
         "White escaped - call the game for black, and warn white.",
     ),
-    call_escaped_game_for_white: pgettext(
+    call_escaped_game_for_white: llm_pgettext(
         "Label for a moderator to select this option",
         "Black escaped - call the game for white, and warn black.",
     ),
-    no_escaping: pgettext(
+    no_escaping: llm_pgettext(
         "Label for a moderator to select this option",
         "No escaping evident - inform the reporter.",
     ),
-    not_escaping_cancel: pgettext(
+    not_escaping_cancel: llm_pgettext(
         "Label for a moderator to select this option",
         "Not escaping, they used 'cancel'.",
     ),
-    annul_stalled: pgettext(
+    annul_stalled: llm_pgettext(
         "Label for a moderator to select this option",
         "Wrong result due to stalling - annul game, warn the staller.",
     ),
-    warn_staller: pgettext(
+    warn_staller: llm_pgettext(
         "Label for a moderator to select this option",
         "The accused stalled - warn them.",
     ),
-    call_stalled_game_for_black: pgettext(
+    call_stalled_game_for_black: llm_pgettext(
         "Label for a moderator to select this option",
         "White stalled - call the game for black, and warn white.",
     ),
-    call_stalled_game_for_white: pgettext(
+    call_stalled_game_for_white: llm_pgettext(
         "Label for a moderator to select this option",
         "Black stalled - call the game for white, and warn black.",
     ),
-    no_stalling: pgettext(
+    no_stalling: llm_pgettext(
         "Label for a moderator to select this option",
         "No stalling evident - inform the reporter.",
     ),
-    warn_duplicate_reporter: pgettext(
+    annul_score_cheat: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Annul the game and warn the cheater.",
+    ),
+    warn_score_cheat: llm_pgettext(
+        "Label for a moderator to select this option",
+        "The accused tried to cheat - warn the cheater.",
+    ),
+    no_score_cheat: llm_pgettext(
+        "Label for a moderator to select this option",
+        "No cheating - inform the reporter.",
+    ),
+    call_score_cheat_for_black: llm_pgettext(
+        "Label for a moderator to select this option",
+        "White is cheating - call the game for black, and warn white.",
+    ),
+    call_score_cheat_for_white: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Black is cheating - call the game for white, and warn black.",
+    ),
+    final_warning_escaping: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Final warning: the accused escaped.",
+    ),
+    final_warning_stalling: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Final warning: the accused stalled.",
+    ),
+    final_warning_score_cheating: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Final warning: the accused tried to cheat.",
+    ),
+    final_warning_escaping_and_annul: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Final warning: the accused escaped - annul game.",
+    ),
+    final_warning_stalling_and_annul: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Final warning: the accused stalled - annul game.",
+    ),
+    final_warning_score_cheating_and_annul: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Final warning: the accused tried to cheat - annul game.",
+    ),
+    warn_duplicate_reporter: llm_pgettext(
         "Label for a moderator to select this option",
         "Duplicate report - ask them not to do that.",
     ),
 
-    suspend_user: pgettext("Label for a moderator to select this option", "Suspend the user."),
+    suspend_user: llm_pgettext("Label for a moderator to select this option", "Suspend the user."),
 
-    suspend_user_and_annul: pgettext(
+    suspend_user_and_annul: llm_pgettext(
         "Label for a moderator to select this option",
         "Suspend user and annul game.",
     ),
 
     // Note: keep this last, so it's positioned above the "note to moderator" input field
-    escalate: pgettext(
+    escalate: llm_pgettext(
         "A label for a community moderator to select this option - send report to to full moderators",
         "Escalate: send direct to moderators.",
     ),
@@ -147,7 +173,7 @@ export function ModerationActionSelector({
     return (
         <div className="ModerationActionSelector" ref={voting_pane}>
             <h4>
-                {pgettext(
+                {llm_pgettext(
                     "The heading for community moderators 'action choices' section",
                     "Actions",
                 )}
@@ -197,7 +223,7 @@ export function ModerationActionSelector({
             <span className="action-buttons">
                 {((reportedBySelf && enable) || null) && (
                     <button className="reject" onClick={report.cancel}>
-                        {pgettext(
+                        {llm_pgettext(
                             "A button for cancelling a report created by yourself",
                             "Cancel Report",
                         )}
@@ -212,7 +238,7 @@ export function ModerationActionSelector({
                             submit(selectedOption, mod_note);
                         }}
                     >
-                        {pgettext("A label on a button for submitting a vote", "Vote")}
+                        {llm_pgettext("A label on a button for submitting a vote", "Vote")}
                     </button>
                 )}
             </span>


### PR DESCRIPTION
... and reorder code for consistent ordering of CM report types etc in code (escape, stall then score-cheat).

* Also moves CannedMessages to llm_pgettext

Fixes CM's not able to give people a final warning before suspending them

## Proposed Changes

  - Add support for voting for the new final warnings in https://github.com/online-go/ogs/pull/2005
  - Reorder lists of these things for consistency
  - Move all `CannedMessage` s to llm_pgettext
  - Remove `\` from `CannedMessage` s 
