### PR TITLE
Support showing mods the reported user's suspend status 

### DIFF
--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -407,6 +407,19 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                             onRetractOffer={this.retractOffer}
                             onRemovePower={this.removePower}
                         />
+                        <ModerationOfferControl
+                            ability={pgettext(
+                                "Label for a button to let a community moderator vote on AI reports",
+                                "See reported user's banned status",
+                            )}
+                            ability_mask={MODERATOR_POWERS.SEE_REPORTED_USER_BANNED_STATUS}
+                            currently_offered={this.state.offered_moderator_powers}
+                            moderator_powers={this.state.moderator_powers}
+                            previously_rejected={this.state.mod_powers_rejected}
+                            onMakeOffer={this.makeOffer}
+                            onRetractOffer={this.retractOffer}
+                            onRemovePower={this.removePower}
+                        />
                     </div>
                 )}
                 <div className="buttons">

--- a/src/lib/moderation.tsx
+++ b/src/lib/moderation.tsx
@@ -33,6 +33,7 @@ export enum MODERATOR_POWERS {
     HANDLE_STALLING = 0b100,
     SUSPEND = 0b1000,
     ASSESS_AI_REPORTS = 0b10000,
+    SEE_REPORTED_USER_BANNED_STATUS = 0b100000,
 }
 
 export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
@@ -53,6 +54,10 @@ export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
     [MODERATOR_POWERS.ASSESS_AI_REPORTS]: pgettext(
         "A label for a moderator power",
         "Assess AI Reports",
+    ),
+    [MODERATOR_POWERS.SEE_REPORTED_USER_BANNED_STATUS]: pgettext(
+        "A label for a moderator power",
+        "See reported user's banned status",
     ),
 };
 

--- a/src/models/moderation.d.ts
+++ b/src/models/moderation.d.ts
@@ -67,6 +67,7 @@ declare namespace rest_api {
             report_type: ReportType;
             reporting_user: PlayerCacheEntry;
             reported_user: PlayerCacheEntry;
+            reported_is_banned?: boolean; // only full mods and empowered CMs get this
             reported_game: number;
             reported_game_move?: number;
             reported_review: number;

--- a/src/views/ReportsCenter/ViewReport.styl
+++ b/src/views/ReportsCenter/ViewReport.styl
@@ -33,6 +33,13 @@
             }
         }
 
+        .reported-user-banned {
+            font-size: smaller;
+            font-style: italic;
+            padding-left: 0.4rem;
+            themed: color info;
+        }
+
         .users-header-right {
             display: flex;
             flex-direction: column;

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -257,6 +257,11 @@ export function ViewReport({
                                         "by",
                                     )}
                                     <Player user={report.reported_user} />
+                                    {report.reported_is_banned && (
+                                        <span className="reported-user-banned">
+                                            {_("suspended account")}
+                                        </span>
+                                    )}
                                 </span>
                             </h3>
                         </div>


### PR DESCRIPTION
... if the back end sends it, and a power for CMs to see it.

Fixes CMs raising alerts when in fact the person is already dealt with

## Proposed Changes

  - Add a CM power to let them see this
  - Show it in ViewReport when the back end sends it
  

(Obviously needs the back end update to do anything, but is OK without it

https://github.com/online-go/ogs/pull/2046
).

