### PR TITLE
Show gamelog timestamps in UTC

### DIFF
--- a/src/views/Game/GameLog.tsx
+++ b/src/views/Game/GameLog.tsx
@@ -135,7 +135,7 @@ export function GameLog({
                                         }
                                     >
                                         <td className="timestamp">
-                                            {moment(entry.timestamp).format("L LTS")}
+                                            {moment(entry.timestamp).utc().format("L LTS")} UTC
                                         </td>
                                         <td className="event">{decodeLogEvent(entry.event)}</td>
                                         <td className="data">


### PR DESCRIPTION
Fixes CMs seeing different timestamps for the same game.

## Proposed Changes

  - Show timestamps in GameLog in UTC
  
Note: they are still shown in local timezone in Game Info.   Potentially confusing but... I think I'd want to know when it was "my time" that I played the game 🤔