### PR TITLE
Require CMs to give an escalation reason, 

### DIFF
--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -214,7 +214,10 @@ export function ModerationActionSelector({
             {selectedOption === "escalate" && (
                 <textarea
                     id="mod-note-text"
-                    placeholder={_("Message for moderators...")}
+                    placeholder={llm_pgettext(
+                        "A placeholder prompting community moderators for the reason why they are escalating a report",
+                        "Reason for escalating?",
+                    )}
                     rows={5}
                     value={mod_note}
                     onChange={(ev) => setModNote(ev.target.value)}
@@ -232,7 +235,9 @@ export function ModerationActionSelector({
                 {((action_choices && enable) || null) && (
                     <button
                         className="success"
-                        disabled={voted || !selectedOption}
+                        disabled={
+                            voted || !selectedOption || (selectedOption === "escalate" && !mod_note)
+                        }
                         onClick={() => {
                             setVoted(true);
                             submit(selectedOption, mod_note);

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -155,7 +155,7 @@ export function ModerationActionSelector({
     const reportedBySelf = user.id === report.reporting_user.id;
 
     const [selectedOption, setSelectedOption] = React.useState("");
-    const [mod_note, setModNote] = React.useState("");
+    const [community_mod_note, setModNote] = React.useState("");
     const [voted, setVoted] = React.useState(false);
 
     const updateSelectedAction = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -219,7 +219,7 @@ export function ModerationActionSelector({
                         "Reason for escalating?",
                     )}
                     rows={5}
-                    value={mod_note}
+                    value={community_mod_note}
                     onChange={(ev) => setModNote(ev.target.value)}
                 />
             )}
@@ -236,11 +236,13 @@ export function ModerationActionSelector({
                     <button
                         className="success"
                         disabled={
-                            voted || !selectedOption || (selectedOption === "escalate" && !mod_note)
+                            voted ||
+                            !selectedOption ||
+                            (selectedOption === "escalate" && !community_mod_note)
                         }
                         onClick={() => {
                             setVoted(true);
-                            submit(selectedOption, mod_note);
+                            submit(selectedOption, community_mod_note);
                         }}
                     >
                         {llm_pgettext("A label on a button for submitting a vote", "Vote")}

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -541,11 +541,12 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                     )}
 
                     {report.escalated &&
-                        report.community_mod_note &&
                         (user.is_moderator || user.moderator_powers & MODERATOR_POWERS.SUSPEND) && (
                             <div className="notes">
                                 <h4>Escalator's note:</h4>
-                                <div className="Card">{report.community_mod_note}</div>
+                                <div className="Card">
+                                    {report.community_mod_note || "(none provided)"}
+                                </div>
                             </div>
                         )}
 


### PR DESCRIPTION
and make sure CMs can see what's going on with the reason in escalated reports

Fixes mysteries about what were we thinking.

## Proposed Changes

  - Always show the escalation note
  - Don't allow an escalation without an escalation note
  
