### PR TITLE
Show AI Detectors all AI reports in "Report History"

### DIFF
--- a/src/views/ReportsCenter/ReportsCenterCMHistory.tsx
+++ b/src/views/ReportsCenter/ReportsCenterCMHistory.tsx
@@ -18,8 +18,11 @@
 import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { PaginatedTable } from "@/components/PaginatedTable";
+import { useUser } from "@/lib/hooks";
+import { MODERATOR_POWERS } from "@/lib/moderation";
 
 export function ReportsCenterCMHistory(): React.ReactElement {
+    const user = useUser();
     const navigateTo = useNavigate();
 
     return (
@@ -79,13 +82,20 @@ export function ReportsCenterCMHistory(): React.ReactElement {
                     {
                         header: "Your vote",
                         className: () => "your-vote",
-                        render: (X) => `"${X.users_vote}"`,
+                        render: (X) => `${X.users_vote || "-"}`,
                     },
-                    {
-                        header: "Your outcome",
-                        className: () => "your-outcome",
-                        render: (X) => voteOutcomePresentation(X.users_vote_category),
-                    },
+                    ...(user.moderator_powers & MODERATOR_POWERS.AI_DETECTOR
+                        ? [
+                              /* "outcome" is not applicable for AI Detectors */
+                          ]
+                        : [
+                              {
+                                  header: "Your outcome",
+                                  className: () => "your-outcome",
+                                  render: (X: any) =>
+                                      voteOutcomePresentation(X.users_vote_category),
+                              },
+                          ]),
                 ]}
             />
         </div>


### PR DESCRIPTION
Fixes AI Detectors not being able to see what is going on and make sure they are aligned

## Proposed Changes

  - Display AI detection votes (only, not Dan CM votes) to AI detectors
  -- Dan CM votes aren't displayed because currently Dan CMs get to be anonymous
  -- We're not using Dan CMs much at all at the moment anyhow

