### PR TITLE
extract utils function getDefaultKomi, refactor update binding of komi op…

### DIFF
--- a/e2e-tests/helpers/challenge-utils.ts
+++ b/e2e-tests/helpers/challenge-utils.ts
@@ -78,7 +78,7 @@ export interface ChallengePOSTPayload {
     max_ranking?: number;
     challenger_color?: string;
     rengo_auto_start?: number;
-    invite_only?: boolean;    
+    invite_only?: boolean;
     game: {
         name?: string;
         rules?: string;

--- a/src/components/ChallengeModal/ChallengeModal.test.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.test.tsx
@@ -20,6 +20,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { ChallengeModalBody } from "./ChallengeModal";
 import { post } from "@/lib/requests";
 import { ChallengeModalProperties } from "@/components/ChallengeModal/ChallengeModal.types";
+import { sanitizeChallengeDetails, sanitizeDemoSettings } from "./ChallengeModal.utils";
 
 // Mock data module
 jest.mock("@/lib/data", () => ({
@@ -300,5 +301,50 @@ describe("ChallengeModalBody", () => {
 
         // Verify the modal was closed
         expect(mockModal.close).toHaveBeenCalled();
+    });
+
+    it("sanitizes legacy data", () => {
+        const demoSettings: any = {
+            name: "test settings 1",
+            rules: "aga",
+            width: 19,
+            height: 19,
+            black_name: "p1",
+            white_name: "p2",
+            white_ranking: 1500,
+            black_ranking: 1500,
+            private: false,
+            komi_auto: "custom",
+        };
+        expect("komi" in sanitizeDemoSettings(demoSettings)).toBeFalsy();
+        demoSettings.komi = "6.5";
+        expect(sanitizeDemoSettings(demoSettings).komi).toBe(6.5);
+
+        const challengeDetails: any = {
+            initialized: false,
+            min_ranking: 20,
+            max_ranking: 30,
+            challenger_color: "automatic",
+            rengo_auto_start: 0,
+            game: {
+                name: "test game 1",
+                rules: "aga",
+                ranked: false,
+                width: 9,
+                height: 9,
+                handicap: "5",
+                komi_auto: "automatic",
+                disable_analysis: false,
+                initial_state: undefined,
+                private: false,
+                rengo: false,
+                rengo_casual_mode: false,
+            },
+        };
+        expect(sanitizeChallengeDetails(challengeDetails).game.handicap).toBe(5);
+        expect("komi" in sanitizeChallengeDetails(challengeDetails)).toBeFalsy();
+
+        challengeDetails.game.komi = "4.5";
+        expect(sanitizeChallengeDetails(challengeDetails).game.komi).toBe(4.5);
     });
 });

--- a/src/components/ChallengeModal/ChallengeModal.types.ts
+++ b/src/components/ChallengeModal/ChallengeModal.types.ts
@@ -102,7 +102,7 @@ export interface ChallengeModalConfig {
             rules: RuleSet;
             ranked: boolean;
             handicap: number;
-            komi_auto: string;
+            komi_auto: rest_api.KomiOption;
             disable_analysis: boolean;
             initial_state: GobanEngineInitialState | null;
             private: boolean;
@@ -151,12 +151,12 @@ export type ChallengeModalChallengeSettings = ChallengeDetails & {
     game: ChallengeModalGameSettings;
 };
 
-export type ChallengeModalDemoSettings = DataSchema["demo.settings"];
+export type DemoSettings = DataSchema["demo.settings"];
 
 export type ChallengeModalState = {
     challenge: ChallengeModalChallengeSettings;
     conf: ChallengeModalConf;
-    demo: ChallengeModalDemoSettings;
+    demo: DemoSettings;
     forking_game: boolean;
     hide_preferred_settings_on_portrait: boolean;
     preferred_settings: ChallengeDetails[];


### PR DESCRIPTION
Refactoring challenge modal continued

## Proposed Changes

  - extract utils function `getDefaultKomi`
  - add type guard for komi option
  - refactor update bindings for `komi_auto` (and remove string values for komi)
  - sanitize legacy komi values from local storage
  - add unit test for sanitize functions
  - rename type
