### PR TITLE
Dissenter note

### DIFF
--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -352,11 +352,17 @@ class ReportManager extends EventEmitter<Events> {
         return res;
     }
 
-    public vote(report_id: number, voted_action: string, escalation_note: string): Promise<Report> {
+    public vote(
+        report_id: number,
+        voted_action: string,
+        escalation_note: string,
+        dissenter_note: string,
+    ): Promise<Report> {
         return post(`moderation/incident/${report_id}`, {
             action: "vote",
             voted_action: voted_action,
             escalation_note: escalation_note,
+            ...(dissenter_note && { dissenter_note }),
         })
             .then((res) => {
                 toast(

--- a/src/lib/report_util.ts
+++ b/src/lib/report_util.ts
@@ -67,6 +67,7 @@ export interface Report {
     vote_counts: { [action: string]: number };
     voters: Vote[]; // votes from community moderators on this report
     escalation_note: string;
+    dissenter_note: string;
 
     unclaim: () => void;
     claim: () => void;

--- a/src/views/ReportsCenter/ModerationActionSelector.styl
+++ b/src/views/ReportsCenter/ModerationActionSelector.styl
@@ -2,7 +2,7 @@
 
     .action-buttons {
         display: flex;
-        justify-content: flex-end;    
+        justify-content: flex-end;
     }
 
 }

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -239,7 +239,7 @@ export function ModerationActionSelector({
                     id="dissenter-note"
                     placeholder={llm_pgettext(
                         "A placeholder prompting community moderators for the reason why they are disagreeing with a vote",
-                        "What is it that the other votes do not seem to take into account?",
+                        "(Optional) What is it that the other votes do not seem to take into account?",
                     )}
                     rows={5}
                     value={dissenter_note}

--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -161,6 +161,7 @@
 
     .notes {
         flex-basis: 50%;
+        white-space: pre-wrap;
     }
 
     .voting {

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -24,7 +24,7 @@ import { report_categories, ReportType } from "@/components/Report";
 import { report_manager } from "@/lib/report_manager";
 import { Report } from "@/lib/report_util";
 import { AutoTranslate } from "@/components/AutoTranslate";
-import { interpolate, _, pgettext } from "@/lib/translate";
+import { interpolate, _, pgettext, llm_pgettext } from "@/lib/translate";
 import { Player, ShowPlayersInReportContext } from "@/components/Player";
 import { Link } from "react-router-dom";
 import { post } from "@/lib/requests";
@@ -555,12 +555,9 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                             <ModerationActionSelector
                                 available_actions={availableActions ?? []}
                                 vote_counts={voteCounts}
-                                claim={() => {
-                                    /* community moderators don't claim reports */
-                                }}
-                                submit={(action, note) => {
+                                submit={(action, note, dissenter_note) => {
                                     void report_manager
-                                        .vote(report.id, action, note)
+                                        .vote(report.id, action, note, dissenter_note)
                                         .then(() => next());
                                 }}
                                 enable={
@@ -571,6 +568,25 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): J
                                 key={report.id}
                                 report={report}
                             />
+                            {report.dissenter_note && (
+                                <div className="notes">
+                                    <h4>
+                                        {llm_pgettext(
+                                            "Heading for a paragraph",
+                                            "Dissenting voter notes:",
+                                        )}
+                                    </h4>
+                                    <div className="Card">{report.dissenter_note}</div>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                    {report.dissenter_note && user.is_moderator && (
+                        <div className="notes">
+                            <h4>
+                                {llm_pgettext("Heading for a paragraph", "Dissenting voter notes:")}
+                            </h4>
+                            <div className="Card">{report.dissenter_note}</div>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
Fixes urge for CMs to escalate when really they just want to clarify.

## Proposed Changes

  - Prompt the CM for an explanatory note if they select a dissenting vote.
  - Display dissenter notes in ViewReport

NEEDS https://github.com/online-go/ogs/pull/2016
