### PR TITLE
Add support for CMs involved in ai detection work

### DIFF
--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -420,6 +420,19 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
                             onRetractOffer={this.retractOffer}
                             onRemovePower={this.removePower}
                         />
+                        <ModerationOfferControl
+                            ability={pgettext(
+                                "Label for a button to let a community moderator join the AI detection team",
+                                "AI detection team",
+                            )}
+                            ability_mask={MODERATOR_POWERS.AI_DETECTOR}
+                            currently_offered={this.state.offered_moderator_powers}
+                            moderator_powers={this.state.moderator_powers}
+                            previously_rejected={this.state.mod_powers_rejected}
+                            onMakeOffer={this.makeOffer}
+                            onRetractOffer={this.retractOffer}
+                            onRemovePower={this.removePower}
+                        />
                     </div>
                 )}
                 <div className="buttons">

--- a/src/lib/moderation.tsx
+++ b/src/lib/moderation.tsx
@@ -34,6 +34,7 @@ export enum MODERATOR_POWERS {
     SUSPEND = 0b1000,
     ASSESS_AI_REPORTS = 0b10000,
     SEE_REPORTED_USER_BANNED_STATUS = 0b100000,
+    AI_DETECTOR = 0b1000000,
 }
 
 export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
@@ -59,6 +60,7 @@ export const MOD_POWER_NAMES: { [key in MODERATOR_POWERS]: string } = {
         "A label for a moderator power",
         "See reported user's banned status",
     ),
+    [MODERATOR_POWERS.AI_DETECTOR]: pgettext("A label for a moderator power", "AI Detection team"),
 };
 
 export function doAnnul(

--- a/src/views/Game/GameTimings.tsx
+++ b/src/views/Game/GameTimings.tsx
@@ -24,6 +24,7 @@ import * as React from "react";
 import { AdHocPackedMove, GobanMovesArray } from "goban";
 import { useUser } from "@/lib/hooks";
 import { showSecondsResolution } from "@/lib/misc";
+import { MODERATOR_POWERS } from "@/lib/moderation";
 
 interface GameTimingProperties {
     moves: GobanMovesArray;
@@ -102,14 +103,15 @@ export function GameTimings(props: GameTimingProperties): React.ReactElement {
         }
     }
 
-    const cm = user.moderator_powers !== 0; // community moderator
+    const have_blurs =
+        user.is_moderator || (user.moderator_powers & MODERATOR_POWERS.AI_DETECTOR) !== 0;
 
     return (
         <div className="GameTimings">
             <div className="timings-header">Game Timings</div>
             <div>Move</div>
-            <div>Black {!cm && "(blur)"}</div>
-            <div>White {!cm && "(blur)"}</div>
+            <div>Black {have_blurs && "(blur)"}</div>
+            <div>White {have_blurs && "(blur)"}</div>
             <div>Elapsed Time</div>
             {white_first_turn ? first_row : ""}
             {
@@ -221,12 +223,12 @@ export function GameTimings(props: GameTimingProperties): React.ReactElement {
                                 <div>{idx * 2 + 1 + handicap_move_offset}</div>
                                 <div>
                                     {black_move_time}
-                                    {!cm && blurDurationFormat(black_blur)}
+                                    {have_blurs && blurDurationFormat(black_blur)}
                                     {black_download_sgf ? <i className="fa fa-download" /> : null}
                                 </div>
                                 <div>
                                     {white_move_time}
-                                    {!cm && blurDurationFormat(white_blur)}
+                                    {have_blurs && blurDurationFormat(white_blur)}
                                     {white_download_sgf ? <i className="fa fa-download" /> : null}
                                 </div>
                                 <div>


### PR DESCRIPTION
Fixes those CMs not being able to see the info they need.

## Proposed Changes

  - Add a CM ability for AI detection
  - Show ai detection info to empowered CMs, if the backend sends it


Needs https://github.com/online-go/ogs-node/pull/80 to actually do anything.
 
 
