### PR TITLE
Clean up ChallengeModalTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ npm-debug.log
 .yalc
 yalc.lock
 
+# Coverage directory used by Jest (yarn test --coverage)
+coverage
+
 # Playwright
 /test-results/
 /playwright-report/

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -227,10 +227,6 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             }
 
             if (this.props.config.time_control) {
-                console.log(
-                    "Loading time control from config:",
-                    JSON.stringify(this.props.config.time_control),
-                );
                 state.time_control = this.props.config.time_control;
             }
         }


### PR DESCRIPTION
The tests are currently over-mocked, including re-implementations of code such as `dup` and `TimeControlPicker`.  This PR removes  all but `data` (needed because we don't want to deal with persistant storage) and `requests` (because we don't want to dispatch network calls).

There are some semi-related changes thrown in, I'll leave comments inline.