### PR TITLE
Fix React import in LearningHub

### DIFF
--- a/src/views/LearningHub/Sections/BasicPrinciples/BPKo.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/BPKo.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class BPKo extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicPrinciples/BPSelfCapture.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/BPSelfCapture.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class BPSelfCapture extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicPrinciples/CountAtari.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/CountAtari.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class CountAtari extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicPrinciples/CountChains.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/CountChains.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class CountChains extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicPrinciples/CountLiberties.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/CountLiberties.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class CountLiberties extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicPrinciples/GroupAlive.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/GroupAlive.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class GroupAlive extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicPrinciples/InAtari.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/InAtari.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class InAtari extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicPrinciples/RealFalseEye.tsx
+++ b/src/views/LearningHub/Sections/BasicPrinciples/RealFalseEye.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class RealFalseEye extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicSkills/BSGroupAlive.tsx
+++ b/src/views/LearningHub/Sections/BasicSkills/BSGroupAlive.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class BSGroupAlive extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicSkills/CompareLiberties.tsx
+++ b/src/views/LearningHub/Sections/BasicSkills/CompareLiberties.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class CompareLiberties extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicSkills/CountTerritory.tsx
+++ b/src/views/LearningHub/Sections/BasicSkills/CountTerritory.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class CountTerritory extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicSkills/EscapePossible.tsx
+++ b/src/views/LearningHub/Sections/BasicSkills/EscapePossible.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class EscapePossible extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BasicSkills/Winner.tsx
+++ b/src/views/LearningHub/Sections/BasicSkills/Winner.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class Winner extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel1/CalculateEscape.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel1/CalculateEscape.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL1CalculateEscape extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel1/CalculateLadder.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel1/CalculateLadder.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL1CalculateLadder extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel1/CountEyes.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel1/CountEyes.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL1CountEyes extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel1/Eye.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel1/Eye.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL1Eye extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel1/GoodPlay.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel1/GoodPlay.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL1GoodPlay extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel1/Seki1.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel1/Seki1.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL1Seki1 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel2/CapturingRace4.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel2/CapturingRace4.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL2CapturingRace4 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel2/Cut2.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel2/Cut2.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL2Cut2 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel2/Endgame2.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel2/Endgame2.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL2Endgame2 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel2/Endgame3.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel2/Endgame3.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL2Endgame3 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel2/Endgame4.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel2/Endgame4.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL2Endgame4 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel2/Shape1.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel2/Shape1.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL2Shape1 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel2/Shape2.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel2/Shape2.tsx
@@ -20,7 +20,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL2Shape2 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/CapturingRace3.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/CapturingRace3.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3CapturingRace3 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Endgame1.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Endgame1.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Endgame1 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Endgame2.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Endgame2.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Endgame2 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Endgame5.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Endgame5.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Endgame5 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/LifeDeath17.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/LifeDeath17.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3LifeDeath17 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/LifeDeath18.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/LifeDeath18.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3LifeDeath18 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Skills1.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Skills1.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Skills1 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Skills3.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Skills3.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Skills3 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Skills5.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Skills5.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Skills5 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Skills6.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Skills6.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Skills6 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/BeginnerLevel3/Skills7.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel3/Skills7.tsx
@@ -19,7 +19,7 @@ import { GobanConfig } from "goban";
 import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
-import React from "react";
+import * as React from "react";
 
 export class BL3Skills7 extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {

--- a/src/views/LearningHub/Sections/Fundamentals/Territory.tsx
+++ b/src/views/LearningHub/Sections/Fundamentals/Territory.tsx
@@ -21,7 +21,7 @@ import { LearningPage, LearningPageProperties } from "../../LearningPage";
 import { _, pgettext } from "@/lib/translate";
 import { LearningHubSection } from "../../LearningHubSection";
 
-import React from "react";
+import * as React from "react";
 
 export class Territory extends LearningHubSection {
     static pages(): Array<typeof LearningPage> {


### PR DESCRIPTION
Fixes "Invalid hook call"'s caused by differing ways React is imported in the LearningHub modules. This caused the build to include two copies of React which is the real root cause of the hook error.

FYI @TCGWim basically we just need to import react like this:

```ts
import * as React from "react";
```

(as opposed to `import React from "react";`)

