### PR TITLE
Decompose `ModerationReportsViewer` into easier to read components.

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -203,6 +203,7 @@ export const defaults = {
 
     "user-history.show-mod-log": false,
     "user-history.warnings-only": false,
+    "debug.test-wanted": false,
 };
 
 defaults["profanity-filter"][current_language] = true;


### PR DESCRIPTION
Fixes hard to work on component.

## Proposed Changes

  -  Break up the header into separate components.
  
*: Note, this is somewhat tested by CM E2E tests, and that's all we can do, because we don't do Moderator E2E at the moment.