### PR TITLE
Fixes bug where ReportsViewer was getting nonCM reports

### DIFF
--- a/src/views/ReportsCenter/ReportsViewer.tsx
+++ b/src/views/ReportsCenter/ReportsViewer.tsx
@@ -28,7 +28,9 @@ interface ViewReportHeaderProps {
 let cached_moderators: PlayerCacheEntry[] = [];
 
 // Provides navigation around a set of report-notifications, with a full view of the current report
-export function ReportsViewer({
+// Intended for use by moderators, not for users looking at their own reports
+// (Users use IncidentReportsList)
+export function ModeratorReportsViewer({
     reports,
     report_id,
     selectReport,


### PR DESCRIPTION
…  and lets CMs vote on their own CM reports

Fixes #  "Access Denied" for CMs who have submitted non CM reports

## Proposed Changes

  - Improve clarify in ReportsCenter about what kind of report is what.
  - Pass only "moderateable" reports to ModerationReportsViewer
  
  
* * * I'm not sure why this is showing a goban update.   When I made this commit, my goban submodule was on main.
  
