### PR TITLE
Fix style of Menu "settings and profile" on mobile

### DIFF
--- a/src/components/NavBar/NavBar.styl
+++ b/src/components/NavBar/NavBar.styl
@@ -215,7 +215,7 @@ header.NavBar {
 
     /* mobile */
     @media only screen and (max-width: hamburger-cutoff) {
-        .left {
+        &>.left {
             display: none !important;
         }
 
@@ -317,7 +317,7 @@ header.NavBar {
             }
         }
 
-        &.hamburger-expanded .left {
+        &.hamburger-expanded>.left {
             display: inline !important;
 
             themed: background-color navbar-background-color;
@@ -442,6 +442,7 @@ header.NavBar {
         width: 100%;
         text-align: left;
         margin: 0;
+        padding: 0;
         box-shadow: none;
 
         &:focus {
@@ -476,7 +477,7 @@ header.NavBar {
         margin-right: 1rem;
     }
 
-    .left {
+    >.left {
         & > ul {
             display: flex;
             align-items: center;
@@ -486,7 +487,7 @@ header.NavBar {
         }
     }
 
-    .left, .Menu {
+    >.left, .Menu {
         .Menu-title {
             display: inline-flex;
             line-height: navbar-height;
@@ -598,6 +599,9 @@ header.NavBar {
         user-select: none;
         z-index: z.nav-menu.menu;
         box-shadow: -2px 2px 1px 0px rgba(0, 0, 0, 0.16);
+        list-style: none;
+        margin: 0;
+        padding: 0;
 
         .NotificationList {
             margin-bottom: 1rem;

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -525,9 +525,9 @@ export function NavBar(): React.ReactElement {
 
                 {/* Right Nav drop down on mobile */}
                 {right_nav_active && (
-                    <div className="RightNav">
+                    <ul className="RightNav">
                         <ProfileAndQuickSettingsBits settingsNavLink={settingsNavLink} />
-                    </div>
+                    </ul>
                 )}
             </header>
         </MenuContext.Provider>


### PR DESCRIPTION
Fixes #3022

## Proposed Changes
on mobile menu the settings and profile is using a different dom element and css selectors, causing a bunch of troubles
  -  ensure it is wrapped in a <ul> (that's waht caused ios browsers to show bullet lists)
  - disconnect button padding
  - "theme" heading left line to not collapse


![image](https://github.com/user-attachments/assets/d018625b-e926-4b3f-91ae-cfddb9730225)

