### PR TITLE
Add "report on first turn not allowed" to `appropriate-check` for escape and stall reports.

### DIFF
--- a/e2e-tests/cm/cm-show-only-post-escalation-votes.ts
+++ b/e2e-tests/cm/cm-show-only-post-escalation-votes.ts
@@ -58,8 +58,8 @@ export const cmShowOnlyPostEscalationVotesTest = async (
         await reportUser(
             reporterPage,
             "E2E_CM_SOPEV_OTHER",
-            "escaping",
-            "E2E test - SOPEV reporting escaping!",
+            "score_cheating",
+            "E2E test - SOPEV reporting score cheating!",
         );
 
         // Now put a pre-escalation vote on the report
@@ -78,7 +78,7 @@ export const cmShowOnlyPostEscalationVotesTest = async (
         ).toBeVisible();
 
         await expect(
-            initialVoterPage.getByText("E2E test - SOPEV reporting escaping!"),
+            initialVoterPage.getByText("E2E test - SOPEV reporting score cheating!"),
         ).toBeVisible();
 
         // Doesn't matter what option we vote for actually, first is handy
@@ -99,7 +99,9 @@ export const cmShowOnlyPostEscalationVotesTest = async (
 
         await expect(escalatorPage.getByRole("heading", { name: "Reports Center" })).toBeVisible();
 
-        await expect(escalatorPage.getByText("E2E test - SOPEV reporting escaping!")).toBeVisible();
+        await expect(
+            escalatorPage.getByText("E2E test - SOPEV reporting score cheating!"),
+        ).toBeVisible();
 
         // escalation is always the last option - yay that's handy
         await escalatorPage.locator('.action-selector input[type="radio"]').last().click();

--- a/e2e-tests/cm/cm-vote-on-own-report.ts
+++ b/e2e-tests/cm/cm-vote-on-own-report.ts
@@ -43,7 +43,12 @@ export const cmVoteOnOwnReportTest = async (
 
         // ... and report the user
         // (The username is truncated inside the player card!  So the "other player" name must not match here!)
-        await reportUser(reporterPage, "E2E_CM_VOOR_", "escaping", "E2E test reporting an escaper");
+        await reportUser(
+            reporterPage,
+            "E2E_CM_VOOR_",
+            "score_cheating",
+            "E2E test reporting a score cheat",
+        );
 
         // Go to the report page
         await reporterPage.goto("/reports-center");

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -19,15 +19,9 @@ import { ogsTest } from "@helpers";
 
 import { cmDontNotifyEscalatedAiTest } from "./cm-dont-notify-escalated-ai";
 import { cmVoteOnOwnReportTest } from "./cm-vote-on-own-report";
-import { cmWarnFirstTurnEscapersTest } from "./cm-auto-warn-first-turn-escaper";
 import { cmShowOnlyPostEscalationVotesTest } from "./cm-show-only-post-escalation-votes";
-import { cmWarnFirstTurnDisconnectorTest } from "./cm-auto-warn-first-turn-disconnector";
-import { cmDontAutoWarnBlitzTest } from "./cm-dont-auto-warn-first-turn-blitz";
 
 ogsTest.describe("@CM Community Moderation Tests", () => {
-    ogsTest("We should warn first turn disconnectors", cmWarnFirstTurnDisconnectorTest);
-    ogsTest("We should not auto-warn blitz games", cmDontAutoWarnBlitzTest);
-    ogsTest("We should warn first turn escapers", cmWarnFirstTurnEscapersTest);
     ogsTest("CM should be able to vote on their own report", cmVoteOnOwnReportTest);
     ogsTest("We should not notify escalated AI reports", cmDontNotifyEscalatedAiTest);
     ogsTest("We should show only post-escalation votes", cmShowOnlyPostEscalationVotesTest);

--- a/e2e-tests/helpers/user-utils.ts
+++ b/e2e-tests/helpers/user-utils.ts
@@ -203,6 +203,37 @@ export const reportUser = async (page: Page, username: string, type: string, not
     await expect(OK).toBeHidden();
 };
 
+export const reportPlayerByColor = async (
+    page: Page,
+    color: string,
+    type: string,
+    notes: string,
+) => {
+    const playerLink = page.locator(`${color}.player-name-container a.Player`);
+    await expect(playerLink).toBeVisible();
+    await playerLink.hover(); // Ensure the dropdown stays open
+    await playerLink.click();
+
+    await expect(page.getByRole("button", { name: /Report$/ })).toBeVisible();
+    await page.getByRole("button", { name: /Report$/ }).click();
+
+    await expect(page.getByText("Request Moderator Assistance")).toBeVisible();
+
+    await page.selectOption(".type-picker select", { value: type }); // cspell:disable-line
+
+    const notesBox = page.locator(".notes");
+    await notesBox.fill(notes);
+
+    const submitButton = await expectOGSClickableByName(page, /Report User$/);
+    await submitButton.click();
+
+    await expect(page.getByText("Thanks for the report!")).toBeVisible();
+    const OK = await expectOGSClickableByName(page, "OK");
+    // tidy up
+    await OK.click();
+    await expect(OK).toBeHidden();
+};
+
 export const assertIncidentReportIndicatorActive = async (page: Page, count: number) => {
     const indicator = page.locator(".IncidentReportIndicator");
     const icon = indicator.locator(".fa-exclamation-triangle.active");

--- a/e2e-tests/moderation/mod-block-early-escape-report.ts
+++ b/e2e-tests/moderation/mod-block-early-escape-report.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * No seeded data in use
+ */
+
+import { Browser, expect } from "@playwright/test";
+
+import { prepareNewUser, newTestUsername } from "@helpers/user-utils";
+import {
+    createDirectChallenge,
+    acceptDirectChallenge,
+    clickInTheMiddle,
+} from "@helpers/game-utils";
+
+export const modBlockEarlyEscapeReportTest = async ({ browser }: { browser: Browser }) => {
+    const { userPage: reporterPage } = await prepareNewUser(
+        browser,
+        newTestUsername("modBEERRep"),
+        "test",
+    );
+
+    const reportedUsername = newTestUsername("modBEEREsc");
+    const { userPage: reportedPage } = await prepareNewUser(browser, reportedUsername, "test");
+
+    await createDirectChallenge(reporterPage, reportedUsername);
+
+    await acceptDirectChallenge(reportedPage);
+
+    await clickInTheMiddle(reporterPage);
+
+    const playerLink = reporterPage.locator(`.white.player-name-container a.Player`);
+    await expect(playerLink).toBeVisible();
+    await playerLink.hover(); // Ensure the dropdown stays open
+    await playerLink.click();
+
+    await expect(reporterPage.getByRole("button", { name: /Report$/ })).toBeVisible();
+    await reporterPage.getByRole("button", { name: /Report$/ }).click();
+
+    await expect(reporterPage.getByText("Request Moderator Assistance")).toBeVisible();
+
+    await reporterPage.selectOption(".type-picker select", { value: "escaping" }); // cspell:disable-line
+
+    const notesBox = reporterPage.locator(".notes");
+
+    // Wait for the placeholder to change to include the expected text
+    await expect(notesBox).toHaveAttribute("placeholder", /leaves the game without playing/);
+
+    await expect(reporterPage.getByRole("button", { name: /Report User$/ })).not.toBeEnabled();
+};

--- a/e2e-tests/moderation/mod-block-early-stall-report.ts
+++ b/e2e-tests/moderation/mod-block-early-stall-report.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * No seeded data in use
+ */
+
+import { Browser, expect } from "@playwright/test";
+
+import { prepareNewUser, newTestUsername } from "@helpers/user-utils";
+import {
+    createDirectChallenge,
+    acceptDirectChallenge,
+    clickInTheMiddle,
+} from "@helpers/game-utils";
+
+export const modBlockEarlyStallingReportTest = async ({ browser }: { browser: Browser }) => {
+    const { userPage: reporterPage } = await prepareNewUser(
+        browser,
+        newTestUsername("modBEESRep"),
+        "test",
+    );
+
+    const reportedUsername = newTestUsername("modBESEsc");
+    const { userPage: reportedPage } = await prepareNewUser(browser, reportedUsername, "test");
+
+    await createDirectChallenge(reporterPage, reportedUsername);
+
+    await acceptDirectChallenge(reportedPage);
+
+    await clickInTheMiddle(reporterPage);
+
+    const playerLink = reporterPage.locator(`.white.player-name-container a.Player`);
+    await expect(playerLink).toBeVisible();
+    await playerLink.hover(); // Ensure the dropdown stays open
+    await playerLink.click();
+
+    await expect(reporterPage.getByRole("button", { name: /Report$/ })).toBeVisible();
+    await reporterPage.getByRole("button", { name: /Report$/ }).click();
+
+    await expect(reporterPage.getByText("Request Moderator Assistance")).toBeVisible();
+
+    await reporterPage.selectOption(".type-picker select", { value: "stalling" });
+
+    const notesBox = reporterPage.locator(".notes");
+
+    // Wait for the placeholder to change to include the expected text
+    await expect(notesBox).toHaveAttribute("placeholder", /leaves the game without playing/);
+
+    await expect(reporterPage.getByRole("button", { name: /Report User$/ })).not.toBeEnabled();
+};

--- a/e2e-tests/moderation/mod-dont-auto-warn-first-turn-blitz.ts
+++ b/e2e-tests/moderation/mod-dont-auto-warn-first-turn-blitz.ts
@@ -29,7 +29,7 @@ import {
     defaultChallengeSettings,
 } from "@helpers/game-utils";
 
-export const cmDontAutoWarnBlitzTest = async ({ browser }: { browser: Browser }) => {
+export const modDontAutoWarnBlitzTest = async ({ browser }: { browser: Browser }) => {
     const { userPage: challengerPage } = await prepareNewUser(
         browser,
         newTestUsername("CmDWBChall"), // cspell:disable-line

--- a/e2e-tests/moderation/moderation.spec.ts
+++ b/e2e-tests/moderation/moderation.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ogsTest } from "@helpers";
+
+import { modWarnFirstTurnEscapersTest } from "./mod-auto-warn-first-turn-escaper";
+import { modWarnFirstTurnDisconnectorTest } from "./mod-auto-warn-first-turn-disconnector";
+import { modDontAutoWarnBlitzTest } from "./mod-dont-auto-warn-first-turn-blitz";
+import { modBlockEarlyEscapeReportTest } from "./mod-block-early-escape-report";
+import { modBlockEarlyStallingReportTest } from "./mod-block-early-stall-report";
+
+ogsTest.describe("@Mod Moderation Tests", () => {
+    ogsTest("We should warn first turn disconnectors", modWarnFirstTurnDisconnectorTest);
+    ogsTest("We should not auto-warn blitz games", modDontAutoWarnBlitzTest);
+    ogsTest("We should warn first turn escapers", modWarnFirstTurnEscapersTest);
+    ogsTest("We should block early escape reports", modBlockEarlyEscapeReportTest);
+    ogsTest("We should block early stalling reports", modBlockEarlyStallingReportTest);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
     // TBD UNCOMMENT
     //workers: process.env.CI ? 1 : undefined,
 
-    workers: 4, // 1 is best for test development: easier to debug
+    workers: 2, // 1 is best for test development: easier to debug
 
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [


### PR DESCRIPTION
Also refactor e2e to put this in with other "Moderation" reports in a Moderation group.

Fixes impatient people still reporting first turn escapes even though we told them we did it for them.

## Proposed Changes

  - Use `ReportDescription.check_applicability` to disallow first turn reporting of escape and stall
  - Add and update e2e accordinly (use score cheat for early report tests instead :) )

 ( E2E needs updated init_e2e  https://github.com/online-go/ogs/pull/2061 )
