### PR TITLE
Use Lichess hamburger

### DIFF
--- a/src/components/NavBar/Hamburger.css
+++ b/src/components/NavBar/Hamburger.css
@@ -9,6 +9,7 @@
   }
 
   .hamburger {
+    position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/components/NavBar/Hamburger.css
+++ b/src/components/NavBar/Hamburger.css
@@ -8,13 +8,19 @@
     align-items: center;
   }
 
-  .hamburger {
+  button.hamburger {
     position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 2rem;
     height: var(--navbar-height);
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    margin: 0;
+    box-shadow: none;
     cursor: pointer;
     z-index: 111;
   }

--- a/src/components/NavBar/Hamburger.css
+++ b/src/components/NavBar/Hamburger.css
@@ -1,0 +1,84 @@
+@import "../../global_styl/00_constants.css";
+
+.hamburger-container {
+  display: none;
+
+  @media (max-width: $hamburger-cutoff) {
+    display: flex;
+    align-items: center;
+  }
+
+  .hamburger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: var(--navbar-height);
+    cursor: pointer;
+    z-index: 111;
+  }
+
+  .hamburger__in,
+  .hamburger__in::before,
+  .hamburger__in::after {
+    display: block;
+    position: absolute;
+    width: 22px;
+    height: 4px;
+    background-color: var(--text-color);
+  }
+
+  .hamburger__in {
+    transition: transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  }
+
+  .hamburger__in::before,
+  .hamburger__in::after {
+    content: '';
+  }
+
+  .hamburger__in::before {
+    top: -7px;
+    transition:
+      top 0.1s 0.25s ease-in,
+      opacity 0.1s ease-in;
+  }
+
+  .hamburger__in::after {
+    bottom: -7px;
+    transition:
+      bottom 0.1s 0.25s ease-in,
+      transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  }
+
+  .hamburger__logo {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .hamburger__logo--hidden {
+    display: none;
+  }
+
+  .hamburger[aria-expanded='true'] .hamburger__in {
+    transform: rotate(225deg);
+    transition-delay: 0.12s;
+    transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+  }
+
+  .hamburger[aria-expanded='true'] .hamburger__in::before {
+    top: 0;
+    opacity: 0;
+    transition:
+      top 0.1s ease-out,
+      opacity 0.1s 0.12s ease-out;
+  }
+
+  .hamburger[aria-expanded='true'] .hamburger__in::after {
+    bottom: 0;
+    transform: rotate(-90deg);
+    transition:
+      bottom 0.1s ease-out,
+      transform 0.22s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
+  }
+}

--- a/src/components/NavBar/Hamburger.tsx
+++ b/src/components/NavBar/Hamburger.tsx
@@ -16,15 +16,21 @@
  */
 
 import * as React from "react";
+import { _ } from "@/lib/translate";
 import { Link } from "react-router-dom";
 import "./Hamburger.css";
 
 export function Hamburger(props: { open: boolean; onClick?: () => void }): React.ReactElement {
     return (
         <div className="hamburger-container">
-            <span className="hamburger" aria-expanded={props.open} onClick={props.onClick}>
+            <button
+                className="hamburger"
+                aria-expanded={props.open}
+                aria-label={_("Menu")}
+                onClick={props.onClick}
+            >
                 <span className="hamburger__in"></span>
-            </span>
+            </button>
             <Link
                 to="/"
                 className={`hamburger__logo ${props.open ? "hamburger__logo--hidden" : ""}`}

--- a/src/components/NavBar/Hamburger.tsx
+++ b/src/components/NavBar/Hamburger.tsx
@@ -33,6 +33,7 @@ export function Hamburger(props: { open: boolean; onClick: () => void }): React.
             </button>
             <Link
                 to="/"
+                aria-label={_("Home")}
                 className={`hamburger__logo ${props.open ? "hamburger__logo--hidden" : ""}`}
             >
                 <span className="ogs-nav-logo" />

--- a/src/components/NavBar/Hamburger.tsx
+++ b/src/components/NavBar/Hamburger.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { Link } from "react-router-dom";
+import "./Hamburger.css";
+
+export function Hamburger(props: { open: boolean; onClick?: () => void }): React.ReactElement {
+    return (
+        <div className="hamburger-container">
+            <span className="hamburger" aria-expanded={props.open} onClick={props.onClick}>
+                <span className="hamburger__in"></span>
+            </span>
+            <Link
+                to="/"
+                className={`hamburger__logo ${props.open ? "hamburger__logo--hidden" : ""}`}
+            >
+                <span className="ogs-nav-logo" />
+            </Link>
+        </div>
+    );
+}

--- a/src/components/NavBar/Hamburger.tsx
+++ b/src/components/NavBar/Hamburger.tsx
@@ -20,7 +20,7 @@ import { _ } from "@/lib/translate";
 import { Link } from "react-router-dom";
 import "./Hamburger.css";
 
-export function Hamburger(props: { open: boolean; onClick?: () => void }): React.ReactElement {
+export function Hamburger(props: { open: boolean; onClick: () => void }): React.ReactElement {
     return (
         <div className="hamburger-container">
             <button

--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -408,22 +408,6 @@ header.NavBar {
         }
     }
 
-    .hamburger {
-        display: none;
-        cursor: pointer;
-
-        @media only screen and (max-width: $hamburger-cutoff) {
-            font-size: 1.7rem;
-            display: inline-flex;
-            align-items: center;
-            padding-left: 0.5rem;
-
-            a {
-                display: inline-flex;
-                align-items: center;
-            }
-        }
-    }
 
     .Menu {
         img {

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -41,6 +41,7 @@ import { Menu, MenuContext } from "./Menu";
 import { logout } from "@/lib/auth";
 import { useUser, useData } from "@/lib/hooks";
 import { OmniSearch } from "./OmniSearch";
+import { Hamburger } from "./Hamburger";
 import { forwardRef, useId, useState } from "react";
 import { MODERATOR_POWERS } from "@/lib/moderation";
 import { openDemoBoardModal } from "../DemoBoardModal";
@@ -163,16 +164,7 @@ export function NavBar(): React.ReactElement {
 
                 {banned_user_id && show_appeal_box ? <BanIndicator /> : null}
 
-                <span className="hamburger">
-                    {hamburger_expanded ? (
-                        <i className="fa fa-times" onClick={toggleHamburgerExpanded} />
-                    ) : (
-                        <i className="fa fa-bars" onClick={toggleHamburgerExpanded} />
-                    )}
-                    <Link to="/">
-                        <span className="ogs-nav-logo" />
-                    </Link>
-                </span>
+                <Hamburger onClick={toggleHamburgerExpanded} open={hamburger_expanded} />
 
                 <nav className="left" aria-label={_("Main Navigation")}>
                     <ul>


### PR DESCRIPTION
## Proposed Changes

This PR replaces the fontawesome times/bars icons used for the hamburger with what lichess does, which is a nifty bit of CSS that draws out the 3 lines in `hbg__in`, `hbg__in:before` and `hbg__in:after` and then spins and collapses them to make an x icon. I've tried my best to keep the size and spacing as similar as possible to the existing icons: the only difference users should notice should be the animation on click.

Claude was used for some of this code but I've read through it and take responsibility for it. The larger contribution candidly is lichess: it's their component and I would not have been able to write the transitions/animation myself. Since this is my first contribution here, please let me know if there are things that could be done better here.