### PR TITLE
Anshulxyz/fix wonky private game info

### DIFF
--- a/src/views/Game/GameInfoModal.tsx
+++ b/src/views/Game/GameInfoModal.tsx
@@ -236,7 +236,7 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, GameIn
                         </dd>
                         <dt>{_("Creator")}</dt>
                         <dd>
-                            {this.props.creatorId && (
+                            {!!this.props.creatorId && (
                                 <Player icon rank user={this.props.creatorId} />
                             )}
                         </dd>


### PR DESCRIPTION
Fixes #2102 

https://github.com/online-go/online-go.com/issues/2102

## Proposed Changes

  - The change makes the "Creator" label in the table always visible, just like all the other labels are.

Demo:
This is the view os someone who should have access to private game looks like. As expected.
<img width="578" height="644" alt="Screenshot 2025-08-13 at 12 11 24 AM" src="https://github.com/user-attachments/assets/b0b53b76-7766-4a03-b2c4-b678a531ed1d" />


And this is the view now for someone other than the invitee:
<img width="515" height="575" alt="Screenshot 2025-08-12 at 11 46 10 PM" src="https://github.com/user-attachments/assets/a0625201-36c4-488a-be73-64137265f5dc" />
