### PR TITLE
Attempt at making the landing page for learn to play go not so overwhelming

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -107,6 +107,7 @@
         "Miai",
         "miniboard",
         "minigoban",
+        "minmax",
         "misclick",
         "misclicks",
         "modlog",

--- a/Makefile.production
+++ b/Makefile.production
@@ -86,6 +86,10 @@ prepare-cdn-files: purge-cdn-files dist/ogs.js dist/ogs.min.css
 	cp -p dist/ogs.js.map deployment-staging-area/$(RELEASE)/ogs.$(OGS_VERSION_HASH).js.map
 	cat dist/ogs.min.css | sed 's/ogs.min.css.map/ogs.min.$(VERSION).css.map/' > deployment-staging-area/$(RELEASE)/ogs.$(VERSION).css
 	cp -p dist/ogs.min.css.map deployment-staging-area/$(RELEASE)/ogs.min.$(VERSION).css.map
+	cp -Rp dist/modules deployment-staging-area/$(RELEASE)/
+	# Fix module imports to reference versioned ogs.js
+	find deployment-staging-area/$(RELEASE)/modules -name "*.js" -type f -exec sed -i 's@from"../ogs\.js"@from"../ogs.$(OGS_VERSION_HASH).js"@g' {} \;
+	find deployment-staging-area/$(RELEASE)/modules -name "*.js" -type f -exec sed -i "s@from'../ogs\.js'@from'../ogs.$(OGS_VERSION_HASH).js'@g" {} \;
 	cp -Rp assets/img deployment-staging-area/$(RELEASE)/
 	cp -Rp assets/sound deployment-staging-area/$(RELEASE)/
 	ls i18n/locale/*.js | sed 's@i18n/locale/\([^\.]\+\).js@\1@' | xargs -n1 -I {} cp i18n/locale/{}.js deployment-staging-area/$(RELEASE)/locale/{}.$(LANGUAGE_VERSION).js

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -224,6 +224,7 @@ export const defaults = {
     "user-history.show-mod-log": false,
     "user-history.warnings-only": false,
     "debug.test-wanted": false,
+    "learning-hub-expanded-section": "Fundamentals",
 };
 
 defaults["profanity-filter"][current_language] = true;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -53,7 +53,6 @@ import { Supporter } from "@/views/Supporter";
 import { Tournament } from "@/views/Tournament";
 import { TournamentRecord } from "@/views/TournamentRecord";
 import { TournamentListMainView } from "@/views/TournamentList";
-import { LearningHub } from "@/views/LearningHub";
 import { User, UserByName } from "@/views/User";
 import { Settings } from "@/views/Settings";
 import { Styling } from "@/views/Styling";
@@ -74,12 +73,42 @@ import { AccountWarning } from "@/components/AccountWarning";
 import { NetworkStatus } from "@/components/NetworkStatus";
 import { PrizeBatchList, PrizeBatch, PrizeRedemption } from "@/views/Prizes";
 import { GoTV } from "@/views/GoTV";
+import { Loading } from "@/components/Loading";
 
 import * as docs from "@/views/docs";
 import { useData } from "./lib/hooks";
 import { MainSection } from "@/components/MainSection";
 import { AccessibilityMenu } from "@/components/AccessibilityMenu";
 import { AIDetection } from "@moderator-ui/AIDetection";
+
+const LearningHub = React.lazy(() =>
+    import("@/views/LearningHub").then((m) => ({ default: m.LearningHub })),
+);
+
+function LearningHubWithLoading() {
+    return (
+        <React.Suspense
+            fallback={
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        position: "fixed",
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                    }}
+                >
+                    <Loading />
+                </div>
+            }
+        >
+            <LearningHub />
+        </React.Suspense>
+    );
+}
 
 /*** Layout our main view and routes ***/
 function AppLayout(props: { children: any }): React.ReactElement {
@@ -343,15 +372,24 @@ export const routes = (
                   <Route path="/admin/tournament-schedule-list" element={<AdminTournamentScheduleList />}/>
                 */}
                 <Route path="/moderator" element={<Moderator />} />
-                <Route path="/learning-hub/:section/:page" element={<LearningHub />} />
-                <Route path="/learning-hub/:section" element={<LearningHub />} />
-                <Route path="/learning-hub" element={<LearningHub />} />
-                <Route path="/learn-to-play-go/:section/:page" element={<LearningHub />} />
-                <Route path="/learn-to-play-go/:section" element={<LearningHub />} />
-                <Route path="/learn-to-play-go" element={<LearningHub />} />
-                <Route path="/docs/learn-to-play-go/:section/:page" element={<LearningHub />} />
-                <Route path="/docs/learn-to-play-go/:section" element={<LearningHub />} />
-                <Route path="/docs/learn-to-play-go" element={<LearningHub />} />
+                <Route path="/learning-hub/:section/:page" element={<LearningHubWithLoading />} />
+                <Route path="/learning-hub/:section" element={<LearningHubWithLoading />} />
+                <Route path="/learning-hub" element={<LearningHubWithLoading />} />
+                <Route
+                    path="/learn-to-play-go/:section/:page"
+                    element={<LearningHubWithLoading />}
+                />
+                <Route path="/learn-to-play-go/:section" element={<LearningHubWithLoading />} />
+                <Route path="/learn-to-play-go" element={<LearningHubWithLoading />} />
+                <Route
+                    path="/docs/learn-to-play-go/:section/:page"
+                    element={<LearningHubWithLoading />}
+                />
+                <Route
+                    path="/docs/learn-to-play-go/:section"
+                    element={<LearningHubWithLoading />}
+                />
+                <Route path="/docs/learn-to-play-go" element={<LearningHubWithLoading />} />
                 <Route path="/gotv" element={<GoTV />} />
                 {/* these aren't meant to be linked anywhere, just entered by hand
                     for developers looking to test and play with things */}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -82,7 +82,9 @@ import { AccessibilityMenu } from "@/components/AccessibilityMenu";
 import { AIDetection } from "@moderator-ui/AIDetection";
 
 const LearningHub = React.lazy(() =>
-    import("@/views/LearningHub").then((m) => ({ default: m.LearningHub })),
+    import(/* webpackChunkName: "learning-hub" */ "@/views/LearningHub").then((m) => ({
+        default: m.LearningHub,
+    })),
 );
 
 function LearningHubWithLoading() {

--- a/src/views/LearningHub/LearningHub.styl
+++ b/src/views/LearningHub/LearningHub.styl
@@ -192,7 +192,7 @@
                 box-sizing: border-box;
 
                 &.expanded {
-                    max-height: 3000px; // Increased to accommodate more rows of cards
+                    max-height: none;
                     opacity: 1;
                     padding: 1.5rem;
                 }

--- a/src/views/LearningHub/LearningHub.styl
+++ b/src/views/LearningHub/LearningHub.styl
@@ -30,7 +30,7 @@
 
 #LearningHub {
     width: 100%;
-    max-width: 80rem;
+    max-width: 120rem;  // Further increased for 3 cards with comfortable spacing
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
@@ -77,40 +77,165 @@
     }
 
     #LearningHub-list {
-        text-align: center;
         display: flex;
         flex-direction: column;
         justify-content: center;
         margin-bottom: 4rem;
+        width: 100%;
+        max-width: 120rem; // Further increased for 3 cards with comfortable spacing
+        margin-left: auto;
+        margin-right: auto;
+
+        // Remove filter and view controls - no longer needed
 
         .section {
-            margin-top: 3rem;
+            margin-top: 2rem;
             display: flex;
-            flex-direction: row;
-            flex-wrap: wrap;
+            flex-direction: column;
+            width: 100%;
+            max-width: 120rem; // Match the parent max-width for 3 cards
+            margin-left: auto;
+            margin-right: auto;
 
-            > h2 {
-                flex: 1;
-                text-align: right;
-                width: 30%;
-                min-width: 15rem;
-                letter-spacing: 8px;
-                text-transform: uppercase;
-                themed(color, shade2);
-                padding-right: 3rem;
+            // Collapsible section header with progress on the right
+            .section-header {
+                height: 80px; // Fixed height for consistency
+                padding: 1rem 1.5rem;
+                themed(background-color, shade5);
+                border-radius: 0.5rem 0.5rem 0 0;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                cursor: pointer;
+                transition: background-color 0.2s ease;
+                width: 100%;
+                box-sizing: border-box;
 
-                .section-number {
-                    padding-right: 1.5rem;
+                &.clickable:hover {
+                    themed(background-color, shade4);
+                }
+
+                .section-left {
+                    display: flex;
+                    align-items: center;
+                    gap: 1rem;
+
+                    .section-chevron {
+                        themed(color, shade2);
+                        font-size: 1rem;
+                        transition: color 0.2s ease, transform 0.2s ease;
+                    }
+
+                    h2 {
+                        margin: 0;
+                        display: flex;
+                        align-items: center;
+                        font-size: 1.3rem;
+                        themed(color, shade0);
+
+                        .section-number {
+                            padding-right: 1rem;
+                            font-weight: bold;
+                        }
+                    }
+                }
+
+                .section-right {
+                    display: flex;
+                    align-items: center;
+
+                    .progress-info {
+                        display: flex;
+                        align-items: center;
+                        gap: 1rem;
+
+                        .progress-bar {
+                            width: 120px;
+                            height: 8px;
+                            themed(background-color, shade4);
+                            border-radius: 4px;
+                            overflow: hidden;
+
+                            .progress-fill {
+                                height: 100%;
+                                themed(background-color, primary);
+                                transition: width 0.3s ease;
+                            }
+                        }
+
+                        .lesson-count {
+                            font-size: 0.9rem;
+                            themed(color, shade2);
+                            white-space: nowrap;
+                        }
+                    }
                 }
             }
 
+            // Collapsible content area with proper card styling
             > .contents {
-                flex: 1;
-                min-width: 24rem;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
+                padding: 1.5rem;
+                themed(background-color, shade5); // Use shade5 instead of shade6 for compatibility
+                border-radius: 0 0 0.5rem 0.5rem;
+                border: 1px solid;
+                themed(border-color, shade4);
+                border-top: none;
+                display: grid;
+                // Use auto-fit with a smaller minimum to allow more flexibility
+                grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+                column-gap: 1.5rem; // Reduced gap for more space
+                row-gap: 1rem; // Keep vertical spacing at 1rem
+                justify-content: space-around; // Space cards evenly
+                transition: max-height 0.3s ease, padding 0.3s ease, opacity 0.3s ease;
+                overflow: hidden;
+                width: 100%;
+                box-sizing: border-box;
+
+                &.expanded {
+                    max-height: 3000px; // Increased to accommodate more rows of cards
+                    opacity: 1;
+                    padding: 1.5rem;
+                }
+
+                &.collapsed {
+                    max-height: 0;
+                    opacity: 0;
+                    padding: 0 1.5rem;
+                }
+
             }
+
+            // Special styling for "What's Next" section
+            &.whats-next {
+                .contents {
+                    max-height: none !important;
+                    opacity: 1 !important;
+                    padding: 1.5rem !important;
+                    display: grid;
+                    // Keep consistent grid layout with other sections
+                    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+                    column-gap: 1.5rem; // Reduced gap for more space
+                    row-gap: 1rem; // Keep vertical spacing at 1rem
+                    justify-content: space-around;
+                    width: 100%;
+                    box-sizing: border-box;
+                }
+
+                .section-header {
+                    height: auto; // Allow auto height for this section
+                    padding-bottom: 1rem;
+
+                    h2 {
+                        font-size: 1.5rem;
+                        letter-spacing: 2px;
+                        text-transform: uppercase;
+                    }
+                }
+            }
+
+            // Removed obsolete styles that were overriding the grid layout
+            // The h2 is now inside .section-header, not a direct child of .section
+            // The .contents now properly uses CSS Grid as defined above
 
             .under-construction {
                 background-image: repeating-linear-gradient(-45deg, darken(#FFCC00, 30%), darken(#FFCC00, 10%) 10px, #000 10px, #000 20px);
@@ -120,7 +245,8 @@
                 display: flex;
                 align-items: center;
                 text-decoration: none;
-                width: 23rem;
+                width: 100%; // Make cards responsive to grid cell width
+                max-width: 23rem; // But don't exceed original max size
                 height: 5rem;
                 color: #f9f9f9;
                 border-radius: 0.3rem;
@@ -180,6 +306,32 @@
                 cursor: pointer;
             }
         }
+
+        // KidsGoServer.com section at the bottom
+        .kids-go-server {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.2rem;
+            margin-top: 3rem;
+            padding: 2rem;
+            themed(background-color, shade5);
+            border-radius: 0.5rem;
+
+            img {
+                width: 8rem;
+                height: 8rem;
+                margin-right: 1rem;
+            }
+
+            a {
+                display: block;
+                font-size: 1.3rem;
+                margin-left: 0.5rem;
+            }
+        }
+
     }
 }
 
@@ -299,7 +451,7 @@
         align-items: stretch;
         align-content: center;
         justify-content: center;
-        text-align: center;
+        text-align: left; // Changed from center to left
 
         > div {
             flex: 1;
@@ -360,6 +512,67 @@
     }
 }
 
+// Large screens: Natural grid layout with auto-fill handles this
+// The grid-template-columns with auto-fill and 18-22rem cards will naturally create 3+ columns
+
+// Large screens: Force 3 cards per row when space allows
+@media (min-width: 75rem) {
+    #LearningHub-Index {
+        #LearningHub-list {
+            .section > .contents {
+                // Explicitly set 3-column layout on large screens
+                grid-template-columns: repeat(3, 1fr);
+                column-gap: 1.5rem; // Reduced gap for more space
+                row-gap: 1rem;
+                justify-content: center; // Center the grid
+            }
+        }
+    }
+}
+
+// Medium screens: 2 cards per row
+@media (min-width: 48rem) and (max-width: 75rem) {
+    #LearningHub-Index {
+        #LearningHub-list {
+            .section > .contents {
+                // Adjust grid for 2 cards on medium screens
+                grid-template-columns: repeat(2, 1fr);
+                column-gap: 1.5rem; // Reduced gap for more space
+                row-gap: 1rem;
+                justify-content: center;
+            }
+        }
+    }
+}
+
+// Small screens: Show 1 card per row
+@media (max-width: 48rem) {
+    #LearningHub-Index {
+        #LearningHub-list {
+            .section > .contents {
+                // Single column on small screens
+                grid-template-columns: 1fr;
+                justify-content: center;
+
+                // Make cards fill available width in single column mode
+                .Card {
+                    max-width: calc(100% - 2rem) !important;
+                }
+            }
+
+            // Also apply to What's Next section
+            .whats-next .contents {
+                grid-template-columns: 1fr;
+
+                .Card {
+                    max-width: calc(100% - 2rem) !important;
+                }
+            }
+        }
+    }
+}
+
+// Mobile-specific adjustments
 @media (max-width: 40rem) {
     .LearningPage {
         padding-top: 0rem;
@@ -371,5 +584,82 @@
 
     .LearningHub-section-nav {
         width: 95%;
+    }
+
+    #LearningHub-Index {
+        #LearningHub-list {
+
+            .section {
+                .section-header {
+                    height: auto; // Allow flexible height on mobile
+                    min-height: 70px;
+                    padding: 0.75rem 1rem;
+                    flex-direction: column;
+                    align-items: flex-start;
+
+                    .section-left {
+                        width: 100%;
+                        margin-bottom: 0.5rem;
+
+                        h2 {
+                            font-size: 1.1rem;
+                        }
+                    }
+
+                    .section-right {
+                        width: 100%;
+
+                        .progress-info {
+                            width: 100%;
+                            justify-content: space-between;
+
+                            .lesson-count {
+                                font-size: 0.8rem;
+                            }
+
+                            .progress-bar {
+                                flex: 1;
+                                max-width: 100px;
+                                margin: 0 0.5rem;
+                            }
+
+                            .progress-percentage {
+                                font-size: 0.85rem;
+                            }
+                        }
+                    }
+                }
+
+                > .contents {
+                    &.expanded {
+                        padding: 1rem; // Smaller padding on mobile
+                    }
+
+                    column-gap: 0; // No gap needed for single column
+                    row-gap: 0.75rem;
+                    grid-template-columns: 1fr;
+                    justify-content: center;
+
+                    // Make cards fill available width on mobile
+                    .Card {
+                        width: 100%;
+                        max-width: none;
+                    }
+                }
+            }
+
+            .kids-go-server {
+                flex-direction: column;
+                text-align: center;
+                padding: 1.5rem 1rem;
+
+                img {
+                    margin-right: 0;
+                    margin-bottom: 1rem;
+                    width: 6rem;
+                    height: 6rem;
+                }
+            }
+        }
     }
 }

--- a/src/views/LearningHub/LearningHub.styl
+++ b/src/views/LearningHub/LearningHub.styl
@@ -27,10 +27,9 @@
     }
 }
 
-
 #LearningHub {
     width: 100%;
-    max-width: 120rem;  // Further increased for 3 cards with comfortable spacing
+    max-width: 120rem; // Further increased for 3 cards with comfortable spacing
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
@@ -54,11 +53,13 @@
         justify-content: center;
         font-size: 1.2rem;
         margin-top: 2rem;
+
         img {
             width: 8rem;
             height: 8rem;
             margin-right: 0.5rem;
         }
+
         a {
             display: block;
             font-size: 1.3rem;
@@ -87,7 +88,6 @@
         margin-right: auto;
 
         // Remove filter and view controls - no longer needed
-
         .section {
             margin-top: 2rem;
             display: flex;
@@ -172,6 +172,16 @@
                 }
             }
 
+            &:has(.contents.expanded) .section-header {
+                position: sticky;
+                top: 0;
+                z-index: 10;
+                //border-top-left-radius: 0.5rem;
+                //border-top-right-radius: 0.5rem;
+                border: 1px solid;
+                themed(border-color, shade4);
+            }
+
             // Collapsible content area with proper card styling
             > .contents {
                 padding: 1.5rem;
@@ -202,7 +212,6 @@
                     opacity: 0;
                     padding: 0 1.5rem;
                 }
-
             }
 
             // Special styling for "What's Next" section
@@ -236,7 +245,6 @@
             // Removed obsolete styles that were overriding the grid layout
             // The h2 is now inside .section-header, not a direct child of .section
             // The .contents now properly uses CSS Grid as defined above
-
             .under-construction {
                 background-image: repeating-linear-gradient(-45deg, darken(#FFCC00, 30%), darken(#FFCC00, 10%) 10px, #000 10px, #000 20px);
             }
@@ -331,7 +339,6 @@
                 margin-left: 0.5rem;
             }
         }
-
     }
 }
 
@@ -588,7 +595,6 @@
 
     #LearningHub-Index {
         #LearningHub-list {
-
             .section {
                 .section-header {
                     height: auto; // Allow flexible height on mobile

--- a/src/views/LearningHub/LearningHub.styl
+++ b/src/views/LearningHub/LearningHub.styl
@@ -451,7 +451,7 @@
         align-items: stretch;
         align-content: center;
         justify-content: center;
-        text-align: left; // Changed from center to left
+        text-align: center;
 
         > div {
             flex: 1;

--- a/src/views/LearningHub/LearningHub.tsx
+++ b/src/views/LearningHub/LearningHub.tsx
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 import * as data from "@/lib/data";
+import * as preferences from "@/lib/preferences";
 import { Link, useParams } from "react-router-dom";
 import { CardLink } from "@/components/material";
 import { _, pgettext } from "@/lib/translate";
@@ -90,46 +91,163 @@ export function LearningHub(): React.ReactElement {
     }
 }
 
-class Index extends React.PureComponent<{}, any> {
-    constructor(props: {}) {
-        super(props);
+// Helper types for better maintainability
+interface SectionProgress {
+    total: number;
+    completed: number;
+    inProgress: number;
+    percentage: number;
+}
+
+interface ExpandedSectionsState {
+    [key: string]: boolean;
+}
+
+// Constants for preferences storage keys
+const LAST_EXPANDED_SECTION_KEY = "learning-hub-expanded-section" as const;
+
+// Helper functions extracted for reusability
+function calculateSectionProgress(lessons: any[]): SectionProgress {
+    const progress = lessons.reduce(
+        (acc, lesson) => {
+            const sc = getSectionCompletion(lesson.section());
+            acc.total++;
+            if (sc.completed) {
+                acc.completed++;
+            } else if (sc.started) {
+                acc.inProgress++;
+            }
+            return acc;
+        },
+        { total: 0, completed: 0, inProgress: 0, percentage: 0 },
+    );
+
+    progress.percentage =
+        progress.total > 0 ? Math.round((progress.completed / progress.total) * 100) : 0;
+    return progress;
+}
+
+function initializeExpandedSections(): ExpandedSectionsState {
+    const expandedSections: ExpandedSectionsState = {};
+    const lastExpandedSection = preferences.get(LAST_EXPANDED_SECTION_KEY);
+
+    sections.forEach(([sectionName], index) => {
+        // Restore from saved state or default to first section
+        expandedSections[sectionName] = lastExpandedSection
+            ? sectionName === lastExpandedSection
+            : index === 0;
+    });
+
+    return expandedSections;
+}
+
+function getRibbonContent(sectionName: string): React.ReactNode {
+    const sc = getSectionCompletion(sectionName);
+
+    if (sc.completed) {
+        return (
+            <span>
+                <i className="fa fa-star" />
+                <i className="fa fa-star" />
+                <i className="fa fa-star" />
+            </span>
+        );
     }
 
-    render() {
-        const user = data.get("user");
+    if (sc.started) {
         return (
-            <div id="LearningHub-Index">
-                <div id="LearningHub-list">
-                    <div className="kids-go-server">
-                        <img src="https://cdn.online-go.com/assets/axol.svg" />
-                        <div>
-                            {pgettext(
-                                "Immediately after this text is a link to Kids Go Server",
-                                "Looking for a great place to learn Go for kids? Check out",
-                            )}
-                            <a href="https://kidsgoserver.com/">KidsGoServer.com</a>
-                        </div>
-                    </div>
-                    {sections.map((arr) => (
+            <span>
+                {sc.finished} / {sc.total}
+            </span>
+        );
+    }
+
+    return <span>{pgettext("Play a tutorial section", "play!")}</span>;
+}
+
+// Convert to functional component for better performance
+function Index(): React.ReactElement {
+    const user = data.get("user");
+    const [expandedSections, setExpandedSections] = React.useState<ExpandedSectionsState>(
+        initializeExpandedSections,
+    );
+
+    const toggleSection = React.useCallback((sectionName: string) => {
+        setExpandedSections((prevState) => {
+            const newExpandedState = !prevState[sectionName];
+
+            // Create new state with only one section expanded at a time
+            const newState: ExpandedSectionsState = {};
+            sections.forEach(([name]) => {
+                newState[name] = false;
+            });
+
+            // Expand the clicked section if it was closed
+            if (newExpandedState) {
+                newState[sectionName] = true;
+                preferences.set(LAST_EXPANDED_SECTION_KEY, sectionName);
+            }
+
+            return newState;
+        });
+    }, []);
+
+    return (
+        <div id="LearningHub-Index">
+            <div id="LearningHub-list">
+                {sections.map((arr) => {
+                    const isExpanded = expandedSections[arr[0]];
+                    const progress = calculateSectionProgress(arr[1]);
+                    return (
                         <div key={arr[0]} className="section">
-                            <h2>
-                                <span className="section-number">{arr[1][0].sectionIndex + 1}</span>
-                                {arr[0]}
-                            </h2>
-                            <div className="contents">
+                            <div
+                                className="section-header clickable"
+                                onClick={() => toggleSection(arr[0])}
+                            >
+                                <div className="section-left">
+                                    <i
+                                        className={`fa fa-chevron-${
+                                            isExpanded ? "down" : "right"
+                                        } section-chevron`}
+                                    />
+                                    <h2>
+                                        <span className="section-number">
+                                            {arr[1][0].sectionIndex + 1}
+                                        </span>
+                                        {arr[0]}
+                                    </h2>
+                                </div>
+                                <div className="section-right">
+                                    <div className="progress-info">
+                                        <div className="progress-bar">
+                                            <div
+                                                className="progress-fill"
+                                                style={{ width: `${progress.percentage}%` }}
+                                            />
+                                        </div>
+                                        <span className="lesson-count">
+                                            {progress.completed}/{progress.total} lessons
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div className={`contents ${isExpanded ? "expanded" : "collapsed"}`}>
                                 {arr[1].map((S) => {
                                     const className = getSectionClassName(S.section());
                                     const sectionNumber = `${S.sectionIndex + 1}.${
                                         S.lessonIndex + 1
                                     }`;
+                                    // Extract MiniGoban configuration
                                     const p = new (S.pages()[0])();
-                                    const config = p.config();
-                                    if (!config.width) {
-                                        config.width = 9;
-                                        config.height = 9;
-                                    }
+                                    const config = {
+                                        ...p.config(),
+                                        width: p.config().width || 9,
+                                        height: p.config().height || 9,
+                                    };
+                                    // Remove unnecessary properties
                                     delete config["mode"];
                                     delete config["move_tree"];
+
                                     return (
                                         <CardLink
                                             key={S.section()}
@@ -154,137 +272,117 @@ class Index extends React.PureComponent<{}, any> {
                                                 <h3>{S.subtext()}</h3>
                                             </div>
                                             {className !== "todo" ? (
-                                                <Ribbon>{this.ribbonText(S.section())}</Ribbon>
+                                                <Ribbon>{getRibbonContent(S.section())}</Ribbon>
                                             ) : null}
                                         </CardLink>
                                     );
                                 })}
                             </div>
                         </div>
-                    ))}
-                    <div className="section">
+                    );
+                })}
+
+                {/* What's next section */}
+                <div className="section whats-next">
+                    <div className="section-header">
                         <h2>
                             {pgettext(
                                 "Tutorial - what's next after learning the game?",
                                 "What's next?",
                             )}
                         </h2>
-                        <div className="contents">
-                            {(!user || user.anonymous) && (
-                                <CardLink className={"done"} to={`/register`}>
-                                    <i className="fa fa-thumbs-up" />
-                                    <div>
-                                        <h1>{pgettext("Sign up for an account", "Register")}</h1>
-                                        <h3>{_("Get a free Online-Go account to play Go!")}</h3>
-                                    </div>
-                                </CardLink>
-                            )}
-
-                            {!(!user || user.anonymous) && (
-                                <CardLink className={"done"} to={`/play`}>
-                                    <i className="ogs-goban" />
-                                    <div>
-                                        <h1>{_("Play Go!")}</h1>
-                                        <h3>
-                                            {_(
-                                                "Play people from around the world, or against the computer",
-                                            )}
-                                        </h3>
-                                    </div>
-                                </CardLink>
-                            )}
-
-                            <CardLink className={"done"} to={`/puzzles`}>
-                                <i className="fa fa-puzzle-piece" />
+                    </div>
+                    <div
+                        className="contents"
+                        style={{
+                            display: "flex",
+                            flexDirection: "row",
+                            flexWrap: "wrap",
+                            alignItems: "center",
+                            justifyContent: "space-around",
+                        }}
+                    >
+                        {!user || user.anonymous ? (
+                            <CardLink className={"done"} to={`/register`}>
+                                <i className="fa fa-thumbs-up" />
                                 <div>
-                                    <h1>{pgettext("Practice go by playing puzzles", "Puzzles")}</h1>
-                                    <h3>{_("Practice by solving Go puzzles")}</h3>
+                                    <h1>{pgettext("Sign up for an account", "Register")}</h1>
+                                    <h3>{_("Get a free Online-Go account to play Go!")}</h3>
                                 </div>
                             </CardLink>
-                        </div>
+                        ) : (
+                            <CardLink className={"done"} to={`/play`}>
+                                <i className="ogs-goban" />
+                                <div>
+                                    <h1>{_("Play Go!")}</h1>
+                                    <h3>
+                                        {_(
+                                            "Play people from around the world, or against the computer",
+                                        )}
+                                    </h3>
+                                </div>
+                            </CardLink>
+                        )}
+
+                        <CardLink className={"done"} to={`/puzzles`}>
+                            <i className="fa fa-puzzle-piece" />
+                            <div>
+                                <h1>{pgettext("Practice go by playing puzzles", "Puzzles")}</h1>
+                                <h3>{_("Practice by solving Go puzzles")}</h3>
+                            </div>
+                        </CardLink>
+                    </div>
+                </div>
+
+                {/* KidsGoServer.com link moved to bottom */}
+                <div className="kids-go-server">
+                    <img
+                        src="https://cdn.online-go.com/assets/axol.svg"
+                        alt="Kids Go Server mascot"
+                    />
+                    <div>
+                        {pgettext(
+                            "Immediately after this text is a link to Kids Go Server",
+                            "Looking for a great place to learn Go for kids? Check out",
+                        )}
+                        <a href="https://kidsgoserver.com/">KidsGoServer.com</a>
                     </div>
                 </div>
             </div>
-        );
-    }
-
-    ribbonText(section_name: string) {
-        const sc = getSectionCompletion(section_name);
-        if (sc.completed) {
-            return (
-                <span>
-                    <i className="fa fa-star" />
-                    <i className="fa fa-star" />
-                    <i className="fa fa-star" />
-                </span>
-            );
-        }
-        if (sc.started) {
-            return (
-                <span>
-                    {sc.finished} / {sc.total}
-                </span>
-            );
-        }
-
-        return <span>{pgettext("Play a tutorial section", "play!")}</span>;
-    }
+        </div>
+    );
 }
 
-class SectionNav extends React.Component<{}, any> {
-    constructor(props: {}) {
-        super(props);
-    }
+// Helper function for progress text in navigation
+function getNavigationProgressText(sectionName: string): React.ReactNode {
+    const sc = getSectionCompletion(sectionName);
 
-    render() {
-        const m = window.location.pathname.match(/\/learn-to-play-go(\/([^\/]+))?(\/([0-9]+))?/);
-        const section_name = (m && m[2]) || "";
-        const page = (m && m[4]) || 0;
-        console.log(m, section_name, page);
-
+    if (sc.completed) {
         return (
-            <div className="LearningHub-section-nav">
-                <Link to="/learn-to-play-go/">
-                    <i className="fa fa-graduation-cap" /> {pgettext("Learning hub menu", "Menu")}
-                </Link>
-
-                {sections.map((arr) => (
-                    <div key={arr[0]} className="section">
-                        <Link to={`/learn-to-play-go/${arr[1][0].section()}`}>
-                            <h2>
-                                <span className="section-number">{arr[1][0].sectionIndex + 1}</span>
-                                {arr[0]}
-                            </h2>
-                        </Link>
-                        {arr[1].reduce((acc, v) => acc + (v.section() === section_name ? 1 : 0), 0) // is our active section?
-                            ? arr[1].map((S) => {
-                                  const sectionNumber = `${S.sectionIndex + 1}.${
-                                      S.lessonIndex + 1
-                                  }`;
-                                  return (
-                                      <Link
-                                          key={S.section()}
-                                          className={S.section() === section_name ? "active" : ""}
-                                          to={`/learn-to-play-go/${S.section()}`}
-                                      >
-                                          <span className="lesson-number">{sectionNumber}</span>
-                                          {S.title()}
-                                          {this.getProgressText(S.section())}
-                                      </Link>
-                                  );
-                              })
-                            : null}
-                    </div>
-                ))}
-
-                <span className="reset-progress" onClick={this.resetProgress}>
-                    {pgettext("Reset learning hub progress", "Reset progress")}
-                </span>
-            </div>
+            <span className="progress-text">
+                <i className="fa fa-star" />
+            </span>
+        );
+    }
+    if (sc.started) {
+        return (
+            <span className="progress-text">
+                {sc.finished} / {sc.total}
+            </span>
         );
     }
 
-    resetProgress = () => {
+    return null;
+}
+
+// Convert to functional component for consistency and better performance
+function SectionNav(): React.ReactElement {
+    // Parse current section from URL
+    const urlMatch = window.location.pathname.match(/\/learn-to-play-go(\/([^\/]+))?(\/([0-9]+))?/);
+    const currentSectionName = urlMatch?.[2] || "";
+
+    // Memoize reset progress handler
+    const handleResetProgress = React.useCallback(() => {
         void alert
             .fire({
                 text: _("Are you sure you wish to reset your tutorial progress?"),
@@ -296,28 +394,59 @@ class SectionNav extends React.Component<{}, any> {
                     browserHistory.push("/learn-to-play-go");
                 }
             });
-    };
+    }, []);
 
-    getProgressText(section_name: string) {
-        const sc = getSectionCompletion(section_name);
+    return (
+        <div className="LearningHub-section-nav">
+            <Link to="/learn-to-play-go/">
+                <i className="fa fa-graduation-cap" /> {pgettext("Learning hub menu", "Menu")}
+            </Link>
 
-        if (sc.completed) {
-            return (
-                <span className="progress-text">
-                    <i className="fa fa-star" />
-                </span>
-            );
-        }
-        if (sc.started) {
-            return (
-                <span className="progress-text">
-                    {sc.finished} / {sc.total}
-                </span>
-            );
-        }
+            {sections.map((sectionArr) => {
+                const [sectionTitle, lessons] = sectionArr;
+                // Check if this section contains the currently active lesson
+                const isActiveSection = lessons.some(
+                    (lesson) => lesson.section() === currentSectionName,
+                );
 
-        return null;
-    }
+                return (
+                    <div key={sectionTitle} className="section">
+                        <Link to={`/learn-to-play-go/${lessons[0].section()}`}>
+                            <h2>
+                                <span className="section-number">
+                                    {lessons[0].sectionIndex + 1}
+                                </span>
+                                {sectionTitle}
+                            </h2>
+                        </Link>
+                        {isActiveSection &&
+                            lessons.map((lesson) => {
+                                const lessonNumber = `${lesson.sectionIndex + 1}.${
+                                    lesson.lessonIndex + 1
+                                }`;
+                                const isCurrentLesson = lesson.section() === currentSectionName;
+
+                                return (
+                                    <Link
+                                        key={lesson.section()}
+                                        className={isCurrentLesson ? "active" : ""}
+                                        to={`/learn-to-play-go/${lesson.section()}`}
+                                    >
+                                        <span className="lesson-number">{lessonNumber}</span>
+                                        {lesson.title()}
+                                        {getNavigationProgressText(lesson.section())}
+                                    </Link>
+                                );
+                            })}
+                    </div>
+                );
+            })}
+
+            <span className="reset-progress" onClick={handleResetProgress}>
+                {pgettext("Reset learning hub progress", "Reset progress")}
+            </span>
+        </div>
+    );
 }
 
 function getSectionClassName(section_name: string): string {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,12 +115,13 @@ export default defineConfig({
                   output: {
                       assetFileNames: "[name].[ext]",
                       entryFileNames: "[name].js",
-                      manualChunks: (id: string) => {
-                          if (id.includes("/views/LearningHub/")) {
-                              return "learning-hub";
-                          }
-                          return;
+                      chunkFileNames: (chunkInfo) => {
+                          // All chunks (including dynamically imported ones) go to modules/
+                          // React.lazy() chunks may not be marked as isDynamicEntry consistently
+                          return "modules/[name]-[hash].js";
                       },
+                      // No manual chunking - React.lazy() handles dynamic imports naturally
+                      manualChunks: undefined,
                   },
               },
           }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,6 +115,12 @@ export default defineConfig({
                   output: {
                       assetFileNames: "[name].[ext]",
                       entryFileNames: "[name].js",
+                      manualChunks: (id: string) => {
+                          if (id.includes("/views/LearningHub/")) {
+                              return "learning-hub";
+                          }
+                          return;
+                      },
                   },
               },
           }


### PR DESCRIPTION
Our current layout was made when we only had a handful of lessons. Now that the collection has grown significantly the original layout is no longer sufficient. This proposed layout organizes our view into collapsible sections and shows up to 3 lesson cards per row, along with a progress bar through that section.

<img width="1339" height="783" alt="image" src="https://github.com/user-attachments/assets/3982df67-153c-40f9-8554-2fa16aceb141" />


Would be interested in how you feel about it @TCGWim 

It's also up on https://beta.online-go.com/learn-to-play-go to play around with