### PR TITLE
Shadow theme selection support

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -16,7 +16,14 @@
  */
 
 import * as data from "@/lib/data";
-import { GobanSelectedThemes, Goban, LabelPosition, JGOFTimeControlSpeed, Size } from "goban";
+import {
+    GobanSelectedThemes,
+    Goban,
+    LabelPosition,
+    JGOFTimeControlSpeed,
+    Size,
+    ShadowTheme,
+} from "goban";
 import * as React from "react";
 import { current_language } from "@/lib/translate";
 import { DataSchema } from "./data_schema";
@@ -85,7 +92,11 @@ export const defaults = {
     //"goban-theme-white_stone_url": null as null | string,
     "goban-theme-removal-graphic": "square" as "square" | "x",
     "goban-theme-removal-scale": 0.9,
-    "goban-theme-disable-stone-shadows": false,
+    "goban-theme-stone-shadows": "default" as ShadowTheme,
+    "goban-theme-custom-black-shadow-color": "#000000",
+    "goban-theme-custom-black-shadow-gradient": "rotate(45) scale(1.10 1.0) translate(0.05 -0.50)",
+    "goban-theme-custom-white-shadow-color": "#000000",
+    "goban-theme-custom-white-shadow-gradient": "rotate(45) scale(1.10 1.0) translate(0.05 -0.50)",
     "goban-theme-custom-board-background": "#DCB35C",
     "goban-theme-custom-board-url": "",
     "goban-theme-custom-board-line": "#000000",
@@ -293,7 +304,11 @@ export function getSelectedThemes(): GobanSelectedThemes {
     let black = get("goban-theme-black") || (default_plain ? "Plain" : "Slate");
     const removal_graphic = get("goban-theme-removal-graphic");
     const removal_scale = get("goban-theme-removal-scale");
-    const disable_stone_shadows = get("goban-theme-disable-stone-shadows");
+    const stone_shadows = get("goban-theme-stone-shadows");
+    const custom_black_shadow_color = get("goban-theme-custom-black-shadow-color");
+    const custom_black_shadow_gradient = get("goban-theme-custom-black-shadow-gradient");
+    const custom_white_shadow_color = get("goban-theme-custom-white-shadow-color");
+    const custom_white_shadow_gradient = get("goban-theme-custom-white-shadow-gradient");
 
     if (!(board in Goban.THEMES["board"])) {
         board = default_plain ? "Plain" : "Kaya";
@@ -314,7 +329,17 @@ export function getSelectedThemes(): GobanSelectedThemes {
         black: black,
         "removal-graphic": removal_graphic as any,
         "removal-scale": removal_scale,
-        "disable-stone-shadows": disable_stone_shadows,
+        "stone-shadows": stone_shadows,
+        "custom-shadow-config": {
+            black: {
+                shadow_color: custom_black_shadow_color,
+                gradientTransform: custom_black_shadow_gradient,
+            },
+            white: {
+                shadow_color: custom_white_shadow_color,
+                gradientTransform: custom_white_shadow_gradient,
+            },
+        },
     };
 }
 
@@ -335,7 +360,11 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
         "goban-theme-white",
         "goban-theme-removal-graphic",
         "goban-theme-removal-scale",
-        "goban-theme-disable-stone-shadows",
+        "goban-theme-stone-shadows",
+        "goban-theme-custom-black-shadow-color",
+        "goban-theme-custom-black-shadow-gradient",
+        "goban-theme-custom-white-shadow-color",
+        "goban-theme-custom-white-shadow-gradient",
         "goban-theme-custom-board-background",
         "goban-theme-custom-board-url",
         "goban-theme-custom-board-line",

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -60,8 +60,18 @@ export function ThemePreferences(): React.ReactElement | null {
     const [theme] = useData("theme", "light");
 
     const [removal_scale] = usePreference("goban-theme-removal-scale");
-    const [disable_stone_shadows, setDisableStoneShadows] = usePreference(
-        "goban-theme-disable-stone-shadows",
+    const [stone_shadows, setStoneShadows] = usePreference("goban-theme-stone-shadows");
+    const [custom_black_shadow_color, setCustomBlackShadowColor] = usePreference(
+        "goban-theme-custom-black-shadow-color",
+    );
+    const [custom_black_shadow_gradient, setCustomBlackShadowGradient] = usePreference(
+        "goban-theme-custom-black-shadow-gradient",
+    );
+    const [custom_white_shadow_color, setCustomWhiteShadowColor] = usePreference(
+        "goban-theme-custom-white-shadow-color",
+    );
+    const [custom_white_shadow_gradient, setCustomWhiteShadowGradient] = usePreference(
+        "goban-theme-custom-white-shadow-gradient",
     );
     const setTheme = React.useCallback((theme: string) => {
         data.set("theme", theme, data.Replication.REMOTE_OVERWRITES_LOCAL);
@@ -279,13 +289,63 @@ export function ThemePreferences(): React.ReactElement | null {
                     checked={removal_scale < 1.0}
                 />
             </PreferenceLine>
-            <PreferenceLine title={_("Disable stone shadows")}>
-                <Toggle
-                    id={"goban-theme-disable-stone-shadows"}
-                    onChange={setDisableStoneShadows}
-                    checked={disable_stone_shadows}
+            <PreferenceLine title={_("Stone shadow style")}>
+                <PreferenceDropdown
+                    value={stone_shadows}
+                    options={[
+                        { value: "default", label: _("Default") },
+                        { value: "low", label: _("Low") },
+                        { value: "mid", label: _("Mid") },
+                        { value: "high", label: _("High") },
+                        { value: "anime", label: _("Anime") },
+                        { value: "custom", label: _("Custom") },
+                        { value: "none", label: _("None") },
+                    ]}
+                    onChange={setStoneShadows}
                 />
             </PreferenceLine>
+            {stone_shadows === "custom" && (
+                <>
+                    <PreferenceLine title={_("Black stone shadow color")}>
+                        <input
+                            type="color"
+                            value={custom_black_shadow_color}
+                            onChange={(e) => setCustomBlackShadowColor(e.target.value)}
+                        />
+                    </PreferenceLine>
+                    <PreferenceLine
+                        title={_("Black stone shadow gradient transform")}
+                        description={_("CSS transform for black stone shadow gradient")}
+                    >
+                        <textarea
+                            value={custom_black_shadow_gradient}
+                            onChange={(e) => setCustomBlackShadowGradient(e.target.value)}
+                            placeholder="rotate(45) scale(1.10 1.0) translate(0.05 -0.50)"
+                            rows={2}
+                            style={{ width: "100%", fontFamily: "monospace" }}
+                        />
+                    </PreferenceLine>
+                    <PreferenceLine title={_("White stone shadow color")}>
+                        <input
+                            type="color"
+                            value={custom_white_shadow_color}
+                            onChange={(e) => setCustomWhiteShadowColor(e.target.value)}
+                        />
+                    </PreferenceLine>
+                    <PreferenceLine
+                        title={_("White stone shadow gradient transform")}
+                        description={_("CSS transform for white stone shadow gradient")}
+                    >
+                        <textarea
+                            value={custom_white_shadow_gradient}
+                            onChange={(e) => setCustomWhiteShadowGradient(e.target.value)}
+                            placeholder="rotate(45) scale(1.10 1.0) translate(0.05 -0.50)"
+                            rows={2}
+                            style={{ width: "100%", fontFamily: "monospace" }}
+                        />
+                    </PreferenceLine>
+                </>
+            )}
             <PreferenceLine
                 title={_("Stone font scale")}
                 description={_("Adjust the size of the font used to display symbols on stones.")}


### PR DESCRIPTION
Adds a drop down to our theme settings to support different shadow styles:

<img width="178" height="349" alt="image" src="https://github.com/user-attachments/assets/272af716-f374-4068-80e5-cd8f99227a3e" />

Low: (what we used to have a few days ago)

<img width="173" height="67" alt="image" src="https://github.com/user-attachments/assets/3fa8229c-c733-4cc3-aa60-42fe2a1bd2a5" />

Mid: 
<img width="184" height="68" alt="image" src="https://github.com/user-attachments/assets/0872a0cb-a3bd-4a65-8839-54cfdc71625d" />

High: 
<img width="175" height="68" alt="image" src="https://github.com/user-attachments/assets/bc8f9778-d9fb-47f6-b024-d541ba0ed981" />

And of course custom because we love options here:

<img width="660" height="542" alt="image" src="https://github.com/user-attachments/assets/4ad57c89-3616-4cb1-8a6d-8d1e798009e8" />


<img width="197" height="85" alt="image" src="https://github.com/user-attachments/assets/2b9616d7-0eaa-4a8c-93a4-5e22fd55507b" />


