### PR TITLE
Added e2e test for OGS PR2057: auto warn disconnecters.

### DIFF
--- a/e2e-tests/cm/cm-auto-warn-first-turn-disconnector.ts
+++ b/e2e-tests/cm/cm-auto-warn-first-turn-disconnector.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// (No seeded data in use)
+
+import { Browser } from "@playwright/test";
+
+import { loginAsUser, newTestUsername, prepareNewUser } from "@helpers/user-utils";
+
+import {
+    acceptDirectChallenge,
+    clickInTheMiddle,
+    createDirectChallenge,
+    defaultChallengeSettings,
+} from "@helpers/game-utils";
+
+import { ogsTest } from "@helpers";
+
+export const cmWarnFirstTurnDisconnectorTest = async ({ browser }: { browser: Browser }) => {
+    ogsTest.setTimeout(6 * 60 * 1000); // Set timeout to 6 minutes, to let disconnect happen
+
+    const { userPage: challengerPage } = await prepareNewUser(
+        browser,
+        newTestUsername("CmFTDChall"), // cspell:disable-line
+        "test",
+    );
+
+    const escaperUsername = newTestUsername("CmFTDis"); // cspell:disable-line
+    const { userPage: escaperPage } = await prepareNewUser(browser, escaperUsername, "test");
+
+    // Challenger challenges the escaper
+    await createDirectChallenge(challengerPage, escaperUsername, {
+        ...defaultChallengeSettings,
+        gameName: "E2E First Turn Disconnector Game",
+        speed: "live",
+        timeControl: "byoyomi",
+        mainTime: "360", // longer than the disconnect timer (which is 5 mins)
+        timePerPeriod: "360",
+        periods: "1",
+    });
+
+    // escaper accepts
+    await acceptDirectChallenge(escaperPage);
+
+    // Challenger is black, plays a turn (to get past slow first-move-timer)
+    // Wait for the Goban to be visible & definitely ready
+    const goban = challengerPage.locator(".Goban[data-pointers-bound]");
+    await goban.waitFor({ state: "visible" });
+
+    await challengerPage.waitForTimeout(3000);
+
+    await clickInTheMiddle(challengerPage);
+
+    console.log(
+        "Note: cmWarnFirstTurnDisconnectorTest waiting for disconnect timer (approximately 5 minutes)...",
+    );
+    await escaperPage.close(); // escaper disconnects
+
+    // ... eventually challenger gets the ack that we are looking for
+    await challengerPage
+        .locator(
+            '.AccountWarningAck .canned-message:has-text("We\'ve noticed that the other player left game")',
+        )
+        .waitFor();
+    await challengerPage.locator(".AccountWarningAck button.primary").click();
+
+    // And escaper should have warning when they log in again
+    const newEscaperContext = await browser.newContext();
+    const newEscaperPage = await newEscaperContext.newPage();
+
+    await loginAsUser(newEscaperPage, escaperUsername, "test");
+
+    await newEscaperPage
+        .locator('.AccountWarning .canned-message:has-text("We\'ve noticed that you joined game")')
+        .waitFor();
+
+    await newEscaperPage.locator("#AccountWarning-accept:not([disabled])").waitFor();
+    await newEscaperPage.locator("#AccountWarning-accept").check();
+    await newEscaperPage.locator(".AccountWarning button.primary:not([disabled])").waitFor();
+    await newEscaperPage.locator(".AccountWarning button.primary").click();
+};

--- a/e2e-tests/cm/cm-show-only-post-escalation-votes.ts
+++ b/e2e-tests/cm/cm-show-only-post-escalation-votes.ts
@@ -26,7 +26,7 @@
  * - E2E_CM_SOPEV_ESCALATOR : CM who escalates the report
  */
 
-import { Browser } from "@playwright/test";
+import { Browser, TestInfo } from "@playwright/test";
 
 import {
     assertIncidentReportIndicatorActive,
@@ -39,89 +39,102 @@ import {
 
 import { expectOGSClickableByName } from "@helpers/matchers";
 import { expect } from "@playwright/test";
+import { withIncidentIndicatorLock } from "@helpers/report-utils";
 
-export const cmShowOnlyPostEscalationVotesTest = async ({ browser }: { browser: Browser }) => {
-    const { userPage: reporterPage } = await prepareNewUser(
-        browser,
-        newTestUsername("CmSOPEVRep"), // cspell:disable-line
-        "test",
-    );
+export const cmShowOnlyPostEscalationVotesTest = async (
+    { browser }: { browser: Browser },
+    testInfo: TestInfo,
+) => {
+    await withIncidentIndicatorLock(testInfo, async () => {
+        const { userPage: reporterPage } = await prepareNewUser(
+            browser,
+            newTestUsername("CmSOPEVRep"), // cspell:disable-line
+            "test",
+        );
 
-    // Report someone for escaping
-    await goToUsersGame(reporterPage, "E2E_CM_SOPEV_REPORTED", "E2E CM SOPEV Game");
+        // Report someone for escaping
+        await goToUsersGame(reporterPage, "E2E_CM_SOPEV_REPORTED", "E2E CM SOPEV Game");
 
-    await reportUser(
-        reporterPage,
-        "E2E_CM_SOPEV_OTHER",
-        "escaping",
-        "E2E test - SOPEV reporting escaping!",
-    );
+        await reportUser(
+            reporterPage,
+            "E2E_CM_SOPEV_OTHER",
+            "escaping",
+            "E2E test - SOPEV reporting escaping!",
+        );
 
-    // Now put a pre-escalation vote on the report
+        // Now put a pre-escalation vote on the report
 
-    const { seededCMPage: initialVoterPage } = await setupSeededCM(
-        browser,
-        "E2E_CM_SOPEV_INITIAL_VOTER",
-    );
+        const { seededCMPage: initialVoterPage } = await setupSeededCM(
+            browser,
+            "E2E_CM_SOPEV_INITIAL_VOTER",
+        );
 
-    let indicator = await assertIncidentReportIndicatorActive(initialVoterPage, 1);
+        let indicator = await assertIncidentReportIndicatorActive(initialVoterPage, 1);
 
-    await indicator.click();
+        await indicator.click();
 
-    await expect(initialVoterPage.getByRole("heading", { name: "Reports Center" })).toBeVisible();
+        await expect(
+            initialVoterPage.getByRole("heading", { name: "Reports Center" }),
+        ).toBeVisible();
 
-    await expect(initialVoterPage.getByText("E2E test - SOPEV reporting escaping!")).toBeVisible();
+        await expect(
+            initialVoterPage.getByText("E2E test - SOPEV reporting escaping!"),
+        ).toBeVisible();
 
-    // Doesn't matter what option we vote for actually, first is handy
-    await initialVoterPage.locator('.action-selector input[type="radio"]').first().click();
-    let voteButton = await expectOGSClickableByName(initialVoterPage, /Vote$/);
+        // Doesn't matter what option we vote for actually, first is handy
+        await initialVoterPage.locator('.action-selector input[type="radio"]').first().click();
+        let voteButton = await expectOGSClickableByName(initialVoterPage, /Vote$/);
 
-    await voteButton.click();
+        await voteButton.click();
 
-    // Now escalate the report
-    const { seededCMPage: escalatorPage } = await setupSeededCM(browser, "E2E_CM_SOPEV_ESCALATOR");
+        // Now escalate the report
+        const { seededCMPage: escalatorPage } = await setupSeededCM(
+            browser,
+            "E2E_CM_SOPEV_ESCALATOR",
+        );
 
-    indicator = await assertIncidentReportIndicatorActive(escalatorPage, 1);
+        indicator = await assertIncidentReportIndicatorActive(escalatorPage, 1);
 
-    await indicator.click();
+        await indicator.click();
 
-    await expect(escalatorPage.getByRole("heading", { name: "Reports Center" })).toBeVisible();
+        await expect(escalatorPage.getByRole("heading", { name: "Reports Center" })).toBeVisible();
 
-    await expect(escalatorPage.getByText("E2E test - SOPEV reporting escaping!")).toBeVisible();
+        await expect(escalatorPage.getByText("E2E test - SOPEV reporting escaping!")).toBeVisible();
 
-    // escalation is always the last option - yay that's handy
-    await escalatorPage.locator('.action-selector input[type="radio"]').last().click();
-    await escalatorPage.locator("#escalation-note").fill("E2E test - SOPEV escalation note");
+        // escalation is always the last option - yay that's handy
+        await escalatorPage.locator('.action-selector input[type="radio"]').last().click();
+        await escalatorPage.locator("#escalation-note").fill("E2E test - SOPEV escalation note");
 
-    voteButton = await expectOGSClickableByName(escalatorPage, /Vote$/);
+        voteButton = await expectOGSClickableByName(escalatorPage, /Vote$/);
 
-    await voteButton.click();
+        await voteButton.click();
 
-    await expect(
-        escalatorPage.getByText("Escalated due to VotingOutcome.VOTED_ESCALATION"),
-    ).toBeVisible();
+        await expect(
+            escalatorPage.getByText("Escalated due to VotingOutcome.VOTED_ESCALATION"),
+        ).toBeVisible();
 
-    // Now the previous vote from the initial voter should be gone
+        // Now the previous vote from the initial voter should be gone
 
-    // Make sure the all the escalated voting options are loaded
-    const radioButtons = escalatorPage.locator('.action-selector input[type="radio"]');
-    await expect(await radioButtons.count()).toBeGreaterThanOrEqual(7);
+        // Make sure the all the escalated voting options are loaded
+        const radioButtons = escalatorPage.locator('.action-selector input[type="radio"]');
+        await expect(await radioButtons.count()).toBeGreaterThanOrEqual(7);
 
-    // Make sure there are no votes showing
-    const voteCounts = escalatorPage.locator(".vote-count");
-    for (let i = 0; i < (await voteCounts.count()); i++) {
-        const text = await voteCounts.nth(i).textContent();
-        expect(text).toBe("(0)");
-    }
+        // Make sure there are no votes showing
+        const voteCounts = escalatorPage.locator(".vote-count");
+        for (let i = 0; i < (await voteCounts.count()); i++) {
+            const text = await voteCounts.nth(i).textContent();
+            expect(text).toBe("(0)");
+        }
 
-    //  (we probably should make sure that the report is not acted on with pre-escalation votes,
-    //   but that's for another day)
-    // reporter cleans up their report
-    await reporterPage.goto("/reports-center");
-    const myReports = reporterPage.getByText("My Own Reports");
-    await expect(myReports).toBeVisible();
-    await myReports.click();
+        //  (we probably should make sure that the report is not acted on with pre-escalation votes,
+        //   but that's for another day)
+        // reporter cleans up their report
+        await reporterPage.goto("/reports-center");
+        const myReports = reporterPage.getByText("My Own Reports");
+        await expect(myReports).toBeVisible();
+        await myReports.click();
 
-    const cancelButton = await expectOGSClickableByName(reporterPage, /Cancel$/);
-    await cancelButton.click();
+        const cancelButton = await expectOGSClickableByName(reporterPage, /Cancel$/);
+        await cancelButton.click();
+    });
 };

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -21,8 +21,10 @@ import { cmDontNotifyEscalatedAiTest } from "./cm-dont-notify-escalated-ai";
 import { cmVoteOnOwnReportTest } from "./cm-vote-on-own-report";
 import { cmWarnFirstTurnEscapersTest } from "./cm-auto-warn-first-turn-escaper";
 import { cmShowOnlyPostEscalationVotesTest } from "./cm-show-only-post-escalation-votes";
+import { cmWarnFirstTurnDisconnectorTest } from "./cm-auto-warn-first-turn-disconnector";
 
 ogsTest.describe("@CM Community Moderation Tests", () => {
+    ogsTest("We should warn first turn disconnectors", cmWarnFirstTurnDisconnectorTest);
     ogsTest("CM should be able to vote on their own report", cmVoteOnOwnReportTest);
     ogsTest("We should not notify escalated AI reports", cmDontNotifyEscalatedAiTest);
     ogsTest("We should warn first turn escapers", cmWarnFirstTurnEscapersTest);

--- a/e2e-tests/helpers/report-utils.ts
+++ b/e2e-tests/helpers/report-utils.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+class IncidentIndicatorLock {
+    private static lockFile = path.join(process.cwd(), ".incident-indicator.lock");
+    private static lockHandle: fs.promises.FileHandle | null = null;
+
+    static async acquire(): Promise<void> {
+        while (true) {
+            try {
+                this.lockHandle = await fs.promises.open(this.lockFile, "wx");
+                return;
+            } catch (err) {
+                if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    continue;
+                }
+                throw err;
+            }
+        }
+    }
+
+    static async release(): Promise<void> {
+        if (this.lockHandle) {
+            await this.lockHandle.close();
+            await fs.promises.unlink(this.lockFile);
+            this.lockHandle = null;
+        }
+    }
+}
+
+export async function withIncidentIndicatorLock<T>(
+    testInfo: { setTimeout: (timeout: number) => void },
+    fn: () => Promise<T>,
+): Promise<T> {
+    testInfo.setTimeout(0); // Disable timeout while waiting for lock
+    await IncidentIndicatorLock.acquire();
+    testInfo.setTimeout(120000); // Restore a timeout after acquiring lock (yuk, hardcoded here)
+
+    try {
+        return await fn();
+    } finally {
+        await IncidentIndicatorLock.release();
+    }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,8 +41,8 @@ export default defineConfig({
     },
 
     /* Run tests in files in parallel */
-    //fullyParallel: true,
-    fullyParallel: false, // for test development, easier to debug
+    fullyParallel: true, // turn off for easier debug
+
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
@@ -52,7 +52,7 @@ export default defineConfig({
     // TBD UNCOMMENT
     //workers: process.env.CI ? 1 : undefined,
 
-    workers: 1, // for test development, easier to debug
+    workers: 4, // 1 is best for test development: easier to debug
 
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [


### PR DESCRIPTION
Also added serialisation of tests using IncidentReportIndicator, so remainder can run in parallel.

Fixes not having a test to prove this works, and not being able to run tests in parallel

## Proposed Changes

  - Test that first turn disconnection triggers the warning
  - Make tests using IncidentReportIndicator get a lock to do that.
  
