### PR TITLE
Fix module alias in the Jest configuration for moderator-ui

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -36,6 +36,7 @@ module.exports = {
         "^goban$": "<rootDir>/submodules/goban/src",
         "^goscorer$": "<rootDir>/submodules/goban/src/third_party/goscorer/goscorer",
         "^d3$": "<rootDir>/src/stubs/d3.ts",
+        "^@moderator-ui/(.*)": "<rootDir>/src/stubs/moderator-ui/$1",
     },
     setupFiles: ["./setup-jest.cjs"],
     setupFilesAfterEnv: ["jest-chain", "@testing-library/jest-dom"],


### PR DESCRIPTION
This fixes the failing tests.
Refer https://github.com/online-go/online-go.com/actions/runs/22882862293

I noticed failing `jest` tests.
<img width="1280" height="577" alt="Screenshot 2026-03-16 at 12 21 16 AM" src="https://github.com/user-attachments/assets/acaa1294-fde6-465e-96ca-4734ee57fbe8" />

In the error logs i found this:
```
    Cannot find module '@moderator-ui/Moderator' from 'src/components/Player/PlayerDetails.tsx'
```


