### PR TITLE
Fix attaching actions to reports in report list view

### DIFF
--- a/src/components/IncidentReportTracker/IncidentReportList.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportList.tsx
@@ -39,8 +39,8 @@ export function IncidentReportList({
         data.set("ui-state.show_incident_list", false);
     }
 
-    const attachActions = (report: Report) => {
-        // Most of these may no longer be needed, since we're using the new ReportsCenter view.
+    // Attach appropriate actions to each report
+    reports.forEach((report) => {
         if (report.state !== "resolved") {
             report.unclaim = () => {
                 post(`moderation/incident/${report.id}`, { id: report.id, action: "unclaim" })
@@ -112,11 +112,7 @@ export function IncidentReportList({
                     });
             };
         }
-    };
-
-    React.useEffect(() => {
-        reports.forEach(attachActions);
-    }, [reports]);
+    });
 
     return (
         <div className="IncidentReportList">


### PR DESCRIPTION
Fixes "Cancel" button (and others perhaps) sometimes not working

## Proposed Changes

  - Directly add the actions during render
  -- I'm not sure why the old implementation needed to do that in a useEffect, but after the refactor it seems to be not-needed, and not reliable.   It was easier to inline it into render than work out why it was intermittent.


