### PR TITLE
create additional time control tests for different time control systems

### DIFF
--- a/src/components/TimeControl/TimeControl.test.tsx
+++ b/src/components/TimeControl/TimeControl.test.tsx
@@ -6,6 +6,7 @@
 import "./TimeControl";
 import { TimeControlTypes } from "./TimeControl";
 import { updateSpeed } from "./TimeControlUpdates";
+import { getDefaultTimeControl } from "./util";
 // import { classifyGameSpeed, getDefaultTimeControl } from "./util";
 
 // test("Default time controls fit their respective categories", () => {
@@ -49,3 +50,20 @@ test("Updating speed away from correspondence + 'pause on weekends' should not m
     const updated = updateSpeed(tc, "live", 19, 19);
     expect(updated.pause_on_weekends).toEqual(false);
 });
+
+test.each(TimeControlTypes.ALL_SYSTEMS_EXCEPT_NONE)(
+    "Updating speed away from correspondence clears pause-on-weekends for %s",
+    (system) => {
+        const tc = {
+            ...getDefaultTimeControl("correspondence", system),
+            speed: "correspondence" as const,
+            pause_on_weekends: true,
+        };
+
+        const updated = updateSpeed(tc, "live", 19, 19);
+
+        expect(updated.pause_on_weekends).toBe(false);
+        expect(updated.speed).toBe("live");
+        expect(updated.system).toBe(system);
+    },
+);

--- a/src/components/TimeControl/TimeControl.test.tsx
+++ b/src/components/TimeControl/TimeControl.test.tsx
@@ -40,25 +40,10 @@ test("Updating speed away from correspondence + none should not maintain 'none' 
     expect(updated.system).not.toEqual("none");
 });
 
-test("Updating speed away from correspondence + 'pause on weekends' should not maintain 'pause on weekends'", () => {
-    const tc: TimeControlTypes.Absolute = {
-        speed: "correspondence",
-        pause_on_weekends: true,
-        system: "absolute",
-        total_time: 0,
-    };
-    const updated = updateSpeed(tc, "live", 19, 19);
-    expect(updated.pause_on_weekends).toEqual(false);
-});
-
 test.each(TimeControlTypes.ALL_SYSTEMS_EXCEPT_NONE)(
     "Updating speed away from correspondence clears pause-on-weekends for %s",
     (system) => {
-        const tc = {
-            ...getDefaultTimeControl("correspondence", system),
-            speed: "correspondence" as const,
-            pause_on_weekends: true,
-        };
+        const tc = getDefaultTimeControl("correspondence", system);
 
         const updated = updateSpeed(tc, "live", 19, 19);
 


### PR DESCRIPTION
I added an additional test for the time control component. For each timing control system, check to make sure that when changed from correspondence to the system in question, the pause on weekends status is no longer true. Also make sure that the timing is switched over to the intended system and speed is updated to live. 

No additional features or behavior, just more test coverage!
