### PR TITLE
Separate test.yml into two

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -67,8 +67,8 @@ jobs:
             - name: Check server ready, wait if needed
               run: curl -s --retry 30 --retry-delay 1 --retry-all-errors http://localhost:8080 > /dev/null
 
-            - name: Run tests
-              run: yarn test:ci
+            - name: Run smoketests
+              run: yarn test:e2e:docker:smoke
 
             - name: Upload e2e test failure results (if any)
               if: always()

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+    push:
+        branches: [devel]
+    pull_request:
+        branches: [devel]
+    workflow_dispatch:
+
+jobs:
+    unit_test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: recursive
+                  lfs: true
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+
+            - name: Cache node modules
+              id: cache-node-modules
+              uses: actions/cache@v4
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-modules-
+
+            - name: yarn install
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              uses: nick-fields/retry@v3
+              with:
+                  timeout_minutes: 10
+                  max_attempts: 3
+                  command: yarn install
+
+            - name: Run unit tests
+              run: yarn test
+


### PR DESCRIPTION
Fixes confusion about which test failed, and waiting for one when you're intersted in the other :)

## Proposed Changes

  - Split unit and e2e tests into separate jobs
  