### PR TITLE
Fix clipped handicap menu

### DIFF
--- a/src/ogs.styl
+++ b/src/ogs.styl
@@ -63,6 +63,7 @@ z = {
         exit-zenmode   : 45,
         score-details  : 50,
     },
+    play-buttons       : 140,
     seek-graph: {
         challenge-list : 150,
     }

--- a/src/views/Play/QuickMatch.styl
+++ b/src/views/Play/QuickMatch.styl
@@ -58,7 +58,6 @@
         align-content: stretch;
         justify-content: space-between;
         align-items: center;
-
     }
 
     .boardSize-picker-list {
@@ -220,7 +219,7 @@
                 themed: background-color shade4;
             }
 
-            .DownCarret {
+            .DownCarret { // cspell:disable-line
                 display: inline-block;
                 float: right;
                 padding-left: 1.5rem;
@@ -389,6 +388,7 @@
         right: 0;
         width: 20rem;
         max-width: 90vw;
+        z-index: z.play-buttons + 1;
 
         .ogs-react-select__group-heading {
             text-transform: none;
@@ -555,7 +555,7 @@
         width: 100%;
         left: 0;
         right: 0;
-        z-index: z.dock;
+        z-index: z.play-buttons;
         themed: background-color, bg;
         gap: 1rem;
 


### PR DESCRIPTION
Gave the `play-buttons` their own z-index, made sure handicap menu is on top.

Fixes handicap menu being obscured by play buttons in mobile view.

## Proposed Changes

  - Give play buttons their own z-index, and put menu above it.
  