### PR TITLE
Fix vite config to understand goban is not in node_modules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -184,6 +184,12 @@ export default [
         },
     },
     {
+        files: ["**/submodules/react-dynamic-help/**"],
+        rules: {
+            "header/header": "off",
+        },
+    },
+    {
         files: ["**/*.test.ts", "**/*.test.tsx"],
 
         languageOptions: {

--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -17,7 +17,7 @@
 
 @require '../node_modules/sweetalert2/dist/sweetalert2.css';
 @require '../node_modules/react-table/react-table.css';
-@require '../node_modules/react-dynamic-help/dist/DynamicHelp.css';
+@require '../submodules/react-dynamic-help/src/DynamicHelp.css';
 
 font-size-big = 16pt
 font-size-mid = 14pt


### PR DESCRIPTION
and update rdh version and get styles from the right place

Fixes thow errors on running vite

## Proposed Changes

  - Get rid of unnecessary references to node_modules/goban (under instructions from ChatGPT)
  - Refer to RDH submodule css source from ogs.styl
     ^^^ needs a look to confirm this will work in prod

Also brings in updates to RDH to fix types
