### PR TITLE
Switch to computer/human buttons on the Play page

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -23,6 +23,7 @@
         "Baduk",
         "badukpop",
         "benjito",
+        "bezier",
         "bitfield",
         "boardsize",
         "byoyomi",

--- a/src/components/ChallengeModal/ChallengeModal.styl
+++ b/src/components/ChallengeModal/ChallengeModal.styl
@@ -132,37 +132,53 @@
         align-items: middle;
     }
 
-    .ogs-react-select__menu {
-        right: 0;
-        width: 20rem;
-        max-width: 90vw;
-
-        .ogs-react-select__group-heading {
-            text-transform: none;
-            font-size: 0.9rem;
-        }
-
-        .option {
-            padding-top: 0.5rem;
-            padding-bottom: 0.5rem;
-
-            &.focused {
-                themed-important: background-color shade3;
+    /*
+        .ogs-react-select__menu {
+            right: 0;
+            width: 20rem;
+            max-width: 90vw;
+    
+            .ogs-react-select__group-heading {
+                text-transform: none;
+                font-size: 0.9rem;
             }
-
-            &.selected {
-                themed-important: background-color shade3;
+    
+            .option {
+                padding-top: 0.5rem;
+                padding-bottom: 0.5rem;
+    
+                &.focused {
+                    themed-important: background-color shade3;
+                }
+    
+                &.selected {
+                    themed-important: background-color shade3;
+                }
+    
+                themed: color fg;
             }
-
-            themed: color fg;
+    
+            .option-label {
+                font-weight: bold;
+                padding-right: 0.5rem;
+                padding-left: 0.5rem;
+            }
+    
+            .option-description {
+                font-size: 0.9rem;
+                font-style: italic;
+                themed: color shade1;
+                padding-right: 0.5rem;
+                padding-left: 0.5rem;
+            }
         }
-
+    
         .option-label {
             font-weight: bold;
             padding-right: 0.5rem;
             padding-left: 0.5rem;
         }
-
+    
         .option-description {
             font-size: 0.9rem;
             font-style: italic;
@@ -170,25 +186,47 @@
             padding-right: 0.5rem;
             padding-left: 0.5rem;
         }
+    
+        .option-label, .ogs-react-select__single-value, .option-label > span {
+            display: flex !important;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        */
+    .computer-opponents {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
     }
 
-    .option-label {
-        font-weight: bold;
-        padding-right: 0.5rem;
-        padding-left: 0.5rem;
+    .bot-options {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        width: 100%;
+        justify-content: space-around;
     }
 
-    .option-description {
-        font-size: 0.9rem;
-        font-style: italic;
-        themed: color shade1;
-        padding-right: 0.5rem;
-        padding-left: 0.5rem;
-    }
-
-    .option-label, .ogs-react-select__single-value, .option-label > span {
-        display: flex !important;
+    .bot-option {
+        display: flex;
         align-items: center;
         gap: 0.5rem;
+        cursor: pointer;
+        border-radius: 0.75rem;
+        padding-right: 0.5rem;
+        gap: 1rem;
+
+        &:hover {
+            themed: background-color shade4;
+        }
+
+        .PlayerIcon {
+            border-radius: 0.75rem;
+        }
+
+        &.selected {
+            themed: background-color shade2;
+        }
     }
 }

--- a/src/components/ChallengeModal/ChallengeModal.styl
+++ b/src/components/ChallengeModal/ChallengeModal.styl
@@ -132,72 +132,37 @@
         align-items: middle;
     }
 
-    /*
-        .ogs-react-select__menu {
-            right: 0;
-            width: 20rem;
-            max-width: 90vw;
-    
-            .ogs-react-select__group-heading {
-                text-transform: none;
-                font-size: 0.9rem;
-            }
-    
-            .option {
-                padding-top: 0.5rem;
-                padding-bottom: 0.5rem;
-    
-                &.focused {
-                    themed-important: background-color shade3;
-                }
-    
-                &.selected {
-                    themed-important: background-color shade3;
-                }
-    
-                themed: color fg;
-            }
-    
-            .option-label {
-                font-weight: bold;
-                padding-right: 0.5rem;
-                padding-left: 0.5rem;
-            }
-    
-            .option-description {
-                font-size: 0.9rem;
-                font-style: italic;
-                themed: color shade1;
-                padding-right: 0.5rem;
-                padding-left: 0.5rem;
-            }
-        }
-    
-        .option-label {
-            font-weight: bold;
-            padding-right: 0.5rem;
-            padding-left: 0.5rem;
-        }
-    
-        .option-description {
-            font-size: 0.9rem;
-            font-style: italic;
-            themed: color shade1;
-            padding-right: 0.5rem;
-            padding-left: 0.5rem;
-        }
-    
-        .option-label, .ogs-react-select__single-value, .option-label > span {
-            display: flex !important;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        */
     .computer-opponents {
         width: 100%;
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
+        max-height: 60vh;
+        overflow: auto;
+    }
+
+    .header.computer-settings-expanded {
+        .computer-opponents {
+            max-height: 20vh;
+        }
+    }
+
+    .bot-categories {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+
+        h1 {
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            themed: color shade1;
+            font-weight: bold !important;
+            padding-bottom: 0.5rem;
+        }
+
+        .bot-category {
+            margin-top: 1rem;
+        }
     }
 
     .bot-options {
@@ -205,7 +170,8 @@
         gap: 0.5rem;
         flex-wrap: wrap;
         width: 100%;
-        justify-content: space-around;
+        align-items: flex-start;
+        // justify-content: space-around;
     }
 
     .bot-option {
@@ -213,20 +179,60 @@
         align-items: center;
         gap: 0.5rem;
         cursor: pointer;
-        border-radius: 0.75rem;
+        border-radius: 0.25rem;
         padding-right: 0.5rem;
+        padding: 0.2rem;
         gap: 1rem;
+        border: 2px solid transparent;
+        overflow: hidden;
+        flex-wrap: wrap;
+        width: 13rem;
 
         &:hover {
             themed: background-color shade4;
         }
 
+        &.disabled {
+            opacity: 0.5;
+            background-color: transparent !important;
+            cursor: not-allowed;
+        }
+
+        .disabled-reason {
+            flex-grow: 1;
+            font-size: 0.8rem;
+            themed: color shade1;
+            display: inline-block;
+            width: 12rem;
+        }
+
+        .username-rank {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .username {
+            display: inline-block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            max-width: 6rem;
+        }
+
+        .rank {
+            display: inline-block;
+            white-space: nowrap;
+            max-width: 2rem;
+        }
+
         .PlayerIcon {
-            border-radius: 0.75rem;
+            border-radius: 0.3rem;
+            themed: background-color shade5;
         }
 
         &.selected {
-            themed: background-color shade2;
+            themed: border-color, primary;
         }
     }
 }

--- a/src/components/ChallengeModal/ChallengeModal.styl
+++ b/src/components/ChallengeModal/ChallengeModal.styl
@@ -131,4 +131,64 @@
         display: inline-flex;
         align-items: middle;
     }
+
+    .ogs-react-select__menu {
+        right: 0;
+        width: 20rem;
+        max-width: 90vw;
+
+        .ogs-react-select__group-heading {
+            text-transform: none;
+            font-size: 0.9rem;
+        }
+
+        .option {
+            padding-top: 0.5rem;
+            padding-bottom: 0.5rem;
+
+            &.focused {
+                themed-important: background-color shade3;
+            }
+
+            &.selected {
+                themed-important: background-color shade3;
+            }
+
+            themed: color fg;
+        }
+
+        .option-label {
+            font-weight: bold;
+            padding-right: 0.5rem;
+            padding-left: 0.5rem;
+        }
+
+        .option-description {
+            font-size: 0.9rem;
+            font-style: italic;
+            themed: color shade1;
+            padding-right: 0.5rem;
+            padding-left: 0.5rem;
+        }
+    }
+
+    .option-label {
+        font-weight: bold;
+        padding-right: 0.5rem;
+        padding-left: 0.5rem;
+    }
+
+    .option-description {
+        font-size: 0.9rem;
+        font-style: italic;
+        themed: color shade1;
+        padding-right: 0.5rem;
+        padding-left: 0.5rem;
+    }
+
+    .option-label, .ogs-react-select__single-value, .option-label > span {
+        display: flex !important;
+        align-items: center;
+        gap: 0.5rem;
+    }
 }

--- a/src/lib/bots.ts
+++ b/src/lib/bots.ts
@@ -33,6 +33,7 @@ interface Events {
 }
 export interface Bot extends User {
     config: BotConfig;
+    disabled?: string; // if not undefined, the string describes why
 }
 
 export const bot_event_emitter = new EventEmitter<Events>();

--- a/src/lib/bots.ts
+++ b/src/lib/bots.ts
@@ -370,7 +370,7 @@ export function getAcceptableTimeSetting(
             null,
             llm_pgettext(
                 "Unable to find a compatible game setting for bot",
-                "Unable to find a compatible settings",
+                "Bot cannot play at this speed",
             ),
         ];
     } catch (e) {

--- a/src/views/Play/CustomGames.styl
+++ b/src/views/Play/CustomGames.styl
@@ -87,7 +87,7 @@
     margin-top: 2rem;
     margin-bottom: 8rem;
     display: flex;
-    gap: 1rem;
+    gap: 2rem;
     justify-content: center;
 
     &.showing-custom-games {
@@ -97,5 +97,6 @@
     button {
         height: 3rem;
         font-size: 1.3rem;
+        width: 17rem;
     }
 }

--- a/src/views/Play/CustomGames.tsx
+++ b/src/views/Play/CustomGames.tsx
@@ -432,6 +432,13 @@ export function CustomGames(): JSX.Element {
             <div>
                 <div className="CustomGames--toggle-container showing-custom-games">
                     <button
+                        disabled={disable_challenge_buttons}
+                        className="custom-games-toggle"
+                        onClick={toggleCustomGames}
+                    >
+                        {_("Hide custom games")}
+                    </button>
+                    <button
                         className="primary"
                         disabled={disable_challenge_buttons}
                         onClick={() => {
@@ -439,23 +446,6 @@ export function CustomGames(): JSX.Element {
                         }}
                     >
                         {_("Create a custom game")}
-                    </button>
-                    <button
-                        disabled={disable_challenge_buttons}
-                        className="custom-games-toggle"
-                        onClick={toggleCustomGames}
-                    >
-                        {_("Hide custom games")}
-                    </button>
-
-                    <button
-                        className="primary"
-                        disabled={disable_challenge_buttons}
-                        onClick={() => {
-                            challenge(undefined, undefined, true, undefined, undefined);
-                        }}
-                    >
-                        {_("Play a custom computer game")}
                     </button>
                 </div>
             </div>

--- a/src/views/Play/QuickMatch.styl
+++ b/src/views/Play/QuickMatch.styl
@@ -80,35 +80,6 @@
         margin-right: 0.5rem;
     }
 
-    .finding-game-container {
-        // flex-shrink: 0;
-        // flex-grow: 0;
-        // flex-basis: 2.5rem;
-        font-size: 1.3rem;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        flex-direction: row;
-        justify-content: space-around;
-        align-items: center;
-        // align-content: center;
-        padding-bottom: 2.5rem;
-        padding-top: 1rem;
-
-        .spinner {
-            margin: 0;
-            height: 20px;
-            width: 20px;
-            margin-left: 1rem;
-            margin-right: 1rem;
-        }
-
-        button {
-            margin-left: 2rem;
-            font-size: 1.1rem;
-        }
-    }
-
     .automatch-row {
         display: flex;
         justify-content: space-around;
@@ -177,14 +148,6 @@
         i {
             padding-right: 0.25rem;
         }
-    }
-
-    .automatch-settings-corr {
-        flex: 0;
-        text-align: justify;
-        font-size: 1rem;
-        padding: 0.5rem;
-        padding-left: 3rem;
     }
 
     .custom-game-row {
@@ -277,20 +240,6 @@
 
     .subtext {
         font-size: 0.9rem;
-    }
-
-    .PlayButton-container {
-        width: 100%;
-    }
-
-    .play-button {
-        // margin-top: 3rem;
-        width: 100%;
-        height: 6rem;
-        font-size: 1.5rem;
-        line-height: 1.5rem;
-        text-align: center;
-        margin-bottom: 0;
     }
 
     .game-speed-option-container {
@@ -401,18 +350,6 @@
                 padding-top: 0.5rem;
             }
 
-            .opponent-rank-range {
-                // display: flex;
-                text-align: center;
-
-                // justify-content: space-around;
-                select {
-                    text-align: center;
-                    margin-left: 0.5rem;
-                    margin-right: 0.5rem;
-                }
-            }
-
             .opponent-rank-range-description {
                 font-size: 0.9rem;
                 themed: color shade1;
@@ -420,25 +357,6 @@
                 padding-right: 0.5rem;
                 padding-left: 0.5rem;
                 margin-bottom: 0.5rem;
-            }
-
-            .computer-select {
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-                flex-wrap: wrap;
-
-                select {
-                    flex-grow: 1;
-                    min-width: 10rem;
-                    max-width: 10rem;
-                    width: 10rem;
-                    overflow: hidden;
-                }
-
-                .fa {
-                    padding-left: 1rem;
-                }
             }
         }
     }
@@ -524,33 +442,6 @@
         margin-bottom: 0.5rem;
     }
 
-    .computer-select {
-        .disabled .option-label {
-            themed: color shade2;
-        }
-
-        .option-label {
-            display: flex;
-            justify-content: space-between;
-            gap: 0.5rem;
-
-            > span {
-                display: flex;
-                align-items: center;
-                gap: 0.5rem;
-            }
-        }
-
-        > div {
-            width: 100%;
-            max-width: 12rem;
-        }
-
-        &.error {
-            border: 1px solid red;
-        }
-    }
-
     .size-button {
         margin-right: 0.2rem;
         margin-left: 0.2rem;
@@ -577,6 +468,66 @@
     .activity.popular:after {
         themed: color, shade1;
     }
+
+    .opponent-rank-range {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        gap: 0.5rem;
+    }
+}
+
+.PlayButton-container {
+    display: flex;
+    justify-content: space-between;
+    gap: 2rem;
+
+    .play-button {
+        // margin-top: 3rem;
+        width: 100%;
+        height: 6rem;
+        font-size: 1.5rem;
+        line-height: 1.5rem;
+        text-align: center;
+        margin-bottom: 0;
+    }
+
+    .finding-game-container {
+        // flex-shrink: 0;
+        // flex-grow: 0;
+        // flex-basis: 2.5rem;
+        font-size: 1.3rem;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
+        align-items: center;
+        // align-content: center;
+        padding-bottom: 2.5rem;
+        padding-top: 1rem;
+
+        .spinner {
+            margin: 0;
+            height: 20px;
+            width: 20px;
+            margin-left: 1rem;
+            margin-right: 1rem;
+        }
+
+        button {
+            margin-left: 2rem;
+            font-size: 1.1rem;
+        }
+    }
+
+    .automatch-settings-corr {
+        flex: 0;
+        text-align: justify;
+        font-size: 1rem;
+        padding: 0.5rem;
+        padding-left: 3rem;
+    }
 }
 
 @media (max-width: hamburger-cutoff) {
@@ -590,14 +541,6 @@
 
         .speed-options {
             margin-bottom: 0;
-        }
-
-        .computer-select {
-            select {
-                min-width: calc(100vw - 6rem) !important;
-                max-width: calc(100vw - 6rem) !important;
-                width: calc(100vw - 6rem) !important;
-            }
         }
     }
 
@@ -613,6 +556,7 @@
         right: 0;
         z-index: z.dock;
         themed: background-color, bg;
+        gap: 1rem;
 
         .play-button {
             margin: 0;
@@ -663,12 +607,6 @@
             .time-control-button {
                 min-width: 4rem !important;
             }
-        }
-    }
-
-    .computer-select {
-        > div {
-            max-width: auto;
         }
     }
 }

--- a/src/views/Play/QuickMatch.tsx
+++ b/src/views/Play/QuickMatch.tsx
@@ -654,6 +654,11 @@ export function QuickMatch(): JSX.Element {
         description: v === 0 ? llm_pgettext("Player is the same rank as you", "Your rank") : "",
     }));
 
+    // ensure a valid handicap value is selected
+    if (!handicap_options.find((o) => o.value === handicaps)) {
+        setHandicaps("standard");
+    }
+
     return (
         <>
             <div id="QuickMatch">


### PR DESCRIPTION
This branch switches away from first having to select if you want to play a human or a computer, and instead replaces those with two buttons, one to challenge a computer, one to challenge a human. This patch (will) also updates the computer challenge modal to be more streamlined with the quick settings on the play page.

![image](https://github.com/user-attachments/assets/3b0d16a5-ff4b-4b66-ba55-954a781f1d40)
