### PR TITLE
Escalation note fieldname update

### DIFF
--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -351,11 +351,11 @@ class ReportManager extends EventEmitter<Events> {
         this.updateIncidentReport(res);
         return res;
     }
-    public vote(report_id: number, voted_action: string, mod_note: string): Promise<Report> {
+    public vote(report_id: number, voted_action: string, escalation_note: string): Promise<Report> {
         const res = post(`moderation/incident/${report_id}`, {
             action: "vote", // darn, yes, two different uses of the word "action" collide here
             voted_action: voted_action,
-            mod_note,
+            escalation_note: escalation_note,
         }).then((res) => {
             toast(
                 <div>

--- a/src/lib/report_util.ts
+++ b/src/lib/report_util.ts
@@ -66,7 +66,7 @@ export interface Report {
     available_actions: Array<string>; // community moderator actions
     vote_counts: { [action: string]: number };
     voters: Vote[]; // votes from community moderators on this report
-    community_mod_note: string;
+    escalation_note: string;
 
     unclaim: () => void;
     claim: () => void;

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -155,7 +155,7 @@ export function ModerationActionSelector({
     const reportedBySelf = user.id === report.reporting_user.id;
 
     const [selectedOption, setSelectedOption] = React.useState("");
-    const [community_mod_note, setModNote] = React.useState("");
+    const [escalation_note, setEscalationNote] = React.useState("");
     const [voted, setVoted] = React.useState(false);
 
     const updateSelectedAction = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -219,8 +219,8 @@ export function ModerationActionSelector({
                         "Reason for escalating?",
                     )}
                     rows={5}
-                    value={community_mod_note}
-                    onChange={(ev) => setModNote(ev.target.value)}
+                    value={escalation_note}
+                    onChange={(ev) => setEscalationNote(ev.target.value)}
                 />
             )}
             <span className="action-buttons">
@@ -238,11 +238,11 @@ export function ModerationActionSelector({
                         disabled={
                             voted ||
                             !selectedOption ||
-                            (selectedOption === "escalate" && !community_mod_note)
+                            (selectedOption === "escalate" && !escalation_note)
                         }
                         onClick={() => {
                             setVoted(true);
-                            submit(selectedOption, community_mod_note);
+                            submit(selectedOption, escalation_note);
                         }}
                     >
                         {llm_pgettext("A label on a button for submitting a vote", "Vote")}

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -545,7 +545,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                             <div className="notes">
                                 <h4>Escalator's note:</h4>
                                 <div className="Card">
-                                    {report.community_mod_note || "(none provided)"}
+                                    {report.escalation_note || "(none provided)"}
                                 </div>
                             </div>
                         )}


### PR DESCRIPTION
Matches changes in backend as part of fixing escalation note handling

## Proposed Changes

  - Change the field name to the less confusing name now used in the back end

** Requires https://github.com/online-go/ogs/pull/2008 to go in at the same time.
  
  

