### PR TITLE
Add clarifying text to CM mod log

### DIFF
--- a/src/views/ReportsCenter/UserHistory.tsx
+++ b/src/views/ReportsCenter/UserHistory.tsx
@@ -41,9 +41,7 @@ export function UserHistory({
             {user.is_moderator && (
                 <ModTools user_id={target_user.id} show_mod_log={true} collapse_same_users={true} />
             )}
-            {!user.is_moderator && !!user.moderator_powers && (
-                <ModLog user_id={target_user.id} warnings_only={true} />
-            )}
+            {!user.is_moderator && !!user.moderator_powers && <ModLog user_id={target_user.id} />}
         </>
     );
 }

--- a/src/views/User/ModLog.styl
+++ b/src/views/User/ModLog.styl
@@ -4,7 +4,7 @@
     }
 
     .date {
-        @extends .monospace;
+        @extend .monospace;
         width: 7em;
         text-align: left;
         padding-right: 1em;
@@ -16,7 +16,7 @@
     }
 
     .action {
-        @extends .monospace;
+        @extend .monospace;
         font-size: 0.8rem;
 
         a {
@@ -38,8 +38,14 @@
     }
 
     .cm-action {
-        themed: color danger;
         float: right;
+        font-size: smaller;
+
+        .cm-action-action {
+            themed: color danger;
+            font-size: medium;
+            margin-left: 1rem;
+        }
     }
 
     .warning-event {

--- a/src/views/User/ModLog.tsx
+++ b/src/views/User/ModLog.tsx
@@ -21,15 +21,13 @@ import moment from "moment";
 import { Player } from "@/components/Player";
 import { Link } from "react-router-dom";
 import { chat_markup } from "@/components/Chat";
+import { pgettext } from "@/lib/translate";
 
 interface ModLogProps {
     user_id: number;
-    warnings_only?: boolean;
 }
 
 export function ModLog(props: ModLogProps): React.ReactElement {
-    const groomFunction = (data: any[]) => data.filter((X) => !X.action.includes("ack"));
-
     return (
         <PaginatedTable
             className="moderator-log"
@@ -40,7 +38,6 @@ export function ModLog(props: ModLogProps): React.ReactElement {
                 event: `modlog-${props.user_id}-updated`,
                 channel: "moderators",
             }}
-            {...(props.warnings_only && { groom: groomFunction })}
             columns={[
                 {
                     header: "",
@@ -113,7 +110,14 @@ function highlight_cm_action(text: string): React.ReactElement | string {
         return (
             <>
                 {prefix}
-                Actioned by community vote: <span className="cm-action">{action}</span>
+                Actioned by community vote:{" "}
+                <span className="cm-action">
+                    {pgettext(
+                        "This is a log message saying what Community Moderators voted for",
+                        "CMs voted for: ",
+                    )}
+                    <span className="cm-action-action">{action}</span>
+                </span>
             </>
         );
     }


### PR DESCRIPTION
… and remove dead filtering code (backend does this now)

Fixes potential confusion about what really happened

## Proposed Changes

  - Clarify somewhat that the vote was an action, but it doesn't mean more than that.
  - Get rid of mod log filtering to "not acks" because the backend already does that now
  - Prettier changed `@extends` to `@extend`  🤷‍♀️