### PR TITLE
Fix report-number-finding (again!)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ npm run test:e2e:debug       # E2E tests in debug mode
 npm run test:ci              # Full CI test suite
 ```
 
+**E2E Test Runner**: When running e2e tests, prefer using `.e2e-ci/run-tests.sh` (located in the `ogs` parent directory) instead of running yarn/npm commands directly. This script performs health checks, logging, and other important validations that help diagnose issues. Use the `-q` (quiet) flag to avoid sending notifications to Slack.
+
 ### Analysis
 
 ```bash

--- a/e2e-tests/cm/cm-vote-escalate-sandbagging.ts
+++ b/e2e-tests/cm/cm-vote-escalate-sandbagging.ts
@@ -174,8 +174,11 @@ export const cmVoteEscalateSandbaggingTest = async (
         await navigateToReport(modPage, reportNumber);
 
         // Verify the escalated report content is visible
+        // Use .first() because the report text may appear in multiple places (Card and content div)
         await expect(
-            modPage.getByText("E2E test reporting sandbagging for escalation: deliberate loss."),
+            modPage
+                .getByText("E2E test reporting sandbagging for escalation: deliberate loss.")
+                .first(),
         ).toBeVisible({ timeout: 15000 });
 
         // Verify the report type has been changed to sandbagging_assessment
@@ -187,7 +190,9 @@ export const cmVoteEscalateSandbaggingTest = async (
         // Verify the report shows the system notes about being escalated
         // Both the specific note from the action function and the generic "Actioned by" note should be present
         await expect(
-            modPage.getByText("Sent to moderators due to CM vote for sandbagging assessment").first(),
+            modPage
+                .getByText("Sent to moderators due to CM vote for sandbagging assessment")
+                .first(),
         ).toBeVisible();
         await expect(
             modPage.getByText("Actioned by community vote: escalate_sandbagging").first(),

--- a/e2e-tests/cm/cm-vote-on-own-report.ts
+++ b/e2e-tests/cm/cm-vote-on-own-report.ts
@@ -87,11 +87,12 @@ export const cmVoteOnOwnReportTest = async (
 
         // Find the specific report's container and click its Cancel button
         // Each report is in a div.incident container
-        // Use regex with negative lookahead to match exact report number (e.g., R1 but not R14)
-        // This ensures the report number isn't followed by another digit
+        // Use the data-report-id attribute on the button to find the correct report
+        // (The displayed report number is truncated to 3 digits, but data-report-id has full ID)
+        const reportId = reportNumber.replace(/^R/, "");
         const reportContainer = reporterPage
             .locator("div.incident")
-            .filter({ hasText: new RegExp(`${reportNumber}(?!\\d)`) });
+            .filter({ has: reporterPage.locator(`button[data-report-id="${reportId}"]`) });
         await expect(reportContainer).toBeVisible();
 
         // Find the Cancel button within this specific report's container

--- a/src/components/IncidentReportTracker/IncidentReportCard.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportCard.tsx
@@ -96,13 +96,16 @@ export function IncidentReportCard({ report }: IncidentReportCardProps): React.R
                     void navigateTo(`/reports-center/all/${report.id}`);
                 }}
                 className="small"
+                data-report-id={report.id}
             >
                 {"R" + report.id.toString().slice(-3)}
             </button>
         );
     } else {
         report_id_button = (
-            <button className="small inactive">{"R" + report.id.toString().slice(-3)}</button>
+            <button className="small inactive" data-report-id={report.id}>
+                {"R" + report.id.toString().slice(-3)}
+            </button>
         );
     }
     return (


### PR DESCRIPTION
Fixes sometimes e2e tests getting confused due to report number wrap around.

## Proposed Changes

  - Supply full report number in css attribute
  