### PR TITLE
Send only updates to the report's moderator note

### DIFF
--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -188,10 +188,12 @@
         flex-basis: 50%;
         white-space: pre-wrap;
 
-        h4>span {
-            padding-left: 2rem;
-            font-style: italic;
-            font-size: smaller;
+        .mod-note-save {
+            height: unset;
+        }
+
+        .new-mod-note {
+            flex: unset;
         }
     }
 


### PR DESCRIPTION
Fixes hassles with simultaneous edits to report's moderator note, and not knowing who made the comment.

## Proposed Changes

  -  Send only new content, assuming the backend will append these.
  
* Needs   https://github.com/online-go/ogs/pull/2045

