### PR TITLE
remove nested <li> in navbar > settings > more settings

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -651,16 +651,11 @@ function ProfileAndQuickSettingsBits({
                     </div>
                 </div>
             </li>
-            <li>
-                <MenuLink
-                    title={pgettext(
-                        "Link to settings page with more theme options",
-                        "More options",
-                    )}
-                    centered={true}
-                    to="/settings/theme"
-                />
-            </li>
+            <MenuLink
+                title={pgettext("Link to settings page with more theme options", "More options")}
+                centered={true}
+                to="/settings/theme"
+            />
         </>
     );
 }


### PR DESCRIPTION
follow up of #2992

## Proposed Changes

  - remove `<li>` nested in `<li>`
