### PR TITLE
add `private` to challenge dto in seekGraph flow

### DIFF
--- a/src/models/challenges.d.ts
+++ b/src/models/challenges.d.ts
@@ -54,6 +54,7 @@ declare namespace socket_api {
             rengo_white_team: number[]; // array of player ids
             rengo_participants: number[]; // array of player ids
             invite_only: boolean;
+            private: boolean;
             uuid: string;
             created?: string | null; // ISO 8601 format datetime
 
@@ -179,6 +180,7 @@ declare namespace rest_api {
         rengo_casual_mode: boolean;
         historical_ratings: { black: MinimalPlayerDTO; white: MinimalPlayerDTO };
         related: any; // not sure what this is, the serializer is a gnarly function
+        private: boolean;
     }
 
     interface RengoParticipantsDTO {

--- a/src/views/Overview/InviteList.tsx
+++ b/src/views/Overview/InviteList.tsx
@@ -94,6 +94,7 @@ function challengeDtoToSeekgraphChallengeSubset(c: ChallengeDTO, user_id: number
         rengo_auto_start: -999, // number;
 
         invite_only: false, // boolean;
+        private: c.game.private, // boolean;
     };
 }
 


### PR DESCRIPTION
~~Fixes~~ supports fix for  #2436

## Proposed Changes

  - Match API for receiving `private` field from seekGraph


* Needs: https://github.com/online-go/ogs/pull/2129    (`private` will be wrong if that's not in)
  