### PR TITLE
Add a menu like to translation under tools

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -290,6 +290,11 @@ export function NavBar(): React.ReactElement {
                         {_("Rating Calculator")}
                     </Link>
 
+                    <a href="https://translate.online-go.com/projects/ogs/" target="_blank">
+                        <i className="fa fa-globe"></i>
+                        {_("Contribute To Translation")}
+                    </a>
+
                     <Link className="admin-link" to="/reports-center">
                         <i className="fa fa-exclamation-triangle"></i>
                         {_("Reports Center")}


### PR DESCRIPTION
Fixes it being fairly well hidden

## Proposed Changes

  - Put "Contribute To Translation" as a link under "Tools"
  
<img width="813" alt="Screenshot 2025-01-19 at 12 57 32 pm (2)" src="https://github.com/user-attachments/assets/12ad6529-b92d-4e9a-b290-5426331566bb" />
