### PR TITLE
Update LearningHub to sync legacy data

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -327,6 +327,8 @@ function safeLocalStorageRemove(key: string) {
     }
 }
 
+export const legacy_learning_hub_data: Record<string, Record<number, true>> = {};
+
 /* Load previously saved data from localStorage */
 try {
     for (let i = 0; i < localStorage.length; ++i) {
@@ -337,6 +339,9 @@ try {
                 const item = localStorage.getItem(`ogs.${key}`);
                 if (item) {
                     store[key as keyof DataSchema] = JSON.parse(item);
+                    if (key.startsWith("learning-hub.")) {
+                        legacy_learning_hub_data[key] = store[key as keyof DataSchema];
+                    }
                 }
             } catch (e) {
                 console.error(

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -658,7 +658,10 @@ socket.on("remote_storage/update", (row) => {
     }
 });
 
+export let initial_sync_complete = false;
+
 socket.on("remote_storage/sync_complete", () => {
+    initial_sync_complete = true;
     events.emit("remote_data_sync_complete");
 });
 

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -331,6 +331,7 @@ export interface DataSchema
 
     [player_notes_key: `player-notes.${number}.${number}`]: string;
     [learning_hub_key: `learning-hub.${string}`]: { [page_number: number]: true };
+    "_learning-hub-migrated"?: boolean;
     [moderator_join_game_publicly_key: `moderator.join-game-publicly.${string}`]: boolean;
     [puzzle_last_visited_key: `puzzle.collection.${number}.last-visited`]: number;
     [paginated_table_page_size_key: `paginated-table.${string}.page_size`]: number;

--- a/src/views/LearningHub/LearningHub.tsx
+++ b/src/views/LearningHub/LearningHub.tsx
@@ -45,20 +45,24 @@ export function LearningHub(): React.ReactElement {
         };
     }, [params.section, params.page]);
 
+    const user = data.get("user");
+
     React.useEffect(() => {
         // One-time migration of local historical progress to remote storage
-        if (!data.get("_learning-hub-migrated")) {
+        if (user && !user.anonymous && !data.get("_learning-hub-migrated")) {
             const legacyData = data.legacy_learning_hub_data;
             for (const key in legacyData) {
+                // Ensure correct key typing for data access
+                const typedKey = key as `learning-hub.${string}`;
                 // We merge learning-hub legacy (pre-sync) data with current server data
-                const currentData: any = data.get(key as any) || {};
+                const currentData = (data.get(typedKey) || {}) as Record<number, true>;
                 const merged = { ...legacyData[key], ...currentData };
-                data.set(key as any, merged, data.Replication.REMOTE_OVERWRITES_LOCAL);
+                data.set(typedKey, merged, data.Replication.REMOTE_OVERWRITES_LOCAL);
             }
-            // Even if they have no data, we mark them as migrated so we don't keep checking
+            // Now mark as migrated locally and remotely
             data.set("_learning-hub-migrated", true, data.Replication.REMOTE_OVERWRITES_LOCAL);
         }
-    }, []);
+    }, [user]);
 
     const section_name = (params.section || "index").toLowerCase();
     let section: any = null;

--- a/src/views/LearningHub/LearningHub.tsx
+++ b/src/views/LearningHub/LearningHub.tsx
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 import * as data from "@/lib/data";
+import { useData } from "@/lib/hooks";
 import "./LearningHub.css";
 import * as preferences from "@/lib/preferences";
 import { Link, useParams } from "react-router-dom";
@@ -36,6 +37,19 @@ interface LearningHubParams {
 
 export function LearningHub(): React.ReactElement {
     const params = useParams<keyof LearningHubParams>();
+    const [user] = useData("user");
+    const [synced, setSynced] = React.useState(data.initial_sync_complete);
+
+    React.useEffect(() => {
+        if (synced) {
+            return;
+        }
+        const handler = () => setSynced(true);
+        data.events.on("remote_data_sync_complete", handler);
+        return () => {
+            data.events.off("remote_data_sync_complete", handler);
+        };
+    }, [synced]);
 
     React.useEffect(() => {
         const oldTitle = window.document.title;
@@ -45,11 +59,9 @@ export function LearningHub(): React.ReactElement {
         };
     }, [params.section, params.page]);
 
-    const user = data.get("user");
-
     React.useEffect(() => {
         // One-time migration of local historical progress to remote storage
-        if (user && !user.anonymous && !data.get("_learning-hub-migrated")) {
+        if (user && !user.anonymous && synced && !data.get("_learning-hub-migrated")) {
             const legacyData = data.legacy_learning_hub_data;
             for (const key in legacyData) {
                 // Ensure correct key typing for data access
@@ -62,7 +74,7 @@ export function LearningHub(): React.ReactElement {
             // Now mark as migrated locally and remotely
             data.set("_learning-hub-migrated", true, data.Replication.REMOTE_OVERWRITES_LOCAL);
         }
-    }, [user]);
+    }, [user, synced]);
 
     const section_name = (params.section || "index").toLowerCase();
     let section: any = null;

--- a/src/views/LearningHub/LearningHub.tsx
+++ b/src/views/LearningHub/LearningHub.tsx
@@ -45,6 +45,21 @@ export function LearningHub(): React.ReactElement {
         };
     }, [params.section, params.page]);
 
+    React.useEffect(() => {
+        // One-time migration of local historical progress to remote storage
+        if (!data.get("_learning-hub-migrated")) {
+            const legacyData = data.legacy_learning_hub_data;
+            for (const key in legacyData) {
+                // We merge learning-hub legacy (pre-sync) data with current server data
+                const currentData: any = data.get(key as any) || {};
+                const merged = { ...legacyData[key], ...currentData };
+                data.set(key as any, merged, data.Replication.REMOTE_OVERWRITES_LOCAL);
+            }
+            // Even if they have no data, we mark them as migrated so we don't keep checking
+            data.set("_learning-hub-migrated", true, data.Replication.REMOTE_OVERWRITES_LOCAL);
+        }
+    }, []);
+
     const section_name = (params.section || "index").toLowerCase();
     let section: any = null;
     let next_section_name = "";


### PR DESCRIPTION
Further fix for #3366

## Proposed Changes

- Updated lib/data.ts because it was triggering "remote_sync" on page load, which was causing the remote data to override the local
- Updated views/LearningHub/LearningHub.tsx to have a one time migration flag for merging and pushing legacy data to remote servers.

@GreenAsJade please check. Open to feedback.