### PR TITLE
Update gameInformation to listen to game rule change

### DIFF
--- a/src/views/Game/fragments.tsx
+++ b/src/views/Game/fragments.tsx
@@ -85,20 +85,25 @@ export function EstimateScore(): React.ReactElement | null {
 export function GameInformation(): React.ReactElement | null {
     const goban_controller = useGobanController();
     const goban = goban_controller.goban;
+    const [config, setConfig] = React.useState(goban?.engine?.config);
     const [zen_mode, set_zen_mode] = React.useState(goban_controller.zen_mode);
 
     React.useEffect(() => {
+        const handleUpdate = () => {
+            setConfig(goban?.engine?.config);
+        };
+        goban?.on("load", handleUpdate);
         goban_controller.on("zen_mode", set_zen_mode);
         return () => {
+            goban?.off("load", handleUpdate);
             goban_controller.off("zen_mode", set_zen_mode);
         };
-    }, [goban]);
+    }, [goban, goban_controller]);
 
     if (zen_mode) {
         return null;
     }
 
-    const config = goban?.engine?.config;
     if (!config) {
         return null;
     }


### PR DESCRIPTION
Fixes the issue of wrong game rules getting displayed on the Demo Board.

I've mentioned about this issue in #3190

Here's a link to the forum proving that this issue is also faced by Users. https://forums.online-go.com/t/demo-board-with-chinese-rules-shows-japanese-rules-instead/57801

### How to reproduce the issue?
1. Create a Demo Board with rule anything other than Japanese.
2. Observe that the rules displayed on top-right is "Japanese"

### How did I figure out the issue?

I noticed that the rules were getting displayed correctly, when I resized the window. Or when I go in-out of Zen mode. Which prompted me to think that resizing is causing a re-render of the element that displays the rule.

## Proposed Changes

  - Update for fragment's `GameInformation` to actively listen to Game rule, so that it renders correct rule the first time, and everytime the Demo Board's rules are changed.

### Test

I had already put a failing assertion statement in #3190 (which now passes due to this change)