### PR TITLE
Hint button bug fix

### DIFF
--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -192,6 +192,7 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                 show_correct: false,
                 show_wrong: false,
                 editing: false,
+                hintsOn: false,
             });
             this.fetchPuzzle(parseInt(this.props.match.params.puzzle_id));
         }


### PR DESCRIPTION
- Fixed a bug where the hint button state would stay set to true after navigating to a new puzzle

- Original bug replication steps:
1. Go to a puzzle, like this one: https://online-go.com/puzzle/2629
2. Click the hint button
3. Swap puzzles by clicking the dropdown to the right of "Puzzle", and selecting a different puzzle
4. Notice how the hint state is still set to true, meaning the user has to click the button TWICE to see the new hint

TODO: Noticed another bug, if we click the hint button, then click something like the fullscreen button, or the reverse color button, the hint is removed from the board, but the hint state is still set to true, meaning the user has to click the hint button twice to see the hint again. 

Proposed solution:
- Simply set the hint button state to false whenever we click another button in that horizontal row (other than the puzzle settings button because this doesn't remove the hint from the board)
- Reasoning: it would be inconsistent to leave the hint visible in some cases (color swap/full screen -> the correct move is still in the same spot), and not leave the hint visible in other cases (rotating board positions -> the correct move will NOT be in the same spot anymore)