### PR TITLE
Refactor ViewReport

### DIFF
--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -88,7 +88,6 @@ class ReportManager extends EventEmitter<Events> {
         const user = data.get("user");
         report.id = parseInt(report.id as unknown as string);
 
-        //console.log("updateIncidentReport", report);
         if (!(report.id in this.active_incident_reports)) {
             if (
                 data.get("user").is_moderator &&
@@ -287,10 +286,6 @@ class ReportManager extends EventEmitter<Events> {
     }
 
     public async getReport(id: number): Promise<Report> {
-        if (id in this.active_incident_reports) {
-            return this.active_incident_reports[id];
-        }
-
         const res = await get(`moderation/incident/${id}`);
 
         if (res) {

--- a/src/views/ReportsCenter/ReportsCenter.styl
+++ b/src/views/ReportsCenter/ReportsCenter.styl
@@ -31,16 +31,6 @@ reports_center_content_width = 56rem;
         margin-right: 0.5rem;
     }
 
-    #ReportsCenterSelectModerator {
-        display: inline-block;
-        width: 10rem;
-
-        .reports-center-assigned-moderator-container {
-            display: inline-flex;
-            align-items: center;
-        }
-    }
-
     .ModerationActionSelector {
         display: flex;
         flex-direction: column;

--- a/src/views/ReportsCenter/ReportsCenter.tsx
+++ b/src/views/ReportsCenter/ReportsCenter.tsx
@@ -25,12 +25,12 @@ import { _ } from "@/lib/translate";
 import { usePreference } from "@/lib/preferences";
 import { community_mod_has_power } from "@/lib/report_util";
 
-import { ViewReport } from "./ViewReport";
 import { ReportsCenterSettings } from "./ReportsCenterSettings";
 import { ReportsCenterHistory } from "./ReportsCenterHistory";
 import { ReportsCenterCMDashboard } from "./ReportsCenterCMDashboard";
 import { ReportsCenterCMHistory } from "./ReportsCenterCMHistory";
 import { IncidentReportList } from "@/components/IncidentReportTracker";
+import { ReportsViewer } from "./ReportsViewer";
 
 interface OtherView {
     special: string;
@@ -324,15 +324,17 @@ export function ReportsCenter(): React.ReactElement | null {
                 ) : category === "my_reports" ? (
                     <IncidentReportList reports={my_reports} modal={false} />
                 ) : category === "hr" ? null : (
-                    <ViewReport
-                        reports={
-                            category === "all"
-                                ? reports
-                                : reports.filter((x) => x.report_type === category)
-                        }
-                        onChange={selectReport}
-                        report_id={report_id}
-                    />
+                    <>
+                        <ReportsViewer
+                            reports={
+                                category === "all"
+                                    ? reports
+                                    : reports.filter((x) => x.report_type === category)
+                            }
+                            report_id={report_id}
+                            selectReport={selectReport}
+                        />
+                    </>
                 )}
             </div>
         </div>

--- a/src/views/ReportsCenter/ReportsCenter.tsx
+++ b/src/views/ReportsCenter/ReportsCenter.tsx
@@ -323,19 +323,19 @@ export function ReportsCenter(): React.ReactElement | null {
                     <ReportsCenterCMDashboard />
                 ) : category === "my_reports" ? (
                     <IncidentReportList reports={my_reports} modal={false} />
-                ) : category === "hr" ? null : (
-                    <>
-                        <ReportsViewer
-                            reports={
-                                category === "all"
-                                    ? reports
-                                    : reports.filter((x) => x.report_type === category)
-                            }
-                            report_id={report_id}
-                            selectReport={selectReport}
-                        />
-                    </>
-                )}
+                ) : category === "my_reports" ? (
+                    <IncidentReportList reports={my_reports} modal={false} />
+                ) : category === "hr" ? null : user.is_moderator || user.moderator_powers ? (
+                    <ReportsViewer
+                        reports={
+                            category === "all"
+                                ? reports
+                                : reports.filter((x) => x.report_type === category)
+                        }
+                        report_id={report_id}
+                        selectReport={selectReport}
+                    />
+                ) : null}
             </div>
         </div>
     );

--- a/src/views/ReportsCenter/ReportsViewer.styl
+++ b/src/views/ReportsCenter/ReportsViewer.styl
@@ -1,0 +1,29 @@
+.ReportsViewer {
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    clear: both;
+
+    .hide {
+        visibility: hidden;
+    }
+
+    .view-report-header {
+        margin-left: 1rem;
+        margin-bottom: 1rem;
+
+        .report-id {
+            margin-right: 1rem;
+        }
+
+        button {
+            margin-left: 0.5rem;
+            margin-right: 0.5rem;
+        }
+
+        .reports-center-selected-report {
+            padding-left: 0.5rem;
+        }
+    }
+}

--- a/src/views/ReportsCenter/ReportsViewer.tsx
+++ b/src/views/ReportsCenter/ReportsViewer.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+import * as React from "react";
+import Select from "react-select";
+import { useUser } from "@/lib/hooks";
+import { Report } from "@/lib/report_util";
+import { report_manager } from "@/lib/report_manager";
+import { _ } from "@/lib/translate";
+import * as DynamicHelp from "react-dynamic-help";
+import { PlayerCacheEntry } from "@/lib/player_cache";
+import { get } from "@/lib/requests";
+import { errorAlerter } from "@/lib/misc";
+import { ViewReport } from "@/views/ReportsCenter/ViewReport";
+
+interface ViewReportHeaderProps {
+    reports: Report[];
+    report_id: number;
+    selectReport: (report_id: number) => void;
+}
+
+let cached_moderators: PlayerCacheEntry[] = [];
+
+export function ReportsViewer({
+    reports,
+    report_id,
+    selectReport,
+}: ViewReportHeaderProps): React.ReactElement {
+    const user = useUser();
+    const { registerTargetItem } = React.useContext(DynamicHelp.Api);
+    const { ref: ignore_button } = registerTargetItem("ignore-button");
+
+    const current_report = reports.find((r) => r.id === report_id);
+    const claimed_by_me = current_report?.moderator?.id === user.id;
+
+    React.useEffect(() => {
+        if (cached_moderators.length === 0) {
+            get("players/?is_moderator=true&page_size=100")
+                .then((res) => {
+                    cached_moderators = res.results.sort(
+                        (a: PlayerCacheEntry, b: PlayerCacheEntry) => {
+                            if (a.id === user.id) {
+                                return -1;
+                            }
+                            if (b.id === user.id) {
+                                return 1;
+                            }
+                            return a.username!.localeCompare(b.username as string);
+                        },
+                    );
+                })
+                .catch(errorAlerter);
+        }
+    }, []);
+
+    const claimReport = () => {
+        if (!report_id) {
+            return;
+        }
+        if (user.is_moderator) {
+            void report_manager.claim(report_id);
+        }
+    };
+
+    const next = () => {
+        const currentIndex = reports.findIndex((r) => r.id === report_id);
+        if (currentIndex + 1 < reports.length) {
+            selectReport(reports[currentIndex + 1].id);
+        } else {
+            selectReport(0);
+        }
+    };
+
+    const prev = () => {
+        const currentIndex = reports.findIndex((r) => r.id === report_id);
+        if (currentIndex > 0) {
+            selectReport(reports[currentIndex - 1].id);
+        }
+    };
+
+    const currentIndex = reports.findIndex((r) => r.id === report_id);
+    const hasPrev = currentIndex > 0;
+    const hasNext = currentIndex + 1 < reports.length;
+
+    if (report_id === 0) {
+        return (
+            <div id="ViewReport">
+                <div className="no-report-selected">All done!</div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="ReportsViewer">
+            <div className="view-report-header">
+                {current_report ? (
+                    <Select
+                        id="ReportsCenterSelectReport"
+                        className="reports-center-category-option-select"
+                        classNamePrefix="ogs-react-select"
+                        value={reports.filter((r) => r.id === report_id)[0]}
+                        getOptionValue={(r) => r.id.toString()}
+                        onChange={(r: any) => r && selectReport(r.id)}
+                        options={reports}
+                        isClearable={false}
+                        isSearchable={false}
+                        blurInputOnSelect={true}
+                        components={{
+                            Option: ({ innerRef, innerProps, isFocused, isSelected, data }) => (
+                                <div
+                                    ref={innerRef}
+                                    {...innerProps}
+                                    className={
+                                        "reports-center-selected-report" +
+                                        (isFocused ? "focused " : "") +
+                                        (isSelected ? "selected" : "")
+                                    }
+                                >
+                                    {R(data.id)}
+                                </div>
+                            ),
+                            SingleValue: ({ innerProps, data }) => (
+                                <span {...innerProps} className="reports-center-selected-report">
+                                    {R(data.id)}
+                                </span>
+                            ),
+                            ValueContainer: ({ children }) => (
+                                <div className="reports-center-selected-report-container">
+                                    {children}
+                                </div>
+                            ),
+                        }}
+                    />
+                ) : (
+                    <span className="historical-report-number">{R(report_id)}</span>
+                )}
+
+                <span>
+                    <button className={"default" + (hasPrev ? "" : " hide")} onClick={prev}>
+                        &lt; Prev
+                    </button>
+
+                    <button className={"default" + (hasNext ? "" : " hide")} onClick={next}>
+                        Next &gt;
+                    </button>
+
+                    {(user.is_moderator || null) &&
+                        (current_report?.moderator ? (
+                            <>
+                                {(current_report.moderator.id === user.id || null) && (
+                                    <button
+                                        className="danger xs"
+                                        onClick={() => {
+                                            void report_manager.unclaim(report_id);
+                                        }}
+                                    >
+                                        {_("Unclaim")}
+                                    </button>
+                                )}
+                            </>
+                        ) : (
+                            <button className="primary" onClick={claimReport}>
+                                {_("Claim")}
+                            </button>
+                        ))}
+                    {!claimed_by_me && (
+                        // Note that CMs _never_ "claim", so they always see this. Yay.
+                        <button
+                            className="default"
+                            ref={ignore_button}
+                            onClick={() => {
+                                report_manager.ignore(report_id);
+                                next();
+                            }}
+                        >
+                            Ignore
+                        </button>
+                    )}
+                </span>
+            </div>
+            <ViewReport report_id={report_id} advanceToNextReport={next} />
+        </div>
+    );
+}
+
+function R(id: number): string {
+    return "R" + `${id}`.slice(-3);
+}

--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -33,27 +33,42 @@
             }
         }
 
-        .reporting-user {
-            float: right;
-            font-size: 0.8rem;
-            font-weight: 400;
-        }
-    }
+        .users-header-right {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
 
-    .view-report-header {
-        margin-bottom: 1 rem;
+            .moderator-selector > span {
+                padding-right: 0.5rem;
+            }
 
-        .report-id {
-            margin-right: 1rem;
-        }
+            #ViewReportSelectModerator {
+                font-size: 0.8rem;
+                font-weight: 400;
+                display: inline-block;
+                width: 10rem;
 
-        button {
-            margin-left: 0.5rem;
-            margin-right: 0.5rem;
-        }
+                .reports-center-assigned-moderator-container {
+                    display: inline-flex;
+                    align-items: center;
+                    padding-left: 0.5rem;
+                }
 
-        .reports-center-selected-report {
-            padding-left: 0.5rem;
+                // Force moderator selector to be vertically small:
+                // get rid of padding and min-height of internals
+                .ogs-react-select__control {
+                    min-height: 0;
+
+                    .ogs-react-select__dropdown-indicator {
+                        padding: 0.2rem 0.5rem 0.2rem 0.5rem;
+                    }
+                }
+            }
+
+            .reporting-user {
+                font-size: 0.8rem;
+                font-weight: 400;
+            }
         }
     }
 


### PR DESCRIPTION
... removing report-navigation to a parent, and ensuring it fetches its own data from Django when told what report we're looking at.

Fixes intermittent bugs/fragility due to different sources of info and timing.

## Proposed Changes

  - Move "Report Navigation" out to a parent (new component, ReportsViewer)
  - Fetch the latest Report data when the selected report changes, or when reports_manager says there's new info
  

