### PR TITLE
Give AI detectors access to moderator note on AI reports

### DIFF
--- a/src/views/ReportsCenter/ViewReport.tsx
+++ b/src/views/ReportsCenter/ViewReport.tsx
@@ -227,6 +227,10 @@ export function ViewReport({
             .catch(errorAlerter);
     };
 
+    const show_moderator_note =
+        user.is_moderator ||
+        (report.report_type === "ai_use" && user.moderator_powers & MODERATOR_POWERS.AI_DETECTOR);
+
     return (
         <div>
             <KBShortcut shortcut="left" action={nav_prev} />
@@ -400,7 +404,7 @@ export function ViewReport({
                             </div>
                         )}
 
-                        {(user.is_moderator || null) && (
+                        {show_moderator_note && (
                             <div className="notes">
                                 <h4>
                                     Moderator Notes{" "}


### PR DESCRIPTION
Fixes AI Detectors not being able to describe the situation

## Proposed Changes

  - Let them access "moderator notes" for AI reports
  

Needs https://github.com/online-go/ogs/pull/2134 or will just error on submission.