### PR TITLE
RFC: Accesibility - integrate with main section

### DIFF
--- a/src/components/MainContent/MainContent.tsx
+++ b/src/components/MainContent/MainContent.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+interface MainContentProps {
+    className?: string;
+    children: any;
+}
+
+export function MainContent(props: MainContentProps): React.ReactElement {
+    return (
+        <main id="page-content" className={props.className} role="main">
+            {props.children}
+        </main>
+    );
+}

--- a/src/components/MainContent/index.ts
+++ b/src/components/MainContent/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./MainContent";

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -75,6 +75,7 @@ import { is_valid_url } from "@/lib/url_validation";
 import { disableTouchAction, enableTouchAction } from "./touch_actions";
 import { BotDetectionResults } from "./BotDetectionResults";
 import { ActiveTournament } from "@/lib/types";
+import { MainContent } from "@/components/MainContent";
 
 export function Game(): React.ReactElement | null {
     const params = useParams<"game_id" | "review_id" | "move_number">();
@@ -1710,7 +1711,7 @@ export function Game(): React.ReactElement | null {
 
     return (
         <div>
-            <div
+            <MainContent
                 className={
                     "Game MainGobanView " +
                     (zen_mode ? "zen " : "") +
@@ -1867,7 +1868,7 @@ export function Game(): React.ReactElement | null {
 
                     <div className="align-row-end"></div>
                 </GobanContext.Provider>
-            </div>
+            </MainContent>
         </div>
     );
 }

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -32,6 +32,7 @@ import { SocialLoginButtons } from "@/components/SocialLoginButtons";
 window.Md5 = Md5;
 import { alert } from "@/lib/swal_config";
 import { LoadingButton } from "@/components/LoadingButton";
+import { MainContent } from "@/components/MainContent/MainContent";
 
 /***
  * Setup a device UUID so we can logout other *devices* and not all other
@@ -199,73 +200,75 @@ export function SignIn(): React.ReactElement {
     };
 
     return (
-        <div id="SignIn">
-            {typeof search.get("login-error") === "string" ? (
-                <h2 className="error">
-                    <i className="fa fa-exclamation-triangle" />{" "}
-                    <span>{_("An error occurred signing in, please try again")}</span>
-                </h2>
-            ) : null}
+        <MainContent>
+            <div id="SignIn">
+                {typeof search.get("login-error") === "string" ? (
+                    <h2 className="error">
+                        <i className="fa fa-exclamation-triangle" />{" "}
+                        <span>{_("An error occurred signing in, please try again")}</span>
+                    </h2>
+                ) : null}
 
-            <Card>
-                <h2>{_("Sign in")}</h2>
-                <form name="login" autoComplete="on" onSubmit={onSubmit}>
-                    <label htmlFor="username">
-                        {_("Username") /* translators: Provide username to sign in with */}
-                    </label>
-                    <input
-                        className="boxed"
-                        id="username"
-                        autoFocus
-                        ref={ref_username}
-                        name="username"
-                        autoCapitalize="off"
+                <Card>
+                    <h2>{_("Sign in")}</h2>
+                    <form name="login" autoComplete="on" onSubmit={onSubmit}>
+                        <label htmlFor="username">
+                            {_("Username") /* translators: Provide username to sign in with */}
+                        </label>
+                        <input
+                            className="boxed"
+                            id="username"
+                            autoFocus
+                            ref={ref_username}
+                            name="username"
+                            autoCapitalize="off"
+                        />
+                        <label htmlFor="password">
+                            {_("Password") /* translators: Provide password to sign in with */}
+                        </label>
+                        <input
+                            className="boxed"
+                            id="password"
+                            ref={ref_password}
+                            type="password"
+                            name="password"
+                        />
+                        <div className="form-actions">
+                            <a onClick={resetPassword}>{_("Forgot password?")}</a>
+                            <LoadingButton
+                                type="submit"
+                                className="primary"
+                                style={{ whiteSpace: "nowrap" }}
+                                loading={submitLoading}
+                                icon={<i className="fa fa-sign-in" />}
+                            >
+                                {_("Sign in")}
+                            </LoadingButton>
+                        </div>
+                    </form>
+
+                    <hr />
+                    <span>
+                        {
+                            _(
+                                "or sign in using another account:",
+                            ) /* translators: username or password, or sign in with social authentication */
+                        }
+                    </span>
+                    <SocialLoginButtons
+                        next_url={"/wait-for-user#" + window.location.hash.substring(1)}
                     />
-                    <label htmlFor="password">
-                        {_("Password") /* translators: Provide password to sign in with */}
-                    </label>
-                    <input
-                        className="boxed"
-                        id="password"
-                        ref={ref_password}
-                        type="password"
-                        name="password"
-                    />
-                    <div className="form-actions">
-                        <a onClick={resetPassword}>{_("Forgot password?")}</a>
-                        <LoadingButton
-                            type="submit"
-                            className="primary"
-                            style={{ whiteSpace: "nowrap" }}
-                            loading={submitLoading}
-                            icon={<i className="fa fa-sign-in" />}
-                        >
-                            {_("Sign in")}
-                        </LoadingButton>
+                </Card>
+
+                <div className="registration">
+                    <h3>{_("New to Online-Go?")} </h3>
+                    <div>
+                        <Link to="/register" className="btn primary">
+                            <b>{_("Register here!") /* translators: register for an account */}</b>
+                        </Link>
                     </div>
-                </form>
-
-                <hr />
-                <span>
-                    {
-                        _(
-                            "or sign in using another account:",
-                        ) /* translators: username or password, or sign in with social authentication */
-                    }
-                </span>
-                <SocialLoginButtons
-                    next_url={"/wait-for-user#" + window.location.hash.substring(1)}
-                />
-            </Card>
-
-            <div className="registration">
-                <h3>{_("New to Online-Go?")} </h3>
-                <div>
-                    <Link to="/register" className="btn primary">
-                        <b>{_("Register here!") /* translators: register for an account */}</b>
-                    </Link>
                 </div>
             </div>
-        </div>
+        </MainContent>
     );
 }


### PR DESCRIPTION
This PR intends to add a main section to each route for accessibility. Importance of a such a thing is outlined here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/main_role

 I faced some challenges related to how the app is architectured. This PR is a draft to discuss of the best implemention.

----

### Approach 1

At first I experimented with wrapping all routes contents directly in [routes.tsx](https://github.com/online-go/online-go.com/blob/b5244f99e617ac6069c935ffb8ba922c1f192d6d/src/routes.tsx#L143)  as per:

```diff
-                    <ErrorBoundary>{props.children}</ErrorBoundary>
+                    <ErrorBoundary>
+                        <main id="app-content" role="main">
+                            {props.children}
+                        </main>
+                    </ErrorBoundary>
```

**Why is this approach preferred? **
 - Including the main region as part of the layout requires less maintenance and ensures no route will get missed in the future.

However a few routes are using a fullscreen view via absolute positioning. Leading the main region to collapse to a height of 0px and that might have side effects on screen readers. 


**Why is this approach hard to implement?**
- because the layout is wrapping the router, the main element unaware of the route's display. There is no easy way to have a specific layout for a given route. It's complicated to implement a one fits all solution and even if we did it might cause more problems in the future.

----


### Approach 2

An alternative that implies very few structural changes is to have a `<MainContent>` component, and make sure that each route use it as a wrapper, as per the changes in this PR. It requires updating all routes components one by one to implement it so I just demonstrated it with 2 components: Game and SignIn.

Pros of this approach:
- No constraint in how each route is rendered

Cons:
- More maintenance
- Routes might potentially forget to add it

-----

### Note on usage of `id` for styling

I also noticed that [some routes are using an `id` property](https://github.com/online-go/online-go.com/blob/b5244f99e617ac6069c935ffb8ba922c1f192d6d/src/views/SignIn/SignIn.tsx#L202) to apply styling. They seem to be old ones, while recent ones seem to use a class name that starts with an uppercase letter. ie: `id="SignIn"` vs `className="SignIn"`. 

Because we want to have an `id` on the main element too for navigation purpose, it conflicts, forcing to nest the route one level deeper in the <main>.

However as it seems to be an old practice, if I go with approach 2 I'll update all routes individually, leaving a chance to change usage if `id` with `className`. Is it a desired change?

## Proposed Changes

  - [ ] wrap all routes content within a <main> element
  - [ ] provide accessibility shortcut to navigate to <main>

Note: the common practice for the id of the <main> element is to use `main-content`, but this id is already taken by the react root element