### PR TITLE
Make a safe use goban controller for when there might be no context

### DIFF
--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -24,7 +24,7 @@ import { goban_view_mode } from "@/views/Game/util";
 //import { generateGobanHook } from "@/views/Game/GameHooks";
 
 import { usePreference } from "@/lib/preferences";
-import { useGobanController } from "@/views/Game/goban_context";
+import { useGobanControllerSafe } from "@/views/Game/goban_context";
 
 interface GobanContainerProps {
     /** The goban to render. If not provided, the goban context goban will be used */
@@ -46,7 +46,7 @@ export function GobanContainer({
     onWheel,
     extra_props,
 }: GobanContainerProps): React.ReactElement {
-    const goban_controller = useGobanController();
+    const goban_controller = useGobanControllerSafe();
     const ref_goban_container = React.useRef<HTMLDivElement>(null);
     const resize_debounce = React.useRef<NodeJS.Timeout | null>(null);
     const [last_move_opacity] = usePreference("last-move-opacity");

--- a/src/views/Game/goban_context.ts
+++ b/src/views/Game/goban_context.ts
@@ -22,6 +22,8 @@ export const GobanControllerContext = React.createContext<GobanController | null
 
 /**
  * A React hook that provides the GameController (which contains our goban).
+ * Always returns a non-null type but may throw at runtime.
+ * Use this for components that certainly have a goban controller in context.
  */
 export function useGobanController(): GobanController {
     const controller = React.useContext(GobanControllerContext);
@@ -33,5 +35,16 @@ export function useGobanController(): GobanController {
         throw TypeError("GobanControllerContext was not set.");
     }
 
+    return controller;
+}
+
+/**
+ * A React hook that provides the GameController (which contains our goban).
+ * Returns null if no context provider is available.
+ * Use this where we don't know if the component has a goban controller in context
+ * (and handles that properly)
+ */
+export function useGobanControllerSafe(): GobanController | null {
+    const controller = React.useContext(GobanControllerContext);
     return controller;
 }


### PR DESCRIPTION
Fixes red screens on joseki and puzzle

## Proposed Changes

  - have a useGobanControllerSafe for Game to use which has context and the others to use which pass goban
  