### PR TITLE
Update dark mode button to have better contrast

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -298,7 +298,7 @@ dark.toast-fg                           = dark.bg
 dark.link-color                         = #539bff
 dark.link-color-active                  = darken(dark.link-color, 20%)
 
-dark.default-button                     = lighten(dark.bg, 10%)
+dark.default-button                     = lighten(dark.bg, 20%)
 dark.default-button-color               = dark.fg
 dark.primary                            = darken(light.primary, core-color-darken-amount)
 dark.danger                             = darken(light.danger, core-color-darken-amount)


### PR DESCRIPTION
Fixes https://github.com/online-go/online-go.com/issues/2566

## Proposed Changes

  -Slightly lightens all of the buttons using dark.default-button for better visibility against the dark background
  
Before:
![image](https://github.com/user-attachments/assets/9cec3b53-4afb-46fa-a7ae-44567c59dd32)

After:
![image](https://github.com/user-attachments/assets/aa73abb4-b857-454b-9263-7df283f5c267)


