### PR TITLE
Disable vote button if its an escalated AI report

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -617,7 +617,8 @@ export function ViewReport({ report_id, reports, onChange }: ViewReportProps): R
                                     enable={
                                         report.state === "pending" &&
                                         (!report.escalated ||
-                                            !!(user.moderator_powers & MODERATOR_POWERS.SUSPEND))
+                                            (!!(user.moderator_powers & MODERATOR_POWERS.SUSPEND) &&
+                                                report.report_type !== "ai_use"))
                                     }
                                     key={report.id}
                                     report={report}


### PR DESCRIPTION
Fixes ugly green button that would do nothing, when escalated AI reports come in to CM queue

## Proposed Changes

  - Disable "ModeratorActionSelector" for escalated AI reports
  -- Because these are not handled by CMs, but they want to view them.
  
Can go in first.