### PR TITLE
Fixes cancel/resign on mobile during AI Review, stone removal phase #3087

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1767,7 +1767,8 @@ export function Game(): React.ReactElement | null {
                         {view_mode === "portrait" &&
                             !zen_mode &&
                             user_is_player &&
-                            phase !== "finished" && <CancelButton className="bold reject" />}
+                            mode === "play" &&
+                            phase === "play" && <CancelButton className="bold reject" />}
 
                         {view_mode === "portrait" && !zen_mode && (
                             <GameDock


### PR DESCRIPTION
Fixes Issue #3087 

Brings Portrait-view `CancelButton` implementation in-line with `PlayControls` func/interfaces (as in wide/desktop view)

#TODO (future feature request?): 
If we want to modify `PlayControls` to include "outright resign" btn during "Stone Removal" phase ->  that should be a very quick fix -> just put `goban.resign()` somewhere between:
https://github.com/online-go/online-go.com/blob/d9dcae91f165583cc24b54b36d583eceaf650727/src/views/Game/PlayControls.tsx#L318-L323
and modify div `stone-removal-controls`: 
https://github.com/online-go/online-go.com/blob/d9dcae91f165583cc24b54b36d583eceaf650727/src/views/Game/PlayControls.tsx#L525-L535
