### PR TITLE
Group open tournaments again

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -481,9 +481,7 @@ export function Tournament(): React.ReactElement {
                     // Backend messages for translation
                     _("Player already has an outstanding invite");
                     _("Player is already participating in this tournament");
-                    _(
-                        "This tournament is only open to group members, so this user cannot be invited",
-                    );
+                    _("Only group members can be invited to group tournaments");
 
                     // The request library rejects and supplies the parsed JSON data directly for HTTP errors
                     if (res && typeof res === "object" && res.error) {


### PR DESCRIPTION
Fixes not being able to create open tournaments in Groups

## Proposed Changes

  - Turn that back on.
  
This is _intended_ to be:

 -  deployed only _after_ https://github.com/online-go/ogs/pull/2136 , which limits invites to group members only.
 - followed up by improved invite handling, currently under discussion
 
 