### PR TITLE
Change the AI report description to be more insistent that the report  is substantiated.

### DIFF
--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -152,8 +152,9 @@ export const report_categories: ReportDescription[] = [
         title: pgettext("Report user for AI use", "AI Use"),
         description: pgettext(
             "Report user for AI use",
-            "User is suspected of using an AI assistance in this game.",
+            "Use this if you are quite certain that AI is being used.  Please don't report unless you have convincing evidence.  Please make sure you provide the evidence in the report.",
         ),
+        min_description_length: 40,
         game_id_required: true,
     },
     {


### PR DESCRIPTION
Fixes [Mr Tal feeling we're not doing enough](https://forums.online-go.com/t/ai-use-not-allowed-message/55291/45?u=greenasjade).

## Proposed Changes

  - Make it say "please be sure that it was AI if you're going to report it"
  