### PR TITLE
Make CMs able to squish or close ModLog.

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -198,6 +198,9 @@ export const defaults = {
     "gotv.user-access-token": "",
     "gotv.followed-channels": [] as FollowedChannel[],
     "gotv.notified-streams": [] as { streamId: string; timestamp: number }[],
+
+    "user-history.show-mod-log": false,
+    "user-history.warnings-only": false,
 };
 
 defaults["profanity-filter"][current_language] = true;

--- a/src/models/moderation.d.ts
+++ b/src/models/moderation.d.ts
@@ -15,10 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//  `/moderation/annul` endpoint
-
 declare namespace rest_api {
     namespace moderation {
+        //  `/moderation/annul` endpoint
         interface AnnulList {
             games: Array<number>; // game ids.  Do we have a type for them?
             annul: boolean;
@@ -28,6 +27,28 @@ declare namespace rest_api {
         interface AnnulResult {
             done: Array<number>;
             failed: Array<number>;
+        }
+
+        //  `/moderation?player_id=123` endpoint
+        export interface ModLogEntry {
+            timestamp: string;
+            actor?: {
+                id: number;
+            };
+            action: string;
+            incident_report?: {
+                id: number;
+                cleared_by_user?: boolean;
+                url?: string;
+                reporter_note?: string;
+                moderator_note?: string;
+                system_note?: string;
+                moderator?: any; // Player type
+            };
+            game?: {
+                id: number;
+            };
+            note?: string;
         }
     }
 }

--- a/src/views/ReportsCenter/UserHistory.tsx
+++ b/src/views/ReportsCenter/UserHistory.tsx
@@ -22,27 +22,6 @@ import { Player } from "@/components/Player";
 import { ModTools } from "@/views/User";
 import { ModLog } from "@/views/User";
 
-interface ModLogEntry {
-    timestamp: string;
-    actor?: {
-        id: number;
-    };
-    action: string;
-    incident_report?: {
-        id: number;
-        cleared_by_user?: boolean;
-        url?: string;
-        reporter_note?: string;
-        moderator_note?: string;
-        system_note?: string;
-        moderator?: any; // Player type
-    };
-    game?: {
-        id: number;
-    };
-    note?: string;
-}
-
 export function UserHistory({
     target_user: target_user,
 }: {
@@ -53,7 +32,7 @@ export function UserHistory({
     const [warningsOnly, setWarningsOnly] = usePreference("user-history.warnings-only");
 
     const groomWarningsOnly = React.useMemo(() => {
-        return (entries: ModLogEntry[]) => {
+        return (entries: rest_api.moderation.ModLogEntry[]) => {
             if (!warningsOnly) {
                 return entries;
             }

--- a/src/views/User/ModLog.tsx
+++ b/src/views/User/ModLog.tsx
@@ -23,8 +23,30 @@ import { Link } from "react-router-dom";
 import { chat_markup } from "@/components/Chat";
 import { pgettext } from "@/lib/translate";
 
+interface ModLogEntry {
+    timestamp: string;
+    actor?: {
+        id: number;
+    };
+    action: string;
+    incident_report?: {
+        id: number;
+        cleared_by_user?: boolean;
+        url?: string;
+        reporter_note?: string;
+        moderator_note?: string;
+        system_note?: string;
+        moderator?: any; // Player type
+    };
+    game?: {
+        id: number;
+    };
+    note?: string;
+}
+
 interface ModLogProps {
     user_id: number;
+    groomData?: (data: ModLogEntry[]) => ModLogEntry[];
 }
 
 export function ModLog(props: ModLogProps): React.ReactElement {
@@ -38,6 +60,7 @@ export function ModLog(props: ModLogProps): React.ReactElement {
                 event: `modlog-${props.user_id}-updated`,
                 channel: "moderators",
             }}
+            groom={props.groomData as (data: any[]) => any[]}
             columns={[
                 {
                     header: "",

--- a/src/views/User/ModLog.tsx
+++ b/src/views/User/ModLog.tsx
@@ -23,30 +23,9 @@ import { Link } from "react-router-dom";
 import { chat_markup } from "@/components/Chat";
 import { pgettext } from "@/lib/translate";
 
-interface ModLogEntry {
-    timestamp: string;
-    actor?: {
-        id: number;
-    };
-    action: string;
-    incident_report?: {
-        id: number;
-        cleared_by_user?: boolean;
-        url?: string;
-        reporter_note?: string;
-        moderator_note?: string;
-        system_note?: string;
-        moderator?: any; // Player type
-    };
-    game?: {
-        id: number;
-    };
-    note?: string;
-}
-
 interface ModLogProps {
     user_id: number;
-    groomData?: (data: ModLogEntry[]) => ModLogEntry[];
+    groomData?: (data: rest_api.moderation.ModLogEntry[]) => rest_api.moderation.ModLogEntry[];
 }
 
 export function ModLog(props: ModLogProps): React.ReactElement {


### PR DESCRIPTION
Fixes lots of scrolling instead of seeing at a glance the important voteable things.

## Proposed Changes

  - Make it so that CMs can collapse the ModLog completely, or filter it to show only CM voted warnings
  