### PR TITLE
Let mods access tourney edit

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1065,7 +1065,7 @@ export function Tournament(): React.ReactElement {
                                 user.id === tournament.director.id) &&
                                 !tournament.started &&
                                 !tournament.start_waiting) ||
-                                null) && (
+                                user.is_moderator) && (
                                 <button className="xs" onClick={startEditing}>
                                     {_("Edit Tournament")}
                                 </button>


### PR DESCRIPTION
Fixes mods not being able to fix silliness in description

## Proposed Changes

  - Let mods press the buttons
  
Needs https://github.com/online-go/ogs/pull/2132 in order for the request to succeed