### PR TITLE
Update AGENTS.md to point to CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,15 +28,15 @@ React/TypeScript frontend for online-go.com. Uses Vite, PostCSS, `yarn`.
 
 ## Before Committing or Considering a Change Complete
 
-Follow [CONTRIBUTING.md](CONTRIBUTING.md) before marking any change as done. Run these checks during development after each meaningful change:
+Follow [CONTRIBUTING.md](CONTRIBUTING.md) before marking any change as done. In particular:
 
-- Run `npm run type-check` to verify TypeScript types compile cleanly.
-- Run `npm run lint` to check for linting errors.
-- Run `npx prettier --write <modified-files>` to auto-fix formatting on only the files that were modified.
+- Run `yarn type-check` to verify TypeScript types compile cleanly.
+- Run `yarn lint` to check for linting errors.
+- Run `yarn prettier:file <modified-files>` to auto-fix formatting on only the files that were modified.
 
 Only run the full build once before the final push, since it is slow and not needed in the normal development loop:
 
-- Run `npm run build` to verify the full build succeeds.
+- Run `yarn build` to verify the build succeeds.
 
 Before submitting a PR, remind the author to perform manual testing in both mobile and desktop browsers.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ You could poke around in `src/` if you are already curious
 
 6. in a command window, cd to the folder that was created when you cloned the repo and do
 
-`npx yarn install`
+`npm clean-install`
 
 `npm run dev`
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "build:i18n": "OGS_I18N_BUILD_MODE=true vite build",
         "type-check": "tsc --skipLibCheck --noEmit",
         "prettier": "prettier --write \"src/**/*.{ts,tsx}\"",
+        "prettier:file": "prettier --write",
         "prettier:check": "prettier --check \"src/**/*.{ts,tsx}\"",
         "lint": "eslint src/",
         "lint:fix": "eslint --fix src/",


### PR DESCRIPTION
There were some inconsistencies between the two files, so I cleaned that up. I believe the `Use yarn, not npm` rule was just referring to package management, not run scripts. Also, `npm run build` is pretty slow, so I updated `AGENTS.md` guidance to remove this from the main development loop, and just do it before pushing up a final commit.