### PR TITLE
Add a test for cm voting to warn about bad AI reports

### DIFF
--- a/e2e-tests/cm/cm-vote-warn-not-ai.ts
+++ b/e2e-tests/cm/cm-vote-warn-not-ai.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// cspell:words VWNAI
+
+/*
+ * Uses init_e2e data:
+ * - E2E_CM_VWNAI_ACCUSED : user supposedly used AI
+ * - "E2E CM VWNAI Game" : game in which the AI use supposedly occurred
+ * - E2E_CM_VWNAI_AI_V1, E2E_CM_VWNAI_AI_V2, E2E_CM_VWNAI_AI_V3 : AI assessors who vote
+ */
+
+import { Browser, TestInfo } from "@playwright/test";
+
+import {
+    assertIncidentReportIndicatorActive,
+    assertIncidentReportIndicatorInactive,
+    goToUsersGame,
+    newTestUsername,
+    prepareNewUser,
+    reportUser,
+    setupSeededCM,
+} from "@helpers/user-utils";
+
+import { expectOGSClickableByName } from "@helpers/matchers";
+import { expect } from "@playwright/test";
+
+import { withIncidentIndicatorLock } from "@helpers/report-utils";
+
+export const cmVoteWarnNotAITest = async (
+    { browser }: { browser: Browser },
+    testInfo: TestInfo,
+) => {
+    await withIncidentIndicatorLock(testInfo, async () => {
+        const { userPage: reporterPage } = await prepareNewUser(
+            browser,
+            newTestUsername("CmVWNAIRep"), // cspell:disable-line
+            "test",
+        );
+
+        // Report someone for AI use
+        await goToUsersGame(reporterPage, "E2E_CM_VWNAI_ACCUSED", "E2E CM VWNAI Game");
+
+        await reportUser(
+            reporterPage,
+            "E2E_CM_VWNAI_ACCUSED",
+            "ai_use",
+            "E2E test reporting AI use: I just have this feeling.", // min 40 chars
+        );
+
+        // Vote to warn the reporter that it was not a good AI report
+
+        const aiAssessors = ["E2E_CM_VWNAI_AI_V1", "E2E_CM_VWNAI_AI_V2", "E2E_CM_VWNAI_AI_V3"];
+
+        const aiAssessorContexts = [];
+        for (const aiUser of aiAssessors) {
+            const { seededCMPage: aiCMPage, seededCMContext: aiContext } = await setupSeededCM(
+                browser,
+                aiUser,
+            );
+
+            aiAssessorContexts.push({ aiCMPage, aiContext }); // keep them alive for the duration of the test
+
+            const indicator = await assertIncidentReportIndicatorActive(aiCMPage, 1);
+
+            await indicator.click();
+
+            await expect(aiCMPage.getByRole("heading", { name: "Reports Center" })).toBeVisible();
+
+            await expect(
+                aiCMPage.getByText("E2E test reporting AI use: I just have this feeling."),
+            ).toBeVisible();
+
+            // Select the definite AI option...
+            await aiCMPage.locator('.action-selector input[type="radio"]').nth(3).click();
+
+            const voteButton = await expectOGSClickableByName(aiCMPage, /Vote$/);
+            await voteButton.click();
+        }
+
+        // The report should no longer be active
+        await assertIncidentReportIndicatorInactive(aiAssessorContexts[0].aiCMPage);
+    });
+};

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -20,9 +20,11 @@ import { ogsTest } from "@helpers";
 import { cmDontNotifyEscalatedAiTest } from "./cm-dont-notify-escalated-ai";
 import { cmVoteOnOwnReportTest } from "./cm-vote-on-own-report";
 import { cmShowOnlyPostEscalationVotesTest } from "./cm-show-only-post-escalation-votes";
+import { cmVoteWarnNotAITest } from "./cm-vote-warn-not-ai";
 
 ogsTest.describe("@CM Community Moderation Tests", () => {
     ogsTest("CM should be able to vote on their own report", cmVoteOnOwnReportTest);
     ogsTest("We should not notify escalated AI reports", cmDontNotifyEscalatedAiTest);
     ogsTest("We should show only post-escalation votes", cmShowOnlyPostEscalationVotesTest);
+    ogsTest("We should warn when an AI report is unfounded", cmVoteWarnNotAITest);
 });


### PR DESCRIPTION
Fixes not having a specific test to about "warnings get issued from voting"

## Proposed Changes

  - Add a test that makes sure a warning is successfully voted.
  
 ( TBD: a separate E2E test, or extend this one, to check the warning is issued to the player )

Needs: https://github.com/online-go/ogs/pull/2068 for seed data before it can be run in beta.

Is not part of smoke test e2e.

