### PR TITLE
Fix navbar link to translations

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -350,6 +350,7 @@ export function NavBar(): React.ReactElement {
                                 to="https://translate.online-go.com/projects/ogs/"
                                 icon={<i className="fa fa-globe" />}
                                 target="_blank"
+                                external={true}
                             />
 
                             <MenuLink


### PR DESCRIPTION
in #2992 I haven't used `external` for the link to the translation (in tools dropdown) 

## Proposed Changes

  - Fix link to translation
