### PR TITLE
Pass the actual state of the report out to where we'd like it

### DIFF
--- a/src/views/ReportsCenter/ReportsViewer.tsx
+++ b/src/views/ReportsCenter/ReportsViewer.tsx
@@ -15,7 +15,7 @@ import { report_manager } from "@/lib/report_manager";
 import { _, pgettext } from "@/lib/translate";
 import * as DynamicHelp from "react-dynamic-help";
 
-import { ViewReport } from "@/views/ReportsCenter/ViewReport";
+import { ViewReport, ReportState } from "@/views/ReportsCenter/ViewReport";
 
 interface ViewReportHeaderProps {
     reports: ReportNotification[];
@@ -31,6 +31,8 @@ export function ModeratorReportsViewer({
     report_id,
     selectReport,
 }: ViewReportHeaderProps): React.ReactElement {
+    const [resolved, setResolved] = React.useState<boolean>(false);
+
     const current_report = reports.find((r) => r.id === report_id);
 
     const next = () => {
@@ -47,6 +49,10 @@ export function ModeratorReportsViewer({
         if (currentIndex > 0) {
             selectReport(reports[currentIndex - 1].id);
         }
+    };
+
+    const updateReportState = (report_state: ReportState) => {
+        setResolved(report_state === "resolved");
     };
 
     if (report_id === 0) {
@@ -74,9 +80,19 @@ export function ModeratorReportsViewer({
                     prev={prev}
                     next={next}
                 />
+
+                {resolved && (
+                    <span className="resolved-report-label">
+                        {pgettext("A label telling moderators the report is resolved", "Resolved")}
+                    </span>
+                )}
             </div>
 
-            <ViewReport report_id={report_id} advanceToNextReport={next} />
+            <ViewReport
+                report_id={report_id}
+                advanceToNextReport={next}
+                onReportState={updateReportState}
+            />
         </div>
     );
 }
@@ -149,10 +165,6 @@ function ReportChooser({ report_id, current_report, reports, prev, next }: Repor
 
     const currentIndex = reports.findIndex((r) => r.id === report_id);
 
-    // assumption here is that if it's not in reports then it's resolved - at least from
-    // the perspective of the current user.
-    const resolved = currentIndex === -1 || reports[currentIndex]?.state === "resolved";
-
     const hasPrev = currentIndex > 0;
     const hasNext = currentIndex + 1 < reports.length;
 
@@ -206,11 +218,6 @@ function ReportChooser({ report_id, current_report, reports, prev, next }: Repor
                 >
                     Ignore
                 </button>
-            )}
-            {resolved && (
-                <span className="resolved-report-label">
-                    {pgettext("A label telling moderators the report is resolved", "Resolved")}
-                </span>
             )}
         </span>
     );

--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -49,14 +49,18 @@ import { useEffect } from "react";
 type ReportDetail = rest_api.moderation.ReportDetail;
 type CommunityModerationAction = rest_api.moderation.CommunityModerationAction;
 
+export type ReportState = "resolved" | "pending" | "claimed"; // SeverToClient.ts
+
 interface ViewReportProps {
     report_id: number;
     advanceToNextReport: () => void;
+    onReportState: (report_state: ReportState) => void;
 }
 
 export function ViewReport({
     report_id,
     advanceToNextReport,
+    onReportState,
 }: ViewReportProps): React.ReactElement {
     const user = useUser();
     const [report, setReport] = React.useState<ReportDetail | null>(null);
@@ -99,6 +103,7 @@ export function ViewReport({
         setReport(report);
         setUsersVote(report?.voters?.find((v) => v.voter_id === user.id)?.action ?? null);
         setModeratorId(report?.moderator?.id ?? null);
+        onReportState(report.state as ReportState);
     };
 
     const fetchAndUpdateReport = async (reportId: number) => {


### PR DESCRIPTION
… instead of trying to deduce it

Fixes slightly strange labelling of "resolved"

## Proposed Changes

  - Pass the actual state of the report out to where we'd like it displayed, once we've fetched it.
  
  
