### PR TITLE
Mark annulled games in AID table

### DIFF
--- a/src/views/AIDetection/AIDetection.tsx
+++ b/src/views/AIDetection/AIDetection.tsx
@@ -379,6 +379,10 @@ export function AIDetection(): React.ReactElement | null {
                                     href={`/game/${row.id}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
+                                    style={{
+                                        textDecoration: row.annulled ? "line-through" : "none",
+                                        fontStyle: row.annulled ? "italic" : "normal",
+                                    }}
                                 >
                                     #{row.id}
                                 </a>


### PR DESCRIPTION
Fixes going to look at games that have already been handled.

## Proposed Changes

  - Mark games that are annulled in the AID table.


Needs https://github.com/online-go/ogs/pull/2086 to work (just doesn't mark them without it)
  
  
