### PR TITLE
Switch to using dvw/dvh to handle mobile browsers dynamic sizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         "postcss-nested": "^6.0.1",
         "postcss-simple-vars": "^7.0.1",
         "postcss-url": "^10.1.3",
+        "postcss-viewport-unit-fallback": "^1.0.1",
         "prettier": "3.6.2",
         "prettier-eslint": "^16.4.2",
         "supervisor": "^0.12.0",

--- a/src/components/ACLModal/ACLModal.css
+++ b/src/components/ACLModal/ACLModal.css
@@ -16,7 +16,7 @@
  */
 .ACLModal.Modal {
     width: 35rem;
-    max-width: 100vw;
+    max-width: 100dvw;
     min-height: 25rem;
 
     .fa-remove {

--- a/src/components/AIReview/AIReview.css
+++ b/src/components/AIReview/AIReview.css
@@ -294,7 +294,7 @@
         display: block;
         width: 15rem;
         margin: auto;
-        max-width: 100vw;
+        max-width: 100dvw;
         font-size: var(--font-size-small);
         word-break: nobreak;
     }

--- a/src/components/AIReview/ReviewChart.css
+++ b/src/components/AIReview/ReviewChart.css
@@ -17,8 +17,8 @@
 .AIReviewChart {
     height: 100px;
     /* margin-bottom: 1rem; */
-    /* max-width: calc(100vw - 2em); */
-    max-width: calc(100vw);
+    /* max-width: calc(100dvw - 2em); */
+    max-width: calc(100dvw);
     /* max-width: 100%; */
     user-select: none;
 

--- a/src/components/AccountWarning/AccountWarning.css
+++ b/src/components/AccountWarning/AccountWarning.css
@@ -38,8 +38,8 @@
     top: 50%;
     transform: translate(-50%, -50%);
     width: 30rem;
-    max-width: calc(95vw - 2rem);
-    max-height: calc(95vh - 2rem);
+    max-width: calc(95dvw - 2rem);
+    max-height: calc(95dvh - 2rem);
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.5);
     z-index: var(--z-account-warning);
     background-color: var(--account-warning-bg);
@@ -107,8 +107,8 @@
     top: 50%;
     transform: translate(-50%, -50%);
     width: 30rem;
-    max-width: calc(95vw - 2rem);
-    max-height: calc(95vh - 2rem);
+    max-width: calc(95dvw - 2rem);
+    max-height: calc(95dvh - 2rem);
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.5);
     z-index: var(--z-account-warning);
     background-color: var(--account-warning-bg);

--- a/src/components/Announcements/Announcements.css
+++ b/src/components/Announcements/Announcements.css
@@ -22,7 +22,7 @@
     display: inline-flex;
     flex-direction: column;
     width: 18rem;  /* Reduced to prevent overflow */
-    max-width: calc(100vw - 1rem);  /* Ensure it doesn't exceed viewport width */
+    max-width: calc(100dvw - 1rem);  /* Ensure it doesn't exceed viewport width */
     box-sizing: border-box;
 
     * {
@@ -209,8 +209,8 @@
 /* Mobile responsiveness */
 @media (max-width: 768px) {
     .Announcements {
-        width: 100vw;  /* Full width on mobile */
-        max-width: 100vw;  /* Override the max-width restriction */
+        width: 100dvw;  /* Full width on mobile */
+        max-width: 100dvw;  /* Override the max-width restriction */
         right: 0;  /* No right spacing */
         left: 0;  /* Ensure it starts from left edge */
 
@@ -235,8 +235,8 @@
 /* Small mobile devices */
 @media (max-width: 480px) {
     .Announcements {
-        width: 100vw;  /* Full width */
-        max-width: 100vw;  /* Override the max-width restriction */
+        width: 100dvw;  /* Full width */
+        max-width: 100dvw;  /* Override the max-width restriction */
         right: 0;  /* No spacing */
         left: 0;  /* Start from left edge */
         border-radius: 0;

--- a/src/components/AnnulQueueModal/AnnulQueueModal.css
+++ b/src/components/AnnulQueueModal/AnnulQueueModal.css
@@ -1,6 +1,6 @@
 .AnnulQueueModal {
-    min-width: 80vw;
-    min-height: 90vh;
+    min-width: 80dvw;
+    min-height: 90dvh;
     z-index: 1000;
     position: fixed;
     top: 50%;

--- a/src/components/BanModal/BanModal.css
+++ b/src/components/BanModal/BanModal.css
@@ -17,8 +17,8 @@
 .BanModal {
     width: 30rem;
     height: 30rem;
-    max-height: 90vh;
-    max-width: 90vw;
+    max-height: 90dvh;
+    max-width: 90dvw;
     text-align: center;
 
     .player-name {

--- a/src/components/ChallengeModal/ChallengeModal.css
+++ b/src/components/ChallengeModal/ChallengeModal.css
@@ -133,7 +133,7 @@
     }
 
     .header {
-        max-height: 80vh;
+        max-height: 80dvh;
         align-items: stretch !important;
     }
 

--- a/src/components/Chat/ChatIndicator.css
+++ b/src/components/Chat/ChatIndicator.css
@@ -66,7 +66,7 @@
         right: 0;
         width: 12rem;
         height: max-content;
-        max-width: 100vw;
+        max-width: 100dvw;
         max-height: 40%;
         overflow-x: hidden;
         box-shadow: -2px 2px 1px 0px rgba(0, 0, 0, 0.16);

--- a/src/components/Chat/ChatList.css
+++ b/src/components/Chat/ChatList.css
@@ -20,7 +20,7 @@
 .ChatList {
     display: flex;
     flex-direction: column;
-    height: calc(100vh - var(--navbar-height) - var(--channel-utils-height));
+    height: calc(100dvh - var(--navbar-height) - var(--channel-utils-height));
     overflow-y: auto;
     width: var(--channel-width);
     max-width: var(--channel-max-width);

--- a/src/components/CollectionSharingModal/CollectionSharingModal.css
+++ b/src/components/CollectionSharingModal/CollectionSharingModal.css
@@ -32,7 +32,7 @@
 
     .body {
         padding: 1rem;
-        max-height: 60vh;
+        max-height: 60dvh;
         overflow-y: auto;
 
         .share-with {

--- a/src/components/DemoBoardModal/DemoBoardModal.css
+++ b/src/components/DemoBoardModal/DemoBoardModal.css
@@ -20,7 +20,7 @@
   max-width: 100%;
 
   .header {
-    max-height: 80vh;
+    max-height: 80dvh;
     align-items: stretch !important;
   }
 
@@ -68,7 +68,7 @@
   }
 
   .header {
-    max-height: 80vh;
+    max-height: 80dvh;
     align-items: stretch !important;
   }
 

--- a/src/components/EmailBanner/EmailBanner.css
+++ b/src/components/EmailBanner/EmailBanner.css
@@ -28,7 +28,7 @@
 
 .EmailBanner {
     width: 40rem;
-    max-width: 100vw;
+    max-width: 100dvw;
     text-align: justify;
 
     .primary {

--- a/src/components/ErrcodeModal/ErrcodeModal.css
+++ b/src/components/ErrcodeModal/ErrcodeModal.css
@@ -16,9 +16,9 @@
  */
 .ErrcodeModal {
     width: 40rem;
-    max-width: 100vw;
+    max-width: 100dvw;
     min-height: 20rem;
-    max-width: 100vh;
+    max-width: 100dvh;
 
     .header {
         text-align: center;

--- a/src/components/ErrcodeModal/ErrcodeModal.css
+++ b/src/components/ErrcodeModal/ErrcodeModal.css
@@ -18,7 +18,7 @@
     width: 40rem;
     max-width: 100dvw;
     min-height: 20rem;
-    max-width: 100dvh;
+    max-height: 100dvh;
 
     .header {
         text-align: center;

--- a/src/components/FreeTrialBanner/FreeTrialBanner.css
+++ b/src/components/FreeTrialBanner/FreeTrialBanner.css
@@ -30,7 +30,7 @@
     display: flex;
     flex-direction: row;
     width: 60rem;
-    max-width: calc(min(100%, 100vw));
+    max-width: calc(min(100%, 100dvw));
     min-height: 12rem;
     overflow: hidden;
 
@@ -104,7 +104,7 @@
         display: flex;
         flex-direction: column;
         width: 50rem;
-        max-width: calc(min(100%, 90vw));
+        max-width: calc(min(100%, 90dvw));
         padding-left: 1rem;
         padding-right: 1rem;
         justify-content: space-between;

--- a/src/components/FreeTrialBanner/LearnMore.css
+++ b/src/components/FreeTrialBanner/LearnMore.css
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 .LearnMore {
-    max-width: 90vw;
+    max-width: 90dvw;
     width: 50rem;
-    max-height: 90vh;
+    max-height: 90dvh;
 
     /* height: 45rem; */
     p {

--- a/src/components/FreeTrialSurvey/FreeTrialSurvey.css
+++ b/src/components/FreeTrialSurvey/FreeTrialSurvey.css
@@ -30,7 +30,7 @@
     display: flex;
     flex-direction: column;
     width: 60rem;
-    max-width: calc(min(100%, 100vw));
+    max-width: calc(min(100%, 100dvw));
     min-height: 12rem;
     overflow: auto;
     padding: 1rem;

--- a/src/components/FriendList/FriendIndicator.css
+++ b/src/components/FriendList/FriendIndicator.css
@@ -44,8 +44,8 @@
         top: var(--navbar-height);
         right: 0;
         width: 15rem;
-        max-width: 100vw;
-        max-height: calc(100vh - var(--navbar-height));
+        max-width: 100dvw;
+        max-height: calc(100dvh - var(--navbar-height));
         overflow-y: scroll;
         overflow-x: hidden;
         box-shadow: -2px 2px 1px 0px rgba(0, 0, 0, 0.16);

--- a/src/components/GameList/GameList.css
+++ b/src/components/GameList/GameList.css
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 .GameList {
-    max-width: 100vw;
+    max-width: 100dvw;
     overflow-x: hidden;
     text-align: center;
 

--- a/src/components/GameLogModal/GameLogModal.css
+++ b/src/components/GameLogModal/GameLogModal.css
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 .GameLogModal.Modal {
-    width: 90vw;
-    min-width: 90vw;
-    max-width: 90vw;
+    width: 90dvw;
+    min-width: 90dvw;
+    max-width: 90dvw;
 }

--- a/src/components/IncidentReportTracker/IncidentReportList.css
+++ b/src/components/IncidentReportTracker/IncidentReportList.css
@@ -125,7 +125,7 @@
     display: flex;
     /* min-height: 100%; */
     /* height: 100%; */
-    max-height: 100vh;
+    max-height: 100dvh;
     top: var(--navbar-height);
     left: 0;
     right: 0;
@@ -141,8 +141,8 @@
     overflow-y: scroll;
     padding: 0.5rem;
     width: 20rem;
-    max-width: 100vw;
-    max-height: calc(100vh - var(--navbar-height));
+    max-width: 100dvw;
+    max-height: calc(100dvh - var(--navbar-height));
     display: inline-block;
     z-index: var(--z-incident-list);
     right: 0;

--- a/src/components/MainSection/MainSection.css
+++ b/src/components/MainSection/MainSection.css
@@ -16,7 +16,7 @@
  */
 
 .MainSection {
-    min-height: calc(100vh - var(--below-navbar) -1px);
+    min-height: calc(100dvh - var(--below-navbar) -1px);
     display: flex;
     flex-direction: column;
 }

--- a/src/components/MergeReportModal/MergeReportModal.css
+++ b/src/components/MergeReportModal/MergeReportModal.css
@@ -17,7 +17,7 @@
 .MergeReportModal {
     width: 30rem;
     max-width: 100%;
-    height: 55vh;
+    height: 55dvh;
     max-height: 100%;
 
     .body {

--- a/src/components/MiniGoban/MiniGoban.css
+++ b/src/components/MiniGoban/MiniGoban.css
@@ -19,8 +19,8 @@
     flex-direction: column;
     width: 22rem;
     height: 25rem;
-    max-width: 100vw;
-    max-height: 100vh;
+    max-width: 100dvw;
+    max-height: 100dvh;
     align-items: center;
     justify-content: center;
     color: var(--fg);

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -19,7 +19,7 @@
     display: flex;
     /* min-height: 100%; */
     /* height: 100%; */
-    max-height: 100vh;
+    max-height: 100dvh;
     top: 0;
     left: 0;
     right: 0;
@@ -51,7 +51,7 @@
     /* Modal-specific styles */
     color: var(--fg);
     max-width: 100%;
-    max-height: 90vh;
+    max-height: 90dvh;
     z-index: var(--z-modal-container);
     display: flex;
     flex-direction: column;

--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -28,7 +28,7 @@ header.NavBar {
     background-color: var(--navbar-background-color);
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.16);
     justify-content: space-between;
-    max-width: 100vw;
+    max-width: 100dvw;
 
     .fa-star {
         /* themed color supporter-gold */
@@ -270,8 +270,8 @@ header.NavBar {
             min-width: 2rem;
 
             &:focus-within {
-                width: calc(100vw - 5rem) !important;
-                /* min-width: calc(100vw - 10rem) !important; */
+                width: calc(100dvw - 5rem) !important;
+                /* min-width: calc(100dvw - 10rem) !important; */
                 max-width: none;
                 margin-right: 0.5rem;
 
@@ -342,7 +342,7 @@ header.NavBar {
             bottom: 0;
             left: 0;
             padding: 0;
-            /* max-height: calc(100vh - var(--navbar-height)) */
+            /* max-height: calc(100dvh - var(--navbar-height)) */
             /* overflow-y: auto; */
             z-index: var(--z-nav-menu-menu);
 
@@ -358,7 +358,7 @@ header.NavBar {
 
             .Menu {
                 order: 2;
-                width: 100vw;
+                width: 100dvw;
                 display: flex;
                 flex-direction: column;
                 height: auto;
@@ -625,8 +625,8 @@ header.NavBar {
         right: 0;
         top: var(--navbar-height);
         width: var(--navbar-menu-width);
-        max-width: 100vw;
-        max-height: calc(100vh - var(--navbar-height));
+        max-width: 100dvw;
+        max-height: calc(100dvh - var(--navbar-height));
         background-color: var(--navbar-background-color);
         overflow-y: auto;
         user-select: none;
@@ -679,7 +679,7 @@ header.NavBar {
         top: var(--navbar-height);
         width: var(--navbar-menu-width);
         background-color: var(--navbar-background-color);
-        max-height: calc(100vh - var(--navbar-height));
+        max-height: calc(100dvh - var(--navbar-height));
         overflow-y: auto;
         padding: 0.5rem;
         z-index: var(--z-nav-menu-menu);
@@ -688,7 +688,7 @@ header.NavBar {
 
     .FriendList {
         top: var(--navbar-height);
-        max-height: calc(100vh - var(--navbar-height));
+        max-height: calc(100dvh - var(--navbar-height));
         background-color: var(--navbar-background-color);
     }
 
@@ -732,8 +732,8 @@ header.NavBar {
     .ChatList {
         background-color: var(--navbar-highlight-background-color);
         padding: 0.5rem;
-        height: calc(100vh - var(--navbar-height));
-        max-height: calc(100vh - var(--navbar-height));
+        height: calc(100dvh - var(--navbar-height));
+        max-height: calc(100dvh - var(--navbar-height));
         width: 15rem;
 
         .channels {
@@ -812,7 +812,7 @@ header.NavBar {
         background-color: var(--navbar-highlight-background-color);
         box-shadow: 2px 2px 1px 0px rgba(0, 0, 0, 0.16);
         z-index: var(--z-nav-menu-menu);
-        max-height: calc(100vh - var(--navbar-height));
+        max-height: calc(100dvh - var(--navbar-height));
     }
 }
 

--- a/src/components/NotesModal/NotesModal.css
+++ b/src/components/NotesModal/NotesModal.css
@@ -17,7 +17,7 @@
 .NotesModal {
     width: 50rem;
     max-width: 100%;
-    height: 95vh;
+    height: 95dvh;
     max-height: 100%;
 
     .body {

--- a/src/components/PaginatedTable/PaginatedTable.css
+++ b/src/components/PaginatedTable/PaginatedTable.css
@@ -16,14 +16,14 @@
  */
 .PaginatedTable {
     position: relative;
-    max-width: 100vw;
+    max-width: 100dvw;
 
     div {
         overflow-x: auto;
 
         table {
             width: 100%;
-            max-width: 100vw;
+            max-width: 100dvw;
             border-collapse: collapse;
 
             tr {

--- a/src/components/PaymentProblemBanner/PaymentProblemBanner.css
+++ b/src/components/PaymentProblemBanner/PaymentProblemBanner.css
@@ -21,7 +21,7 @@
 
 .PaymentProblemBanner {
     width: 40rem;
-    max-width: 100vw;
+    max-width: 100dvw;
 
     /* text-align: justify; */
     .buttons {

--- a/src/components/PlayerNotesModal/PlayerNotesModal.css
+++ b/src/components/PlayerNotesModal/PlayerNotesModal.css
@@ -17,7 +17,7 @@
 .PlayerNotesModal {
     width: 30rem;
     max-width: 100%;
-    height: 55vh;
+    height: 55dvh;
     max-height: 100%;
 
     .body {

--- a/src/components/PriceIncreaseMessage/PriceIncreaseMessage.css
+++ b/src/components/PriceIncreaseMessage/PriceIncreaseMessage.css
@@ -30,7 +30,7 @@
     display: flex;
     flex-direction: column;
     width: 60rem;
-    max-width: calc(min(100%, 100vw));
+    max-width: calc(min(100%, 100dvw));
     /*min-height: 12rem; */
     overflow: auto;
     padding: 1rem;

--- a/src/components/RatingsChart/RatingsChart.css
+++ b/src/components/RatingsChart/RatingsChart.css
@@ -16,10 +16,10 @@
  */
 .RatingsChart {
     height: 380px;
-    max-width: calc(100vw - 2em);
+    max-width: calc(100dvw - 2em);
 
     /* Uncomment this to make charts resize.  But only when they support that. */
-    /* max-width: calc(100vw - 2em); */
+    /* max-width: calc(100dvw - 2em); */
     svg {
         font-size: var(--font-size-smaller);
     }

--- a/src/components/RatingsChartByGame/RatingsChartByGame.css
+++ b/src/components/RatingsChartByGame/RatingsChartByGame.css
@@ -17,7 +17,7 @@
 .RatingsChartByGame {
     /* height needs to match constant in .tsx file */
     height: 380px;
-    max-width: calc(100vw - 2em);
+    max-width: calc(100dvw - 2em);
     position: relative; /* so we can position the minigoban on over */
 
     .MiniGoban {
@@ -27,7 +27,7 @@
     }
 
     /* Uncomment this to make charts resize.  But only when they support that. */
-    /* max-width: calc(100vw - 2em); */
+    /* max-width: calc(100dvw - 2em); */
     svg {
         font-size: var(--font-size-smaller);
     }

--- a/src/components/RatingsChartDistribution/RatingsChartDistribution.css
+++ b/src/components/RatingsChartDistribution/RatingsChartDistribution.css
@@ -17,7 +17,7 @@
 
 .RatingsChartDistribution {
     height: 300px;
-    max-width: calc(100vw - 2em);
+    max-width: calc(100dvw - 2em);
 
     h4 {
         text-align: center;

--- a/src/components/Report/Report.css
+++ b/src/components/Report/Report.css
@@ -16,8 +16,8 @@
     flex-direction: column;
     width: 25rem;
     height: 40rem;
-    max-height: 90vh;
-    max-width: 90vw;
+    max-height: 90dvh;
+    max-width: 90dvw;
     color: var(--fg);
     border-radius: 0.5rem;
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.5);

--- a/src/components/SGFPasteModal/SGFPasteModal.css
+++ b/src/components/SGFPasteModal/SGFPasteModal.css
@@ -17,7 +17,7 @@
 .SGFPasteModal {
     width: 30rem;
     max-width: 100%;
-    height: 55vh;
+    height: 55dvh;
     max-height: 100%;
 
     .body {

--- a/src/components/Sortable/components/ConfirmModal/ConfirmModal.module.css
+++ b/src/components/Sortable/components/ConfirmModal/ConfirmModal.module.css
@@ -7,8 +7,8 @@
         width: var(--width);
         height: var(--height);
         position: fixed;
-        top: calc(100vh / 2 - var(--height) / 2);
-        left: calc(100vw / 2 - var(--width) / 2);
+        top: calc(100dvh / 2 - var(--height) / 2);
+        left: calc(100dvw / 2 - var(--width) / 2);
         border-radius: 10px;
         box-shadow: -1px 0 15px 0 rgba(34, 33, 81, 0.01), 0px 15px 15px 0 rgba(34, 33, 81, 0.25);
         padding: 15px;

--- a/src/global_styl/misc-ui.css
+++ b/src/global_styl/misc-ui.css
@@ -246,6 +246,6 @@
         flex-basis: 1rem;
         display: flex;
         flex-direction: column;
-        max-width: 95vw;
+        max-width: 95dvw;
     }
 }

--- a/src/models/postcss-plugins.d.ts
+++ b/src/models/postcss-plugins.d.ts
@@ -62,6 +62,12 @@ declare module "postcss-functions" {
     export default plugin;
 }
 
+declare module "postcss-viewport-unit-fallback" {
+    import { PluginCreator } from "postcss";
+    const plugin: PluginCreator<Record<string, unknown>>;
+    export default plugin;
+}
+
 declare module "postcss-url" {
     import { PluginCreator } from "postcss";
     interface UrlOptions {

--- a/src/views/AnnouncementCenter/AnnouncementCenter.css
+++ b/src/views/AnnouncementCenter/AnnouncementCenter.css
@@ -357,12 +357,12 @@
         margin: auto;
         display: inline-block;
         width: 40rem;
-        max-width: 100vw;
+        max-width: 100dvw;
     }
 
     input, select {
         width: 30rem;
-        max-width: 90vw;
+        max-width: 90dvw;
 
         &.invalid {
             border-color: var(--reject) !important;

--- a/src/views/Appeal/Appeal.css
+++ b/src/views/Appeal/Appeal.css
@@ -19,7 +19,7 @@
     flex-direction: column;
     justify-content: space-around;
     align-items: center;
-    width: 100vw;
+    width: 100dvw;
     max-width: 40rem;
     margin: 0 auto;
 

--- a/src/views/BlockedVPN/BlockedVPN.css
+++ b/src/views/BlockedVPN/BlockedVPN.css
@@ -1,6 +1,6 @@
 .BlockedVPN {
     width: 30rem;
-    max-width: 90vw;
+    max-width: 90dvw;
     margin: auto;
     font-size: 1.2rem;
 

--- a/src/views/ChatView/ChatView.css
+++ b/src/views/ChatView/ChatView.css
@@ -21,8 +21,8 @@
     left: 0;
     right: 0;
     display: flex;
-    width: 100vw;
-    max-width: 100vw;
+    width: 100dvw;
+    max-width: 100dvw;
     flex-direction: row;
 
     .ChatChannelList, .ChatUsersList {

--- a/src/views/Firewall/Firewall.css
+++ b/src/views/Firewall/Firewall.css
@@ -92,7 +92,7 @@
     .TestResultRow {
         display: inline-block;
         width: 50rem;
-        max-width: 90vw;
+        max-width: 90dvw;
 
         > span {
             margin-left: 1rem;

--- a/src/views/ForceUsernameChange/ForceUsernameChange.css
+++ b/src/views/ForceUsernameChange/ForceUsernameChange.css
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ForceUsernameChange-container {
-    height: 90vh;
+    height: 90dvh;
     width: 100%;
-    max-height: 100vh;
-    max-width: 100vw;
+    max-height: 100dvh;
+    max-width: 100dvw;
     display: flex;
     margin: 0;
     padding: 0;
@@ -36,7 +36,7 @@
     .Card {
         padding: 1rem;
         width: 25rem;
-        max-width: 100vw;
+        max-width: 100dvw;
 
         h2 {
             margin-top: 0;

--- a/src/views/Game/Game.css
+++ b/src/views/Game/Game.css
@@ -474,7 +474,7 @@
                 flex-grow: 0;
             }
 
-            flex-basis: 100vh;
+            flex-basis: 100dvh;
             justify-content: flex-start;
             flex-grow: 0;
         }

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -27,7 +27,7 @@
     /* height: 100%; */
     border: 1px solid transparent;
     border-color: var(--shade4);
-    flex-basis: 100vh;
+    flex-basis: 100dvh;
 
     .log-player-container {
         flex-grow: 1;

--- a/src/views/Game/PlayControls.css
+++ b/src/views/Game/PlayControls.css
@@ -8,7 +8,7 @@
     flex-direction: column;
     justify-content: center;
     padding-top: 0.5rem;
-    max-width: 100vw;
+    max-width: 100dvw;
     min-height: 5rem;
 
     /* height: 23rem; */
@@ -47,7 +47,7 @@
             color: var(--fg);
             padding: 0.5rem;
             border-radius: 0.5rem;
-            max-width: 90vw;
+            max-width: 90dvw;
             text-align: justify;
         }
     }

--- a/src/views/GoTV/GoTV.css
+++ b/src/views/GoTV/GoTV.css
@@ -18,7 +18,7 @@
     display: flex;
     flex-direction: column;
     height: calc(100dvh - var(--navbar-height) - 4px);
-    width: 100vw;
+    width: 100dvw;
     overflow: hidden;
 
     div {
@@ -338,7 +338,7 @@
         flex-wrap: wrap;
         justify-content: center;
         align-content: flex-start;
-        width: 100vw;
+        width: 100dvw;
         height: 100%;
         position: absolute;
         top: 0;
@@ -355,7 +355,7 @@
 
     #gotv-container .gotv-layout .list-pane.expanded {
         transform: translateY(0);
-        width: 100vw;
+        width: 100dvw;
         height: 100%;
     }
 
@@ -420,10 +420,10 @@
     }
 
     #gotv-container .gotv-layout .stream-pane {
-        width: 100vw;
+        width: 100dvw;
         margin-top: 50px;
         flex: none;
-        height: calc((100vw * 9 / 16));
+        height: calc((100dvw * 9 / 16));
         border-bottom: 1px solid transparent;
         border-bottom-color: var(--shade4);
 
@@ -433,7 +433,7 @@
     }
 
     #gotv-container .gotv-layout .chat-pane {
-        width: 100vw;
+        width: 100dvw;
         flex: 1 1 auto;
         overflow: hidden;
         background-color: var(--bg);

--- a/src/views/Group/Group.css
+++ b/src/views/Group/Group.css
@@ -19,12 +19,12 @@
         text-align: center;
 
         img {
-            max-width: 100vw;
-            max-height: 20vh;
+            max-width: 100dvw;
+            max-height: 20dvh;
         }
 
         .fa-picture-o {
-            font-size: 15vh;
+            font-size: 15dvh;
             color: var(--shade3);
         }
 

--- a/src/views/Home/ChallengesList.css
+++ b/src/views/Home/ChallengesList.css
@@ -35,7 +35,7 @@
     .Challenge {
         width: 19rem;
         min-height: 19rem;
-        max-width: 100vw;
+        max-width: 100dvw;
         display: flex;
         flex-direction: column;
         align-items: center;

--- a/src/views/Home/Home.css
+++ b/src/views/Home/Home.css
@@ -44,8 +44,8 @@
         flex-direction: column;
         justify-content: center;
         flex-basis: 5rem;
-        max-height: 100vh;
-        max-height: calc(100vh - var(--navbar-height));
+        max-height: 100dvh;
+        max-height: calc(100dvh - var(--navbar-height));
     }
 
     .active-games {
@@ -78,7 +78,7 @@
     .left {
         flex: 1;
         min-width: 0;
-        max-width: 100vw;
+        max-width: 100dvw;
         display: flex;
         flex-direction: column;
         overflow-x: hidden;
@@ -88,7 +88,7 @@
         flex: 0;
         flex-basis: 20rem;
         min-width: 20rem;
-        max-width: 100vw;
+        max-width: 100dvw;
         text-align: left;
         margin-left: 1rem;
 

--- a/src/views/Home/HomeDebug.css
+++ b/src/views/Home/HomeDebug.css
@@ -44,7 +44,7 @@
         margin-bottom: 2px;
         padding: 4px 0;
         min-width: 240px;
-        max-height: 80vh;
+        max-height: 80dvh;
         overflow-y: auto;
     }
 

--- a/src/views/Home/InviteList.css
+++ b/src/views/Home/InviteList.css
@@ -28,7 +28,7 @@
 
     .Card {
         width: 20rem;
-        max-width: 100vw;
+        max-width: 100dvw;
 
         .name-and-buttons {
             flex-grow: 1;

--- a/src/views/Joseki/Joseki.css
+++ b/src/views/Joseki/Joseki.css
@@ -63,9 +63,9 @@
         padding-top: 1em;
 
         @media screen and (max-width: 800px) {
-            height: 100vw;
-            min-height: 100vw; /* firefox needs this */
-            max-height: 100vw; /* firefox needs this */
+            height: 100dvw;
+            min-height: 100dvw; /* firefox needs this */
+            max-height: 100dvw; /* firefox needs this */
             flex-basis: 99%;
         }
     }

--- a/src/views/Ladder/Ladder.css
+++ b/src/views/Ladder/Ladder.css
@@ -21,8 +21,8 @@
     display: flex;
     align-items: stretch;
     justify-content: center;
-    max-height: calc(100vh - var(--navbar-height) - 0.2rem);
-    height: calc(100vh - var(--navbar-height) - 0.2rem);
+    max-height: calc(100dvh - var(--navbar-height) - 0.2rem);
+    height: calc(100dvh - var(--navbar-height) - 0.2rem);
 }
 
 .Ladder {
@@ -79,7 +79,7 @@
     .LadderRow {
         overflow: hidden;
         max-width: 30rem;
-        width: 100vw;
+        width: 100dvw;
         height: 30px;
         cursor: pointer;
 

--- a/src/views/LadderList/LadderList.css
+++ b/src/views/LadderList/LadderList.css
@@ -23,7 +23,7 @@
 
     .Card {
         width: 20rem;
-        max-width: 100vw;
+        max-width: 100dvw;
         min-height: 30rem;
         text-align: center;
     }
@@ -49,7 +49,7 @@
 
     .MyLadders-row {
         margin-left: 2rem;
-        max-width: 100vw;
+        max-width: 100dvw;
         padding-bottom: 0.5rem;
     }
 

--- a/src/views/LearningHub/LearningHub.css
+++ b/src/views/LearningHub/LearningHub.css
@@ -17,7 +17,7 @@
 #LearningHub-container {
     display: flex;
     justify-content: center;
-    height: calc(100vh - var(--below-navbar));
+    height: calc(100dvh - var(--below-navbar));
     overflow-y: auto;
 }
 
@@ -349,7 +349,7 @@
     margin: 2rem;
     margin-top: 5rem;
     min-height: 30rem;
-    max-height: calc(100vh - 10rem);
+    max-height: calc(100dvh - 10rem);
     overflow-y: auto;
 
     > a { /* main menu */

--- a/src/views/Play/Play.css
+++ b/src/views/Play/Play.css
@@ -177,7 +177,7 @@
     width: 100%;
     text-align: center;
     margin-top: 1rem;
-    max-width: 100vw;
+    max-width: 100dvw;
     overflow-y: auto;
 }
 

--- a/src/views/Play/PlayPageHelp.css
+++ b/src/views/Play/PlayPageHelp.css
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 .PlayPageHelp {
-    width: 90vw;
+    width: 90dvw;
     max-width: 50rem;
 
     .activity {

--- a/src/views/Play/QuickMatch.css
+++ b/src/views/Play/QuickMatch.css
@@ -394,7 +394,7 @@
     .ogs-react-select__menu {
         right: 0;
         width: 20rem;
-        max-width: 90vw;
+        max-width: 90dvw;
         z-index: calc(var(--z-play-buttons) + 1);
 
         .ogs-react-select__group-heading {
@@ -492,7 +492,7 @@
         .ogs-react-select__menu {
             right: 0;
             width: 6rem;
-            max-width: 40vw;
+            max-width: 40dvw;
         }
     }
 }

--- a/src/views/Puzzle/Puzzle.css
+++ b/src/views/Puzzle/Puzzle.css
@@ -43,9 +43,9 @@
     }
 
     &.portrait .center-col {
-        height: 100vw;
-        min-height: 100vw; /* firefox needs this */
-        max-height: 100vw; /* firefox needs this */
+        height: 100dvw;
+        min-height: 100dvw; /* firefox needs this */
+        max-height: 100dvw; /* firefox needs this */
         flex-basis: 99%;
     }
 
@@ -62,8 +62,8 @@
         overflow-y: visible;
         overflow-x: visible;
         align-self: center;
-        min-height: 100vh;
-        max-width: calc(100vw - 1rem);
+        min-height: 100dvh;
+        max-width: calc(100dvw - 1rem);
     }
 
     .btn-container {

--- a/src/views/PuzzleCollection/SortablePuzzleList.css
+++ b/src/views/PuzzleCollection/SortablePuzzleList.css
@@ -17,7 +17,7 @@
 .SortablePuzzleList {
     width: 35rem;
     padding: 0;
-    max-width: 100vw;
+    max-width: 100dvw;
 }
 
 /* this has to be outside, the drag/drop stuff creates a wandering <li> node */

--- a/src/views/RatingCalculator/RatingCalculator.css
+++ b/src/views/RatingCalculator/RatingCalculator.css
@@ -7,7 +7,7 @@
 
     #Rating-Table-Div {
         table {
-            max-width: 100vw;
+            max-width: 100dvw;
         }
 
         input {

--- a/src/views/Register/Register.css
+++ b/src/views/Register/Register.css
@@ -21,7 +21,7 @@
     justify-content: space-around;
     align-items: center;
 
-    /* min-height: 100vh; */
+    /* min-height: 100dvh; */
     .Card {
         padding: 1rem;
         width: 15rem;

--- a/src/views/Settings/Settings.css
+++ b/src/views/Settings/Settings.css
@@ -37,7 +37,7 @@
     }
 
     .PreferenceLine {
-        max-width: 100vw;
+        max-width: 100dvw;
         flex-wrap: wrap;
         margin-bottom: 2rem;
         align-items: center;
@@ -150,7 +150,7 @@
             > h4 {
                 display: inline-block;
                 width: 10rem;
-                max-width: 100vw;
+                max-width: 100dvw;
                 flex: 0;
                 flex-basis: 10rem;
                 margin-right: 2rem;
@@ -232,7 +232,7 @@
         margin-bottom: 0.5rem;
         display: flex;
         align-items: center;
-        max-width: 95vw;
+        max-width: 95dvw;
 
         label {
             flex: 1;
@@ -369,7 +369,7 @@
 
             .blocked-player {
                 width: 20rem;
-                max-width: 100vw;
+                max-width: 100dvw;
             }
         }
     }

--- a/src/views/Supporter/BecomeASiteSupporter.css
+++ b/src/views/Supporter/BecomeASiteSupporter.css
@@ -1,6 +1,6 @@
 .BecomeASiteSupporterModal {
     width: 90rem;
-    max-width: 100vw;
+    max-width: 100dvw;
     margin-top: 2rem;
 
     p {

--- a/src/views/Supporter/Supporter.css
+++ b/src/views/Supporter/Supporter.css
@@ -5,7 +5,7 @@
     justify-content: center;
 
     h3 {
-        width: 100vw;
+        width: 100dvw;
         max-width: 40rem;
     }
 
@@ -118,7 +118,7 @@
         display: inline-flex;
         flex-direction: column;
         width: 20rem;
-        max-width: 95vw;
+        max-width: 95dvw;
         /* themed background-color shade3 */
         /* margin: 1rem; */
         margin-left: 0.2rem;
@@ -199,7 +199,7 @@
     }
 
     .SiteSupporterText {
-        width: 100vw;
+        width: 100dvw;
         max-width: 50rem;
         text-align: justify;
 

--- a/src/views/Tournament/Tournament.css
+++ b/src/views/Tournament/Tournament.css
@@ -229,7 +229,7 @@
             flex-wrap: wrap;
 
             .top-right-details {
-                width: 100vw;
+                width: 100dvw;
             }
 
             table {
@@ -328,7 +328,7 @@
 
         select {
             min-width: 20rem;
-            max-width: 100vw;
+            max-width: 100dvw;
         }
 
         .scheduled-matches {
@@ -418,7 +418,7 @@
 
             textarea {
                 width: 20rem;
-                max-width: 100vw;
+                max-width: 100dvw;
             }
         }
     }
@@ -427,7 +427,7 @@
         border: 2px solid transparent;
         border-color: var(--fg);
         width: 24rem;
-        max-width: 85vw;
+        max-width: 85dvw;
         margin-left: auto;
         margin-right: auto;
         padding: 1rem;

--- a/src/views/TournamentRecord/TournamentRecord.css
+++ b/src/views/TournamentRecord/TournamentRecord.css
@@ -19,7 +19,7 @@
     flex: 1;
     flex-direction: column;
     align-items: stretch;
-    width: 100vw;
+    width: 100dvw;
     max-width: 60rem;
     margin: auto;
 
@@ -63,7 +63,7 @@
     }
 
     .round-entries-container {
-        max-width: 100vw;
+        max-width: 100dvw;
         overflow-x: auto;
     }
 
@@ -85,14 +85,14 @@
             .name {
                 display: inline-block;
                 min-width: 15rem;
-                max-width: 50vw;
+                max-width: 50dvw;
                 overflow: hidden;
             }
 
             .Player {
                 display: inline-block;
                 min-width: 8rem;
-                max-width: 15vw;
+                max-width: 15dvw;
                 overflow: hidden;
             }
         }

--- a/src/views/WhatsNew/WhatsNew.css
+++ b/src/views/WhatsNew/WhatsNew.css
@@ -4,7 +4,7 @@
 .WhatsNew {
     padding: 1rem;
     width: 40rem;
-    max-width: 100vw;
+    max-width: 100dvw;
     margin: 0 auto;
     color: var(--text-color);
 

--- a/src/views/docs/RulesMatrix.css
+++ b/src/views/docs/RulesMatrix.css
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #RulesMatrix {
-    max-width: 100vw;
+    max-width: 100dvw;
     overflow: auto;
 
     #docs-go-rules-comparison-matrix {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,7 @@ import simpleVars from "postcss-simple-vars";
 import functions from "postcss-functions";
 import postcssUrl from "postcss-url";
 import inline_svg from "postcss-inline-svg";
+import viewportUnitFallback from "postcss-viewport-unit-fallback";
 import autoprefixer from "autoprefixer";
 import cssnano from "cssnano";
 import Color from "color";
@@ -279,6 +280,7 @@ export default defineConfig({
                 inline_svg({
                     paths: [path.resolve(__dirname, "assets"), path.resolve(__dirname, "src")],
                 }),
+                viewportUnitFallback(),
                 autoprefixer() as any,
                 // Only minify CSS in production
                 ...(process.env.NODE_ENV === "production" ? [cssnano()] : []),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8573,6 +8573,11 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
+postcss-viewport-unit-fallback@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-viewport-unit-fallback/-/postcss-viewport-unit-fallback-1.0.1.tgz#2bea6574837ef10a7d78932266fe242e84302cd5"
+  integrity sha512-J2UiqTXKHTCICBIV/Yqn3fFVd42yzwiG4ogVdr8WQ8kJ5f72bKLZO30sd3Xs0n4sIRj3qDgMbz4AMCG/OtyXgg==
+
 postcss@^6.0.0:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"


### PR DESCRIPTION
With the postcss-viewport-unit-fallback the generated css still includes the old vw/vh as well for browsers that don't yet support dvw/dvh
