### PR TITLE
Add teardown, to get rid of "failed to exit" warning

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -37,4 +37,5 @@ module.exports = {
     },
     setupFiles: ["./setup-jest.cjs"],
     setupFilesAfterEnv: ["jest-chain", "@testing-library/jest-dom"],
+    globalTeardown: "<rootDir>/teardown-jest.cjs",
 };

--- a/teardown-jest.cjs
+++ b/teardown-jest.cjs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+module.exports = async () => {
+    // Force garbage collection to clean up any remaining references
+    if (global.gc) {
+        global.gc();
+    }
+
+    // Clean up any remaining socket connections
+    if (global.window && global.window.socket) {
+        try {
+            global.window.socket.disconnect();
+        } catch (e) {
+            // Ignore errors during cleanup
+        }
+    }
+
+    // Clean up any remaining WebSocket connections
+    if (global.window && global.window.WebSocket) {
+        // Close any remaining WebSocket connections
+        const openSockets = global.window.WebSocket.prototype.constructor;
+        if (openSockets && openSockets.readyState !== 3) {
+            // 3 = CLOSED
+            try {
+                openSockets.close();
+            } catch (e) {
+                // Ignore errors during cleanup
+            }
+        }
+    }
+};


### PR DESCRIPTION
Fixes #  "A worker process has failed to exit gracefully and has been force exited."

## Proposed Changes

  - jest teardown
  