### PR TITLE
Add Aji level to pricing types and getMonthlyPrice

### DIFF
--- a/src/views/Prizes/SponsorshipRequestTypes.ts
+++ b/src/views/Prizes/SponsorshipRequestTypes.ts
@@ -46,6 +46,7 @@ export interface SponsorshipRequestData {
 }
 
 export interface SupporterPricing {
+    aji: { monthly_price_usd: number };
     hane: { monthly_price_usd: number };
     tenuki: { monthly_price_usd: number };
     meijin: { monthly_price_usd: number };
@@ -79,6 +80,8 @@ export function getLevelName(level: number): string {
 
 export function getMonthlyPrice(pricing: SupporterPricing, level: number): number {
     switch (level) {
+        case 1:
+            return pricing.aji.monthly_price_usd / 100;
         case 2:
             return pricing.hane.monthly_price_usd / 100;
         case 3:


### PR DESCRIPTION
## Proposed Changes

  - Add `aji` field to `SupporterPricing` interface
  - Add `case 1` (Aji) to `getMonthlyPrice` function so prize batch value calculations cover all supporter tiers

**Companion PRs:**
  - online-go/ogs - add Aji pricing to API endpoint
  - online-go/moderator-ui - prize batch total value UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)