### PR TITLE
Simul detect test, util function rename

### DIFF
--- a/e2e-tests/cm/cm-ack-ack.ts
+++ b/e2e-tests/cm/cm-ack-ack.ts
@@ -29,7 +29,7 @@ import { Browser, TestInfo } from "@playwright/test";
 import {
     assertIncidentReportIndicatorActive,
     assertIncidentReportIndicatorInactive,
-    goToUsersGame,
+    goToUsersFinishedGame,
     newTestUsername,
     prepareNewUser,
     reportUser,
@@ -53,7 +53,7 @@ export const cmAckAcknowledgementTest = async (
         );
 
         // Report someone for score cheating
-        await goToUsersGame(reporterPage, "E2E_CM_AA_ACCUSED", "E2E CM AA Game");
+        await goToUsersFinishedGame(reporterPage, "E2E_CM_AA_ACCUSED", "E2E CM AA Game");
 
         await reportUser(reporterPage, "E2E_CM_AA_ACCUSED", "score_cheating", "he's a cheater!");
 

--- a/e2e-tests/cm/cm-ack-warning.ts
+++ b/e2e-tests/cm/cm-ack-warning.ts
@@ -34,7 +34,7 @@ import { Browser, TestInfo } from "@playwright/test";
 import {
     assertIncidentReportIndicatorActive,
     assertIncidentReportIndicatorInactive,
-    goToUsersGame,
+    goToUsersFinishedGame,
     newTestUsername,
     prepareNewUser,
     reportUser,
@@ -55,7 +55,7 @@ export const cmAckWarningTest = async ({ browser }: { browser: Browser }, testIn
         );
 
         // Report someone for AI use
-        await goToUsersGame(reporterPage, "E2E_CM_VWNAI_ACCUSED", "E2E CM VWNAI Game");
+        await goToUsersFinishedGame(reporterPage, "E2E_CM_VWNAI_ACCUSED", "E2E CM VWNAI Game");
 
         await reportUser(
             reporterPage,

--- a/e2e-tests/cm/cm-ai-assess-dismiss.ts
+++ b/e2e-tests/cm/cm-ai-assess-dismiss.ts
@@ -34,7 +34,7 @@ import { Browser, TestInfo } from "@playwright/test";
 import {
     assertIncidentReportIndicatorActive,
     assertIncidentReportIndicatorInactive,
-    goToUsersGame,
+    goToUsersFinishedGame,
     newTestUsername,
     prepareNewUser,
     reportUser,
@@ -58,7 +58,7 @@ export const cmAiAssessDismissTest = async (
         );
 
         // Report someone for AI use
-        await goToUsersGame(reporterPage, "E2E_CM_DNEA_AI_ACCUSED", "E2E CM DNEA Game");
+        await goToUsersFinishedGame(reporterPage, "E2E_CM_DNEA_AI_ACCUSED", "E2E CM DNEA Game");
 
         await reportUser(
             reporterPage,

--- a/e2e-tests/cm/cm-dont-notify-escalated-ai.ts
+++ b/e2e-tests/cm/cm-dont-notify-escalated-ai.ts
@@ -32,7 +32,7 @@ import { Browser, TestInfo } from "@playwright/test";
 import {
     assertIncidentReportIndicatorActive,
     assertIncidentReportIndicatorInactive,
-    goToUsersGame,
+    goToUsersFinishedGame,
     newTestUsername,
     prepareNewUser,
     reportUser,
@@ -56,7 +56,7 @@ export const cmDontNotifyEscalatedAiTest = async (
         );
 
         // Report someone for AI use
-        await goToUsersGame(reporterPage, "E2E_CM_DNEA_AI_ACCUSED", "E2E CM DNEA Game");
+        await goToUsersFinishedGame(reporterPage, "E2E_CM_DNEA_AI_ACCUSED", "E2E CM DNEA Game");
 
         await reportUser(
             reporterPage,

--- a/e2e-tests/cm/cm-show-only-post-escalation-votes.ts
+++ b/e2e-tests/cm/cm-show-only-post-escalation-votes.ts
@@ -30,7 +30,7 @@ import { Browser, TestInfo } from "@playwright/test";
 
 import {
     assertIncidentReportIndicatorActive,
-    goToUsersGame,
+    goToUsersFinishedGame,
     newTestUsername,
     prepareNewUser,
     reportUser,
@@ -53,7 +53,7 @@ export const cmShowOnlyPostEscalationVotesTest = async (
         );
 
         // Report someone for escaping
-        await goToUsersGame(reporterPage, "E2E_CM_SOPEV_REPORTED", "E2E CM SOPEV Game");
+        await goToUsersFinishedGame(reporterPage, "E2E_CM_SOPEV_REPORTED", "E2E CM SOPEV Game");
 
         await reportUser(
             reporterPage,

--- a/e2e-tests/cm/cm-vote-on-own-report.ts
+++ b/e2e-tests/cm/cm-vote-on-own-report.ts
@@ -28,7 +28,7 @@
 import { Browser, TestInfo, expect } from "@playwright/test";
 
 import { expectOGSClickableByName } from "@helpers/matchers";
-import { goToUsersGame, reportUser, setupSeededUser } from "@helpers/user-utils";
+import { goToUsersFinishedGame, reportUser, setupSeededUser } from "@helpers/user-utils";
 
 import { withIncidentIndicatorLock } from "@helpers/report-utils";
 
@@ -39,7 +39,7 @@ export const cmVoteOnOwnReportTest = async (
     await withIncidentIndicatorLock(testInfo, async () => {
         const { userPage: reporterPage } = await setupSeededUser(browser, "E2E_CM_VOOR_REPORTER");
 
-        await goToUsersGame(reporterPage, "E2E_CM_VOOR_REPORTED", "E2E CM VOOR Game");
+        await goToUsersFinishedGame(reporterPage, "E2E_CM_VOOR_REPORTED", "E2E CM VOOR Game");
 
         // ... and report the user
         // (The username is truncated inside the player card!  So the "other player" name must not match here!)

--- a/e2e-tests/cm/cm-vote-warn-not-ai.ts
+++ b/e2e-tests/cm/cm-vote-warn-not-ai.ts
@@ -29,7 +29,7 @@ import { Browser, TestInfo } from "@playwright/test";
 import {
     assertIncidentReportIndicatorActive,
     assertIncidentReportIndicatorInactive,
-    goToUsersGame,
+    goToUsersFinishedGame,
     newTestUsername,
     prepareNewUser,
     reportUser,
@@ -53,7 +53,7 @@ export const cmVoteWarnNotAITest = async (
         );
 
         // Report someone for AI use
-        await goToUsersGame(reporterPage, "E2E_CM_VWNAI_ACCUSED", "E2E CM VWNAI Game");
+        await goToUsersFinishedGame(reporterPage, "E2E_CM_VWNAI_ACCUSED", "E2E CM VWNAI Game");
 
         await reportUser(
             reporterPage,

--- a/e2e-tests/games/bot-detect.ts
+++ b/e2e-tests/games/bot-detect.ts
@@ -17,6 +17,8 @@
 
 // (No seeded data in use)
 
+// incomplete test
+
 import { Browser } from "@playwright/test";
 import { expect } from "@playwright/test";
 

--- a/e2e-tests/games/games.spec.ts
+++ b/e2e-tests/games/games.spec.ts
@@ -18,8 +18,10 @@
 import { ogsTest } from "@helpers";
 import { basicScoringTest } from "./basic-scoring";
 import { conditionalMovesArrowBugTest } from "./conditional-moves-arrow";
+import { detectContainedSimulTest } from "./simul-detection";
 
 ogsTest.describe("@Games Tests", () => {
     ogsTest("Should be able to pass and score a game", basicScoringTest);
     ogsTest("Should be able to use arrow in conditional moves", conditionalMovesArrowBugTest);
+    ogsTest("Should be able to detect contained simultaneous game", detectContainedSimulTest);
 });

--- a/e2e-tests/games/simul-detection.ts
+++ b/e2e-tests/games/simul-detection.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/*
+* Uses init_e2e data:
+
+* - E2E_GAMES_SIMUL_CM : user who will check the report
+*/
+
+import { Browser, TestInfo } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+import {
+    assertIncidentReportIndicatorActive,
+    assertIncidentReportIndicatorInactive,
+    loginAsUser,
+    newTestUsername,
+    prepareNewUser,
+    reportUser,
+    setupSeededCM,
+} from "@helpers/user-utils";
+import {
+    acceptDirectChallenge,
+    createDirectChallenge,
+    defaultChallengeSettings,
+} from "@helpers/challenge-utils";
+
+import { playMoves, resignActiveGame } from "@helpers/game-utils";
+// @ts-expect-error - unused import until we uncomment the test implementation
+import { withIncidentIndicatorLock, withIncidentReportIndicatorLock } from "@helpers/report-utils";
+
+export const detectContainedSimulTest = async (
+    { browser }: { browser: Browser },
+    testInfo: TestInfo,
+) => {
+    // The user who plays simultaneous games
+    const challengerUsername = newTestUsername("gamesSimulCh"); // cspell:disable-line
+    const { userPage: challengerContainingGamePage } = await prepareNewUser(
+        browser,
+        challengerUsername,
+        "test",
+    );
+
+    const acceptor1Username = newTestUsername("gamesSmlAc1"); // cspell:disable-line
+    const { userPage: acceptor1Page } = await prepareNewUser(browser, acceptor1Username, "test");
+
+    // Challenger challenges the first acceptor
+    await createDirectChallenge(challengerContainingGamePage, acceptor1Username, {
+        ...defaultChallengeSettings,
+        gameName: "E2E Games Simul Containing Test Game",
+        boardSize: "9x9",
+        speed: "live",
+        timeControl: "byoyomi",
+        mainTime: "45", // heaps of time to get organised with the other one :)
+        timePerPeriod: "10",
+        periods: "1",
+    });
+
+    // escaper accepts
+    await acceptDirectChallenge(acceptor1Page);
+
+    // Challenger is black
+    // Wait for the Goban to be visible & definitely ready
+    const goban = challengerContainingGamePage.locator(".Goban[data-pointers-bound]");
+    await goban.waitFor({ state: "visible" });
+
+    await challengerContainingGamePage.waitForTimeout(1000);
+
+    // Wait for the game state to indicate it's the challenger's move
+    const challengersMove = challengerContainingGamePage.getByText("Your move", { exact: true });
+    await expect(challengersMove).toBeVisible();
+
+    // Now a new tab for the challenger!  (2 tabs for a person in PW!)
+    // Log in as the challenger
+
+    const userContext = await browser.newContext();
+    const challengerContainedGamePage = await userContext.newPage();
+
+    await loginAsUser(challengerContainedGamePage, challengerUsername, "test");
+
+    const acceptor2Username = newTestUsername("gamesSmlAc2"); // cspell:disable-line
+    const { userPage: acceptor2Page } = await prepareNewUser(browser, acceptor2Username, "test");
+
+    // Challenger challenges the second acceptor
+    await createDirectChallenge(challengerContainedGamePage, acceptor2Username, {
+        ...defaultChallengeSettings,
+        gameName: `E2E Games Simul Contained Test Game`,
+        boardSize: "9x9",
+        speed: "live",
+        timeControl: "byoyomi",
+        mainTime: "45", // heaps of time to get organised with the other one :)
+        timePerPeriod: "10",
+        periods: "1",
+    });
+
+    // escaper accepts
+    await acceptDirectChallenge(acceptor2Page);
+
+    // Challenger is black
+    // Wait for the Goban to be visible & definitely ready
+    const goban2 = challengerContainedGamePage.locator(".Goban[data-pointers-bound]");
+    await goban2.waitFor({ state: "visible" });
+
+    await challengerContainedGamePage.waitForTimeout(1000);
+
+    // Wait for the game state to indicate it's the challenger's move
+    const challengersOtherMove = challengerContainedGamePage.getByText("Your move", {
+        exact: true,
+    });
+    await expect(challengersOtherMove).toBeVisible();
+
+    // Whoa, we have two games going at once!
+    // Play a few moves to give the games an actual duration
+
+    let moves = ["D9", "E9", "D8", "E8", "D7", "E7", "D6", "E6"];
+
+    await playMoves(challengerContainedGamePage, acceptor2Page, moves, "9x9", 1000);
+
+    await resignActiveGame(acceptor2Page);
+
+    moves = ["D5", "E5", "D4", "E4", "D3", "E3"];
+
+    await playMoves(challengerContainingGamePage, acceptor1Page, moves, "9x9", 1000);
+
+    await resignActiveGame(acceptor1Page);
+
+    // Create a report so we can check the log for Simul detected
+    await reportUser(acceptor1Page, challengerUsername, "ai_use", "reporting to see simul flag");
+
+    // Check the log: should show stone acceptance and game end
+    await withIncidentIndicatorLock(testInfo, async () => {
+        const cm = "E2E_GAMES_SIMUL_CM";
+
+        const { seededCMPage: cmPage } = await setupSeededCM(browser, cm);
+
+        const indicator = await assertIncidentReportIndicatorActive(cmPage, 1);
+
+        await indicator.click();
+
+        await expect(cmPage.getByRole("heading", { name: "Reports Center" })).toBeVisible();
+
+        await expect(cmPage.getByText("reporting to see simul flag")).toBeVisible();
+
+        await expect(
+            cmPage.locator(".reported-game-important-info").getByText("Simul", { exact: true }),
+        ).toBeVisible();
+    });
+
+    // clean up the report
+
+    const indicator = await assertIncidentReportIndicatorActive(acceptor1Page, 1);
+
+    await indicator.click();
+
+    const cancelButton = acceptor1Page.getByText("Cancel");
+    await expect(cancelButton).toBeVisible();
+
+    await cancelButton.click();
+
+    await assertIncidentReportIndicatorInactive(acceptor1Page);
+};

--- a/e2e-tests/helpers/game-utils.ts
+++ b/e2e-tests/helpers/game-utils.ts
@@ -98,6 +98,7 @@ export const playMoves = async (
     white: Page,
     moves: string[],
     boardSize: BoardSize = "19x19",
+    delay: number = 0,
     handicap: number = 0, // Japanese
 ) => {
     for (let i = 0; i < moves.length; i++) {
@@ -113,5 +114,24 @@ export const playMoves = async (
         const moveText = page.getByText("Your move", { exact: true });
         await expect(moveText).toBeVisible();
         await clickOnGobanIntersection(page, moves[i], boardSize);
+        await page.waitForTimeout(delay);
     }
+};
+
+export const resignActiveGame = async (page: Page) => {
+    const resign = page.locator(".play-buttons .cancel-button");
+    await expect(resign).toBeVisible();
+    await resign.click();
+
+    // Handle the confirmation dialog
+    const confirmDialog = page.locator('[role="dialog"]').filter({ hasText: "resign" });
+    await expect(confirmDialog).toBeVisible();
+
+    const confirmButton = confirmDialog.getByRole("button", { name: "Yes" });
+    await expect(confirmButton).toBeVisible();
+    await confirmButton.click();
+
+    // Verify the resignation was successful
+    const resignationText = page.getByText("by Resignation");
+    await expect(resignationText).toBeVisible();
 };

--- a/e2e-tests/helpers/user-utils.ts
+++ b/e2e-tests/helpers/user-utils.ts
@@ -259,7 +259,7 @@ export const goToUsersProfile = async (page: Page, username: string) => {
 
 // Note: if there are multiple matches, this grabs the first.   This is avoids issues if we
 // accidentally have more seed games than intended.
-export const goToUsersGame = async (page: Page, username: string, gameName: string) => {
+export const goToUsersFinishedGame = async (page: Page, username: string, gameName: string) => {
     await goToUsersProfile(page, username);
 
     const gameHistory = page.getByText("Game History");


### PR DESCRIPTION
Fixes not having a test for new simul code

## Proposed Changes

  - Test "contained game" scenario, as a "useful start"
  
Note: Needs https://github.com/online-go/ogs/pull/2144 and init_e2e run on beta for anyone to be able to run this against beta (but hardly anyone will).
