### PR TITLE
Fix bot strength category gaps in ChallengeModal

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1535,13 +1535,13 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             {
                 sort_index: 2,
                 label: pgettext("Bot strength category", "Intermediate"),
-                lower_bound: 11,
+                lower_bound: 10,
                 upper_bound: 25,
             },
             {
-                sort_index: 2,
+                sort_index: 3,
                 label: pgettext("Bot strength category", "Advanced"),
-                lower_bound: 26,
+                lower_bound: 25,
                 upper_bound: 99,
             },
         ];
@@ -1579,7 +1579,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             for (const category of categories) {
                 if (
                     b.ranking &&
-                    b.ranking >= category.lower_bound &&
+                    b.ranking > category.lower_bound &&
                     b.ranking <= category.upper_bound
                 ) {
                     b.category = category;
@@ -1629,12 +1629,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
                             <div key={category.upper_bound} className="bot-options">
                                 {available_bots
                                     //.filter((bot) => !bot.disabled)
-                                    .filter(
-                                        (bot) => bot.ranking && bot.ranking >= category.lower_bound,
-                                    )
-                                    .filter(
-                                        (bot) => bot.ranking && bot.ranking <= category.upper_bound,
-                                    )
+                                    .filter((bot) => bot.category === category)
                                     .map((bot) => {
                                         return (
                                             <div


### PR DESCRIPTION
# Fixes
Missing bots in the bot challenge view.

e.g. At the time of PR creation [this 5kyu bot](https://online-go.com/player/1953165/Kata5k-HumanSL) (ranking 25.06...) is missing from the bot challenge page and only available by challenging from it's profile page. Checking network activity on the bot challenge page confirms this bot is being sent over the websocket then being filtered out due to the rank gap. This also happens for a few other bots falling in the gaps.

## Proposed Changes
  - Updated `categories` constants in `ChallengeModal.tsx` to close gaps at ranks 10-11 (19.001-20kyu gap) and 25-26 (4.001-5kyu gap).
  - Refined the categorization loop to ensure bots at boundary ranks (e.g., 10.1) are correctly assigned to the next category up.
  - Simplified the UI filtering logic to rely on the pre-calculated `bot.category` to prevent rendering overlaps or omissions.
  - Expanded `ChallengeModal.test.tsx` with a new `ChallengeModalBotFiltering` suite to verify boundary sorting (10, 10.1, 25, 25.1, 99).