### PR TITLE
Add a smoke test for joseki page basic render.

### DIFF
--- a/e2e-tests/smoke/joseki_screenshot_mask.css
+++ b/e2e-tests/smoke/joseki_screenshot_mask.css
@@ -14,7 +14,13 @@ section.right { /* NavBar changeable icons and user name */
   visibility: hidden !important;
 }
 
+/* Hide all the user generated content! 
+ * We're left testing that the page skeleton renders. */
+
 .Goban {
+  visibility: hidden !important;
+}
+.explore-pane {
   visibility: hidden !important;
 }
 

--- a/e2e-tests/smoke/joseki_screenshot_mask.css
+++ b/e2e-tests/smoke/joseki_screenshot_mask.css
@@ -1,0 +1,23 @@
+section.right { /* NavBar changeable icons and user name */
+  visibility: hidden !important;
+}
+
+.username, .Player, .PlayerIcon { /* hide the username, player icon, and player name */
+  visibility: hidden !important;
+}
+
+.ObserveGames { 
+  visibility: hidden !important;
+}
+
+.announcement {
+  visibility: hidden !important;
+}
+
+.Goban {
+  visibility: hidden !important;
+}
+
+.continuations-pane {
+  visibility: hidden !important;
+}

--- a/e2e-tests/smoke/smoke-css-sanity.ts
+++ b/e2e-tests/smoke/smoke-css-sanity.ts
@@ -69,5 +69,11 @@ export const smokeCssSanityTest = async ({ browser }: { browser: Browser }) => {
         stylePath: path.join(currentDir, "basic_screenshot_mask.css"),
     });
 
+    await load(userPage, "/joseki");
+    await expect(userPage).toHaveScreenshot("joseki-page.png", {
+        fullPage: true,
+        stylePath: path.join(currentDir, "joseki_screenshot_mask.css"),
+    });
+
     await userPage.close();
 };

--- a/e2e-tests/smoke/smoketests.spec.ts-snapshots/groups-page-chromium-linux.png
+++ b/e2e-tests/smoke/smoketests.spec.ts-snapshots/groups-page-chromium-linux.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a56c280c298994f5c6cd690ef328458d69bb464db9c46730e3e4de17af94462b
-size 21202

--- a/e2e-tests/smoke/smoketests.spec.ts-snapshots/joseki-page-chromium-linux.png
+++ b/e2e-tests/smoke/smoketests.spec.ts-snapshots/joseki-page-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f399c23a2c85829fba3736d331e73483035480511f941cc37ef91fc519e7ea61
+size 39014

--- a/e2e-tests/smoke/smoketests.spec.ts-snapshots/joseki-page-chromium-linux.png
+++ b/e2e-tests/smoke/smoketests.spec.ts-snapshots/joseki-page-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f399c23a2c85829fba3736d331e73483035480511f941cc37ef91fc519e7ea61
-size 39014
+oid sha256:ccdf3ef819103e6380865c4a72faf7da855e7ec3d711476604dfa04df33083fc
+size 19565


### PR DESCRIPTION
Fixes not having something that makes sure Joseki page is kinda live.

## Proposed Changes

  - Add a basic screenshot comparison
  
(get rid of unused old png)

