### PR TITLE
Just use one worker

### DIFF
--- a/e2e-tests/helpers/user-utils.ts
+++ b/e2e-tests/helpers/user-utils.ts
@@ -378,11 +378,11 @@ export const openPlayerDetailsPopover = async (page: Page, playerLinkLocator: Lo
             // Close any partial state and retry
             await page.keyboard.press("Escape");
             // Wait for popover to fully close before retrying
-            await expect(page.locator(".PlayerDetails"))
-                .not.toBeVisible({ timeout: 1000 })
-                .catch(() => {
-                    // Popover may already be gone, that's fine
-                });
+            try {
+                await expect(page.locator(".PlayerDetails")).not.toBeVisible({ timeout: 1000 });
+            } catch {
+                // Popover may already be gone, that's fine
+            }
         }
     }
 };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -89,10 +89,13 @@ export default defineConfig({
     retries: process.env.CI ? 0 : process.env.E2E ? 2 : 0,
 
     /* Workers configuration for parallel execution */
+    // Ideally...
     // CI: 1 worker (sequential for reliability, smoke tests only)
     // E2E: 2 workers (parallel execution with isolation via worker IDs)
     // Dev: 2 workers (parallel execution for faster feedback)
-    workers: process.env.CI ? 1 : 2,
+
+    // But ... it just doesn't work.
+    workers: process.env.CI ? 1 : 1,
 
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     /* (note that e2etesting run_test override this from command line) */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -86,7 +86,10 @@ export default defineConfig({
     // CI: 0 retries (smoke tests should be stable)
     // E2E: 2 retry (handle flakiness in full test suite)
     // Dev: 0 retries (fail fast for development)
-    retries: process.env.CI ? 0 : process.env.E2E ? 2 : 0,
+
+    // retries: process.env.CI ? 0 : process.env.E2E ? 2 : 0,
+
+    retries: 0, // we're currently expecting stability ( no parallel tests, so fail fast )
 
     /* Workers configuration for parallel execution */
     // Ideally...
@@ -95,7 +98,9 @@ export default defineConfig({
     // Dev: 2 workers (parallel execution for faster feedback)
 
     // But ... it just doesn't work.
-    workers: process.env.CI ? 1 : 1,
+    // workers: process.env.CI ? 1 : 1,
+
+    workers: 1, // parallel execution is disabled for stability
 
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     /* (note that e2etesting run_test override this from command line) */


### PR DESCRIPTION
Fixes hassles with stability from running in parallel
