### PR TITLE
Put the "sign in to play" message in a visual frame (Card)

### DIFF
--- a/src/views/Play/QuickMatch.styl
+++ b/src/views/Play/QuickMatch.styl
@@ -58,7 +58,6 @@
         align-content: stretch;
         justify-content: space-between;
         align-items: center;
-
     }
 
     .boardSize-picker-list {
@@ -464,7 +463,7 @@
 
 .PlayButton-container {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     gap: 2rem;
 
     .anonymous-container {
@@ -472,10 +471,12 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        margin-top: 2rem;
+        margin-top: 3rem;
         margin-bottom: 2rem;
         font-size: 1.3rem;
-        width: 100%;
+        width: fit-content;
+        padding: 1rem 2rem 1rem 2rem;
+        max-width: max-content;
 
         .Link {
             margin-left: 0.5rem;

--- a/src/views/Play/QuickMatch.tsx
+++ b/src/views/Play/QuickMatch.tsx
@@ -45,6 +45,7 @@ import { SPEED_OPTIONS } from "./SPEED_OPTIONS";
 import { useHaveActiveGameSearch } from "./hooks";
 import { openPlayPageHelp } from "./PlayPageHelp";
 import { notification_manager, Notification } from "@/components/Notifications/NotificationManager";
+import { Card } from "@/components/material";
 
 moment.relativeTimeThreshold("m", 56);
 export interface SelectOption {
@@ -1158,14 +1159,14 @@ export function QuickMatch(): React.ReactElement {
                     </div>
                 )}
                 {user.anonymous && (
-                    <div className="anonymous-container">
+                    <Card className="anonymous-container">
                         {_("Please sign in to play")}
                         <div>
                             <Link to="/register#/play">{_("Register for Free")}</Link>
                             {" | "}
                             <Link to="/sign-in#/play">{_("Sign in")}</Link>
                         </div>
-                    </div>
+                    </Card>
                 )}
 
                 {!automatch_search_active && !user.anonymous && (


### PR DESCRIPTION
... for better tidiness on the Play page.

Fixes  words about please sign in kind of floating in a jumble on the page.

## Proposed Changes

  - Make the `anonymous-container` in QuickMatch be a Card, with suitable margins.
  