### PR TITLE
Say "Report System Messages" for the section that contains these.

### DIFF
--- a/e2e-tests/smoke/smoketests.spec.ts-snapshots/profile-page-chromium-linux.png
+++ b/e2e-tests/smoke/smoketests.spec.ts-snapshots/profile-page-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a40ac45472fb38a7d37fef7027366c98b7bb6ac6955534189eae3e66c31c92f
-size 86492
+oid sha256:627137480640ba40e00c31e5b97bd00dfb5201a5ca3b574e4281874d09b7758e
+size 87259

--- a/src/views/User/ActivityCard.tsx
+++ b/src/views/User/ActivityCard.tsx
@@ -169,7 +169,10 @@ export function ActivityCard({
                 <div className="WarningSystemMessage-container">
                     <div className="warning-system-messages-header">
                         <h4 className="warning-system-messages-title">
-                            {_("Warning System Messages")}
+                            {pgettext(
+                                "The title of the report system messages section",
+                                "Report System Messages",
+                            )}
                         </h4>
                         <label className="warning-system-messages-toggle">
                             {_("Show already acknowledged")}


### PR DESCRIPTION
Fixes confusing language about what is an "acknowledgement"

## Proposed Changes

  - Use "Report System Messages" as the title of the thing that contains warnings and acks, rather than "Warning System Messages"
  
