### PR TITLE
Let mods see unescalated AI reports

### DIFF
--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -129,19 +129,9 @@ class ReportManager extends EventEmitter<Events> {
                 (game_id) => game_id !== report.reported_game,
             );
         } else {
-            // It should go into the active list BUT there are some reports that we hide from full moderators because
-            // CMs are doing them.
-            if (
-                !user.is_moderator ||
-                !(
-                    ["escaping", "score_cheating", "stalling"].includes(report.report_type) ||
-                    (report.report_type === "ai_use" && !report.escalated)
-                )
-            ) {
-                this.active_incident_reports[report.id] = report;
-                if (report.reported_game && report.reporting_user?.id === user.id) {
-                    this.this_user_reported_games.push(report.reported_game);
-                }
+            this.active_incident_reports[report.id] = report;
+            if (report.reported_game && report.reporting_user?.id === user.id) {
+                this.this_user_reported_games.push(report.reported_game);
             }
         }
         data.set("reported-games", this.this_user_reported_games);
@@ -213,12 +203,11 @@ class ReportManager extends EventEmitter<Events> {
 
             // Don't offer community moderation reports to full mods, because community moderators do these.
             // (The only way full moderators see CM-class reports is if they go hunting and claim them)
-            // (AI reports are CM handled pre-escalation, full moderators after escalation)
+            // (We do allow full moderators to see all AI reports, even while they're being voted on, at least for now
             if (
                 user.is_moderator &&
                 !(report.moderator?.id === user.id) && // maybe they already have it, so they need to see it
-                (["escaping", "score_cheating", "stalling"].includes(report.report_type) ||
-                    (report.report_type === "ai_use" && !report.escalated))
+                ["escaping", "score_cheating", "stalling"].includes(report.report_type)
             ) {
                 return false;
             }

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -398,7 +398,12 @@ export function ModerationActionSelector({
                     {_("This report has no available actions yet.  You can escalate or ignore it.")}
                 </div>
             )}
-            {!enable && (
+            {!enable && report.state === "claimed" && (
+                <div className="disabled-actions-note">
+                    {_("This report is being looked at by a moderator.")}
+                </div>
+            )}
+            {!enable && report.state === "resolved" && (
                 <div className="disabled-actions-note">
                     {_("This report was handled after you decided to look at it!")}
                 </div>

--- a/src/views/ReportsCenter/ReportTypeSelector.tsx
+++ b/src/views/ReportsCenter/ReportTypeSelector.tsx
@@ -23,20 +23,30 @@ import { ReportType } from "@/components/Report";
 
 const DropdownIndicator = components.DropdownIndicator as any;
 
-const REPORT_TYPE_SELECTIONS: ReportTypeSelection[] = [
-    { value: "escaping", label: "Stopped Playing" },
-    { value: "stalling", label: "Stalling" },
-    { value: "score_cheating", label: "Score Cheating" },
-    { value: "inappropriate_content", label: "Inappropriate Content" },
-    { value: "harassment", label: "Harassment" },
-    { value: "sandbagging", label: "Sandbagging" },
-    { value: "ai_use", label: "AI Use" },
-    { value: "other", label: "Other" },
+const REPORT_TYPE_SELECTIONS: ReportTypeGroup[] = [
+    {
+        label: "Change type",
+        options: [
+            { value: "escaping", label: "Stopped Playing" },
+            { value: "stalling", label: "Stalling" },
+            { value: "score_cheating", label: "Score Cheating" },
+            { value: "inappropriate_content", label: "Inappropriate Content" },
+            { value: "harassment", label: "Harassment" },
+            { value: "sandbagging", label: "Sandbagging" },
+            { value: "ai_use", label: "AI Use" },
+            { value: "other", label: "Other" },
+        ],
+    },
 ];
 
 export interface ReportTypeSelection {
     value: ReportType;
     label: string;
+}
+
+interface ReportTypeGroup {
+    label: string;
+    options: ReportTypeSelection[];
 }
 
 interface ReportTypeSelectorProps {
@@ -52,7 +62,7 @@ export function ReportTypeSelector(props: ReportTypeSelectorProps) {
         }
     };
 
-    const current_selection = REPORT_TYPE_SELECTIONS.filter(
+    const current_selection = REPORT_TYPE_SELECTIONS[0].options.find(
         (selection) => selection.value === props.current_type,
     );
     return (


### PR DESCRIPTION
and be clearer if mods have claimed but not resolved reports.

Fixes mods not being able to help in the case of CM AI report bugs, and CMs wondering what happened to the report.

## Proposed Changes

  - Put unescalated AI reports back into full mod queue
  - Give a different message if a mod has claimed but not resolved a report
  
