### PR TITLE
Fix window tab titles

### DIFF
--- a/e2e-tests/navigation/title-check.spec.ts
+++ b/e2e-tests/navigation/title-check.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from "@playwright/test";
+import { ogsTest, load } from "@helpers";
+import { registerNewUser, newTestUsername } from "@helpers/user-utils";
+
+ogsTest("Navigation title check", async ({ page, createContext }) => {
+    await load(page, "/");
+    await expect(page).toHaveTitle("Games");
+
+    const { userPage } = await registerNewUser(
+        createContext,
+        newTestUsername("TitleCheck"),
+        "test",
+    );
+
+    await userPage.goto("/");
+    await expect(userPage).toHaveTitle("OGS");
+
+    // 1. Check static views
+    // Note: Use real resources (dynamic board creation) for views that depend on engine state
+    const views = [
+        { path: "/developer", title: "Play Go at online-go.com!" },
+        { path: "/docs/about", title: "About" },
+        { path: "/docs/contact-information", title: "Play Go at online-go.com!" },
+        { path: "/docs/go-rules-comparison-matrix", title: "Play Go at online-go.com!" },
+        { path: "/docs/other-go-resources", title: "Other Go Resources" },
+        { path: "/docs/privacy-policy", title: "Play Go at online-go.com!" },
+        { path: "/docs/refund-policy", title: "Play Go at online-go.com!" },
+        { path: "/docs/team", title: "Play Go at online-go.com!" },
+        { path: "/docs/terms-of-service", title: "Play Go at online-go.com!" },
+        { path: "/gotv", title: "GoTV" },
+        { path: "/groups", title: "Groups" },
+        { path: "/joseki", title: "Joseki" },
+        { path: "/ladders", title: "Ladders" },
+        { path: "/learn-to-play-go", title: "Learn to play Go" },
+        { path: "/library/1", title: "Library" },
+        { path: "/observe-games", title: "Games" },
+        { path: "/play", title: "Play" },
+        { path: "/puzzles", title: "Puzzles" },
+        { path: "/rating-calculator", title: "Rating Calculator" },
+        { path: "/redeem", title: "Play Go at online-go.com!" },
+        { path: "/settings/link", title: "Settings" },
+        { path: "/sponsorship-request", title: "Sponsorship Request" },
+        { path: "/support", title: "Support OGS" },
+        { path: "/tournaments", title: "Tournaments" },
+        { path: "/whats-new", title: "What's New" },
+    ];
+
+    for (const view of views) {
+        await load(userPage, view.path);
+        await expect(userPage).toHaveTitle(view.title);
+    }
+
+    // Create a real demo board to verify the "Demo" title
+    const { createDemoBoard } = await import("@helpers/demo-board-utils");
+    await createDemoBoard(userPage, { gameName: "E2E Title Test" });
+    await expect(userPage).toHaveTitle("Demo");
+
+    // Check that it remains "Demo" even if we refresh or "state_text" is emitted
+    await userPage.reload();
+    await expect(userPage).toHaveTitle("Demo");
+
+    // Now we test Review page
+    // NOTE: We're only able to do this because Backend treats Review and Demo similarly.
+    const demoUrl = userPage.url();
+
+    const reviewUrl = demoUrl.replace("/demo/", "/review/");
+    await load(userPage, reviewUrl);
+    await expect(userPage).toHaveTitle("Review");
+
+    await userPage.reload();
+    await expect(userPage).toHaveTitle("Review");
+});

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -146,6 +146,25 @@ export function Game(): React.ReactElement | null {
         }
     };
 
+    const applyReviewFallback = React.useCallback((title: string) => {
+        if (window.location.pathname.startsWith("/review/")) {
+            return _("Review");
+        }
+        if (window.location.pathname.startsWith("/demo/")) {
+            return _("Demo");
+        }
+        return title || _("OGS");
+    }, []);
+
+    const setTabTitle = React.useCallback(
+        (title: string) => {
+            const finalTitle = applyReviewFallback(title);
+            window.document.title = finalTitle;
+            on_refocus_title.current = finalTitle;
+        },
+        [applyReviewFallback],
+    );
+
     const onFocus = () => {
         if (goban?.engine) {
             last_move_viewed.current = goban.engine.getMoveNumber();
@@ -254,6 +273,9 @@ export function Game(): React.ReactElement | null {
             opts.isPlayerController = () =>
                 goban_controller.current?.goban?.review_controller_id === data.get("user").id;
         }
+        if (review_id) {
+            setTabTitle("");
+        }
 
         goban_controller.current?.destroy();
         goban_controller.current = new GobanController(opts);
@@ -302,15 +324,17 @@ export function Game(): React.ReactElement | null {
             last_move_viewed.current = 0;
             on_refocus_title.current = last_title;
             goban.on("state_text", (state) => {
-                on_refocus_title.current = state.title;
+                const title = applyReviewFallback(state.title);
+
+                on_refocus_title.current = title;
                 if (state.show_moves_made_count) {
                     if (!goban) {
-                        window.document.title = state.title;
+                        window.document.title = title;
                         return;
                     }
                     if (document.hasFocus()) {
                         last_move_viewed.current = goban!.engine.getMoveNumber();
-                        window.document.title = state.title;
+                        window.document.title = title;
                     } else {
                         const diff = goban!.engine.getMoveNumber() - last_move_viewed.current;
                         if (diff > 0) {
@@ -318,7 +342,7 @@ export function Game(): React.ReactElement | null {
                         }
                     }
                 } else {
-                    window.document.title = state.title;
+                    window.document.title = title;
                 }
             });
         }
@@ -440,9 +464,7 @@ export function Game(): React.ReactElement | null {
                         black_username.current &&
                         !preferences.get("dynamic-title")
                     ) {
-                        on_refocus_title.current =
-                            black_username.current + " vs " + white_username.current;
-                        window.document.title = on_refocus_title.current;
+                        setTabTitle(black_username.current + " vs " + white_username.current);
                     }
                     if (goban_controller.current) {
                         goban_controller.current.creator_id = game.creator;

--- a/src/views/Supporter/Supporter.tsx
+++ b/src/views/Supporter/Supporter.tsx
@@ -242,6 +242,9 @@ export function Supporter(props: SupporterProperties): React.ReactElement {
     const [prizes, setPrizes] = React.useState<Service[]>([]);
 
     React.useEffect(() => {
+        if (!inline) {
+            window.document.title = _("Support OGS");
+        }
         Promise.all([
             get(`/billing/summary/${Math.max(0, account_id)}`)
                 .then((config: Config) => {
@@ -295,7 +298,7 @@ export function Supporter(props: SupporterProperties): React.ReactElement {
             .then(ignore)
             .catch(ignore)
             .finally(() => setLoading(false));
-    }, [account_id, refresh]);
+    }, [account_id, refresh, inline]);
 
     if (error) {
         return (

--- a/src/views/User/ReviewsAndDemosTable.tsx
+++ b/src/views/User/ReviewsAndDemosTable.tsx
@@ -58,8 +58,10 @@ export function ReviewsAndDemosTable(props: ReviewsAndDemosProps): React.ReactEl
                     : "library-lost"
                 : "";
             item.name = r.name;
-            item.href = "/review/" + item.id;
-            item.historical = r.game.historical_ratings || {
+            const isReviewOfGame = !!(r.game && (typeof r.game === "number" || r.game.id));
+            const prefix = isReviewOfGame ? "/review/" : "/demo/";
+            item.href = prefix + item.id;
+            item.historical = (r.game && r.game.historical_ratings) || {
                 black: item.black,
                 white: item.white,
             };


### PR DESCRIPTION
Recently there was a PR #3472 that attempted to fix this issue.

I however found some routes were not covered in that PR. Such as:

1. `/support`
2. `/review`
3. `/demo`

So first I have added an E2E test for this. (I tried to add a Jest unit test, but that meant a lot of mocking, so I stuck to e2e).

Review and Demo tabs are special cases as they rely on same view as normal games `Games.tsx`. So I have introduced a helper functions to reduce duplicated logic.


Let me know if I have missed anything.