### PR TITLE
Automatically focus submit move button

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -45,6 +45,7 @@ export const defaults = {
     "always-disable-analysis": false,
     "asked-to-enable-desktop-notifications": false,
     "auto-advance-after-submit": true,
+    "autofocus-submit-button": false,
     "autoplay-delay": 10000,
     "play.tab": "automatch" as "automatch" | "custom",
     "automatch.size": "9x9" as Size,

--- a/src/views/Game/Game.styl
+++ b/src/views/Game/Game.styl
@@ -38,6 +38,12 @@
     .submit-button {
         white-space: nowrap;
     }
+    .autofocus-submit-button:focus::after {
+        content: ' ⏎';
+    }
+    .autofocus-submit-button:active::after {
+        content: none;
+    }
 }
 
 .condensed-game-information {

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -190,8 +190,14 @@ export function PlayButtons({ show_cancel = true }: PlayButtonsProps): React.Rea
                     )}
                 {show_submit && engine.undo_requested !== engine.getMoveNumber() && (
                     <button
-                        className="sm primary bold submit-button"
+                        className={
+                            "sm primary bold submit-button " +
+                            (preferences.get("autofocus-submit-button")
+                                ? "autofocus-submit-button"
+                                : "")
+                        }
                         id="game-submit-move"
+                        autoFocus={preferences.get("autofocus-submit-button")}
                         disabled={submitting_move || !goban.submit_move}
                         onClick={() => {
                             if (goban.submit_move) {

--- a/src/views/Settings/GamePreferences.tsx
+++ b/src/views/Settings/GamePreferences.tsx
@@ -44,6 +44,8 @@ export function GamePreferences(): React.ReactElement {
         getSubmitMode("correspondence"),
     );
     const [chat_mode, _setChatMode] = usePreference("chat-mode");
+    const [autofocus_submit_button, setAutoFocusSubmitButton] =
+        usePreference("autofocus-submit-button");
 
     const [auto_advance, setAutoAdvance] = usePreference("auto-advance-after-submit");
     const [always_disable_analysis, setAlwaysDisableAnalysis] =
@@ -172,6 +174,10 @@ export function GamePreferences(): React.ReactElement {
                     ]}
                     onChange={setCorrSubmitMode}
                 />
+            </PreferenceLine>
+
+            <PreferenceLine title={_("Autofocus submit button")}>
+                <Toggle checked={autofocus_submit_button} onChange={setAutoFocusSubmitButton} />
             </PreferenceLine>
 
             <PreferenceLine title={_("Auto-advance to next game after making a move")}>


### PR DESCRIPTION
When playing on my notebook with just the touch pad, I find moving the mouse to the submit button and back to the board the whole (live) game quite cumbersome.

That's why this pull request
- adds a setting to automatically focus the submit move button,
- adds a symbol to the submit move button when focused (if the setting is turned on), to show that it can be activated by pressing the enter key.

---

There's a small issue though:
- If the setting is turned on and the button loses focus (e.g. by focusing the chat before submitting), once the button is clicked it gets focused (by the browser) and briefly shows the symbol too, before the whole button disappears.

I'm not happy about that, but I don't know how to prevent it neatly.