### PR TITLE
#1823: made avatar bigger when no remaining time is displayed or game is paused

### DIFF
--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -135,6 +135,7 @@
         display: flex;
         align-items: stretch;
         width: 100%;
+        min-height: 44px;
     }
 
     .player-icon-container {


### PR DESCRIPTION
Fixes #1823

**Bug**
On a finished game, in the mobile view, the avatars get smaller, making the activity dot look ridiculously huge and messing up the alignment with the new flags.

**Changes**
Added min-height to `.player-icon-clock-row`