### PR TITLE
Tweak github trigger for ogs-ui out of ogs.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
                   if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
                     echo "source=github-trigger" >> $GITHUB_OUTPUT
                   elif [ "$EVENT_NAME" = "push" ]; then
-                    echo "source=online-go.com" >> $GITHUB_OUTPUT
+                    echo "source=ogs-ui" >> $GITHUB_OUTPUT
                   else
                     echo "source=unknown" >> $GITHUB_OUTPUT
                   fi


### PR DESCRIPTION
Fixes trigger name update needed 'cause we put ogs-ui back out.

## Proposed Changes

  - name change in trigger.
  

Note: trivial: this only affects what the messages say the trigger was for.
