### PR TITLE
Display reason when game is bulk annulled due to AI

### DIFF
--- a/src/models/games.d.ts
+++ b/src/models/games.d.ts
@@ -223,6 +223,9 @@ declare namespace rest_api {
 
         /** For invalid handicaps that got into the system, don't rate */
         handicap_out_of_range?: boolean;
+
+        /** Game was annulled as part of AI cheating remediation */
+        ai_cheating_remediation?: boolean;
     }
 
     interface AIReviewParams {

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -1486,6 +1486,13 @@ function AnnulmentReason({
                     </div>,
                 );
                 break;
+            case "ai_cheating_remediation":
+                arr.push(
+                    <div key={key}>
+                        {_("This game has been annulled as part of AI cheating remediation.")}
+                    </div>,
+                );
+                break;
             default:
                 arr.push(<div key={key}>{key}</div>);
                 break;


### PR DESCRIPTION
Fixes people complaining that we aren't explaining why games are annulled

## Proposed Changes

  - Add a comment to the "annulment reason" popup stating that it was part of AI cheating remediation
  

Needs https://github.com/online-go/ogs/pull/2236 to do anything.

