### PR TITLE
fix detected of saved restrict rank prefs

### DIFF
--- a/e2e-tests/challenges/ch-handicap-prefs.ts
+++ b/e2e-tests/challenges/ch-handicap-prefs.ts
@@ -73,6 +73,11 @@ export const chHandicapPrefsTest = async ({ browser }: { browser: Browser }) => 
     });
 
     await testChallengePOSTPayload(challengerPage, {
+        initialized: false,
+        min_ranking: -1000,
+        max_ranking: 1000,
+        challenger_color: "automatic",
+        rengo_auto_start: 0,
         game: {
             name: "Friendly Match",
             rules: "japanese",

--- a/e2e-tests/challenges/ch-preferred-rank.ts
+++ b/e2e-tests/challenges/ch-preferred-rank.ts
@@ -22,7 +22,11 @@ import { expect } from "@playwright/test";
 
 import { newTestUsername, prepareNewUser } from "@helpers/user-utils";
 
-import { getRankIndex, loadChallengeModal } from "@helpers/challenge-utils";
+import {
+    getRankIndex,
+    loadChallengeModal,
+    testChallengePOSTPayload,
+} from "@helpers/challenge-utils";
 import { expectOGSClickableByName } from "@helpers/matchers";
 
 export const chPreferredSettingsRankTest = async ({ browser }: { browser: Browser }) => {
@@ -78,4 +82,41 @@ export const chPreferredSettingsRankTest = async ({ browser }: { browser: Browse
     await expect(checkbox).not.toBeChecked();
 
     await expect(deleteButton).toBeVisible();
+
+    // Check that the payload is correct
+    await testChallengePOSTPayload(challengerPage, {
+        initialized: false,
+        min_ranking: -1000,
+        max_ranking: 1000,
+        challenger_color: "automatic",
+        rengo_auto_start: 0,
+        game: {
+            name: "Friendly Match",
+            rules: "japanese",
+            ranked: true,
+            width: 19,
+            height: 19,
+            handicap: -1,
+            komi_auto: "automatic",
+            komi: null,
+            disable_analysis: false,
+            initial_state: null,
+            private: false,
+            rengo: false,
+            rengo_casual_mode: true,
+            time_control: "byoyomi",
+            time_control_parameters: {
+                main_time: 604800,
+                period_time: 86400,
+                periods: 5,
+                periods_min: 1,
+                periods_max: 300,
+                pause_on_weekends: true,
+                speed: "correspondence",
+                system: "byoyomi",
+                time_control: "byoyomi",
+            },
+            pause_on_weekends: true,
+        },
+    });
 };

--- a/e2e-tests/challenges/ch.spec.ts
+++ b/e2e-tests/challenges/ch.spec.ts
@@ -21,10 +21,10 @@ import { chPreferredSettingsRankTest } from "./ch-preferred-rank";
 import { chBasicCreationTest } from "./ch-basic-creation";
 import { chHandicapPrefsTest } from "./ch-handicap-prefs";
 ogsTest.describe("@Challenges Challenge Tests", () => {
+    ogsTest("Should be able to create a challenge with a correct call", chBasicCreationTest);
     ogsTest(
         "Should be able to have different preferred settings based on rank",
         chPreferredSettingsRankTest,
     );
-    ogsTest("Should be able to create a challenge with a correct call", chBasicCreationTest);
     ogsTest("Should handle handicap preferences correctly", chHandicapPrefsTest);
 });

--- a/e2e-tests/helpers/challenge-utils.ts
+++ b/e2e-tests/helpers/challenge-utils.ts
@@ -362,6 +362,11 @@ export const checkChallengeForm = async (page: Page, settings: ChallengeModalFie
 };
 
 export interface ChallengePOSTPayload {
+    initialized?: boolean;
+    min_ranking?: number;
+    max_ranking?: number;
+    challenger_color?: string;
+    rengo_auto_start?: number;
     game: {
         name?: string;
         rules?: string;
@@ -395,10 +400,32 @@ export interface ChallengePOSTPayload {
 export const testChallengePOSTPayload = async (
     page: Page,
     expectedPayload: ChallengePOSTPayload,
+    log_request_body: boolean = false,
 ) => {
     await page.route("**/challenges", async (route) => {
         const request = route.request();
         const requestBody = JSON.parse(request.postData() || "{}");
+
+        if (log_request_body) {
+            console.log("Challenge POST payload:", JSON.stringify(requestBody, null, 2));
+        }
+
+        // Verify top-level fields
+        if (expectedPayload.initialized !== undefined) {
+            expect(requestBody.initialized).toBe(expectedPayload.initialized);
+        }
+        if (expectedPayload.min_ranking !== undefined) {
+            expect(requestBody.min_ranking).toBe(expectedPayload.min_ranking);
+        }
+        if (expectedPayload.max_ranking !== undefined) {
+            expect(requestBody.max_ranking).toBe(expectedPayload.max_ranking);
+        }
+        if (expectedPayload.challenger_color !== undefined) {
+            expect(requestBody.challenger_color).toBe(expectedPayload.challenger_color);
+        }
+        if (expectedPayload.rengo_auto_start !== undefined) {
+            expect(requestBody.rengo_auto_start).toBe(expectedPayload.rengo_auto_start);
+        }
 
         // Verify all game parameters
         if (expectedPayload.game.name !== undefined) {

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -227,10 +227,6 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             }
 
             if (this.props.config.time_control) {
-                console.log(
-                    "Loading time control from config:",
-                    JSON.stringify(this.props.config.time_control),
-                );
                 state.time_control = this.props.config.time_control;
             }
         }
@@ -1655,20 +1651,37 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             }),
         );
 
+        const handicap = this.state.challenge.game.handicap;
+
+        // see usePreferredSetting
         const rank_min = this.state.conf.restrict_rank ? this.state.challenge.min_ranking : -1000;
-        const rank_max = this.state.conf.restrict_rank ? this.state.challenge.max_ranking : 1000;
+        const rank_max = this.state.challenge.max_ranking;
+
         const selected =
-            options.find(
-                (opt: PreferredSettingOption) =>
-                    opt.setting.game.rules === this.state.challenge.game.rules &&
-                    opt.setting.game.width === this.state.challenge.game.width &&
-                    opt.setting.game.height === this.state.challenge.game.height &&
-                    opt.setting.game.handicap === this.state.challenge.game.handicap &&
-                    opt.setting.min_ranking === rank_min &&
-                    opt.setting.max_ranking === rank_max &&
-                    JSON.stringify(opt.setting.game.time_control_parameters) ===
-                        JSON.stringify(this.state.time_control),
-            ) || null;
+            options.find((opt: PreferredSettingOption) => {
+                // note that for some reason this.state.conf.restrict_rank is not stored with prefs
+                const opt_restrict_rank =
+                    opt.setting.min_ranking > -1000 && opt.setting.max_ranking < 1000;
+
+                const rank_choice_match =
+                    (!opt_restrict_rank && !this.state.conf.restrict_rank) ||
+                    (opt_restrict_rank &&
+                        this.state.conf.restrict_rank &&
+                        opt.setting.min_ranking === rank_min &&
+                        opt.setting.max_ranking === rank_max);
+
+                const selected =
+                    (opt.setting.game.rules === this.state.challenge.game.rules &&
+                        opt.setting.game.width === this.state.challenge.game.width &&
+                        opt.setting.game.height === this.state.challenge.game.height &&
+                        opt.setting.game.handicap === handicap &&
+                        rank_choice_match &&
+                        JSON.stringify(opt.setting.game.time_control_parameters) ===
+                            JSON.stringify(this.state.time_control)) ||
+                    null;
+
+                return selected;
+            }) || null;
 
         return (
             <div


### PR DESCRIPTION
Fixes not detecting that a current no-restrict-ranks setting matches an old saved one

## Proposed Changes

  - Detect rank restriction during match consistently with the way it is loaded
  