### PR TITLE
Fixed seek-graph-container hidden CSS to stop margin overflow #2989

### DIFF
--- a/src/views/Play/CustomGames.styl
+++ b/src/views/Play/CustomGames.styl
@@ -63,6 +63,7 @@
     .seek-graph-container.hidden {
         clip-path: inset(0 100% 100% 0); /* Clip the entire element */
         position: absolute; /* Remove it from the layout */
+        display: none; /* Hide the element properly without right margin overflowing*/
     }
 
     .seek-graph-container.visible {


### PR DESCRIPTION
Fixes #2989
`seek-graph-container hidden` div element in `CustomGames` inside `/play` page causes **right-margin overflow** where width is 150% of initial viewport size on Desktops. See my comment for full description: https://github.com/online-go/online-go.com/issues/2989#issuecomment-2711499418

## Proposed Changes
  - Modify [src/views/Play/CustomGames.styl ](https://github.com/online-go/online-go.com/blob/b5244f99e617ac6069c935ffb8ba922c1f192d6d/src/views/Play/CustomGames.styl#L61-L73) with: 
```
 .seek-graph-container.hidden {
     // ... existing code ...
     display: none;
}
```
- This modification is least invasive, while robustly fixing the right-margin overflow on Desktops. The element is already `.hidden` so setting display to none will not impact other processes, while properly fixing width of canvas.