### PR TITLE
Cancel live automatche searches when any live game starts

### DIFF
--- a/src/components/Notifications/NotificationManager.tsx
+++ b/src/components/Notifications/NotificationManager.tsx
@@ -46,6 +46,7 @@ export interface NotificationManagerEvents {
     notification: any;
     "notification-list-updated": never;
     "notification-count": number;
+    "game-started": Notification;
 }
 
 const boot_time = Date.now();
@@ -456,6 +457,10 @@ export class NotificationManager {
                     _("Friend Request Declined"),
                     _("Your friend request has been declined"),
                 );
+            }
+
+            if (notification.type === "gameStarted") {
+                this.event_emitter.emit("game-started", notification);
             }
 
             if (

--- a/src/views/Play/CustomGames.tsx
+++ b/src/views/Play/CustomGames.tsx
@@ -618,7 +618,12 @@ export function CustomGames(): JSX.Element {
                             <div style={{ marginTop: "2em" }}></div>
 
                             <div className="challenge-row" style={{ marginTop: "1em" }}>
-                                <span className="cell break">{_("Long Games")}</span>
+                                <span className="cell break">
+                                    {pgettext(
+                                        "Game speed: multi-day games",
+                                        "Daily Correspondence",
+                                    )}
+                                </span>
                                 <CellBreaks width={8} />
                             </div>
 


### PR DESCRIPTION
This patch makes it so if a player is actively searching for an automatch and a live game starts, either by accepting an open challenge, or accepting a direct challenge, or someone accepting their direct challenge, the automatch search is canceled.

Requires https://github.com/online-go/ogs/pull/2028