### PR TITLE
hide ranks to show dist & text overflow

### DIFF
--- a/src/components/RatingsChartDistribution/RatingsChartDistribution.styl
+++ b/src/components/RatingsChartDistribution/RatingsChartDistribution.styl
@@ -22,6 +22,8 @@ rating-chart-height = 300px;
     max-width: calc(100vw - 2em)
     h4
         text-align: center
+        overflow: hidden
+        white-space: normal
     .wrapper
         height: rating-chart-height
         position: relative

--- a/src/components/RatingsChartDistribution/RatingsChartDistribution.tsx
+++ b/src/components/RatingsChartDistribution/RatingsChartDistribution.tsx
@@ -212,6 +212,11 @@ const RatingsChartDistribution: React.FC<RatingsChartDistributionProps> = ({
         effectiveMaxRating: number;
     } | null>(null);
 
+    const truncatedPlayerName =
+        otherPlayerName && otherPlayerName.length > 20
+            ? `${otherPlayerName.substring(0, 20)}...`
+            : otherPlayerName;
+
     React.useEffect(() => {
         const fetchData = async () => {
             const data = await createRatingDistribution();
@@ -345,7 +350,7 @@ const RatingsChartDistribution: React.FC<RatingsChartDistributionProps> = ({
                                   strokeWidth: 2,
                                   strokeDasharray: "10,0",
                               },
-                              legend: otherPlayerName,
+                              legend: truncatedPlayerName,
                               legendPosition: "top" as const,
                               legendOrientation: "horizontal" as const,
                               textStyle: {
@@ -483,7 +488,7 @@ const RatingsChartDistribution: React.FC<RatingsChartDistributionProps> = ({
                                   "{{name}} has a higher rating than {{percentile}}% of players",
                               ),
                               {
-                                  name: otherPlayerName || _("User"),
+                                  name: truncatedPlayerName || _("User"),
                                   percentile: percentile.toFixed(2),
                               },
                           )}

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -413,7 +413,7 @@ export function User(props: { user_id?: number }): React.ReactElement {
                                                         <span>
                                                             {pgettext(
                                                                 "label for button to hide the global distribution chart",
-                                                                "Hide distribution",
+                                                                "Hide Distribution",
                                                             )}
                                                         </span>
                                                     ) : (
@@ -435,24 +435,25 @@ export function User(props: { user_id?: number }): React.ReactElement {
                 </div>
             </div>
             <div className="ratings-row">
-                {showDistributionChart && (
-                    <div className="ratings-chart">
-                        <RatingsChartDistribution
-                            myRating={
-                                viewer.id === user.id
-                                    ? (getUserRating(user, "overall", 0).rating || 0) | 0
-                                    : undefined
-                            }
-                            otherRating={
-                                viewer.id === user.id
-                                    ? undefined
-                                    : (getUserRating(user, "overall", 0).rating || 0) | 0
-                            }
-                            otherPlayerName={viewer.id === user.id ? undefined : user.username}
-                            showRatings={show_ratings_in_rating_grid ?? true}
-                        />
-                    </div>
-                )}
+                {showDistributionChart &&
+                    (!preferences.get("hide-ranks") || temporary_show_ratings) && (
+                        <div className="ratings-chart">
+                            <RatingsChartDistribution
+                                myRating={
+                                    viewer.id === user.id
+                                        ? (getUserRating(user, "overall", 0).rating || 0) | 0
+                                        : undefined
+                                }
+                                otherRating={
+                                    viewer.id === user.id
+                                        ? undefined
+                                        : (getUserRating(user, "overall", 0).rating || 0) | 0
+                                }
+                                otherPlayerName={viewer.id === user.id ? undefined : user.username}
+                                showRatings={show_ratings_in_rating_grid ?? true}
+                            />
+                        </div>
+                    )}
             </div>
             {(!preferences.get("hide-ranks") || temporary_show_ratings) &&
                 (!user.professional || global_user.id === user.id) && (


### PR DESCRIPTION
## Fixes
- Syncs hide_ranks preference and temporary_show_ratings with showDistributionChart toggle in https://github.com/online-go/online-go.com/commit/352950d9df5330264b1286660dc6f2626f48b85c

## Proposed Changes
  - adds text overflow eclipse (truncates string) to player names plotted on chart 