### PR TITLE
Update the way we identify Home page, hopefully more resilient this time

### DIFF
--- a/e2e-tests/helpers/user-utils.ts
+++ b/e2e-tests/helpers/user-utils.ts
@@ -156,7 +156,7 @@ export const prepareNewUser = async (
     const chooseButton = await expectOGSClickableByName(userPage, /^Basic/);
     await chooseButton.click();
 
-    await expect(userPage.locator(".PlayBar")).toBeVisible();
+    await expect(userPage.locator("#Home")).toBeVisible();
 
     await turnOffDynamicHelp(userPage); // the popups can get in the way.
 


### PR DESCRIPTION
Fixes mass fail

## Proposed Changes

  - Look for the home page container as confirmation we navigated and rendered the page
  