### PR TITLE
Change the background of filter selectors when they have an active selection

### DIFF
--- a/src/components/JosekiTagSelector/JosekiTagSelector.tsx
+++ b/src/components/JosekiTagSelector/JosekiTagSelector.tsx
@@ -40,7 +40,9 @@ export function JosekiTagSelector(props: JosekiTagSelectorProps) {
 
     return (
         <Select
-            className="joseki-tag-selector"
+            className={
+                "joseki-tag-selector " + (props.selected_tags.length > 0 ? "filter-active" : "")
+            }
             classNamePrefix="ogs-react-select"
             value={props.selected_tags}
             options={props.available_tags}

--- a/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
+++ b/src/components/JosekiVariationFilter/JosekiVariationFilter.tsx
@@ -165,14 +165,22 @@ export function JosekiVariationFilter(props: JosekiVariationFilterProps) {
 
             <div className="filter-set">
                 <div className="filter-label">{_("Filter by Contributor")}</div>
-                <select value={current_contributor} onChange={onContributorChange}>
+                <select
+                    value={current_contributor}
+                    onChange={onContributorChange}
+                    className={current_contributor !== "none" ? "filter-active" : ""}
+                >
                     {contributors}
                 </select>
             </div>
 
             <div className="filter-set">
                 <div className="filter-label">{_("Filter by Source")}</div>
-                <select value={current_source} onChange={onSourceChange}>
+                <select
+                    value={current_source}
+                    onChange={onSourceChange}
+                    className={current_source !== "none" ? "filter-active" : ""}
+                >
                     {sources}
                 </select>
             </div>

--- a/src/views/Joseki/Joseki.styl
+++ b/src/views/Joseki/Joseki.styl
@@ -397,6 +397,20 @@
                 themed: background-color shade4;
             }
 
+            .filter-container.filter-active {
+                .joseki-tag-selector.filter-active {
+                    .ogs-react-select__value-container {
+                        themed: background shade0;
+                    }
+                }
+            }
+
+            .joseki-variation-filter {
+                select.filter-active {
+                    themed: background shade0;
+                }
+            }
+
             .discussion-container {
                 display: flex;
                 flex-direction: column;
@@ -463,6 +477,12 @@
 
                 div {
                     margin-left: 0.5rem;
+                }
+            }
+
+            .extra-info-selector.filter-active {
+                .ogs-react-select__value-container {
+                    themed: background shade0;
                 }
             }
         }

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1728,7 +1728,7 @@ class ExplorePane extends React.Component<ExploreProps, ExploreState> {
                     )}
                 </div>
                 <div className={"extra-info-column extra-info-open"}>
-                    <div className="btn-group extra-info-selector">
+                    <div className={"btn-group extra-info-selector"}>
                         <button
                             className={
                                 "btn s " +
@@ -1742,7 +1742,13 @@ class ExplorePane extends React.Component<ExploreProps, ExploreState> {
                                     : this.showFilterSelector
                             }
                         >
-                            <span>{_("Filter")}</span>
+                            <span>
+                                {_("Filter") +
+                                    (this.state.extra_info_selected !== "variation-filter" &&
+                                    filter_active
+                                        ? " *"
+                                        : "")}
+                            </span>
                             {this.state.extra_info_selected === "variation-filter" ? (
                                 <i className={"fa fa-filter hide"} />
                             ) : (
@@ -1828,7 +1834,9 @@ class ExplorePane extends React.Component<ExploreProps, ExploreState> {
                     )}
 
                     {this.state.extra_info_selected === "variation-filter" && (
-                        <div className="filter-container">
+                        <div
+                            className={"filter-container" + (filter_active ? " filter-active" : "")}
+                        >
                             <JosekiVariationFilter
                                 contributor_list_url={server_url + "contributors"}
                                 source_list_url={server_url + "josekisources"}


### PR DESCRIPTION


Fixes people complaining that they don't notice that it's filtered.

## Proposed Changes

  - Background-highlight active filter selectors
  - Add a * to the Filter tab label when there's a filter active but not shown on the current extra info tab
  
