### PR TITLE
Put back ability to display the value `open` for exclusivity field

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -952,14 +952,14 @@ export function Tournament(): React.ReactElement {
 
     let tournament_exclusivity = "";
     switch (tournament.exclusivity) {
+        case "open":
+            tournament_exclusivity = pgettext("Open tournament", "Open");
+            break;
         case "group":
             tournament_exclusivity = pgettext("Group tournament", "Members only");
             break;
         case "invite":
             tournament_exclusivity = pgettext("Group tournament", "Invite only");
-            break;
-        default:
-            tournament_exclusivity = pgettext("Group tournament", "Members only");
             break;
     }
 


### PR DESCRIPTION
Fixes saying "Members Only" when we mean "Open"

## Proposed Changes

  - Add back the string creation for "open"
