### PR TITLE
Fix for issue #3031

### DIFF
--- a/src/views/PuzzleCollection/SortablePuzzleList.tsx
+++ b/src/views/PuzzleCollection/SortablePuzzleList.tsx
@@ -179,7 +179,7 @@ function SortablePuzzleListContainer({
         // Without this activation constraint, the "Edit" button doesn't work
         // because dnd swallows click events.
         useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
-        useSensor(TouchSensor),
+        useSensor(TouchSensor, { activationConstraint: { delay: 100, tolerance: 0 } }),
     );
     return (
         <DndContext onDragEnd={onDragEnd} sensors={sensors}>


### PR DESCRIPTION
Fixes #3031

## Proposed Changes

  - [SortablePuzzleList.tsx] Added an activation constraint to `TouchSensor`. This constraint has a delay of 100 ms and a 0 px tolerance. With this, it's allowed to scroll through the list of the puzzles without unintentionally moving them. To move an element, one must press the item for 100 ms.