### PR TITLE
Feat: Persist "watch" filter preference across sessions

### DIFF
--- a/src/components/ObserveGamesComponent/ObserveGamesComponent.tsx
+++ b/src/components/ObserveGamesComponent/ObserveGamesComponent.tsx
@@ -189,7 +189,11 @@ export class ObserveGamesComponent extends React.PureComponent<
     setPageSize = (ev: React.ChangeEvent<HTMLInputElement>) => {
         if (ev.target.value && parseInt(ev.target.value) >= 3 && parseInt(ev.target.value) <= 100) {
             const ct: number = parseInt(ev.target.value);
-            this.namespacedPreferenceSet("observed-games-page-size", ct);
+            this.namespacedPreferenceSet(
+                "observed-games-page-size",
+                ct,
+                data.Replication.REMOTE_OVERWRITES_LOCAL,
+            );
             this.setState({
                 page_size: ct,
                 page_size_text_input: ct,
@@ -297,12 +301,20 @@ export class ObserveGamesComponent extends React.PureComponent<
 
     viewLive = () => {
         this.setState({ viewing: "live", page: 0 });
-        this.namespacedPreferenceSet("observed-games-viewing", "live");
+        this.namespacedPreferenceSet(
+            "observed-games-viewing",
+            "live",
+            data.Replication.REMOTE_OVERWRITES_LOCAL,
+        );
         setTimeout(this.refresh, 1);
     };
     viewCorrespondence = () => {
         this.setState({ viewing: "corr", page: 0 });
-        this.namespacedPreferenceSet("observed-games-viewing", "corr");
+        this.namespacedPreferenceSet(
+            "observed-games-viewing",
+            "corr",
+            data.Replication.REMOTE_OVERWRITES_LOCAL,
+        );
         setTimeout(this.refresh, 1);
     };
 
@@ -310,7 +322,11 @@ export class ObserveGamesComponent extends React.PureComponent<
         this.setState({ show_filters: !this.state.show_filters });
     };
     toggleForceList = () => {
-        this.namespacedPreferenceSet("observed-games-force-list", !this.state.force_list);
+        this.namespacedPreferenceSet(
+            "observed-games-force-list",
+            !this.state.force_list,
+            data.Replication.REMOTE_OVERWRITES_LOCAL,
+        );
         this.setState({ force_list: !this.state.force_list });
     };
 


### PR DESCRIPTION
Updated ObserveGamesComponent to pass on the game persistence setting to the "data.ts"'s "set" function.

This was done after a user requested, refer:
https://forums.online-go.com/t/feature-persistent-filter-settings-for-game-watching/59275/3?u=greenasjade

## Proposed Changes

  - Add persistence for the watch games preferences
  
@GreenAsJade had advised me where to look to make this change.

Open to changes.

<img width="1272" height="368" alt="Screenshot 2026-02-07 at 8 52 11 PM" src="https://github.com/user-attachments/assets/056fa16d-fd3c-4e15-9739-64dc45a39ae7" />
