### PR TITLE
Add remote sync the progress of "Learn" section.

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -181,19 +181,22 @@ export function remove<KeyT extends Extract<keyof DataSchema, string>>(
     emitForKey(key);
 }
 
-export function removePrefix(key_prefix: string): any {
-    const hits: Partial<DataSchema> = {};
+export function removePrefix(key_prefix: string, replication?: Replication): void {
+    const hits: string[] = [];
 
-    Object.keys(store).map((key) => {
+    Object.keys(store).forEach((key) => {
         if (key.indexOf(key_prefix) === 0) {
-            hits[key as keyof DataSchema] = key;
+            hits.push(key);
+        }
+    });
+    Object.keys(remote_store).forEach((key) => {
+        if (key.indexOf(key_prefix) === 0 && !hits.includes(key)) {
+            hits.push(key);
         }
     });
 
-    for (const key in hits) {
-        safeLocalStorageRemove(`ogs.${key}`);
-        delete store[key as keyof DataSchema];
-        emitForKey(key as keyof DataSchema);
+    for (const key of hits) {
+        remove(key as keyof DataSchema, replication);
     }
 }
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -406,12 +406,13 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
  */
 export function usePreference<KeyT extends ValidPreference>(
     key: KeyT,
+    replication?: data.Replication,
 ): [PreferencesType[KeyT], (v: PreferencesType[KeyT]) => void] {
     const [value, stateSetter] = React.useState(get(key));
 
     const setStateAndPreference = (v: PreferencesType[KeyT]) => {
         stateSetter(v);
-        set(key, v);
+        set(key, v, replication);
     };
 
     React.useEffect(() => {

--- a/src/views/LearningHub/LearningHub.tsx
+++ b/src/views/LearningHub/LearningHub.tsx
@@ -131,19 +131,6 @@ function calculateSectionProgress(lessons: any[]): SectionProgress {
 }
 
 // Initializes section expansion state from saved preferences or defaults to first section
-function initializeExpandedSections(): ExpandedSectionsState {
-    const expandedSections: ExpandedSectionsState = {};
-    const lastExpandedSection = preferences.get(LAST_EXPANDED_SECTION_KEY);
-
-    sections.forEach(([sectionName], index) => {
-        // Restore from saved state or default to first section
-        expandedSections[sectionName] = lastExpandedSection
-            ? sectionName === lastExpandedSection
-            : index === 0;
-    });
-
-    return expandedSections;
-}
 
 // Returns the appropriate ribbon content based on lesson completion status
 function getRibbonContent(sectionName: string): React.ReactNode {
@@ -173,28 +160,30 @@ function getRibbonContent(sectionName: string): React.ReactNode {
 // Convert to functional component for better performance
 function Index(): React.ReactElement {
     const user = data.get("user");
-    const [expandedSections, setExpandedSections] = React.useState<ExpandedSectionsState>(
-        initializeExpandedSections,
+    const [lastExpandedSection, setLastExpandedSection] = preferences.usePreference(
+        LAST_EXPANDED_SECTION_KEY,
+        data.Replication.REMOTE_OVERWRITES_LOCAL,
     );
 
-    const toggleSection = React.useCallback((sectionName: string) => {
-        setExpandedSections((prevState) => {
-            // Accordion behavior: always keep exactly one section expanded.
-            // If user clicks the currently expanded section, ignore the click.
-            if (prevState[sectionName]) {
-                return prevState;
-            }
-
-            // Collapse all sections except the clicked one
-            const newState = Object.keys(prevState).reduce<ExpandedSectionsState>((acc, key) => {
-                acc[key] = key === sectionName;
-                return acc;
-            }, {});
-
-            preferences.set(LAST_EXPANDED_SECTION_KEY, sectionName);
-            return newState;
+    const expandedSections = React.useMemo(() => {
+        const state: ExpandedSectionsState = {};
+        sections.forEach(([sectionName], index) => {
+            state[sectionName] = lastExpandedSection
+                ? sectionName === lastExpandedSection
+                : index === 0;
         });
-    }, []);
+        return state;
+    }, [lastExpandedSection]);
+
+    const toggleSection = React.useCallback(
+        (sectionName: string) => {
+            if (expandedSections[sectionName]) {
+                return;
+            }
+            setLastExpandedSection(sectionName);
+        },
+        [expandedSections, setLastExpandedSection],
+    );
 
     return (
         <div id="LearningHub-Index">
@@ -395,17 +384,14 @@ function SectionNav(): React.ReactElement {
     const urlMatch = window.location.pathname.match(/\/learn-to-play-go(\/([^\/]+))?(\/([0-9]+))?/);
     const currentSectionName = urlMatch?.[2] || "";
 
-    const [autoAdvance, setAutoAdvance] = React.useState(() =>
-        preferences.get("learning-hub-auto-advance"),
+    const [autoAdvance, setAutoAdvance] = preferences.usePreference(
+        "learning-hub-auto-advance",
+        data.Replication.REMOTE_OVERWRITES_LOCAL,
     );
 
     const handleAutoAdvanceToggle = React.useCallback(() => {
-        setAutoAdvance((prev) => {
-            const next = !prev;
-            preferences.set("learning-hub-auto-advance", next);
-            return next;
-        });
-    }, []);
+        setAutoAdvance(!autoAdvance);
+    }, [autoAdvance, setAutoAdvance]);
 
     // Memoize reset progress handler
     const handleResetProgress = React.useCallback(() => {
@@ -416,7 +402,7 @@ function SectionNav(): React.ReactElement {
             })
             .then(({ value: accept }) => {
                 if (accept) {
-                    data.removePrefix("learning-hub.");
+                    data.removePrefix("learning-hub.", data.Replication.REMOTE_OVERWRITES_LOCAL);
                     browserHistory.push("/learn-to-play-go");
                 }
             });


### PR DESCRIPTION
Fixes #3366

## Proposed Changes

- Update 'removePrefix' to remove/reset the progress across all the clients.
- update 'usePreference' to take in a replication flag
- Remove 'initializeExpandedSections' as it is not needed anymore since we not refer LAST_EXPANDED_SECTION_KEY for it.
- Update functions in LearningHub.tsx to refer 'REMOTE_OVERWRITES_LOCAL'

---

Tested manually.