### PR TITLE
Use flag from backend to enable group creation button

### DIFF
--- a/src/lib/cached.ts
+++ b/src/lib/cached.ts
@@ -144,6 +144,7 @@ export const cached = {
         groups: () => {
             if (anon()) {
                 data.set(cached.groups, []);
+                data.set("can-create-groups", false);
                 return;
             }
 
@@ -154,6 +155,9 @@ export const cached = {
                         a.name.localeCompare(b.name),
                     );
                     data.set(cached.groups, groups);
+
+                    const canCreateGroups = res.can_create_groups || false;
+                    data.set("can-create-groups", canCreateGroups);
                 })
                 .catch((err) => {
                     console.error("Error retrieving groups: ", err);

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -254,6 +254,7 @@ export interface DataSchema
     "free-trial-saved-for-later-timestamp": number;
     "free-trial-survey-submitted-timestamp": number;
     "price-increase-message-dismissed-timestamp": number;
+    "can-create-groups": boolean;
 
     "chat-manager.last-seen": { [channel: string]: number };
     "device.uuid": string;

--- a/src/views/GroupList/GroupList.tsx
+++ b/src/views/GroupList/GroupList.tsx
@@ -22,14 +22,13 @@ import { _ } from "@/lib/translate";
 import { PaginatedTable } from "@/components/PaginatedTable";
 import { SearchInput } from "@/components/misc-ui";
 import { navigateTo } from "@/lib/misc";
-import { useUser } from "@/lib/hooks";
 import { user_uploads_url } from "@/lib/cdn";
 
 export function GroupList(): React.ReactElement {
-    const user = useUser();
     const [name_contains_filter, setNameContainsFilter] = React.useState("");
 
     const my_groups = data.get("cached.groups", []);
+    const canCreateGroups = data.get("can-create-groups", false);
 
     React.useEffect(() => {
         window.document.title = _("Groups");
@@ -45,7 +44,7 @@ export function GroupList(): React.ReactElement {
                         <i className="fa fa-users"></i> {_("Groups")}
                     </h2>
                     <div>
-                        {(!user.anonymous || null) && (
+                        {canCreateGroups && (
                             <Link className="primary" to="/group/create">
                                 <i className="fa fa-plus-square"></i> {_("New group")}
                             </Link>


### PR DESCRIPTION
Fixes dumdums creating groups with ban evasion accounts immediately

## Proposed Changes

  -  Use the `can_create_groups` flag from the backend to see if we trust the person enough
  
Needs https://github.com/online-go/ogs-node/pull/95  otherwise only mods can create groups.