### PR TITLE
Support `no_ai_use_bad_report` CM vote action

### DIFF
--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -297,18 +297,33 @@ Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
             ),
             { reported },
         ),
-    no_ai_use_evident: (reported) =>
+    no_ai_use_evident: (game_id) =>
         interpolate(
             llm_pgettext(
                 "Acknowledgement message to a user",
                 `
-Thank you for bringing the possible instance of AI use by '{{reported}}' to our attention. We looked into the game and couldn't see evidence of AI use.   
+Thank you for bringing the possible instance of AI use in Game #{{game_id}} to our attention. We looked into the game and couldn't see evidence of AI use.   
 
 It may be that you need to provide more explanation - you are welcome to raise a new report if that is the case.
 
 Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
             ),
-            { reported },
+            { game_id },
+        ),
+    no_ai_use_bad_report: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Acknowledgement and education message to a user",
+                `
+    Thank you for bringing the possible instance of AI use in Game #{{game_id}} to our attention. We looked into the game and couldn't see evidence of AI use.   
+    
+    Your report did not contain any real evidence of AI use - we'd prefer if you could provide more details, so our time is not wasted guessing.
+    
+    If you have a good reason to suspect AI use, please take some time to provide a detailed report describing why.
+
+    Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
+            ),
+            { game_id },
         ),
     annul_no_warning: (game_id) =>
         interpolate(

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -45,6 +45,7 @@ declare namespace rest_api {
             | "ack_warned_score_cheat_and_annul"
             | "no_score_cheating_evident"
             | "no_ai_use_evident"
+            | "no_ai_use_bad_report"
             | "annul_no_warning"
             | "ack_annul_no_warning"
             | "final_warn_escaper"

--- a/src/views/ReportsCenter/ModerationActionSelector.tsx
+++ b/src/views/ReportsCenter/ModerationActionSelector.tsx
@@ -348,6 +348,16 @@ Be completely unambiguous with regards to the meaning of the word annul: \
 this means to declare the game invalid, and this is not the same as cancelling a game.",
         "No AI use evident - inform the reporter.",
     ),
+    no_ai_use_bad_report: llm_pgettext(
+        "This phrase to be translated is the label of an option for a moderator of an \
+online Go game server to select: an action to apply to a report about a game of Go. \
+In the phrase you are asked to translate, 'no cheating' is a conclusion meaning the \
+moderator concluded cheating did not occur, rather than an instruction meaning the \
+reader should not cheat. \
+Be completely unambiguous with regards to the meaning of the word annul: \
+this means to declare the game invalid, and this is not the same as cancelling a game.",
+        "No AI use, educate reporter about reporting AI use.",
+    ),
 };
 
 export function ModerationActionSelector({


### PR DESCRIPTION
Fixes CM AI Assessors having no way of pushing back on silly AI reports

## Proposed Changes

  - Add a voting option that lets them send an "educate reporter" Canned message.

Needs to go in with https://github.com/online-go/ogs/pull/2041 due to different message interpolation content 
(reported game instead of reported user)
  