### PR TITLE
Make only warning block games

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,7 @@
     "words": [
         "abcdefghjklmnopqrstuvwxyz",
         "Acked",
+        "acks",
         "AFAICT",
         "AILR",
         "aireview",

--- a/e2e-tests/cm/cm-ack-ack.ts
+++ b/e2e-tests/cm/cm-ack-ack.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// cspell:words AA
+
+/*
+ * Uses init_e2e data:
+ * - E2E_CM_AA_ACCUSED : user supposedly score cheated
+ * - "E2E CM AA Game" : game in which the score cheat supposedly occurred
+ * - E2E_CM_AA_V1, E2E_CM_AA_V2, E2E_CM_AA_V3 : assessors who vote
+ */
+
+import { Browser, TestInfo } from "@playwright/test";
+
+import {
+    assertIncidentReportIndicatorActive,
+    assertIncidentReportIndicatorInactive,
+    goToUsersGame,
+    newTestUsername,
+    prepareNewUser,
+    reportUser,
+    setupSeededCM,
+} from "@helpers/user-utils";
+
+import { expectOGSClickableByName } from "@helpers/matchers";
+import { expect } from "@playwright/test";
+
+import { withIncidentIndicatorLock } from "@helpers/report-utils";
+
+export const cmAckAcknowledgementTest = async (
+    { browser }: { browser: Browser },
+    testInfo: TestInfo,
+) => {
+    await withIncidentIndicatorLock(testInfo, async () => {
+        const { userPage: reporterPage } = await prepareNewUser(
+            browser,
+            newTestUsername("CmAAReporter"), // cspell:disable-line
+            "test",
+        );
+
+        // Report someone for score cheating
+        await goToUsersGame(reporterPage, "E2E_CM_AA_ACCUSED", "E2E CM AA Game");
+
+        await reportUser(reporterPage, "E2E_CM_AA_ACCUSED", "score_cheating", "he's a cheater!");
+
+        // Vote to tell the reporter that there's no score cheating
+
+        const cmAssessors = ["E2E_CM_AA_V1", "E2E_CM_AA_V2", "E2E_CM_AA_V3"];
+
+        const cmAssessorContexts = [];
+        for (const cmUser of cmAssessors) {
+            const { seededCMPage: cmPage, seededCMContext: cmContext } = await setupSeededCM(
+                browser,
+                cmUser,
+            );
+
+            cmAssessorContexts.push({ CMPage: cmPage, cmContext }); // keep them alive for the duration of the test
+
+            const indicator = await assertIncidentReportIndicatorActive(cmPage, 1);
+
+            await indicator.click();
+
+            await expect(cmPage.getByRole("heading", { name: "Reports Center" })).toBeVisible();
+
+            await expect(cmPage.getByText("he's a cheater!")).toBeVisible();
+
+            // Select the no cheating...
+            await cmPage.locator('.action-selector input[type="radio"]').nth(2).click();
+
+            const voteButton = await expectOGSClickableByName(cmPage, /Vote$/);
+            await voteButton.click();
+        }
+
+        // The report should no longer be active
+        await assertIncidentReportIndicatorInactive(cmAssessorContexts[0].CMPage);
+
+        // The reporter should see an acknowledgement
+        await reporterPage.goto("/");
+
+        await expect(reporterPage.locator("div.AccountWarningAck")).toBeVisible();
+
+        await expect(
+            reporterPage
+                .locator("div.AccountWarningAck")
+                .locator("div.canned-message.no_score_cheating_evident"),
+        ).toBeVisible();
+
+        let okButton = reporterPage.locator("div.AccountWarningAck").locator("button.primary");
+        await expect(okButton).toBeVisible();
+        await expect(okButton).toBeEnabled(); // acks are enabled immediately
+
+        // Since its an acknowledgement, they _should_ be able to play
+        await reporterPage.goto("/play");
+
+        const playComputerButton = reporterPage.locator("button.play-button", {
+            hasText: "Play Computer",
+        });
+        await expect(playComputerButton).toBeEnabled();
+
+        const playHumanButton = reporterPage.locator("button.play-button", {
+            hasText: "Play Human",
+        });
+        await expect(playHumanButton).toBeEnabled();
+
+        // The message got reloaded when we went to /play
+
+        okButton = reporterPage.locator("div.AccountWarningAck").locator("button.primary");
+        await expect(okButton).toBeVisible();
+        await expect(okButton).toBeEnabled();
+
+        await okButton.click();
+
+        await expect(reporterPage.locator("div.AccountWarningAck")).not.toBeVisible();
+
+        // And play of course
+        await expect(playComputerButton).toBeVisible();
+        await expect(playHumanButton).toBeVisible();
+        await expect(playComputerButton).toBeEnabled();
+        await expect(playHumanButton).toBeEnabled();
+    });
+};

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -21,10 +21,14 @@ import { cmDontNotifyEscalatedAiTest } from "./cm-dont-notify-escalated-ai";
 import { cmVoteOnOwnReportTest } from "./cm-vote-on-own-report";
 import { cmShowOnlyPostEscalationVotesTest } from "./cm-show-only-post-escalation-votes";
 import { cmVoteWarnNotAITest } from "./cm-vote-warn-not-ai";
+import { cmAckWarningTest } from "./cm-ack-warning";
+import { cmAckAcknowledgementTest } from "./cm-ack-ack";
 
 ogsTest.describe("@CM Community Moderation Tests", () => {
     ogsTest("CM should be able to vote on their own report", cmVoteOnOwnReportTest);
     ogsTest("We should not notify escalated AI reports", cmDontNotifyEscalatedAiTest);
     ogsTest("We should show only post-escalation votes", cmShowOnlyPostEscalationVotesTest);
     ogsTest("We should warn when an AI report is unfounded", cmVoteWarnNotAITest);
+    ogsTest("We should be able to acknowledge warnings", cmAckWarningTest);
+    ogsTest("We should be able to acknowledge acknowledgements", cmAckAcknowledgementTest);
 });

--- a/e2e-tests/moderation/moderation.spec.ts
+++ b/e2e-tests/moderation/moderation.spec.ts
@@ -22,7 +22,6 @@ import { modWarnFirstTurnDisconnectorTest } from "./mod-auto-warn-first-turn-dis
 import { modDontAutoWarnBlitzTest } from "./mod-dont-auto-warn-first-turn-blitz";
 import { modBlockEarlyEscapeReportTest } from "./mod-block-early-escape-report";
 import { modBlockEarlyStallingReportTest } from "./mod-block-early-stall-report";
-import { modAckWarningTest } from "./mod-ack-warning";
 
 ogsTest.describe("@Mod Moderation Tests", () => {
     ogsTest("@Slow We should warn first turn disconnectors", modWarnFirstTurnDisconnectorTest);
@@ -30,5 +29,4 @@ ogsTest.describe("@Mod Moderation Tests", () => {
     ogsTest("@Slow We should warn first turn escapers", modWarnFirstTurnEscapersTest);
     ogsTest("We should block early escape reports", modBlockEarlyEscapeReportTest);
     ogsTest("We should block early stalling reports", modBlockEarlyStallingReportTest);
-    ogsTest("We should be able to acknowledge warnings", modAckWarningTest);
 });

--- a/src/components/AccountWarning/AccountWarning.tsx
+++ b/src/components/AccountWarning/AccountWarning.tsx
@@ -29,6 +29,7 @@ import { CANNED_MESSAGES } from "./CannedMessages";
 
 const BUTTON_COUNTDOWN_TIME = 10000; // ms;
 
+// This is now better called  "Report System Messages", because it has acks as well as warnings.
 export function AccountWarning() {
     const user = useUser();
     const location = useLocation();
@@ -43,7 +44,7 @@ export function AccountWarning() {
         mainGoban.engine.time_control.speed !== "correspondence";
 
     React.useEffect(() => {
-        if (user && !user.anonymous && user.has_active_warning_flag) {
+        if (user && !user.anonymous && user.has_pending_warnings_system_message) {
             get("me/warning")
                 .then((warning) => {
                     console.log(warning);
@@ -59,7 +60,7 @@ export function AccountWarning() {
         } else {
             setWarning(null);
         }
-    }, [user, user?.has_active_warning_flag]);
+    }, [user, user?.has_pending_warnings_system_message]);
 
     // If a live game is in progress, we'll need to check back later to see if it has
     // finished so we can display the warning...
@@ -86,7 +87,7 @@ export function AccountWarning() {
         return null;
     }
 
-    if (!user || user.anonymous || !user.has_active_warning_flag) {
+    if (!user || user.anonymous || !user.has_pending_warnings_system_message) {
         return null;
     }
 

--- a/src/models/user.d.ts
+++ b/src/models/user.d.ts
@@ -84,6 +84,7 @@ declare namespace rest_api {
         email_validated: boolean | string; // VerifyEmail sets this to a Date string
         is_announcer: boolean;
         has_active_warning_flag?: boolean;
+        has_pending_warnings_system_message?: boolean;
         reports_handled_today?: number;
         last_supporter_trial: string; // Date
     }
@@ -225,7 +226,6 @@ declare namespace rest_api {
         aga_id: null;
         ui_class: string;
         icon: string;
-        has_active_warning_flag?: boolean;
     }
 
     interface MinimalPlayerDetail {


### PR DESCRIPTION
Fixes dubious logic that was blocking users from playing games if they have an outstanding ack message.

Theoretically should have been OK, but better not to have that logic.

## Proposed Changes

  - Use the new `has_pending_warning_system_message` flag to display acks and warnings
  - Use the rescoped has_active_warnings to block the "play a game" buttons (no change)
  - Adds e2e test to make sure the buttons are blocked for warnings and not for acks.

** Needs https://github.com/online-go/ogs/pull/2073  (breaking).

Note that this is transparent to mobile apps: they use the existing has_active_warnings flag, and that will continue to work.

The only change for mobile aps would be that mobile apps that don't update to use the new flag will not display "acks".   I doubt if any do that anyhow, and since acks now are not blocking, it doesn't adversely impact the users.