### PR TITLE
README: link to the newer Real Time API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ regularly visits this github page and the issue tracker. As such:
 -   https://forums.online-go.com should be used to discuss any proposed functional changes or any new notable features, allowing non developers to chime in with their thoughts and ideas.
 -   The [github issue tracker](https://github.com/online-go/online-go.com/issues) should be used to track all bugs, minor "obvious" enhancements, and accepted major enhancements. Any enhancements (and ideally bugs) posted need to be articulated in a way that it is obvious what needs to be done, partial thoughts will be closed and should be moved back to the forums for further discussion.
 
-# Utilizing the Website
+# Developer resources
 
 Online-go provides several resources that allows you to interact with the project to create your own. These resources help to get you started.
 
 -   https://online-go.com/developer to access documentation.
 -   https://github.com/online-go/online-go.com/wiki to get started and how to use the website.
--   https://ogs.readme.io/docs/real-time-api for real time API documentation
+-   https://docs.online-go.com/goban/modules/protocol.html for real time API documentation
 -   https://online-go.com/oauth2/applications/ OAuth2 Application Manager (you must be signed into an account on OGS.)
 
 # Acknowledgements


### PR DESCRIPTION
It's currently got a link to socket.io docs.  https://docs.online-go.com appears to host the latest on interacting with the RT API.