### PR TITLE
Fix login error handling so that suspended users can log in 

### DIFF
--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -155,10 +155,10 @@ export function SignIn(): React.ReactElement {
                     }
                 })
                 .catch((response) => {
-                    if (response.responseJSON && response.responseJSON.error_code === "banned") {
-                        data.set("appeals.banned_user_id", response.responseJSON.banned_user_id);
-                        data.set("appeals.jwt", response.responseJSON.jwt);
-                        data.set("appeals.ban-reason", response.responseJSON.ban_reason);
+                    if (response && response.error_code === "banned") {
+                        data.set("appeals.banned_user_id", response.banned_user_id);
+                        data.set("appeals.jwt", response.jwt);
+                        data.set("appeals.ban-reason", response.ban_reason);
                         window.location.pathname = "/appeal";
                     } else {
                         errorAlerter(response);


### PR DESCRIPTION
(so they can appeal)

Fixes # users who are suspended while they are logged out can't log in to appeal

## Proposed Changes

  - Fix the error handling around the catch for login error code "banned": we were looking at the JSON but that's not where it is.

  