### PR TITLE
small change to CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ is to have [Node.js](https://nodejs.org/) installed then clone the repository
 or your fork with the `--recurse-submodules` flag:
 
 ```
-git clone --recurse-submodules git@github.com:online-go/online-go.com.git
+git clone --recurse-submodules https://github.com/online-go/online-go.com.git
 ```
 
 And then perform the following actions:


### PR DESCRIPTION
Updated the contributing.md file to use https url to repo instead of the git@github one. 
**Reason:** It's the [GitHub's recommended way to clone repositories](https://docs.github.com/en/get-started/git-basics/set-up-git#authenticating-with-github-from-git) and since relatively few, in my experience, developers have github's SSH keys added to their machine they will get greeted with the same message as I did today:
<img width="858" height="256" alt="image" src="https://github.com/user-attachments/assets/7fbfb595-7f66-4abd-9af6-41c5fe55b682" />

**Side note:**

```
_PS C:\dev\online-go.com> npx husky install
husky - install command is DEPRECATED
```

So the readme should probably be updated to the current command, but upon finding conflicting suggestions online of what it should actually be now, I ran both:

```
_PS C:\dev\online-go.com> npx husky
_PS C:\dev\online-go.com> npx husky init
```

Since it doesn't produce any console output it's hard to tell which one worked (or maybe both did?). I can update the PR with the correct version if you let me know which one is it. Thanks :)!