### PR TITLE
fix: multiple positions in a row now display properly in chat (e.g., 'a1 b1')

### DIFF
--- a/src/components/Chat/chat_markup.tsx
+++ b/src/components/Chat/chat_markup.tsx
@@ -414,6 +414,7 @@ export function chat_markup(
 
     return fragments.map((fragment, i) => {
         for (const r of replacements) {
+            r.pattern.lastIndex = 0; // ensures regex scans from start of fragment
             const m = r.pattern.exec(fragment);
             if (m) {
                 return r.replacement(m, i);


### PR DESCRIPTION
Previously, display of back-to-back positions in chat worked in the following way (format of [input] => [output]):
- "a1 b1" => "**a1** b1" (b1 isn't marked as a position)
- "a1 b1 c1" => "**a1** b1 **c1** d1" (b1 and d1 aren't marked as positions)

And it now works (how you'd expect) like so:
- "a1 b1" => "**a1** **b1**" (both are correctly marked as positions)
- "a1 b1 c1" => "**a1** **b1** **c1** **d1**" (all four are correctly marked as positions)

I noticed this while working on a fix to https://github.com/online-go/online-go.com/issues/3338. The `RegExp.prototype.exec` function has internal state in this use case (specifically, a regex with the global flag set) and must be manually reset. You can find more information in the documentation for exec, especially [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#finding_successive_matches).

For completeness here is what the old flow was for the chat "a1 b1":

1. "a1" is matched and marked correctly and `LastIndex` is set to 2.
2. The position regex attempts to match " b1" but because `LastIndex` is set to 2 it looks at the string starting from that index and sees "" and fails to match (thus resetting `LastIndex` to 0 and making the next position match work correctly).

Note that the only reason this didn't also break for something like URLs is because those don't match their leading space the way that positions do. So, for a chat message like "[URL1] [URL2]" the process would be along the lines of:

1. URL1 is matched and marked correctly and `LastIndex` is set to some high value (~the length of URL1).
2. The URL regex attempts to match the the string of " " between URL1 and URL2 and fails to find any matches resetting it's internal `LastIndex` to 0.
3. URL2 is matched and marked correctly (and `LastIndex` is once again left at some high value)


