### PR TITLE
AI Detection Results page

### DIFF
--- a/e2e-tests/challenge-modal/ch-private-invite.ts
+++ b/e2e-tests/challenge-modal/ch-private-invite.ts
@@ -46,7 +46,7 @@ export const chPrivateInviteTest = async ({ browser }: { browser: Browser }) => 
     });
 
     // First test interactions without submitting
-    
+
     // Turn on private
     await fillOutStandardChallengeForm(
         challengerPage,
@@ -77,10 +77,10 @@ export const chPrivateInviteTest = async ({ browser }: { browser: Browser }) => 
     // Toggle invite only
     await fillOutStandardChallengeForm(
         challengerPage,
-    {
-        invite_only: true,
-    },
-    { fillWithDefaults: false }, // don't set any other values
+        {
+            invite_only: true,
+        },
+        { fillWithDefaults: false }, // don't set any other values
     );
 
     await checkChallengeForm(challengerPage, {
@@ -90,17 +90,16 @@ export const chPrivateInviteTest = async ({ browser }: { browser: Browser }) => 
         invite_only: true,
     });
 
-
     await expect(ranked_checkbox).toBeDisabled();
     await expect(rengo_checkbox).toBeDisabled();
 
     // Turn off private
     await fillOutStandardChallengeForm(
         challengerPage,
-    {
-        private: false,
-    },
-    { fillWithDefaults: false }, // don't set any other values
+        {
+            private: false,
+        },
+        { fillWithDefaults: false }, // don't set any other values
     );
 
     await checkChallengeForm(challengerPage, {
@@ -112,7 +111,7 @@ export const chPrivateInviteTest = async ({ browser }: { browser: Browser }) => 
 
     await expect(ranked_checkbox).toBeEnabled();
     await expect(rengo_checkbox).toBeEnabled();
-    await expect(auto_start_input).not.toBeVisible();   
+    await expect(auto_start_input).not.toBeVisible();
 
     // Now test POST payloads for the flags
     await testChallengePOSTPayload(challengerPage, {
@@ -127,17 +126,13 @@ export const chPrivateInviteTest = async ({ browser }: { browser: Browser }) => 
 
     await reloadChallengeModal(challengerPage);
 
-    await fillOutStandardChallengeForm(
-        
-        challengerPage,
-        {
-            gameName: "Private Match 2",
-            private: true,
-            rengo: false,
-            ranked: false,
-            invite_only: true,
-        },
-    );
+    await fillOutStandardChallengeForm(challengerPage, {
+        gameName: "Private Match 2",
+        private: true,
+        rengo: false,
+        ranked: false,
+        invite_only: true,
+    });
 
     await checkChallengeForm(challengerPage, {
         rengo: false,
@@ -158,16 +153,13 @@ export const chPrivateInviteTest = async ({ browser }: { browser: Browser }) => 
 
     await reloadChallengeModal(challengerPage);
 
-    await fillOutStandardChallengeForm(
-        challengerPage,
-        {
-            gameName: "Private Match 3",
-            private: true,
-            rengo: false,
-            ranked: false,
-            invite_only: false,
-        },
-    );
+    await fillOutStandardChallengeForm(challengerPage, {
+        gameName: "Private Match 3",
+        private: true,
+        rengo: false,
+        ranked: false,
+        invite_only: false,
+    });
 
     await checkChallengeForm(challengerPage, {
         gameName: "Private Match 3",
@@ -186,5 +178,4 @@ export const chPrivateInviteTest = async ({ browser }: { browser: Browser }) => 
             ranked: false,
         },
     });
-    
 };

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -43,6 +43,7 @@ import { logout } from "@/lib/auth";
 import { useUser, useData } from "@/lib/hooks";
 import { OmniSearch } from "./OmniSearch";
 import { forwardRef, useId, useState } from "react";
+import { MODERATOR_POWERS } from "@/lib/moderation";
 
 const body = document.body;
 
@@ -359,6 +360,14 @@ export function NavBar(): React.ReactElement {
                                 icon={<i className="fa fa-exclamation-triangle" />}
                             />
 
+                            {(user.is_moderator ||
+                                (user.moderator_powers && MODERATOR_POWERS.AI_DETECTOR)) && (
+                                <MenuLink
+                                    title={_("AI Detection")}
+                                    to="/ai-detection"
+                                    icon={<i className="fa fa-search" />}
+                                />
+                            )}
                             {user.is_moderator && (
                                 <MenuLink
                                     title={_("Moderator Center")}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -359,15 +359,6 @@ export function NavBar(): React.ReactElement {
                                 to="/reports-center"
                                 icon={<i className="fa fa-exclamation-triangle" />}
                             />
-
-                            {(user.is_moderator ||
-                                (user.moderator_powers && MODERATOR_POWERS.AI_DETECTOR)) && (
-                                <MenuLink
-                                    title={_("AI Detection")}
-                                    to="/ai-detection"
-                                    icon={<i className="fa fa-search" />}
-                                />
-                            )}
                             {user.is_moderator && (
                                 <MenuLink
                                     title={_("Moderator Center")}
@@ -380,6 +371,14 @@ export function NavBar(): React.ReactElement {
                                     title={_("Appeals Center")}
                                     to="/appeals-center"
                                     icon={<i className="fa fa-gavel" />}
+                                />
+                            )}
+                            {(user.is_moderator ||
+                                (user.moderator_powers & MODERATOR_POWERS.AI_DETECTOR) !== 0) && (
+                                <MenuLink
+                                    title={_("AI Detection")}
+                                    to="/ai-detection"
+                                    icon={<i className="fa fa-search" />}
                                 />
                             )}
                             {user.is_moderator && (

--- a/src/models/games.d.ts
+++ b/src/models/games.d.ts
@@ -225,11 +225,44 @@ declare namespace rest_api {
         handicap_out_of_range?: boolean;
     }
 
+    interface AIReviewParams {
+        network_size: string;
+        strength: number;
+        type: "fast" | "full";
+    }
+
+    interface BotDetectionResults {
+        // Parameters of the AI review used for detection
+        ai_review_params: AIReviewParams;
+
+        // List of player IDs suspected of using AI/bots
+        ai_suspected: number[];
+
+        // Composite scores for both players
+        black_composite: number;
+        white_composite: number;
+
+        // List of reasons why the game was flagged for analysis
+        fast_pass_flagged_for: string[];
+
+        // Per-player detailed analysis
+        [playerId: number]: {
+            color: "black" | "white";
+            blur_rate: number; // Rate of moves that are "blurry"
+            has_sgf_downloads: boolean; // Whether the player downloaded the SGF
+            timing_consistency: number; // Measure of move timing consistency
+            AILR: number; // AI Likelihood Ratio
+            composite: number; // Overall composite score
+            average_point_loss: number; // Average point loss per move
+        };
+    }
+
     /**
      * The response from `games/%game_id%`
      */
+
     interface GameDetails extends GameBase {
-        bot_detection_results: null | Record<string, any>;
+        bot_detection_results: null | BotDetectionResults;
         related: {
             reviews: string; // route to reviews
         };
@@ -239,6 +272,15 @@ declare namespace rest_api {
         flags: null | {
             [player_id: string]: GamePlayerFlags;
         };
+    }
+
+    interface GameAIDetection {
+        game_id: number;
+        players: {
+            black: games.Player;
+            white: games.Player;
+        };
+        bot_detection_results: null | BotDetectionResults;
     }
 
     namespace players.full {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -85,7 +85,7 @@ import * as docs from "@/views/docs";
 import { useData } from "./lib/hooks";
 import { MainSection } from "@/components/MainSection";
 import { AccessibilityMenu } from "@/components/AccessibilityMenu";
-
+import { AIDetection } from "@/views/AIDetection";
 /*** Layout our main view and routes ***/
 function AppLayout(props: { children: any }): React.ReactElement {
     const [user] = useData("config.user");
@@ -238,6 +238,7 @@ export const routes = (
                 <Route path="/appeal/:player_id" element={<Appeal />} />
                 <Route path="/appeal" element={<Appeal />} />
                 <Route path="/appeals-center" element={<AppealsCenter />} />
+                <Route path="/ai-detection" element={<AIDetection />} />
                 <Route path="/reports-center/:category/:report_id" element={<ReportsCenter />} />
                 <Route path="/reports-center/:category" element={<ReportsCenter />} />
                 <Route path="/reports-center" element={<ReportsCenter />} />

--- a/src/views/AIDetection/AIDetection.styl
+++ b/src/views/AIDetection/AIDetection.styl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#AI-Detection {
+    width: 100vw;
+    max-width: 60rem;
+    margin: 0 auto;
+
+    h1 {
+        display: flex;
+        justify-content: space-between;
+
+        label {
+            font-size: 1.2rem;
+        }
+    }
+}

--- a/src/views/AIDetection/AIDetection.tsx
+++ b/src/views/AIDetection/AIDetection.tsx
@@ -16,9 +16,12 @@
  */
 
 import * as React from "react";
-
+import { _ } from "@/lib/translate";
+import { Player } from "@/components/Player";
 import * as data from "@/lib/data";
 import { MODERATOR_POWERS } from "@/lib/moderation";
+import { PaginatedTable } from "@/components/PaginatedTable";
+import { ReviewStrengthIcon } from "@/views/Game/AIReview";
 //import { alert } from "@/lib/swal_config";
 
 export function AIDetection(): React.ReactElement | null {
@@ -31,6 +34,145 @@ export function AIDetection(): React.ReactElement | null {
     return (
         <div id="AI-Detection">
             <h1>AI Detection</h1>
+            <PaginatedTable
+                name="ai-detection"
+                className="ai-detection"
+                source="games/ai_detection"
+                columns={[
+                    {
+                        header: _("Game"),
+                        render: (row) => (
+                            // Inline styles to avoid messing with Player and ReviewStrengthIcon styles globally
+                            <span
+                                style={{
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    gap: "0.5rem",
+                                }}
+                            >
+                                <a
+                                    href={`/game/${row.id}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    #{row.id}
+                                </a>
+
+                                {row.bot_detection_results?.ai_review_params && (
+                                    <ReviewStrengthIcon
+                                        review={row.bot_detection_results.ai_review_params}
+                                    />
+                                )}
+                                {!row.bot_detection_results?.ai_review_params && (
+                                    <i className="fa fa-question-circle" />
+                                )}
+                            </span>
+                        ),
+                    },
+                    {
+                        header: _("Black"),
+                        render: (row) => (
+                            <>
+                                <Player user={row.players.black} />
+                                {row.bot_detection_results?.ai_suspected?.includes(
+                                    row.players.black.id,
+                                ) && (
+                                    <i
+                                        className="fa fa-flag"
+                                        style={{ marginLeft: "0.5em", color: "red" }}
+                                    />
+                                )}
+                                {row.bot_detection_results?.black_composite != null && (
+                                    <span
+                                        style={{ marginLeft: "0.5em", color: "#666" }}
+                                        title="AI Detection composite score"
+                                    >
+                                        <i className="fa fa-calculator" />
+                                        {row.bot_detection_results.black_composite.toFixed(2)}
+                                    </span>
+                                )}
+                                {row.bot_detection_results?.[row.players.black.id]
+                                    ?.average_point_loss != null && (
+                                    <span
+                                        style={{ marginLeft: "0.5em", color: "#666" }}
+                                        title="Average point loss per move"
+                                    >
+                                        <i className="fa fa-arrow-circle-down" />
+                                        {row.bot_detection_results[
+                                            row.players.black.id
+                                        ].average_point_loss.toFixed(2)}
+                                    </span>
+                                )}
+                                {row.bot_detection_results?.[row.players.black.id]?.blur_rate !=
+                                    null && (
+                                    <span
+                                        style={{ marginLeft: "0.5em", color: "#666" }}
+                                        title="Blur rate"
+                                    >
+                                        <i className="fa fa-window-restore" />
+                                        {Math.round(
+                                            row.bot_detection_results[row.players.black.id]
+                                                .blur_rate,
+                                        )}
+                                        %
+                                    </span>
+                                )}
+                            </>
+                        ),
+                    },
+                    {
+                        header: _("White"),
+                        render: (row) => (
+                            <span style={{ display: "inline-flex", alignItems: "center" }}>
+                                <Player user={row.players.white} />
+
+                                {row.bot_detection_results?.ai_suspected?.includes(
+                                    row.players.white.id,
+                                ) && (
+                                    <i
+                                        className="fa fa-flag"
+                                        style={{ marginLeft: "0.5em", color: "red" }}
+                                    />
+                                )}
+                                {row.bot_detection_results?.white_composite != null && (
+                                    <span
+                                        style={{ marginLeft: "0.5em", color: "#666" }}
+                                        title="AI Detection composite score"
+                                    >
+                                        <i className="fa fa-calculator" />
+                                        {row.bot_detection_results.white_composite.toFixed(2)}
+                                    </span>
+                                )}
+                                {row.bot_detection_results?.[row.players.white.id]
+                                    ?.average_point_loss != null && (
+                                    <span
+                                        style={{ marginLeft: "0.5em", color: "#666" }}
+                                        title="Average point loss per move"
+                                    >
+                                        <i className="fa fa-arrow-circle-down" />
+                                        {(-row.bot_detection_results[row.players.white.id]
+                                            .average_point_loss).toFixed(2)}
+                                    </span>
+                                )}
+                                {row.bot_detection_results?.[row.players.white.id]?.blur_rate !=
+                                    null && (
+                                    <span
+                                        style={{ marginLeft: "0.5em", color: "#666" }}
+                                        title="Window blur rate - percentage of time spent with window not in focus"
+                                    >
+                                        <i className="fa fa-window-restore" />
+                                        {Math.round(
+                                            row.bot_detection_results[row.players.white.id]
+                                                .blur_rate,
+                                        )}
+                                        %
+                                    </span>
+                                )}
+                            </span>
+                        ),
+                    },
+                ]}
+            />
         </div>
     );
 }

--- a/src/views/AIDetection/AIDetection.tsx
+++ b/src/views/AIDetection/AIDetection.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import * as data from "@/lib/data";
+import { MODERATOR_POWERS } from "@/lib/moderation";
+//import { alert } from "@/lib/swal_config";
+
+export function AIDetection(): React.ReactElement | null {
+    const user = data.get("user");
+
+    if (!user.is_moderator && (user.moderator_powers & MODERATOR_POWERS.AI_DETECTOR) === 0) {
+        return null;
+    }
+
+    return (
+        <div id="AI-Detection">
+            <h1>AI Detection</h1>
+        </div>
+    );
+}

--- a/src/views/AIDetection/index.ts
+++ b/src/views/AIDetection/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./AIDetection";

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1791,7 +1791,11 @@ function sanityCheck(ai_review: JGOFAIReview) {
 function isEqualMoveIntersection(a: JGOFIntersection, b: JGOFIntersection): boolean {
     return a.x === b.x && a.y === b.y;
 }
-function ReviewStrengthIcon({ review }: { review: JGOFAIReview }): React.ReactElement {
+export function ReviewStrengthIcon({
+    review,
+}: {
+    review: JGOFAIReview | rest_api.AIReviewParams;
+}): React.ReactElement {
     let strength: string;
     let content = "";
     if (review.type === "fast") {


### PR DESCRIPTION
Fixes AI detection enthusiasts complaining that they don't have data to work with

## Proposed Changes

  - Add a "Tools" page that lists recent games' AI detection results summary
  
This is a "very first pass" to see what might be useful and how to present it.

Needs https://github.com/online-go/ogs/pull/2064

(Just shows nothing without it).
