### PR TITLE
Fix: 19x19 boards in "Learn to play Go" are too small

### DIFF
--- a/src/views/LearningHub/InstructionalGoban.tsx
+++ b/src/views/LearningHub/InstructionalGoban.tsx
@@ -77,7 +77,7 @@ export class InstructionalGoban extends React.Component<InstructionalGobanProps>
                     this.props.displayWidth ||
                     Math.min(
                         document.body.offsetWidth - 50,
-                        (document.getElementById("em10")?.offsetWidth ?? 0) * 2,
+                        (document.getElementById("em10")?.offsetWidth ?? 0) * 3,
                     ),
                 square_size: "auto",
 


### PR DESCRIPTION
Fixes #3326


## Proposed Changes

  - Changed the width multiplier from 2 to 3
  -
  -
