### PR TITLE
fix: invalid positions in chat now display preceding whitespace

### DIFF
--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -607,12 +607,12 @@ function MarkupChatLine({ line }: { line: ChatLine }): React.ReactElement {
             <React.Fragment>
                 {chat_markup(body, [
                     {
-                        split: /((?:^|\s)[a-zA-Z][0-9]{1,2}\b(?=\s|$))/gm,
-                        pattern: /^(\s)?([a-zA-Z][0-9]{1,2})\b$/gm,
+                        split: /((?:^|\s)[a-zA-Z][0-9]{1,2}(?=\s|$))/gm,
+                        pattern: /\s?([a-zA-Z][0-9]{1,2})/gm,
                         replacement: (m, idx) => {
-                            const pos = m[2];
+                            const pos = m[1];
                             if (parsePosition(pos, goban).i < 0) {
-                                return <span key={idx}>{m[2]}</span>;
+                                return <span key={idx}>{m[0]}</span>;
                             }
                             return (
                                 <span
@@ -621,7 +621,7 @@ function MarkupChatLine({ line }: { line: ChatLine }): React.ReactElement {
                                     onMouseEnter={highlight_position}
                                     onMouseLeave={unhighlight_position}
                                 >
-                                    {m[2]}
+                                    {m[1]}
                                 </span>
                             );
                         },


### PR DESCRIPTION
This pr aims to close https://github.com/online-go/online-go.com/issues/3338. This appears to have been introduced in 7247cce03f3088a3210d3e0ebb64ab18b411fcb7 which was intended as a backwards compatibility improvement after the fixes made in https://github.com/online-go/online-go.com/pull/3226.

### Cause

The issue is caused by the fact that the board position regexes capture preceding whitespace. This is fine when the text matched as a position is valid but when it's invalid (e.g., "u2") it is printed without the originally captured whitespace and we see in the linked issue. After my change, in the case where the matched position is not valid on the current board, the entire string is used including any preceding whitespace.

### Other Notes

There is an additional issue caused by this which is that if we have text like "a b1 a" then we get back something that looks like "a **b1**  a" (notice the difference in space on each side of **b1**) as the space between 'a' and 'b' gets eaten by the regex while the space after doesn't. I figure this is maybe best left to the larger overhaul to this text-replacement system discussed here https://github.com/online-go/online-go.com/issues/2026#issuecomment-1278041547 but let me know if you think it should be handled now.

Note: I also removed some extraneous assertions from the position regexes. For example, in the split regex, the remove `\b` is not required as there is already a lookahead for `\s|$` which would imply a word boundry (i.e., `\b`)
