### PR TITLE
Overhaul `IncidentReportIndicator` 

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -175,6 +175,7 @@ export const defaults = {
     },
     "moderator.report-sort-order": "oldest-first" as "oldest-first" | "newest-first",
     "moderator.hide-player-card-mod-controls": false,
+    "moderator.prefer-incident-list": false,
 
     "table-color-default-on": false,
 

--- a/src/views/Settings/ModeratorPreferences.tsx
+++ b/src/views/Settings/ModeratorPreferences.tsx
@@ -39,6 +39,9 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): React.React
     const [hide_player_card_mod_controls, setHidePlayerCardModControls] = usePreference(
         "moderator.hide-player-card-mod-controls",
     );
+    const [prefer_incident_list, setPreferIncidentList] = usePreference(
+        "moderator.prefer-incident-list",
+    );
 
     const [report_quota, _setReportQuota] = React.useState(
         preferences.get("moderator.report-quota"),
@@ -120,6 +123,9 @@ export function ModeratorPreferences(_props: SettingGroupPageProps): React.React
                             checked={hide_player_card_mod_controls}
                             onChange={setHidePlayerCardModControls}
                         />
+                    </PreferenceLine>
+                    <PreferenceLine title="Prefer incident list">
+                        <Toggle checked={prefer_incident_list} onChange={setPreferIncidentList} />
                     </PreferenceLine>
 
                     <ReportsCenterSettings />


### PR DESCRIPTION
…and its interaction with `ReportManager`

Fixes flakey or confusing behaviour 

## Proposed Changes

  - Make ReportManager properly responsible for sorting out who sees what.
  -- Put all quota and "the already voted" stuff in ReportManager
  - Have ReportManager eat its own dogfood for counting reports, so it always gives the same answer in all situations
  - Be clear about what IncidentReportIndicatior is going to show:
  -- Moderators and CMs: the count of things we want them to act on
  -- Non-mod: the count of reports they submitted
 - Show the count of "My Report" in Reports Center (so moderators have a way to see this)
 - Provide full moderators with the option to have the old "Report Queue Dropdown" aka `IncidentReportList`
 -- CMs can't have this because voting options don't fit into an `IncidentReportCard`


** Needs: https://github.com/online-go/ogs-node/pull/78  to work properly 
(although it won't be worse than the current thing even without that backend change!)
