### PR TITLE
Show CMs the mod log actor

### DIFF
--- a/src/views/User/ModLog.tsx
+++ b/src/views/User/ModLog.tsx
@@ -51,7 +51,7 @@ export function ModLog(props: ModLogProps): React.ReactElement {
                     header: "",
                     className: "logging-user",
                     render: (X) => {
-                        return X?.moderator?.id ? <Player user={X.moderator} /> : "-";
+                        return X?.actor?.id ? <Player user={X.actor} /> : "-";
                     },
                 },
                 {


### PR DESCRIPTION
Fixes `-` appearing where it should be the `reporter` in ModLog

## Proposed Changes

  - Use the renamed `actor` field in that position of the ModLog
  
Needs: https://github.com/online-go/ogs/pull/2031

(won't totally break without it, but won't show any names in that column until the backend is in)
