### PR TITLE
fix: append seek graph modal to container to ensure correct text color

### DIFF
--- a/src/components/SeekGraph/SeekGraph.tsx
+++ b/src/components/SeekGraph/SeekGraph.tsx
@@ -894,7 +894,7 @@ export class SeekGraph extends TypedEventEmitter<Events> {
             list.appendChild(e);
         }
 
-        document.body.appendChild(list);
+        appendModalElement(list);
         this.moveChallengeList(ev);
     }
     closeChallengeList() {
@@ -935,11 +935,23 @@ function createModal(close_callback: () => void, priority: number): SeekGraphMod
     const binding = kb_bind("escape", onClose, priority);
     modal = { modal: elt, binding: binding };
     elt.style.zIndex = priority.toString();
-    document.body.appendChild(elt);
+    appendModalElement(elt);
     return modal;
 }
 
 function removeModal(modal: SeekGraphModal) {
     kb_unbind(modal.binding);
     modal.modal.remove();
+}
+
+function appendModalElement(elt: HTMLElement): HTMLElement {
+    const customGamesElt = document.getElementById("CustomGames");
+    if (!customGamesElt) {
+        return document.body.appendChild(elt);
+    }
+    const seekGraphContainerElt = customGamesElt.querySelector(".seek-graph-container");
+    if (!seekGraphContainerElt) {
+        return document.body.appendChild(elt);
+    }
+    return seekGraphContainerElt.appendChild(elt);
 }


### PR DESCRIPTION
## Proposed Changes

  - append seek graph modals to seek graph container to ensure correct text color
  - currently text color in **dark** _and_ **accessible** mode is black but should be white for readability
  - could just add styling, but appending to the seek graph container seems like the correct approach so that it inherits existing `body.dark #main-content` and `body.accessible #main-content` text styling

## Optional TODO

  - This implementation currently falls back to the existing implementation of appending the modal to the body for robustness if for whatever reason the seek graph container is unavailable. Now that I'm thinking about it, it's probably better to add `SeekGraphConfig.modalContainer` to specify the container element to add the modal to, and use the implemented defaults if the config is not set. May submit a follow-up commit on my own or definitely if requested during review.

## Showcase

### Incorrect modal text color in *CURRENT* implementation

![Screenshot 2025-05-19 at 11 27 49](https://github.com/user-attachments/assets/84b0e715-651f-45f8-81e2-d48386a5cad8)

### Correct modal text color in *PROPOSED* implementation

![Screenshot 2025-05-19 at 11 28 13](https://github.com/user-attachments/assets/352a7e11-e9f8-4492-8d32-d61aca6508b7)