### PR TITLE
Keep track of which annotations were created by AI (issue #2874)

### DIFF
--- a/src/views/Game/AIDemoReview.tsx
+++ b/src/views/Game/AIDemoReview.tsx
@@ -435,7 +435,7 @@ function renderAnalysis(goban: GobanRenderer, data: any) {
 
         // blue move, not what player made
         if (i === 0) {
-            goban.setMark(mv.x, mv.y, "blue_move", true);
+            goban.setMark(mv.x, mv.y, "blue_move", true, true);
             circle.border_width = 0.2;
             circle.border_color = "rgb(0, 130, 255)";
             circle.color = "rgba(0, 130, 255, 0.7)";
@@ -447,7 +447,8 @@ function renderAnalysis(goban: GobanRenderer, data: any) {
     marks = trimMaxMoves(marks);
 
     try {
-        goban.setMarks(marks, true); /* draw the remaining AI sequence as ghost marks, if any */
+        /* draw the remaining AI sequence as ghost marks, if any */
+        goban.setMarks(marks, true, true);
         goban.setHeatmap(heatmap, true);
         goban.setColoredCircles(colored_circles, false);
     } catch (e) {

--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -667,7 +667,7 @@ class AIReviewClass extends React.Component<AIReviewProperties, AIReviewState> {
                         if (parseFloat(key).toPrecision(2).length < key.length) {
                             key = parseFloat(key).toPrecision(2);
                         }
-                        goban.setSubscriptMark(mv.x, mv.y, key, true);
+                        goban.setSubscriptMark(mv.x, mv.y, key, true, true);
                     }
 
                     const circle: ColoredCircle = {
@@ -677,7 +677,7 @@ class AIReviewClass extends React.Component<AIReviewProperties, AIReviewState> {
 
                     if (next_move && sameIntersection(branch.moves[0], next_move)) {
                         goban.setMark(mv.x, mv.y, "sub_triangle", true);
-                        goban.setMark(mv.x, mv.y, "blue_move", true);
+                        goban.setMark(mv.x, mv.y, "blue_move", true, true);
 
                         circle.border_width = 0.1;
                         circle.border_color = "rgb(0, 0, 0)";
@@ -689,7 +689,7 @@ class AIReviewClass extends React.Component<AIReviewProperties, AIReviewState> {
                         colored_circles.push(circle);
                     } else if (i === 0) {
                         // blue move, not what player made
-                        goban.setMark(mv.x, mv.y, "blue_move", true);
+                        goban.setMark(mv.x, mv.y, "blue_move", true, true);
                         circle.border_width = 0.2;
                         circle.border_color = "rgb(0, 130, 255)";
                         circle.color = "rgba(0, 130, 255, 0.7)";
@@ -712,7 +712,8 @@ class AIReviewClass extends React.Component<AIReviewProperties, AIReviewState> {
         marks = this.trimMaxMoves(marks);
 
         try {
-            goban.setMarks(marks, true); /* draw the remaining AI sequence as ghost marks, if any */
+            /* draw the remaining AI sequence as ghost marks, if any */
+            goban.setMarks(marks, true, true);
             goban.setHeatmap(heatmap as any, true);
             goban.setColoredCircles(colored_circles, false);
         } catch (e) {

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -607,7 +607,7 @@ export function Game(): React.ReactElement | null {
         if (ai_review_enabled) {
             goban.current.setHeatmap(undefined);
             goban.current.setColoredCircles(undefined);
-            goban.current.engine.move_tree.traverse((node: MoveTree) => node.clearMarks());
+            goban.current.engine.move_tree.traverse((node: MoveTree) => node.clearAIMarks());
             goban.current.redraw();
         }
         set_ai_review_enabled(!ai_review_enabled);


### PR DESCRIPTION
Fixes #2874

## Proposed Changes

When AI analysis is enabled, the old board annotations are saved, and when AI analysis is disabled, the old board annotations are reloaded.

Requires: online-go/goban#193