### PR TITLE
Improve mobile menu left padding to match hamburger

### DIFF
--- a/src/components/NavBar/NavBar.styl
+++ b/src/components/NavBar/NavBar.styl
@@ -190,8 +190,8 @@ header.NavBar {
 
     @media only screen and (max-width: 910px) {
         .Menu-title {
-            padding-left: 0.1rem !important;
-            padding-right: 0.1rem !important;
+            padding-left: 0.5rem !important;
+            padding-right: 0.5rem !important;
         }
     }
 
@@ -202,7 +202,7 @@ header.NavBar {
             display: none !important;
         }
 
-        .Menu.desktop-only { 
+        .Menu.desktop-only {
             display: none !important;
         }
 


### PR DESCRIPTION
# Overview

I noticed the mobile menu items left padding currently doesn't match that of the hamburger and it was bothering me a bit, hope this is welcome!

## Before

<img width="414" alt="mobileMenuBefore" src="https://github.com/user-attachments/assets/859b6ded-772d-47e7-baf9-17ef11a56463" />

## After

<img width="415" alt="mobileMenuAfter" src="https://github.com/user-attachments/assets/f7517ad6-2fd0-4569-aae0-27819a194e57" />
