### PR TITLE
Always show suspend reason

### DIFF
--- a/src/views/Appeal/Appeal.tsx
+++ b/src/views/Appeal/Appeal.tsx
@@ -125,7 +125,7 @@ export function Appeal(props: { player_id?: number }): React.ReactElement | null
             {/* ban_reason comes from the backend and can't be translated on the frontend */}
             {ban_reason && still_banned && (
                 <h2 ref={suspensionReasonRef}>
-                    {_("Reason for suspension:")} {ban_reason}
+                    {interpolate(_("Reason for suspension: {{reason}}"), { reason: ban_reason })}
                 </h2>
             )}
             {ban_expiration && still_banned && (


### PR DESCRIPTION
Fixes some users not seeing suspend reason - maybe

## Proposed Changes

  - Don't try to translate moderator-supplied ban reason
  
I thought that translation fallback would take care of this, but I can't find any other reason why typically non-english users are saying they don't see a reason.