### PR TITLE
Add support for "auto warn first turn escapers".

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -68,6 +68,7 @@
         "Gulpfile",
         "hane",
         "Heatmaps",
+        "Hoshi",
         "hostinfo",
         "hoverable",
         "icontains",

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -19,8 +19,10 @@ import { ogsTest } from "@helpers";
 
 import { cmDontNotifyEscalatedAiTest } from "./cm-dont-notify-escalated-ai";
 import { cmVoteOnOwnReportTest } from "./cm-vote-on-own-report";
+import { cmWarnFirstTurnEscapersTest } from "./cm-auto-warn-first-turn-escaper";
 
 ogsTest.describe("@CM Community Moderation Tests", () => {
     ogsTest("CM should be able to vote on their own report", cmVoteOnOwnReportTest);
     ogsTest("We should not notify escalated AI reports", cmDontNotifyEscalatedAiTest);
+    ogsTest("We should warn first turn escapers", cmWarnFirstTurnEscapersTest);
 });

--- a/e2e-tests/helpers/game-utils.ts
+++ b/e2e-tests/helpers/game-utils.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ */
+
+import { expect } from "@playwright/test";
+import { Page } from "@playwright/test";
+
+export interface ChallengeSettings {
+    gameName: string;
+    boardSize: string;
+    speed: string;
+    timeControl: string;
+    mainTime: string;
+    timePerPeriod: string;
+    periods: string;
+    color: string;
+}
+
+export const defaultChallengeSettings: ChallengeSettings = {
+    gameName: "E2E Test game",
+    boardSize: "19x19",
+    speed: "blitz",
+    timeControl: "byoyomi",
+    mainTime: "2",
+    timePerPeriod: "2",
+    periods: "1",
+    color: "black",
+};
+
+export const createDirectChallenge = async (
+    page: Page,
+    challenged: string,
+    settings: ChallengeSettings = defaultChallengeSettings,
+) => {
+    await page.fill(".OmniSearch-input", challenged);
+    await page.waitForSelector(".results .result");
+    await page.click(`.results .result:has-text('${challenged}')`);
+    const playerLink = page.locator(`a.Player:has-text("${challenged}")`);
+    await expect(playerLink).toBeVisible();
+    await playerLink.hover(); // Ensure the dropdown stays open
+    await playerLink.click();
+
+    await expect(page.getByRole("button", { name: /Challenge$/ })).toBeVisible();
+    await page.getByRole("button", { name: /Challenge$/ }).click();
+
+    // Fill out the challenge form
+    await page.fill("#challenge-game-name", settings.gameName);
+    await page.selectOption("#challenge-board-size", settings.boardSize);
+    await page.selectOption("#challenge-speed", settings.speed);
+    await page.selectOption("#challenge-time-control", settings.timeControl);
+    await page.selectOption("#tc-main-time-byoyomi", settings.mainTime);
+    await page.selectOption("#tc-per-period-byoyomi", settings.timePerPeriod);
+    await page.fill("#tc-periods-byoyomi", settings.periods);
+    await page.selectOption("#challenge-color", settings.color);
+
+    // Send the challenge
+    await page.getByRole("button", { name: "Send Challenge" }).click();
+    await expect(page.getByText("Waiting for opponent")).toBeVisible();
+};
+
+export const acceptDirectChallenge = async (page: Page) => {
+    await page.goto("/");
+
+    // Click skip button if present
+    const skipButton = page.getByRole("button", { name: /skip/i });
+    if (await skipButton.isVisible()) {
+        await skipButton.click();
+    }
+
+    await page.locator(".fab.primary.raiser").click();
+};
+
+export const clickInTheMiddle = async (page: Page) => {
+    // Wait for the Goban to be visible
+    const goban = page.locator(".Goban[data-pointers-bound]");
+    await goban.waitFor({ state: "visible" });
+
+    // Get the bounding box of the Goban
+    const box = await goban.boundingBox();
+    if (!box) {
+        throw new Error("Could not get Goban dimensions");
+    }
+
+    // Calculate center point
+    const centerX = box.x + box.width / 2;
+    const centerY = box.y + box.height / 2;
+
+    // Click in the center of the Goban
+    await page.mouse.click(centerX, centerY);
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:8080";
 export default defineConfig({
     testDir: "./e2e-tests",
     testMatch: ["**/*.spec.ts"],
-    timeout: 60 * 1000, // overall test timeout - we have some long multi-user tests
+    timeout: 120 * 1000, // overall test timeout - we have some long multi-user tests
     expect: {
         timeout: process.env.CI ? 30000 : 5000,
     },

--- a/src/components/AccountWarning/CannedMessages.ts
+++ b/src/components/AccountWarning/CannedMessages.ts
@@ -119,6 +119,36 @@ Thank you for helping keep OGS enjoyable for everyone. We appreciate it.`,
             ),
             { reported },
         ),
+    warn_first_turn_escaper: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Warning message to a user",
+                `
+We've noticed that you joined game #{{game_id}} but didn't make any moves.
+
+It's possible you didn't notice this game start - we understand that.
+
+However, could you please take care avoid this situation, so that other users are not left waiting and wondering.
+
+Thank you for helping keep OGS enjoyable for everyone. We appreciate it.
+`,
+            ),
+            { game_id },
+        ),
+    notify_warned_first_turn_escaper: (game_id) =>
+        interpolate(
+            llm_pgettext(
+                "Notification message to a user",
+                `
+We've noticed that the other player left game #{{game_id}} without making any moves.
+
+We've automatically alerted that person about this, and asked them to be more respectful of people's time - you don't need to report it.
+
+Hopefully they'll be more careful next time!
+`,
+            ),
+            { game_id },
+        ),
     warn_beginner_staller: (game_id) =>
         interpolate(
             llm_pgettext(

--- a/src/models/warning.d.ts
+++ b/src/models/warning.d.ts
@@ -30,6 +30,8 @@ declare namespace rest_api {
             | "ack_warned_escaper_and_annul"
             | "no_escaping_evident"
             | "not_escaping_cancel"
+            | "warn_first_turn_escaper"
+            | "notify_warned_first_turn_escaper"
             | "warn_beginner_staller"
             | "warn_staller"
             | "ack_educated_beginner_staller"


### PR DESCRIPTION
E2E test included, with "game utils" started.

Fixes CMs having to vote on this frequent annoying trivial case.

## Proposed Changes

  - Added messages to support backend warnings issued for this
  - Added game-utils to E2E test helpers
  - Added E2E test for this case (under CM)

Need https://github.com/online-go/ogs/pull/2052

Won't break anything if this goes in first
