### PR TITLE
Wrap main content in <main> and add an accessibility menu.

### DIFF
--- a/src/components/AccessibilityMenu/AccessibilityMenu.styl
+++ b/src/components/AccessibilityMenu/AccessibilityMenu.styl
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.AccessibilityMenu {
+    themed: background-color navbar-background-color;
+    box-shadow: 2px 4px 3px 0px rgba(0, 0, 0, 0.16);
+
+    position absolute;
+    overflow: hidden;
+
+    z-index: 0;
+    margin: -1px;
+    width: 1px;
+    height: 1px;
+
+    &:focus-within {
+        z-index: 9999;
+        margin: .3rem;
+        width: initial;
+        padding: 3px;
+        height: initial;
+    }
+
+    a {
+        padding: .6rem;
+        display: block;
+
+        &:focus {
+            outline: 2px solid #2480ff;
+        }
+    }
+}

--- a/src/components/AccessibilityMenu/AccessibilityMenu.tsx
+++ b/src/components/AccessibilityMenu/AccessibilityMenu.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { _ } from "@/lib/translate";
+import React from "react";
+
+/**
+ * Accessibility menu for screen readers.
+ * - Displays when focused to provide navigation assistance.
+ * - The link points to `#app-content`, which corresponds to the `<main>` element's `id`.
+ * - Should be placed as high as possible in the DOM for proper accessibility.
+ */
+export function AccessibilityMenu() {
+    return (
+        <div className="AccessibilityMenu">
+            <a href="#app-content" role="link" tabIndex={0}>
+                {_("Skip to content")}
+            </a>
+        </div>
+    );
+}

--- a/src/components/AccessibilityMenu/index.ts
+++ b/src/components/AccessibilityMenu/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./AccessibilityMenu";

--- a/src/components/MainSection/MainSection.styl
+++ b/src/components/MainSection/MainSection.styl
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.MainSection {
+    min-height: calc(100vh - var(--below-navbar) -1px)
+}

--- a/src/components/MainSection/MainSection.tsx
+++ b/src/components/MainSection/MainSection.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+export function MainSection(props: { children: any }) {
+    return (
+        <main id="app-content" role="main" className="MainSection">
+            {props.children}
+        </main>
+    );
+}

--- a/src/components/MainSection/index.ts
+++ b/src/components/MainSection/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./MainSection";

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -83,9 +83,11 @@ import { GoTV } from "@/views/GoTV";
 
 import * as docs from "@/views/docs";
 import { useData } from "./lib/hooks";
+import { MainSection } from "@/components/MainSection";
+import { AccessibilityMenu } from "@/components/AccessibilityMenu";
 
 /*** Layout our main view and routes ***/
-function Main(props: { children: any }): React.ReactElement {
+function AppLayout(props: { children: any }): React.ReactElement {
     const [user] = useData("config.user");
     let username_needs_to_be_updated = false;
 
@@ -115,9 +117,14 @@ function Main(props: { children: any }): React.ReactElement {
             <Variant value="enabled" bodyClass="v6">
                 <div id="variant-container">
                     <ErrorBoundary>
+                        <AccessibilityMenu />
+                    </ErrorBoundary>
+                    <ErrorBoundary>
                         <NavBar />
                     </ErrorBoundary>
-                    <ErrorBoundary>{props.children}</ErrorBoundary>
+                    <ErrorBoundary>
+                        <MainSection>{props.children}</MainSection>
+                    </ErrorBoundary>
                     <ErrorBoundary>
                         <Announcements />
                     </ErrorBoundary>
@@ -132,6 +139,9 @@ function Main(props: { children: any }): React.ReactElement {
             <ExDefault>
                 <div id="default-variant-container">
                     <ErrorBoundary>
+                        <AccessibilityMenu />
+                    </ErrorBoundary>
+                    <ErrorBoundary>
                         <NavBar />
                     </ErrorBoundary>
                     <ErrorBoundary>
@@ -140,7 +150,9 @@ function Main(props: { children: any }): React.ReactElement {
                     <ErrorBoundary>
                         <NetworkStatus />
                     </ErrorBoundary>
-                    <ErrorBoundary>{props.children}</ErrorBoundary>
+                    <ErrorBoundary>
+                        <MainSection>{props.children}</MainSection>
+                    </ErrorBoundary>
                     <ErrorBoundary>
                         <AccountWarning />
                     </ErrorBoundary>
@@ -217,7 +229,7 @@ function WaitForUser(): React.ReactElement | null {
 
 export const routes = (
     <Router history={browserHistory}>
-        <Main>
+        <AppLayout>
             <Routes>
                 <Route path="/sign-in" element={<SignIn />} />
                 <Route path="/register" element={<Register />} />
@@ -376,6 +388,6 @@ export const routes = (
                 <Route path="/" element={<Default />} />
                 <Route path="/*" element={<PageNotFound />} />
             </Routes>
-        </Main>
+        </AppLayout>
     </Router>
 );


### PR DESCRIPTION
## Proposed Changes

  - wrap all route content into <main>
  - add an accessibility menu to jump to <main> directly
  - in routes.tsx, renamed `Main` to `AppLayout` to avoid confusion with the new `MainSection` component
