### PR TITLE
Make the AI stats table show up in Reports view 

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -30,6 +30,7 @@ import { PlayerIcon } from "@/components/PlayerIcon";
 import * as player_cache from "@/lib/player_cache";
 import * as preferences from "@/lib/preferences";
 import online_status from "@/lib/online_status";
+import { ReportContext } from "@/contexts/ReportContext";
 
 /* There are cases where what we are handed is some odd looking dirty data. We
  * should probably start warning about remaining uses of these fields and then
@@ -73,14 +74,6 @@ export interface PlayerProperties {
     forceShowRank?: boolean;
 }
 
-type ShowPlayersInReportContextType = {
-    reporter: player_cache.PlayerCacheEntry;
-    reported: player_cache.PlayerCacheEntry;
-};
-
-export const ShowPlayersInReportContext =
-    React.createContext<ShowPlayersInReportContextType | null>(null);
-
 export function Player(props: PlayerProperties): React.ReactElement {
     const user = data.get("user");
     const player_id: number =
@@ -107,7 +100,7 @@ export function Player(props: PlayerProperties): React.ReactElement {
     const base = player || historical;
     const combined = base ? Object.assign({}, base, historical ? historical : {}) : null;
 
-    const viewReportContext = React.useContext(ShowPlayersInReportContext);
+    const viewReportContext = React.useContext(ReportContext);
 
     React.useEffect(() => {
         if (!props.disableCacheUpdate) {

--- a/src/contexts/ReportContext.tsx
+++ b/src/contexts/ReportContext.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+import * as React from "react";
+import * as player_cache from "@/lib/player_cache";
+
+type ReportContextType = {
+    reporter: player_cache.PlayerCacheEntry;
+    reported: player_cache.PlayerCacheEntry;
+    moderator_powers: number;
+};
+
+export const ReportContext = React.createContext<ReportContextType | null>(null);

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -25,7 +25,7 @@ import { report_manager } from "@/lib/report_manager";
 import { Report } from "@/lib/report_util";
 import { AutoTranslate } from "@/components/AutoTranslate";
 import { interpolate, _, pgettext, llm_pgettext } from "@/lib/translate";
-import { Player, ShowPlayersInReportContext } from "@/components/Player";
+import { Player } from "@/components/Player";
 import { Link } from "react-router-dom";
 import { post } from "@/lib/requests";
 import { PlayerCacheEntry } from "@/lib/player_cache";
@@ -44,6 +44,7 @@ import * as DynamicHelp from "react-dynamic-help";
 import { MODERATOR_POWERS } from "@/lib/moderation";
 import { KBShortcut } from "@/components/KBShortcut";
 import { GobanRenderer } from "goban";
+import { ReportContext } from "@/contexts/ReportContext";
 
 interface ViewReportProps {
     reports: Report[];
@@ -331,8 +332,12 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): R
             <KBShortcut shortcut="left" action={nav_prev} />
             <KBShortcut shortcut="right" action={nav_next} />
 
-            <ShowPlayersInReportContext.Provider
-                value={{ reporter: report.reporting_user, reported: report.reported_user }}
+            <ReportContext.Provider
+                value={{
+                    reporter: report.reporting_user,
+                    reported: report.reported_user,
+                    moderator_powers: user.moderator_powers,
+                }}
             >
                 <div id="ViewReport" className="show-players-in-report">
                     {isAnnulQueueModalOpen && (
@@ -795,7 +800,7 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): R
                         )}
                     </ErrorBoundary>
                 </div>
-            </ShowPlayersInReportContext.Provider>
+            </ReportContext.Provider>
         </div>
     );
 }


### PR DESCRIPTION
... for CMs doing AI assessment (only).

Fixes CMs with ASSESS_AI_REPORTS power not really having all the information they could do with.

## Proposed Changes
  - Make the AI stats table visible in the Report context for such CMs.
  -- Refactored the "ReportContext" to be more generic, so it handles this and the "player annotation".
  
Rationale: we're not showing them anything they can't get computed for themselves, no particular secret sauce in this information.
