### PR TITLE
Support for the option for CMs to vote to annul without issuing warnings

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -295,6 +295,32 @@ Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
             ),
             { reported },
         ),
+    annul_no_warning: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Message to opponent who's game was annulled without warnings being given to either player",
+                `
+Just a note to let you know that we've annulled game #{{game_id}}, as the outcome was wrong.
+
+No-one was at fault, but we felt it was the best way to resolve the situation.
+`,
+            ),
+            { game_id },
+        ),
+    ack_annul_no_warning: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement message to a user who reported a game that needed to be annulled",
+                `
+Thanks for your report about #{{game_id}}.
+
+We annulled that game, as the outcome was wrong.
+
+No-one was at fault - we felt this was the best way to resolve the situation.
+`,
+            ),
+            { game_id },
+        ),
     final_warn_escaper: (game_id) =>
         interpolate(
             llm_pgettext(

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -18,6 +18,7 @@
 
 declare namespace rest_api {
     namespace warnings {
+        // Note that "warnings" are actually "any message we present in a dialog and track acknowledgement of".
         // These must match voting handling in django moderation.py
         // Don't forget to also update ACTION_PROMPTS as needed: new messages usually mean new actions.
         type WarningMessageId =
@@ -43,6 +44,8 @@ declare namespace rest_api {
             | "ack_warned_score_cheat"
             | "ack_warned_score_cheat_and_annul"
             | "no_score_cheating_evident"
+            | "annul_no_warning"
+            | "ack_annul_no_warning"
             | "final_warn_escaper"
             | "final_warn_escaper_and_annul"
             | "final_warn_staller"

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -100,6 +100,10 @@ const ACTION_PROMPTS = {
         "Label for a moderator to select this option",
         "Black is cheating - call the game for white, and warn black.",
     ),
+    annul_no_warning: llm_pgettext(
+        "Label for a moderator to select this option",
+        "Annul the game, but issue no warnings.",
+    ),
     final_warning_escaping: llm_pgettext(
         "Label for a moderator to select this option",
         "Final warning: the accused escaped.",


### PR DESCRIPTION
Fixes not being able to vote to annul when no-one actually did anything wrong.

## Proposed Changes

  - Support https://github.com/online-go/ogs/pull/2012 with appropriate messages.
  