### PR TITLE
Add Recently Blocked moderator page to UI

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -359,6 +359,14 @@ export function NavBar(): React.ReactElement {
                                     icon={<i className="fa fa-search" />}
                                 />
                             )}
+                            {(user.is_moderator ||
+                                (user.moderator_powers & MODERATOR_POWERS.AI_DETECTOR) !== 0) && (
+                                <MenuLink
+                                    title={_("Recently Blocked")}
+                                    to="/moderator/recently-blocked"
+                                    icon={<i className="fa fa-ban" />}
+                                />
+                            )}
                             {user.is_moderator && (
                                 <MenuLink
                                     title="Firewall"

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -80,6 +80,7 @@ import { useData } from "./lib/hooks";
 import { MainSection } from "@/components/MainSection";
 import { AccessibilityMenu } from "@/components/AccessibilityMenu";
 import { AIDetection } from "@moderator-ui/AIDetection";
+import { RecentlyBlocked } from "@moderator-ui/RecentlyBlocked";
 
 const LearningHub = React.lazy(() =>
     import(/* webpackChunkName: "learning-hub" */ "@/views/LearningHub").then((m) => ({
@@ -359,6 +360,7 @@ export const routes = (
                 />
                 <Route path="/developer" element={<Developer />} />
                 <Route path="/moderator/ai-detection" element={<AIDetection />} />
+                <Route path="/moderator/recently-blocked" element={<RecentlyBlocked />} />
                 <Route path="/admin/merchant_log" element={<MerchantLog />} />
                 <Route path="/admin/firewall" element={<Firewall />} />
                 <Route path="/admin/flagged_games" element={<FlaggedGames />} />

--- a/src/stubs/moderator-ui/RecentlyBlocked/RecentlyBlocked.tsx
+++ b/src/stubs/moderator-ui/RecentlyBlocked/RecentlyBlocked.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C)  Online-Go.com
+ */
+
+import * as React from "react";
+
+export type RecentlyBlockedT = () => React.ReactElement;
+
+export const RecentlyBlocked: RecentlyBlockedT = () => {
+    return (
+        <div>
+            <iframe
+                width="560"
+                height="315"
+                src="https://www.youtube.com/embed/xvFZjo5PgG0?si=fi9TF9klw52tuC5e"
+                referrerPolicy="strict-origin-when-cross-origin"
+                allowFullScreen
+            />
+        </div>
+    );
+};

--- a/src/stubs/moderator-ui/RecentlyBlocked/index.ts
+++ b/src/stubs/moderator-ui/RecentlyBlocked/index.ts
@@ -1,0 +1,5 @@
+/*
+ * Copyright (C)  Online-Go.com
+ */
+
+export * from "./RecentlyBlocked";


### PR DESCRIPTION
Integrates the Recently Blocked moderator page into the OGS UI with comprehensive e2e test coverage.

## Summary

Adds a new moderator page that displays users automatically suspended after their first game due to Browser ID matching previously suspended accounts. This helps moderators and AI detectors track ban evasion attempts.

## Changes

### UI Integration

**NavBar.tsx**
- Added "Recently Blocked" menu item in Tools menu
- Visible to moderators (is_moderator) and AI detectors (AI_DETECTOR power)
- Icon: fa-ban
- Positioned after "AI Detection" in the menu

**routes.tsx**
- Added route: /moderator/recently-blocked
- Imports and renders RecentlyBlocked component
- Protected by component-level permission check

**Stub Component**
- Added src/stubs/moderator-ui/RecentlyBlocked/ (2 files)
- Provides placeholder when moderator-ui submodule not available
- Shows Rick Roll video (standard stub pattern)

### E2E Test Coverage

**mod-auto-suspension.ts**
- Extended existing auto-suspension test to verify Recently Blocked page
- After auto-suspension is verified:
  1. Logs in as E2E_MODERATOR
  2. Navigates to /moderator/recently-blocked
  3. Verifies suspended user appears in table
  4. Tests matched accounts dropdown functionality:
     - Verifies count display ("1 account" or "N accounts")
     - Clicks to expand (caret changes from right to down)
     - Confirms E2E_SUSPENDED_BID_USER appears in expanded list
- Requires E2E_MODERATOR_PASSWORD environment variable

## Dependencies

**Required PRs (must be merged first):**
1. Backend: https://github.com/online-go/ogs/pull/2199
2. Moderator-UI: https://github.com/online-go/moderator-ui/pull/22

## Testing

- ✅ TypeScript type checking: Passed
- ✅ E2E test: Comprehensive coverage of page and dropdown functionality
- 🔄 Integration test: Will be validated after dependency PRs are merged

## Features

The Recently Blocked page displays:
- User who was suspended
- Matched suspended account(s) - expandable dropdown showing which banned accounts had the same BID
- Matching Browser ID
- Trigger game (the first game that triggered the auto-suspension)
- Time since suspension (human-readable: "2d 5h", "3h 25m", etc.)

The matched accounts dropdown follows the same UI pattern as the "Shared BIDs" column in player profile ModTools for consistency.

Generated with Claude Code
https://claude.com/claude-code

Co-Authored-By: Claude <noreply@anthropic.com>