### PR TITLE
Avatar too small on finished games (mobile)

### DIFF
--- a/src/views/Game/Players.styl
+++ b/src/views/Game/Players.styl
@@ -366,7 +366,7 @@
 
 .MainGobanView.portrait .player-icons {
     .player-icon-container {
-        flex-basis: 1.5rem;
+        flex-basis: 3rem;
         min-height: 3rem;
         min-width: 4rem; // need this width to accomodate disconnect timer
         position: relative;


### PR DESCRIPTION
change min-height of player-icon-container to fit in same size before game finished when clock is disabled

Fixes #1823 

## Proposed Changes
- The issue - after clock is deleted from DOM, portrait height resized to min-height 1.5, that is smaller, than height of portrait with clock timer, which is actually 48px (or 3 rem). Changed the min-height of player-icon-container to 3 rem, so it fit to the current units in code. 
- Attached 3 screenshots, before and after game cancellation, that reproduce bug. And solution with 3 rem min-height. 
- Repoduced in Chrome Devtools, Version 141.0.7390.67 (Official Build) (64-bit)

<img width="1915" height="974" alt="before_resignation" src="https://github.com/user-attachments/assets/6b01324c-4af6-4061-979c-e2b169e038dc" />
<img width="1918" height="968" alt="after_resignation" src="https://github.com/user-attachments/assets/de81ab44-b3d5-473d-956a-32b351de476c" />
<img width="1915" height="965" alt="after_resignation_fixed" src="https://github.com/user-attachments/assets/c3e9b53a-ad86-48ea-b790-067ccf9586d7" />