### PR TITLE
Use analyzer_version to hide old data, 

### DIFF
--- a/src/models/games.d.ts
+++ b/src/models/games.d.ts
@@ -234,11 +234,13 @@ declare namespace rest_api {
     interface BotDetectionResults {
         // Parameters of the AI review used for detection
         ai_review_params: AIReviewParams;
+        move_count?: number;
+        analyzer_version?: string;
 
         // List of player IDs suspected of using AI/bots
         ai_suspected: number[];
 
-        // Composite scores for both players
+        // Composite scores for both players (seems redundant with the per-player composite scores)
         black_composite: number;
         white_composite: number;
 
@@ -251,7 +253,7 @@ declare namespace rest_api {
             blur_rate: number; // Rate of moves that are "blurry"
             has_sgf_downloads: boolean; // Whether the player downloaded the SGF
             timing_consistency: number; // Measure of move timing consistency
-            AILR: number; // AI Likelihood Ratio
+            AILR: number; // AI-like move Ratio
             composite: number; // Overall composite score
             average_point_loss: number; // Average point loss per move
         };
@@ -276,7 +278,6 @@ declare namespace rest_api {
 
     interface GameAIDetection {
         id: number;
-        length: number;
         width: number;
         height: number;
         players: {


### PR DESCRIPTION
and tweak ai detection table layout for better interpretation.

Fixes # Not knowing which algorithm generated the data.

## Proposed Changes

  - Show analyzer version
  - Hide data from pre-new-AILR versions
  - Hide APL and timing for now, because they still seem suss
  - Use query param to turn those on for debug
  - Get game length from bot_detection_results, because that's where it is now.


Needs https://github.com/online-go/ogs/pull/2077
