### PR TITLE
Change chat coordinate matcher to require whitespace or line start/end

### DIFF
--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -598,8 +598,8 @@ function MarkupChatLine({ line }: { line: ChatLine }): React.ReactElement {
             <React.Fragment>
                 {chat_markup(body, [
                     {
-                        split: /(\b[a-zA-Z][0-9]{1,2}\b)/gm,
-                        pattern: /\b([a-zA-Z][0-9]{1,2})\b/gm,
+                        split: /((?<=^|\s)\b[a-zA-Z][0-9]{1,2}\b(?=\s|$))/gm,
+                        pattern: /(?<=^|\s)\b([a-zA-Z][0-9]{1,2})\b(?=\s|$)/gm,
                         replacement: (m, idx) => {
                             const pos = m[1];
                             if (parsePosition(pos, goban).i < 0) {


### PR DESCRIPTION
Fixes #1321, partial fix for #2026

The initial problem here was that URLs like `https://github.com/online-go/online-go.com/blob/b3fde06d24cb33e62d68ecb091baa48a366e528e/src/components/Chat/chat_markup.tsx#L78` get mangled in chat, such that the "L78" doesn't become part of the URL.

The URL regex is fine. It turns out, because the coordinate matcher fires before the URL matcher, the "L78" gets flagged as a potential coordinate, then rejected for not being a valid coordinate. This results in it getting wrapped in a `<span>` tag, which causes it to not be included in the URL regex.

The ultimate fix, as @bhostetler18 describes in #2026 discussion, is probably a smarter system for prioritizing different regex matchers and making sure a given substring only gets targeted by a single matcher. However, for now, modifying the coordinate regex to only accept coordinates that are surrounded by whitespace on either end (or the start/end of a line) would effectively fix this issue, plus several of the usecases presented in #2026, including the one that triggered opening the issue.

Didn't see any obvious easy path to writing a regression test (the existing chat_markup tests just test the URL regexes in isolation, and it would require a bunch more setup to test the full "comment to parsed comment" path, which currently doesn't have any existing tests to crib setup from), but manually tested. Happy to write that test if folks think it's high-impact, but it strikes me the most likely next time someone will touch this code is if someone wants to do the bigger refactor.

In case it's unfamiliar, the regex syntax here is negative lookahead/lookback, which will match the whitespace/line-start/line-end characters without consuming them. We could also write this as `(^|\s)([a-zA-Z][0-9]{1,2})(\s|$)`, which might be slightly more performant (in a way that's almost certainly negligible for this usecase), but would require us to then properly handle the lookahead/lookbehind capture groups since we'd be consuming those tokens that we otherwise want to print as whitespace. IMO that would make things more complicated than just using maybe slightly more obtuse regex syntax. Open to suggestion!

