### PR TITLE
Default bots to unranked; fix bot board size selection settings

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1524,8 +1524,6 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
         const user = data.get("user");
         let available_bots: (Bot & { category?: Category })[] = bots_list().filter((b) => b.id > 0);
         const board_size = `${this.state.challenge.game.width}x${this.state.challenge.game.height}`;
-        console.log(board_size, this.state.challenge.game.speed, this.state.time_control.system);
-        console.log(this.state.challenge.game.speed);
 
         const categories = [
             {

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -204,6 +204,14 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             if (this.props.config.time_control) {
                 state.time_control = this.props.config.time_control;
             }
+
+            // Update selected_board_size to match the potentially updated width/height
+            if (this.props.config.challenge?.game) {
+                const width = state.challenge.game.width;
+                const height = state.challenge.game.height;
+                state.conf.selected_board_size =
+                    standard_board_sizes[`${width}x${height}`] || "custom";
+            }
         }
 
         if (this.state.conf.mode === "computer" && bot_count()) {
@@ -471,6 +479,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             }
 
             console.log("Bot set to ", player_id);
+            preferences.set("automatch.bot-ranked", next.challenge.game.ranked);
         }
 
         const challenge = this.getChallenge();

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -55,6 +55,7 @@ export const defaults = {
     "automatch.time-control": "fischer" as "fischer" | "byoyomi",
     "automatch.opponent": "human" as "human" | "bot",
     "automatch.bot": 0 as number | string,
+    "automatch.bot-ranked": false as boolean,
     "automatch.lower-rank-diff": 3,
     "automatch.upper-rank-diff": 3,
     "automatch.show-custom-games": false,

--- a/src/views/Play/QuickMatch.tsx
+++ b/src/views/Play/QuickMatch.tsx
@@ -370,16 +370,19 @@ export function QuickMatch(): React.ReactElement {
                   pause_on_weekends: false,
               };
 
-    const playComputerX = React.useCallback(() => {
-        // Try to guess whether the player wants a ranked game or not by looking at
-        // the past challenges.
-        let ranked = data.get(`challenge.challenge.${game_speed}`)?.game?.ranked;
-        if (ranked === undefined) {
-            ranked =
-                data.get(`challenge.challenge.blitz`)?.game?.ranked ??
-                data.get(`challenge.challenge.rapid`)?.game?.ranked ??
-                data.get(`challenge.challenge.live`)?.game?.ranked ??
-                true;
+    const playComputer = React.useCallback(() => {
+        const ranked = preferences.get("automatch.bot-ranked");
+
+        let size = parseInt(board_size);
+        if (game_clock === "multiple") {
+            console.log(multiple_sizes);
+            if (multiple_sizes["9x9"]) {
+                size = 9;
+            } else if (multiple_sizes["13x13"]) {
+                size = 13;
+            } else if (multiple_sizes["19x19"]) {
+                size = 19;
+            }
         }
 
         const settings: ChallengeModalConfig = {
@@ -387,8 +390,8 @@ export function QuickMatch(): React.ReactElement {
                 challenger_color: "automatic",
                 invite_only: false,
                 game: {
-                    width: parseInt(board_size),
-                    height: parseInt(board_size),
+                    width: size,
+                    height: size,
                     ranked,
                     handicap: handicaps === "disabled" ? 0 : -1,
                     time_control,
@@ -408,7 +411,7 @@ export function QuickMatch(): React.ReactElement {
         console.log(settings);
 
         challengeComputer(settings);
-    }, [board_size, handicaps, time_control_system, game_speed]);
+    }, [board_size, game_clock, multiple_sizes, handicaps, time_control_system, game_speed]);
 
     const play = React.useCallback(() => {
         if (data.get("user").anonymous) {
@@ -1126,7 +1129,7 @@ export function QuickMatch(): React.ReactElement {
                 {!automatch_search_active && !user.anonymous && (
                     <button
                         className="play-button"
-                        onClick={playComputerX}
+                        onClick={playComputer}
                         disabled={anon || warned || have_active_game_search}
                     >
                         {_("Play Computer")}

--- a/src/views/Play/QuickMatch.tsx
+++ b/src/views/Play/QuickMatch.tsx
@@ -375,7 +375,6 @@ export function QuickMatch(): React.ReactElement {
 
         let size = parseInt(board_size);
         if (game_clock === "multiple") {
-            console.log(multiple_sizes);
             if (multiple_sizes["9x9"]) {
                 size = 9;
             } else if (multiple_sizes["13x13"]) {
@@ -408,7 +407,7 @@ export function QuickMatch(): React.ReactElement {
             time_control,
         };
 
-        console.log(settings);
+        // console.log(settings);
 
         challengeComputer(settings);
     }, [board_size, game_clock, multiple_sizes, handicaps, time_control_system, game_speed]);


### PR DESCRIPTION
This change makes it so the 'ranked' checkbox is false by default for bots, but if you want to play ranked bot games it'll remember your setting once you change it.

Also fixed is the board size selection for bots, which wasn't working correctly before.