### PR TITLE
Supports ASSESS_AI_REPORT power for CMs

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -297,6 +297,19 @@ Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
             ),
             { reported },
         ),
+    no_ai_use_evident: (reported) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement message to a user",
+                `
+Thank you for bringing the possible instance of AI use by '{{reported}}' to our attention. We looked into the game and couldn't see evidence of AI use.   
+
+It may be that you need to provide more explanation - you are welcome to raise a new report if that is the case.
+
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
+            ),
+            { reported },
+        ),
     annul_no_warning: (game_id) =>
         interpolate(
             llm_pgettext(

--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -394,6 +394,19 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                             onRetractOffer={this.retractOffer}
                             onRemovePower={this.removePower}
                         />
+                        <ModerationOfferControl
+                            ability={pgettext(
+                                "Label for a button to let a community moderator vote on AI reports",
+                                "Assess AI Reports",
+                            )}
+                            ability_mask={MODERATOR_POWERS.ASSESS_AI_REPORTS}
+                            currently_offered={this.state.offered_moderator_powers}
+                            moderator_powers={this.state.moderator_powers}
+                            previously_rejected={this.state.mod_powers_rejected}
+                            onMakeOffer={this.makeOffer}
+                            onRetractOffer={this.retractOffer}
+                            onRemovePower={this.removePower}
+                        />
                     </div>
                 )}
                 <div className="buttons">

--- a/src/lib/moderation.tsx
+++ b/src/lib/moderation.tsx
@@ -32,6 +32,7 @@ export enum MODERATOR_POWERS {
     HANDLE_ESCAPING = 0b010,
     HANDLE_STALLING = 0b100,
     SUSPEND = 0b1000,
+    ASSESS_AI_REPORTS = 0b10000,
 }
 
 export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
@@ -49,6 +50,10 @@ export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
         "Handle Stalling Reports",
     ),
     [MODERATOR_POWERS.SUSPEND]: pgettext("A label for a moderator power", "Vote for Suspension"),
+    [MODERATOR_POWERS.ASSESS_AI_REPORTS]: pgettext(
+        "A label for a moderator power",
+        "Assess AI Reports",
+    ),
 };
 
 export function doAnnul(

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -44,6 +44,7 @@ declare namespace rest_api {
             | "ack_warned_score_cheat"
             | "ack_warned_score_cheat_and_annul"
             | "no_score_cheating_evident"
+            | "no_ai_use_evident"
             | "annul_no_warning"
             | "ack_annul_no_warning"
             | "final_warn_escaper"

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -318,6 +318,36 @@ Be completely unambiguous with regards to the meaning of the word annul: \
 this means to declare the game invalid, and this is not the same as cancelling a game.",
         "Escalate: report needs final warning or suspension, or other unusual action.",
     ),
+    definitely_ai: llm_pgettext(
+        "This phrase to be translated is the label of an option for a moderator of an \
+online Go game server to select: an action to apply to a report about a game of Go. \
+In the phrase you are asked to translate, 'no cheating' is a conclusion meaning the \
+moderator concluded cheating did not occur, rather than an instruction meaning the \
+reader should not cheat. \
+Be completely unambiguous with regards to the meaning of the word annul: \
+this means to declare the game invalid, and this is not the same as cancelling a game.",
+        "Definitely AI - escalate to moderators for warning or suspension and game annulment.",
+    ),
+    check_ai_tools: llm_pgettext(
+        "This phrase to be translated is the label of an option for a moderator of an \
+online Go game server to select: an action to apply to a report about a game of Go. \
+In the phrase you are asked to translate, 'no cheating' is a conclusion meaning the \
+moderator concluded cheating did not occur, rather than an instruction meaning the \
+reader should not cheat. \
+Be completely unambiguous with regards to the meaning of the word annul: \
+this means to declare the game invalid, and this is not the same as cancelling a game.",
+        "Check AI - ask moderators to check with analysis tools for AI use.",
+    ),
+    no_ai_use_evident: llm_pgettext(
+        "This phrase to be translated is the label of an option for a moderator of an \
+online Go game server to select: an action to apply to a report about a game of Go. \
+In the phrase you are asked to translate, 'no cheating' is a conclusion meaning the \
+moderator concluded cheating did not occur, rather than an instruction meaning the \
+reader should not cheat. \
+Be completely unambiguous with regards to the meaning of the word annul: \
+this means to declare the game invalid, and this is not the same as cancelling a game.",
+        "No AI use evident - inform the reporter.",
+    ),
 };
 
 export function ModerationActionSelector({


### PR DESCRIPTION
Fixes: the situation of "nothing we can do" about backlog of AI reports.

## Proposed Changes

  - Have an ASSESS_AI_REPORTS power for CMs
  - Show AI reports initially to these CMs, and not full moderators
  - If the CMs vote that there certainly is AI, then escalate the report to full moderators (for warn/suspend and annull games)
  - If the CMs vote that there might be AI, then escalate to full moderators for full tool analysis and follow up
  - If the CMs vote that theres no sign of it, then close it and tell the reporter.


Needs https://github.com/online-go/ogs/pull/2034 and its dependency in node.

Will break (by submitting votes that don't work) without the backend changes.

