### PR TITLE
Use player color information from backend (if provided) to annotate p…

### DIFF
--- a/src/components/Player/Player.styl
+++ b/src/components/Player/Player.styl
@@ -207,6 +207,26 @@
         padding-left: 3px;
         vertical-align: middle;
     }
+
+    &.white-player::before {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: #fff;
+        border: 1px solid rgba(0, 0, 0, 0.3);
+        margin-left: 0.4rem;
+    }
+
+    &.black-player::before {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: #000;
+        border: 1px solid rgba(255, 255, 255, 0.3);
+        margin-left: 0.4rem;
+    }
 }
 
 .Player-with-icon {

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -270,6 +270,9 @@ export function Player(props: PlayerProperties): React.ReactElement {
         }
     }
 
+    const is_white_player = viewReportContext?.white_player === player_id;
+    const is_black_player = viewReportContext?.black_player === player_id;
+
     const nolink = !!props.nolink;
     let rank: React.ReactElement | null = null;
 
@@ -308,6 +311,14 @@ export function Player(props: PlayerProperties): React.ReactElement {
 
     if (props.noextracontrols) {
         main_attrs.className += " noextracontrols";
+    }
+
+    if (is_white_player) {
+        main_attrs.className += " white-player";
+    }
+
+    if (is_black_player) {
+        main_attrs.className += " black-player";
     }
 
     if (props.rank !== false) {

--- a/src/contexts/ReportContext.tsx
+++ b/src/contexts/ReportContext.tsx
@@ -13,6 +13,8 @@ type ReportContextType = {
     reporter: player_cache.PlayerCacheEntry;
     reported: player_cache.PlayerCacheEntry;
     moderator_powers: number;
+    white_player: number | undefined;
+    black_player: number | undefined;
 };
 
 export const ReportContext = React.createContext<ReportContextType | null>(null);

--- a/src/models/moderation.d.ts
+++ b/src/models/moderation.d.ts
@@ -68,6 +68,8 @@ declare namespace rest_api {
             reporting_user: PlayerCacheEntry;
             reported_user: PlayerCacheEntry;
             reported_game: number;
+            reported_game_white?: number;
+            reported_game_black?: number;
             reported_game_move?: number;
             reported_review: number;
             reported_conversation: ReportedConversation;

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -231,6 +231,8 @@ export function ViewReport({
                     reporter: report.reporting_user,
                     reported: report.reported_user,
                     moderator_powers: user.moderator_powers,
+                    white_player: report.reported_game_white,
+                    black_player: report.reported_game_black,
                 }}
             >
                 <div id="ViewReport" className="show-players-in-report">


### PR DESCRIPTION
...to annotate players in report view

Fixes  scrolling up and down trying to remember what color the accused was playing

## Proposed Changes

  - Player: Use CSS to put a stone color in front of the player's username if that value is found in the report contex
  - ViewReport: provide the player's color (coming from back end) in the context
  

Needs https://github.com/online-go/ogs/pull/2047 to do anything, but shouldn't break without it.
