### PR TITLE
Don't provide 'non-exclusive' as an option to choose 

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,7 +37,7 @@ export interface Group {
 export type GroupList = Array<Group>;
 
 export type TournamentPairingMethod = "slaughter" | "random" | "slide" | "strength";
-export type TournamentExclusivity = "open" | "group" | "invite";
+export type TournamentExclusivity = "group" | "invite";
 export type TournamentType =
     | "mcmahon"
     | "s_mcmahon"

--- a/src/views/TournamentList/TournamentList.tsx
+++ b/src/views/TournamentList/TournamentList.tsx
@@ -38,7 +38,7 @@ interface TournamentListProperties {
     phase: "open" | "active" | "finished";
     speed?: "live" | "correspondence";
     hide_stale?: boolean; // Hides tournaments that were supposed to have started already
-    hide_exclusive?: boolean; // Hides tournaments that are invite-only or members-only
+    hide_exclusive?: boolean; // Hides invite-only tournaments (shows only members-only tournaments)
     group?: IdType;
 }
 
@@ -395,7 +395,7 @@ function makeTournamentFilter(
     }
 
     if (hide_exclusive) {
-        filter["exclusivity"] = "open";
+        filter["exclusivity"] = "group";
     }
 
     if (group !== undefined) {


### PR DESCRIPTION
(and fix broken error dialog)

Fixes suffering from tourney invite spammers

## Proposed Changes

  - Don't provide 'non-exclusive' as an option to choose, frontend
  -- Leave backend, so it's easy to revert this
  - Error handling code had the wrong idea about what would be in the response
  
