### PR TITLE
Don't blow away CM actions when we receive null from term server

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -87,7 +87,9 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): R
         setModeratorId(report?.moderator?.id);
         setReportState(report?.state);
         setAnnulQueue(report?.detected_ai_games);
-        setAvailableActions(report?.available_actions);
+        if (report?.available_actions !== null) {
+            setAvailableActions(report.available_actions);
+        }
         setVoteCounts(report?.vote_counts);
         setUsersVote(report?.voters?.find((v) => v.voter_id === user.id)?.action ?? null);
     };


### PR DESCRIPTION
Fixes # CM actions disappearing

## Proposed Changes

  - Don't call setAvailableActions if the incoming report doesn't have them
  
** This is a workaround, because the incoming report should always have them :(

Something odd going on in backend.