### PR TITLE
Add screen reader support for initial loading indicator

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -251,6 +251,17 @@
             body.accessible {
                 background-color: #1a1a1a;
             }
+            .sr-only {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                padding: 0;
+                margin: -1px;
+                overflow: hidden;
+                clip: rect(0, 0, 0, 0);
+                white-space: nowrap;
+                border-width: 0;
+            }
         </style>
         {{EXTRA_CONFIG}}
     </head>
@@ -346,8 +357,9 @@
             }
         </script>
         <div id="em10"></div>
-        <div id="loading-svg-container">
-            <div id="svg-bouncer">
+        <div id="loading-svg-container" role="status" aria-live="polite">
+            <span class="sr-only">Loading...</span>
+            <div id="svg-bouncer" aria-hidden="true">
                 <svg
                     xmlns:svg="http://www.w3.org/2000/svg"
                     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
That's a first PR of a series a changes I'll propose to improve accessibility of OGS for visually impaired users. 
I'll keep each PR minimal to make it easy to review and move forward with individual pieces of work.

## Proposed Changes

  - Add a class `.sr-only` (screen-reader only), that will hide content from screen but make it available for screen readers. Added directly in the html to make it available from the very beginning as it's used for the loading message.
  - Add a "loading" message for screen readers, using `.sr-only`.
  - Add aria- properties [`role status` + `aria-live polite`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role) to make it a low priority information
  - mark the svg loader as hidden for screen readers

Note: I don't think there is a good way to translate the loading message as the index.html file is served as a static file, right?
