### PR TITLE
Rationalise naming and seed data use

### DIFF
--- a/e2e-tests/cm/cm-auto-warn-first-turn-escaper.ts
+++ b/e2e-tests/cm/cm-auto-warn-first-turn-escaper.ts
@@ -15,9 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// (No seeded data in use)
+
 import { Browser } from "@playwright/test";
 
-import { setupStandardUser } from "@helpers/user-utils";
+import { newTestUsername, prepareNewUser } from "@helpers/user-utils";
 
 import {
     acceptDirectChallenge,
@@ -27,11 +29,17 @@ import {
 } from "@helpers/game-utils";
 
 export const cmWarnFirstTurnEscapersTest = async ({ browser }: { browser: Browser }) => {
-    const { userPage: challengerPage } = await setupStandardUser(browser, "E2E_CM_OTHER");
-    const { userPage: escaperPage } = await setupStandardUser(browser, "E2E_CM_REPORTED");
+    const { userPage: challengerPage } = await prepareNewUser(
+        browser,
+        newTestUsername("CmFTEChall"), // cspell:disable-line
+        "test",
+    );
+
+    const escaperUsername = newTestUsername("CmFTEEscaper"); // cspell:disable-line
+    const { userPage: escaperPage } = await prepareNewUser(browser, escaperUsername, "test");
 
     // Challenger challenges the escaper
-    await createDirectChallenge(challengerPage, "E2E_CM_REPORTED", {
+    await createDirectChallenge(challengerPage, escaperUsername, {
         ...defaultChallengeSettings,
         gameName: "E2E First Turn Escape Game",
     });

--- a/e2e-tests/cm/cm-vote-on-own-report.ts
+++ b/e2e-tests/cm/cm-vote-on-own-report.ts
@@ -15,20 +15,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// cspell:words VOOR REPOR
+
+/*
+ * Uses init_e2e data:
+ * - E2E_CM_VOOR_REPORTER : user who reports
+ * - E2E_CM_VOOR_REPORTED : user who is reported
+ * - "E2E CM VOOR Sample Game" : game in which the report is made
+ * - E2E_CM_OTHER_VOOR : The other person in that game (who's name must not match E2E_CM_VOOR_! See below!)
+ */
+
 import { Browser, expect } from "@playwright/test";
 
 import { expectOGSClickableByName } from "@helpers/matchers";
-import { goToUsersGame, reportUser, setupStandardUser } from "@helpers/user-utils";
+import { goToUsersGame, reportUser, setupSeededUser } from "@helpers/user-utils";
 
 export const cmVoteOnOwnReportTest = async ({ browser }: { browser: Browser }) => {
-    const { userPage: reporterPage } = await setupStandardUser(browser, "E2E_CM_ESC");
+    const { userPage: reporterPage } = await setupSeededUser(browser, "E2E_CM_VOOR_REPORTER");
 
-    await goToUsersGame(reporterPage, "E2E_CM_REPORTED", "E2E CM Sample Game");
+    await goToUsersGame(reporterPage, "E2E_CM_VOOR_REPORTED", "E2E CM VOOR Game");
 
     // ... and report the user
-    // (the username is truncated inside the player card!)
-    // cspell:disable-next-line
-    await reportUser(reporterPage, "E2E_CM_REPOR", "escaping", "E2E test reporting an escaper");
+    // (The username is truncated inside the player card!  So the "other player" name must not match here!)
+    await reportUser(reporterPage, "E2E_CM_VOOR_", "escaping", "E2E test reporting an escaper");
 
     // Go to the report page
     await reporterPage.goto("/reports-center");

--- a/e2e-tests/smoke/smoke-register-operations.ts
+++ b/e2e-tests/smoke/smoke-register-operations.ts
@@ -15,9 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ogsTest } from "@helpers";
-import { smokeRegisterLogoutLogin } from "./smoke-register-operations";
+// (No seeded data in use - must not use seeded data for smoke tests!)
 
-ogsTest.describe("@Smoke Basic self contained tests to confirm server is functional", () => {
-    ogsTest("Should be able to register, logout, login", smokeRegisterLogoutLogin);
-});
+import { Browser } from "@playwright/test";
+
+import { logoutUser, registerNewUser, loginAsUser, newTestUsername } from "@helpers/user-utils";
+
+export const smokeRegisterLogoutLogin = async ({ browser }: { browser: Browser }) => {
+    const testInfo = {
+        newUsername: newTestUsername("SmokeReg"),
+    };
+
+    const { userPage } = await registerNewUser(browser, testInfo.newUsername, "test");
+
+    await logoutUser(userPage);
+
+    await loginAsUser(userPage, testInfo.newUsername, "test");
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -119,7 +119,7 @@ export default defineConfig({
     webServer: process.env.FRONTEND_URL
         ? undefined
         : {
-              command: `yarn vite`,
+              command: `echo "Starting vite server: ${process.env.OGS_BACKEND}" && yarn vite`,
               url: FRONTEND_URL,
               reuseExistingServer: !process.env.CI,
               timeout: 120 * 1000, // server startup.


### PR DESCRIPTION
Fixes potential to get confused and flakey with seeded data.

## Proposed Changes

  - Each test that needs seeded data gets its own seeded data
  - Consistent naming of seeded data artefacts and their connection to test names
 
Needs https://github.com/online-go/ogs/pull/2053  to be run on e2e target.

