### PR TITLE
Filter ai detection by player

### DIFF
--- a/src/views/AIDetection/AIDetection.styl
+++ b/src/views/AIDetection/AIDetection.styl
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #AI-Detection {
-    width: 100vw;
-    max-width: 60rem;
+    width: 90vw;
+
     margin: 0 auto;
 
     h1 {

--- a/src/views/AIDetection/AIDetection.tsx
+++ b/src/views/AIDetection/AIDetection.tsx
@@ -22,10 +22,12 @@ import * as data from "@/lib/data";
 import { MODERATOR_POWERS } from "@/lib/moderation";
 import { PaginatedTable } from "@/components/PaginatedTable";
 import { ReviewStrengthIcon } from "@/views/Game/AIReview";
+import { PlayerAutocomplete } from "@/components/PlayerAutocomplete";
 //import { alert } from "@/lib/swal_config";
 
 export function AIDetection(): React.ReactElement | null {
     const user = data.get("user");
+    const [player_filter, setPlayerFilter] = React.useState<number>();
 
     if (!user.is_moderator && (user.moderator_powers & MODERATOR_POWERS.AI_DETECTOR) === 0) {
         return null;
@@ -36,11 +38,29 @@ export function AIDetection(): React.ReactElement | null {
     return (
         <div id="AI-Detection">
             <h1>AI Detection</h1>
+            <div className="game-options">
+                <div
+                    className="search"
+                    style={{ display: "flex", alignItems: "center", paddingBottom: "0.5rem" }}
+                >
+                    <i className="fa fa-search"></i>
+                    <PlayerAutocomplete
+                        onComplete={(player) => {
+                            setPlayerFilter(player?.id);
+                        }}
+                    />
+                </div>
+            </div>
             <PaginatedTable
                 name="ai-detection"
                 className="ai-detection"
                 source="games/ai_detection"
                 pageSizeOptions={[10, 25, 50, 100]}
+                filter={{
+                    ...(player_filter !== undefined && {
+                        player: player_filter,
+                    }),
+                }}
                 columns={[
                     {
                         header: _("Game"),

--- a/src/views/AIDetection/AIDetection.tsx
+++ b/src/views/AIDetection/AIDetection.tsx
@@ -31,6 +31,8 @@ export function AIDetection(): React.ReactElement | null {
         return null;
     }
 
+    const hide_bad_data = true;
+
     return (
         <div id="AI-Detection">
             <h1>AI Detection</h1>
@@ -38,11 +40,11 @@ export function AIDetection(): React.ReactElement | null {
                 name="ai-detection"
                 className="ai-detection"
                 source="games/ai_detection"
+                pageSizeOptions={[10, 25, 50, 100]}
                 columns={[
                     {
                         header: _("Game"),
                         render: (row: rest_api.GameAIDetection) => (
-                            // Inline styles to avoid messing with Player and ReviewStrengthIcon styles globally
                             <span
                                 style={{
                                     display: "inline-flex",
@@ -81,105 +83,180 @@ export function AIDetection(): React.ReactElement | null {
                     },
                     {
                         header: _("Black"),
+                        render: (row) => <Player user={row.players.black} />,
+                    },
+                    {
+                        header: _("APL"),
+                        render: (row) =>
+                            row.bot_detection_results?.[row.players.black.id]?.average_point_loss !=
+                            null ? (
+                                <span title="Average point loss per move">
+                                    {row.bot_detection_results[
+                                        row.players.black.id
+                                    ].average_point_loss.toFixed(2)}
+                                </span>
+                            ) : null,
+                    },
+                    {
+                        header: _("Blur"),
+                        render: (row) =>
+                            row.bot_detection_results?.[row.players.black.id]?.blur_rate != null ? (
+                                <span title="Window blur rate - percentage of time spent with window not in focus">
+                                    {Math.round(
+                                        row.bot_detection_results[row.players.black.id].blur_rate,
+                                    )}
+                                    %
+                                </span>
+                            ) : null,
+                    },
+                    {
+                        header: _("SGF"),
                         render: (row) => (
-                            <>
-                                <Player user={row.players.black} />
-                                {row.bot_detection_results?.ai_suspected?.includes(
-                                    row.players.black.id,
-                                ) && (
-                                    <i
-                                        className="fa fa-flag"
-                                        style={{ marginLeft: "0.5em", color: "red" }}
-                                    />
-                                )}
-                                {row.bot_detection_results?.black_composite != null && (
-                                    <span
-                                        style={{ marginLeft: "0.5em", color: "#666" }}
-                                        title="AI Detection composite score"
-                                    >
-                                        <i className="fa fa-calculator" />
-                                        {row.bot_detection_results.black_composite.toFixed(2)}
-                                    </span>
-                                )}
+                            <span title="SGF downloads">
                                 {row.bot_detection_results?.[row.players.black.id]
-                                    ?.average_point_loss != null && (
-                                    <span
-                                        style={{ marginLeft: "0.5em", color: "#666" }}
-                                        title="Average point loss per move"
-                                    >
-                                        <i className="fa fa-arrow-circle-down" />
-                                        {row.bot_detection_results[
-                                            row.players.black.id
-                                        ].average_point_loss.toFixed(2)}
-                                    </span>
-                                )}
-                                {row.bot_detection_results?.[row.players.black.id]?.blur_rate !=
-                                    null && (
-                                    <span
-                                        style={{ marginLeft: "0.5em", color: "#666" }}
-                                        title="Blur rate"
-                                    >
-                                        <i className="fa fa-window-restore" />
-                                        {Math.round(
-                                            row.bot_detection_results[row.players.black.id]
-                                                .blur_rate,
-                                        )}
-                                        %
-                                    </span>
-                                )}
-                            </>
+                                    ?.has_sgf_downloads ? (
+                                    <i className="fa fa-download" style={{ color: "#666" }} />
+                                ) : null}
+                            </span>
                         ),
                     },
                     {
-                        header: _("White"),
+                        header: _("Timing"),
+                        render: (row) =>
+                            row.bot_detection_results?.[row.players.black.id]?.timing_consistency !=
+                            null ? (
+                                <span title="Timing consistency score">
+                                    {row.bot_detection_results[
+                                        row.players.black.id
+                                    ].timing_consistency.toFixed(0)}
+                                </span>
+                            ) : null,
+                    },
+                    {
+                        header: _("Composite"),
                         render: (row) => (
                             <span style={{ display: "inline-flex", alignItems: "center" }}>
-                                <Player user={row.players.white} />
-
-                                {row.bot_detection_results?.ai_suspected?.includes(
-                                    row.players.white.id,
-                                ) && (
-                                    <i
-                                        className="fa fa-flag"
-                                        style={{ marginLeft: "0.5em", color: "red" }}
-                                    />
-                                )}
-                                {row.bot_detection_results?.white_composite != null && (
-                                    <span
-                                        style={{ marginLeft: "0.5em", color: "#666" }}
-                                        title="AI Detection composite score"
-                                    >
-                                        <i className="fa fa-calculator" />
-                                        {row.bot_detection_results.white_composite.toFixed(2)}
-                                    </span>
-                                )}
-                                {row.bot_detection_results?.[row.players.white.id]
-                                    ?.average_point_loss != null && (
-                                    <span
-                                        style={{ marginLeft: "0.5em", color: "#666" }}
-                                        title="Average point loss per move"
-                                    >
-                                        <i className="fa fa-arrow-circle-down" />
-                                        {(-row.bot_detection_results[row.players.white.id]
-                                            .average_point_loss).toFixed(2)}
-                                    </span>
-                                )}
-                                {row.bot_detection_results?.[row.players.white.id]?.blur_rate !=
-                                    null && (
-                                    <span
-                                        style={{ marginLeft: "0.5em", color: "#666" }}
-                                        title="Window blur rate - percentage of time spent with window not in focus"
-                                    >
-                                        <i className="fa fa-window-restore" />
-                                        {Math.round(
-                                            row.bot_detection_results[row.players.white.id]
-                                                .blur_rate,
-                                        )}
-                                        %
-                                    </span>
-                                )}
+                                {!hide_bad_data &&
+                                    row.bot_detection_results?.ai_suspected?.includes(
+                                        row.players.black.id,
+                                    ) && (
+                                        <i
+                                            className="fa fa-flag"
+                                            style={{ marginRight: "0.5em", color: "red" }}
+                                        />
+                                    )}
+                                {!hide_bad_data &&
+                                    row.bot_detection_results?.[row.players.black.id]?.composite !=
+                                        null && (
+                                        <span title="AI Detection composite score">
+                                            {row.bot_detection_results[
+                                                row.players.black.id
+                                            ].composite.toFixed(2)}
+                                        </span>
+                                    )}
                             </span>
                         ),
+                    },
+                    {
+                        header: _("AILR"),
+                        render: (row) =>
+                            !hide_bad_data &&
+                            row.bot_detection_results?.[row.players.black.id]?.AILR != null ? (
+                                <span title="AI-like moves">
+                                    {row.bot_detection_results[row.players.black.id].AILR.toFixed(
+                                        0,
+                                    )}
+                                    %
+                                </span>
+                            ) : null,
+                    },
+                    {
+                        header: _("White"),
+                        render: (row) => <Player user={row.players.white} />,
+                    },
+                    {
+                        header: _("APL"),
+                        render: (row) =>
+                            row.bot_detection_results?.[row.players.white.id]?.average_point_loss !=
+                            null ? (
+                                <span title="Average point loss per move">
+                                    {(-row.bot_detection_results[row.players.white.id]
+                                        .average_point_loss).toFixed(2)}
+                                </span>
+                            ) : null,
+                    },
+                    {
+                        header: _("Blur"),
+                        render: (row) =>
+                            row.bot_detection_results?.[row.players.white.id]?.blur_rate != null ? (
+                                <span title="Window blur rate - percentage of time spent with window not in focus">
+                                    {Math.round(
+                                        row.bot_detection_results[row.players.white.id].blur_rate,
+                                    )}
+                                    %
+                                </span>
+                            ) : null,
+                    },
+                    {
+                        header: _("SGF"),
+                        render: (row) => (
+                            <span title="SGF downloads">
+                                {row.bot_detection_results?.[row.players.white.id]
+                                    ?.has_sgf_downloads ? (
+                                    <i className="fa fa-download" style={{ color: "#666" }} />
+                                ) : null}
+                            </span>
+                        ),
+                    },
+                    {
+                        header: _("Timing"),
+                        render: (row) =>
+                            row.bot_detection_results?.[row.players.white.id]?.timing_consistency !=
+                            null ? (
+                                <span title="Timing consistency score">
+                                    {row.bot_detection_results[
+                                        row.players.white.id
+                                    ].timing_consistency.toFixed(0)}
+                                </span>
+                            ) : null,
+                    },
+                    {
+                        header: _("Composite"),
+                        render: (row) => (
+                            <span style={{ display: "inline-flex", alignItems: "center" }}>
+                                {!hide_bad_data &&
+                                    row.bot_detection_results?.ai_suspected?.includes(
+                                        row.players.white.id,
+                                    ) && (
+                                        <i
+                                            className="fa fa-flag"
+                                            style={{ marginRight: "0.5em", color: "red" }}
+                                        />
+                                    )}
+                                {!hide_bad_data &&
+                                    row.bot_detection_results?.[row.players.white.id]?.composite !=
+                                        null && (
+                                        <span title="AI Detection composite score">
+                                            {row.bot_detection_results[
+                                                row.players.white.id
+                                            ].composite.toFixed(2)}
+                                        </span>
+                                    )}
+                            </span>
+                        ),
+                    },
+                    {
+                        header: _("AILR"),
+                        render: (row) =>
+                            !hide_bad_data &&
+                            row.bot_detection_results?.[row.players.white.id]?.AILR != null ? (
+                                <span title="AI-like moves">
+                                    {row.bot_detection_results[row.players.white.id].AILR.toFixed(
+                                        0,
+                                    )}
+                                    %
+                                </span>
+                            ) : null,
                     },
                 ]}
             />


### PR DESCRIPTION
Fixes # inability to see an overall view of a player's ai analysis profile

## Proposed Changes

  - Add a PlayerSearch thingo and ask the backend to filter by player

Needs https://github.com/online-go/ogs/pull/2075
