### PR TITLE
fix Delete button overflowing challenge modal

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1476,7 +1476,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
                 <hr />
                 <div className="preferred-settings-container">
                     <div style={{ display: "flex", gap: "1em", alignItems: "center" }}>
-                        <div style={{ flex: 1 }}>
+                        <div style={{ flex: 1, minWidth: 0 }}>
                             <Select
                                 classNamePrefix="ogs-react-select"
                                 value={selected}


### PR DESCRIPTION
Fixes https://github.com/online-go/online-go.com/issues/3377

## Proposed Changes

In a flexbox, `minWidth: 0` on a child component makes the parent properly calculate that child's width based on its box bounds. Without it, the width is calculated based on child content, i.e. the long text. Even if the text is cut off with an `overflow: hidden`, its non-truncated width bubbles up to the flex parent and is used to calculate the container width.

Before:
<img width="888" height="602" alt="Screenshot_20260116_212427" src="https://github.com/user-attachments/assets/18fe0fb0-cb79-436b-862a-eba0bbcb8bff" />

After:
<img width="822" height="611" alt="Screenshot_20260116_212440" src="https://github.com/user-attachments/assets/074cbabe-5a21-48cc-9d50-9401ae9523d4" />
