### PR TITLE
List red moves as the worst moves when viewing a fast review

### DIFF
--- a/src/views/Game/AIReview.tsx
+++ b/src/views/Game/AIReview.tsx
@@ -1026,7 +1026,16 @@ class AIReviewClass extends React.Component<AIReviewProperties, AIReviewState> {
         let black_moves = 0;
         let white_moves = 0;
 
-        let worst_move_list = getWorstMoves(goban.engine.move_tree, this.ai_review, 100);
+        let worst_move_list =
+            this.ai_review.type === "fast"
+                ? Object.values(this.ai_review.moves).map((move) => ({
+                      move_number: move.move_number + 1,
+                      player: goban.engine.move_tree.index(move.move_number).player,
+                      delta: move.win_rate,
+                      move: move.move,
+                  }))
+                : getWorstMoves(goban.engine.move_tree, this.ai_review, 100);
+
         worst_move_list = worst_move_list.filter(
             (move) =>
                 (move.player === 1 && black_moves++ < 3) ||


### PR DESCRIPTION
Before, we'd list out lots of moves that didn't have anything interesting on the board when clicked:

<img width="344" height="171" alt="image" src="https://github.com/user-attachments/assets/8694ee49-73ff-42b3-a206-b147236a6ac4" />

Now we just show the red moves, ie the moves we have data for

<img width="349" height="128" alt="image" src="https://github.com/user-attachments/assets/9ee77fb5-c278-4ae0-81c6-d54b1ac300dd" />

