### PR TITLE
Fix SGF upload failure from Google Drive on Android Chrome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,11 @@ React/TypeScript frontend for online-go.com. Uses Vite, PostCSS, `yarn`.
 - No pulsing/throbbing animations. No `translateY`/`translateX` on hover. No hover background changes on non-interactive elements.
 - All user-visible strings must be translated. Use `pgettext(context, msgid)` (or `llm_pgettext` for LLM-translated strings), `ngettext`/`npgettext` for plurals, and `interpolate()` for parameterized strings. Import from `@/lib/translate`. See `src/lib/translate.ts` for details.
 - Code must build and pass linting/formatting.
+
+## Before Committing or Considering a Change Complete
+
+Follow [CONTRIBUTING.md](CONTRIBUTING.md) before marking any change as done. In particular:
+
+- Run `yarn build` to verify the build succeeds.
+- Run `yarn lint` to check for linting errors.
+- Run `yarn prettier` to check formatting (use `yarn prettier --write` to auto-fix).

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -293,7 +293,23 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
     uploadSGFs = (files: File[]) => {
         if (parseInt(this.props.match.params.player_id) === data.get("user").id) {
             files = files.filter((file) => /.sgf$/i.test(file.name));
-            Promise.all(files.map((file) => post(`me/games/sgf/${this.state.collection_id}`, file)))
+            Promise.all(
+                files.map((file) =>
+                    // Read the file into memory before uploading. Files from
+                    // Google Drive via Android Chrome's file picker are backed
+                    // by a content:// URI that may not be fully materialized
+                    // yet, causing fetch() to fail when it tries to read the
+                    // FormData body.
+                    file
+                        .arrayBuffer()
+                        .then((buf) =>
+                            post(
+                                `me/games/sgf/${this.state.collection_id}`,
+                                new File([buf], file.name, { type: "application/x-go-sgf" }),
+                            ),
+                        ),
+                ),
+            )
                 .then(() => {
                     this.refresh(this.props.match.params.player_id).then(ignore).catch(ignore);
                 })


### PR DESCRIPTION
When uploading SGFs from Google Drive using the Android file picker in Chrome, I got a `TypeError: Failed to fetch` error pop-up.

Adding eruda devtools so I could check the logs in Android Chrome, I saw this error:
```
Error: TypeError: Failed to fetch
    at window.fetch (http://cdn.jsdelivr.net/npm/eruda:8:336410)
    at http://10.0.0.5:8080/@fs/Users/jdndeveloper/ogs/node_modules/.vite/deps/@sentry_browser.js?v=b13f11a0:10576:28
    at http://10.0.0.5:8080/lib/requests.ts:73:7
    at new Promise (<anonymous>)
    at http://10.0.0.5:8080/lib/requests.ts:46:46
    at http://10.0.0.5:8080/views/LibraryPlayer/LibraryPlayer.tsx:77:41
    at Array.map (<anonymous>)
    at uploadSGFs (http://10.0.0.5:8080/views/LibraryPlayer/LibraryPlayer.tsx:77:27)
    at http://10.0.0.5:8080/@fs/Users/jdndeveloper/ogs/node_modules/.vite/deps/react-dropzone.js?v=b13f11a0:2276:7
    at http://10.0.0.5:8080/@fs/Users/jdndeveloper/ogs/node_modules/.vite/deps/react-dropzone.js?v=b13f11a0:2295:9
```

The issue was that SGF files selected from Google Drive via Android Chrome's native file picker are backed by a `content://` URI that may not be fully materialized locally when `fetch()` attempts to serialize the `FormData` request body, causing a `TypeError: Failed to fetch`. Local files (e.g. from the Downloads folder) are always immediately available on disk and are unaffected.

## Proposed Changes

Read SGF file content into memory via `arrayBuffer()` before uploading.

Tested on mobile.