### PR TITLE
Put seek graph alongside create game on desktop screens

### DIFF
--- a/src/views/Play/CustomGames.styl
+++ b/src/views/Play/CustomGames.styl
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
  #CustomGames {
     display: flex;
     flex-direction: column;
@@ -23,13 +23,35 @@
     justify-content: center;
     box-sizing: border-box;
     
+    .top-stuff {
+        display: flex;
+        flex-direction: column;
+
+        @media screen and (min-width: 850px){
+            // On deskop, put the seek graph next to the CreateGame form
+            flex-direction: row;
+            width: max-content; // Causes seek graph to be as wide as possible
+
+            .Card {
+                flex: 1;
+            }
+        }
+        .seek-graph{
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+        }
+    }
+
     .Modal {
         border: none;
         box-shadow: none;
     }
-    
+
     .ChallengeModal {
         width: 100%;
         max-height: unset;
     }
+
+
  }

--- a/src/views/Play/CustomGames.tsx
+++ b/src/views/Play/CustomGames.tsx
@@ -397,86 +397,92 @@ export function CustomGames(): JSX.Element {
             }}
         >
             <div id="CustomGames">
-                <Card>
-                    {liveOwnChallengePending() ? (
-                        <>
-                            <div className="automatch-header">{_("Waiting for opponent...")}</div>
-                            <div className="automatch-row-container">
-                                <div className="spinner">
-                                    <div className="double-bounce1"></div>
-                                    <div className="double-bounce2"></div>
+                <div className="top-stuff">
+                    <Card>
+                        {liveOwnChallengePending() ? (
+                            <>
+                                <div className="automatch-header">
+                                    {_("Waiting for opponent...")}
                                 </div>
-                            </div>
-                            <div className="automatch-settings">
-                                <button className="danger sm" onClick={cancelOwnChallenges}>
-                                    {pgettext("Cancel challenge", "Cancel")}
-                                </button>
-                            </div>
-                        </>
-                    ) : live_rengo_challenge_to_show ? (
-                        <>
-                            <RengoManagementPane
-                                challenge_id={live_rengo_challenge_to_show.challenge_id}
-                                rengo_challenge_list={rengo_list}
-                                startRengoChallenge={rengo_utils.startOwnRengoChallenge}
-                                cancelChallenge={cancelOpenRengoChallenge}
-                                withdrawFromRengoChallenge={unNominateForRengoChallenge}
-                                joinRengoChallenge={rengo_utils.nominateForRengoChallenge}
-                                lock={
-                                    rengo_manage_pane_lock[
-                                        live_rengo_challenge_to_show?.challenge_id
-                                    ]
-                                }
-                            >
-                                <RengoTeamManagementPane
+                                <div className="automatch-row-container">
+                                    <div className="spinner">
+                                        <div className="double-bounce1"></div>
+                                        <div className="double-bounce2"></div>
+                                    </div>
+                                </div>
+                                <div className="automatch-settings">
+                                    <button className="danger sm" onClick={cancelOwnChallenges}>
+                                        {pgettext("Cancel challenge", "Cancel")}
+                                    </button>
+                                </div>
+                            </>
+                        ) : live_rengo_challenge_to_show ? (
+                            <>
+                                <RengoManagementPane
                                     challenge_id={live_rengo_challenge_to_show.challenge_id}
-                                    challenge_list={rengo_list}
-                                    moderator={user.is_moderator}
-                                    show_chat={false}
-                                    assignToTeam={rengo_utils.assignToTeam}
-                                    kickRengoUser={rengo_utils.kickRengoUser}
-                                    locked={
+                                    rengo_challenge_list={rengo_list}
+                                    startRengoChallenge={rengo_utils.startOwnRengoChallenge}
+                                    cancelChallenge={cancelOpenRengoChallenge}
+                                    withdrawFromRengoChallenge={unNominateForRengoChallenge}
+                                    joinRengoChallenge={rengo_utils.nominateForRengoChallenge}
+                                    lock={
                                         rengo_manage_pane_lock[
-                                            live_rengo_challenge_to_show.challenge_id
+                                            live_rengo_challenge_to_show?.challenge_id
                                         ]
                                     }
-                                    lock={(lock: boolean) =>
-                                        setPaneLock(live_rengo_challenge_to_show.challenge_id, lock)
-                                    }
+                                >
+                                    <RengoTeamManagementPane
+                                        challenge_id={live_rengo_challenge_to_show.challenge_id}
+                                        challenge_list={rengo_list}
+                                        moderator={user.is_moderator}
+                                        show_chat={false}
+                                        assignToTeam={rengo_utils.assignToTeam}
+                                        kickRengoUser={rengo_utils.kickRengoUser}
+                                        locked={
+                                            rengo_manage_pane_lock[
+                                                live_rengo_challenge_to_show.challenge_id
+                                            ]
+                                        }
+                                        lock={(lock: boolean) =>
+                                            setPaneLock(
+                                                live_rengo_challenge_to_show.challenge_id,
+                                                lock,
+                                            )
+                                        }
+                                    />
+                                </RengoManagementPane>
+                            </>
+                        ) : (
+                            <div>
+                                <ChallengeModalBody
+                                    mode="open"
+                                    modal={{
+                                        on: (event: "open" | "close", callback: () => void) => {
+                                            console.log("on", event, callback);
+                                        },
+                                        off: (event: "open" | "close", callback: () => void) => {
+                                            console.log("off", event, callback);
+                                        },
+                                    }}
                                 />
-                            </RengoManagementPane>
-                        </>
-                    ) : (
-                        <div>
-                            <ChallengeModalBody
-                                mode="open"
-                                modal={{
-                                    on: (event: "open" | "close", callback: () => void) => {
-                                        console.log("on", event, callback);
-                                    },
-                                    off: (event: "open" | "close", callback: () => void) => {
-                                        console.log("off", event, callback);
-                                    },
-                                }}
-                            />
+                            </div>
+                        )}
+                    </Card>
+                    <div className="seek-graph">
+                        <h2>{pgettext("Games available to accept", "Available Games")}</h2>
+
+                        <div ref={ref_container} className="seek-graph-container">
+                            <OgsResizeDetector onResize={onResize} targetRef={ref_container} />
+                            <PersistentElement elt={canvas} />
                         </div>
-                    )}
-                </Card>
-                <div className="row">
-                    <h2>{pgettext("Games available to accept", "Available Games")}</h2>
 
-                    <div ref={ref_container} className="seek-graph-container">
-                        <OgsResizeDetector onResize={onResize} targetRef={ref_container} />
-                        <PersistentElement elt={canvas} />
+                        <SeekGraphLegend
+                            filter={filter}
+                            showIcons={true}
+                            toggleHandler={toggleFilterHandler}
+                        ></SeekGraphLegend>
                     </div>
-
-                    <SeekGraphLegend
-                        filter={filter}
-                        showIcons={true}
-                        toggleHandler={toggleFilterHandler}
-                    ></SeekGraphLegend>
                 </div>
-
                 <div id="challenge-list-container">
                     <div id="challenge-list-inner-container">
                         <div id="challenge-list" onMouseMove={freezeChallenges}>


### PR DESCRIPTION
Fixes 
 - the list that people are looking for being way down the bottom.
 - seek-graph being curiously wide and space-consuming

## Proposed Changes

  - Put `seek-graph` alongside `create game` form for wide screens
  -- Note the deliberate choice to make the row containing these two wider than normal
  ---  So that Create Game is the focus, and can be a nice width.
  
