### PR TITLE
E2e cms can suspend

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -184,6 +184,7 @@
         "unannulable",
         "ungap",
         "unhighlight",
+        "uniquification",
         "unitify",
         "Unranked",
         "unroute",

--- a/e2e-tests/AGENTS.md
+++ b/e2e-tests/AGENTS.md
@@ -1,0 +1,25 @@
+This is information for Agents to take into account when working on e2e tests.
+
+(Also useful for humans to know :) )
+
+When creating e2e tests, note that:
+
+-   Any actions involving looking at reports should be wrapped in `withIncidentIndicatorLock`, and should check that there are no open reports at the start, so that debug of "already open reports" is easy.
+
+(The problem is that tests can fail if the wrong number of reports is open, due to previously failed tests)
+
+-   Any actions or assertions using buttons need to use `expectOGSClickable` to find the button, because OGS buttons are implemented in a range of ways.
+
+-   Users (user data) can be created either by seeding it or using `prepareNewUser`.
+
+-   Seeded data is to be used when we need users with privileges that can only be given by full moderators. We do not have full moderator powers in the test suite.
+
+-   `prepareNewUser` creates a new user with suitable settings and guaranteed unique name.
+
+-   The string argument of `newTestUsername` must be less than 21 characters. This is because OGS username limit is 20 chars and 8 are used for uniquification. It's helpful to have characters identifying which test and which role
+
+-   Avoid direct API calls - the intent of e2e testing is to test by driving the system as a user does.
+
+-   We do all our testing in English, we don't have to worry about pgettext
+
+-   Community Moderation is controlled by MODERATOR_POWERS. This is different to "full moderation", which is controlled by is_moderator.

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -148,10 +148,10 @@ Things of note:
     -   `newTestUsername` provides a means of creating a unique new username.
     -   It takes as an argument a user-identifier, which is intended to help understand what test
         and what role this user plays in it.
-    -   \*\* _This can be at most 12 characters_
+    -   \*\* _This can be at most 21 characters_
         unfortunately a run-time failure because typing can't specify this
         -   The reason is because it uses time to generate the uniquifier, and we only have a total
-            of 20 characters to play with in an OGS username! 8 characters gives us unique names at about 1 minute intervals.
+            of 30 characters to play with in an OGS username! 9 characters gives us unique names at about 1.3 second intervals.
 
 ## Seeded Data
 

--- a/e2e-tests/cm/cm-vote-suspend-user.ts
+++ b/e2e-tests/cm/cm-vote-suspend-user.ts
@@ -199,8 +199,10 @@ export const cmVoteSuspendUserTest = async (
         });
         await expect(reasonHeading).toBeVisible();
 
-        // Check that the heading contains human-readable "Stopped Playing"
-        await expect(reasonHeading).toContainText("Stopped Playing");
+        // Check that the heading contains the full sentence with human-readable report type
+        await expect(reasonHeading).toContainText(
+            "Community moderation vote for suspension based on Stopped Playing reports",
+        );
 
         // Verify the ugly code-style version "escaping" is NOT shown
         const reasonText = await reasonHeading.textContent();

--- a/e2e-tests/cm/cm-vote-suspend-user.ts
+++ b/e2e-tests/cm/cm-vote-suspend-user.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Test Community Moderation voting to suspend users
+ *
+ * This test verifies the CM escalation and suspension flow with human-readable ban reasons:
+ * 1. Two new users play a game to completion
+ * 2. Fresh reporter reports one player for escaping (stopped playing)
+ * 3. One CM escalates the report (requires only 1 vote)
+ * 4. Three CMs vote to suspend (requires 3 votes for consensus)
+ * 5. Verifies suspended user sees human-readable ban reason
+ *
+ * Uses init_e2e data:
+ * - E2E_CM_VSU_V1, E2E_CM_VSU_V2, E2E_CM_VSU_V3 : CMs who escalate and vote to suspend
+ *
+ * Creates fresh users for each test run.
+ */
+
+import { Browser, TestInfo, expect } from "@playwright/test";
+import { reportUser, setupSeededCM, prepareNewUser, newTestUsername } from "@helpers/user-utils";
+import {
+    createDirectChallenge,
+    acceptDirectChallenge,
+    defaultChallengeSettings,
+} from "@helpers/challenge-utils";
+import { playMoves } from "@helpers/game-utils";
+import { expectOGSClickableByName } from "@helpers/matchers";
+import { withIncidentIndicatorLock } from "@helpers/report-utils";
+
+export const cmVoteSuspendUserTest = async (
+    { browser }: { browser: Browser },
+    testInfo: TestInfo,
+) => {
+    await withIncidentIndicatorLock(testInfo, async () => {
+        console.log("=== CM Vote Suspend User Test ===");
+
+        // Create two users who will play a game
+        console.log("Creating two users to play a game...");
+        const accusedUsername = newTestUsername("Accused");
+        const opponentUsername = newTestUsername("Opponent");
+
+        const { userPage: accusedPage } = await prepareNewUser(browser, accusedUsername, "test");
+        const { userPage: opponentPage } = await prepareNewUser(browser, opponentUsername, "test");
+
+        // Have them play a quick 9x9 game
+        console.log("Creating and playing game...");
+        await createDirectChallenge(accusedPage, opponentUsername, {
+            ...defaultChallengeSettings,
+            gameName: "E2E CM Suspend Test Game",
+            boardSize: "9x9",
+            speed: "live",
+            timeControl: "byoyomi",
+            mainTime: "45",
+            timePerPeriod: "10",
+            periods: "1",
+        });
+
+        await acceptDirectChallenge(opponentPage);
+
+        // Wait for the Goban to be visible
+        const goban = accusedPage.locator(".Goban[data-pointers-bound]");
+        await goban.waitFor({ state: "visible" });
+        await accusedPage.waitForTimeout(1000);
+
+        // Play a few moves
+        const moves = ["D9", "E9", "D8", "E8", "D7", "E7"];
+        await playMoves(accusedPage, opponentPage, moves, "9x9");
+
+        // Both players pass to end the game
+        const accusedPass = accusedPage.getByText("Pass", { exact: true });
+        await expect(accusedPass).toBeVisible();
+        await accusedPass.click();
+
+        const opponentPass = opponentPage.getByText("Pass", { exact: true });
+        await expect(opponentPass).toBeVisible();
+        await opponentPass.click();
+
+        // Accept scores
+        const opponentAccept = opponentPage.getByText("Accept");
+        await expect(opponentAccept).toBeVisible();
+        await opponentAccept.click();
+
+        const accusedAccept = accusedPage.getByText("Accept");
+        await expect(accusedAccept).toBeVisible();
+        await accusedAccept.click();
+
+        // Wait for game to finish
+        await expect(accusedPage.getByText("wins by")).toBeVisible();
+        console.log("Game completed ✓");
+
+        // Create a reporter and report the accused user for escaping
+        console.log("Creating reporter and reporting user...");
+        const reporterUsername = newTestUsername("EscReporter");
+        const { userPage: reporterPage } = await prepareNewUser(browser, reporterUsername, "test");
+
+        // Navigate to the finished game and report
+        await reporterPage.goto(accusedPage.url());
+        await reporterPage.waitForLoadState("networkidle");
+
+        await reportUser(
+            reporterPage,
+            accusedUsername,
+            "escaping",
+            "This user stopped playing and abandoned the game",
+        );
+        await reporterPage.close();
+        console.log("Report submitted ✓");
+
+        // Have one CM escalate the report
+        console.log("E2E_CM_VSU_V1 escalating escaping report...");
+        const { seededCMPage: escalatorPage } = await setupSeededCM(browser, "E2E_CM_VSU_V1");
+
+        await escalatorPage.goto("/reports-center");
+        await escalatorPage.waitForLoadState("networkidle");
+
+        await escalatorPage.click('input[value="escalate"]');
+        await escalatorPage.fill("#escalation-note", "Repeat offender - needs moderator attention");
+
+        const escalateVoteButton = await expectOGSClickableByName(escalatorPage, /Vote/);
+        await escalateVoteButton.click();
+        await escalatorPage.waitForLoadState("networkidle");
+
+        console.log("E2E_CM_VSU_V1 escalated the report");
+        await escalatorPage.close();
+
+        // Keep the accused user logged in and browsing while suspension happens
+        console.log("Accused user staying logged in...");
+        await accusedPage.goto("/");
+        await accusedPage.waitForLoadState("networkidle");
+        console.log("Accused user is browsing ✓");
+
+        // Have three CMs vote to suspend the escalated report
+        const suspensionVoters = ["E2E_CM_VSU_V1", "E2E_CM_VSU_V2", "E2E_CM_VSU_V3"];
+
+        for (const voter of suspensionVoters) {
+            console.log(`${voter} voting to suspend escaper...`);
+            const { seededCMPage: voterPage } = await setupSeededCM(browser, voter);
+
+            await voterPage.goto("/reports-center");
+            await voterPage.waitForLoadState("networkidle");
+
+            await voterPage.click('input[value="suspend_user"]');
+
+            const suspendVoteButton = await expectOGSClickableByName(voterPage, /Vote/);
+            await suspendVoteButton.click();
+            await voterPage.waitForLoadState("networkidle");
+
+            console.log(`${voter} voted to suspend`);
+            await voterPage.close();
+        }
+
+        // Wait for suspension processing
+        console.log("Waiting for suspension processing...");
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+
+        // Verify suspended user sees human-readable ban reason
+        console.log("=== Verifying suspended user sees human-readable ban reason ===");
+
+        // Navigate to home page - should see a banner with appeal link
+        await accusedPage.goto("/");
+        await accusedPage.waitForLoadState("networkidle");
+
+        // Should see a banner with "appeal here" link
+        const appealLink = accusedPage.getByRole("link", { name: /appeal here/i });
+        await expect(appealLink).toBeVisible();
+        console.log("Appeal banner visible with 'appeal here' link ✓");
+
+        // Click the appeal link to navigate to appeal page
+        await appealLink.click();
+        await accusedPage.waitForLoadState("networkidle");
+
+        // Should now be on the appeal page
+        await expect(accusedPage).toHaveURL(/\/appeal/);
+        console.log("Navigated to appeal page via banner link ✓");
+
+        // Verify suspension message is visible
+        await expect(accusedPage.getByText(/suspended/i)).toBeVisible();
+        console.log("Suspension message visible ✓");
+
+        // Verify human-readable ban reason is shown in the "Reason for suspension:" heading
+        // The Appeal page shows: "Reason for suspension: {{reason}}"
+        const reasonHeading = accusedPage.locator("h2", {
+            hasText: /Reason for suspension:/i,
+        });
+        await expect(reasonHeading).toBeVisible();
+
+        // Check that the heading contains human-readable "Stopped Playing"
+        await expect(reasonHeading).toContainText("Stopped Playing");
+
+        // Verify the ugly code-style version "escaping" is NOT shown
+        const reasonText = await reasonHeading.textContent();
+        expect(reasonText).not.toContain("escaping");
+
+        console.log("Human-readable ban reason displayed to user ✓");
+        await accusedPage.close();
+        await opponentPage.close();
+
+        console.log("=== CM Vote Suspend User Test Complete ===");
+        console.log("✓ CMs can vote to suspend users");
+        console.log("✓ Ban reason displays human-readable report type");
+    });
+};

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -24,6 +24,7 @@ import { cmVoteWarnNotAITest } from "./cm-vote-warn-not-ai";
 import { cmAckWarningTest } from "./cm-ack-warning";
 import { cmAckAcknowledgementTest } from "./cm-ack-ack";
 import { cmAiAssessDismissTest } from "./cm-ai-assess-dismiss";
+import { cmVoteSuspendUserTest } from "./cm-vote-suspend-user";
 
 ogsTest.describe("@CM Community Moderation Tests", () => {
     ogsTest("CM should be able to vote on their own report", cmVoteOnOwnReportTest);
@@ -33,4 +34,8 @@ ogsTest.describe("@CM Community Moderation Tests", () => {
     ogsTest("We should be able to acknowledge warnings", cmAckWarningTest);
     ogsTest("We should be able to acknowledge acknowledgements", cmAckAcknowledgementTest);
     ogsTest("AI Assessors should be able to dismiss AI reports", cmAiAssessDismissTest);
+    ogsTest(
+        "CMs should be able to vote to suspend users with human-readable ban reasons",
+        cmVoteSuspendUserTest,
+    );
 });

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -41,18 +41,19 @@ export async function checkLastRunTime() {
         const lastRunTime = new Date(fs.readFileSync(lastRunFile, "utf8").trim());
         const now = new Date();
         const diffMs = now.getTime() - lastRunTime.getTime();
-        const diffMinutes = diffMs / (1000 * 60);
+        const diffSeconds = diffMs / 1000;
+        const minWaitMs = 2000; // Wait minimum 2 seconds for username uniqueness (~1.3s actual)
 
-        if (diffMinutes < 1) {
-            const waitTime = Math.ceil((60000 - diffMs) / 1000);
+        if (diffMs < minWaitMs) {
+            const waitTime = Math.ceil((minWaitMs - diffMs) / 1000);
             console.log(
                 `Waiting ${waitTime} seconds for next unique username, since last run was ${Math.round(
-                    diffMinutes * 60,
+                    diffSeconds,
                 )} seconds ago`,
             );
             const sharedArray = new SharedArrayBuffer(4);
             const sharedArrayView = new Int32Array(sharedArray);
-            Atomics.wait(sharedArrayView, 0, 0, 60000 - diffMs);
+            Atomics.wait(sharedArrayView, 0, 0, minWaitMs - diffMs);
         }
     } else {
         console.log("No last run time found");

--- a/e2e-tests/helpers/report-utils.ts
+++ b/e2e-tests/helpers/report-utils.ts
@@ -46,7 +46,8 @@ export async function withIncidentIndicatorLock<T>(
 ): Promise<T> {
     testInfo.setTimeout(0); // Disable timeout while waiting for lock
     await IncidentIndicatorLock.acquire();
-    testInfo.setTimeout(120000); // Restore a timeout after acquiring lock (yuk, hardcoded here)
+    // Added a 42 here to make it clear if this is the one that gets activated!
+    testInfo.setTimeout(150042); // Restore a timeout after acquiring lock (matches playwright.config.ts)
 
     try {
         return await fn();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,9 +47,9 @@ if (!process.env.TEST_WORKER_INDEX && !process.env.PW_UI) {
         console.log("Running in local mode: FULL TEST SUITE (except smoketests)");
     }
 
-    // This chicanery is all due to OGS having a 20 char limit on usernames :p
+    // This chicanery is all due to OGS having a 30 char limit on usernames
     // That limits the resolution of unique test users based on time, so we need to
-    // make sure we don't run more tests closer together than 60 seconds.
+    // make sure we don't run more tests closer together than ~2 seconds.
 
     checkLastRunTime()
         .then(() => {
@@ -64,7 +64,8 @@ export default defineConfig({
     globalTeardown: "./e2e-tests/global-teardown.ts",
     testDir: "./e2e-tests",
     testMatch: process.env.CI ? ["smoketests.spec.ts"] : ["**/*.spec.ts", "!**/smoketests/**"],
-    timeout: 120 * 1000, // overall test timeout - we have some long multi-user tests
+    // If you change this you need to change report-utils to match
+    timeout: 150 * 1000, // overall test timeout - we have some long multi-user tests
     expect: {
         timeout: process.env.CI ? 30000 : 10000,
     },


### PR DESCRIPTION
Fixes not having a test for suspension->appeal path

## Proposed Changes

  - Add a test for CM suspension->appeal.
  

Needs https://github.com/online-go/ogs/pull/2145 for increased username length support and 

 init_e2e  rerun on beta for front end devs to run this test against beta.

