### PR TITLE
Add indicator for which color's turn it is for puzzle/tsumego. 

### DIFF
--- a/e2e-tests/puzzles/puzzle-turn-indicator.ts
+++ b/e2e-tests/puzzles/puzzle-turn-indicator.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { BrowserContext, expect } from "@playwright/test";
+import { log } from "@helpers/logger";
+
+export const puzzleTurnIndicatorTest = async ({
+    createContext,
+}: {
+    createContext: (options?: any) => Promise<BrowserContext>;
+}) => {
+    log("=== Puzzle Turn Indicator Test (Anonymous) ===");
+
+    const userContext = await createContext();
+    const userPage = await userContext.newPage();
+
+    await userPage.goto("/puzzle/1");
+
+    const turnIndicator = userPage.locator(".game-state");
+
+    await expect(turnIndicator).toBeVisible({ timeout: 15000 });
+
+    await expect(turnIndicator).toHaveText(/Black to move|White to move/);
+
+    const text = await turnIndicator.textContent();
+    log(`Turn indicator found: "${text}"`);
+
+    log("=== Puzzle Turn Indicator Test Complete ===");
+};

--- a/e2e-tests/puzzles/puzzles.spec.ts
+++ b/e2e-tests/puzzles/puzzles.spec.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ogsTest } from "@helpers";
+import { puzzleTurnIndicatorTest } from "./puzzle-turn-indicator";
+
+ogsTest.describe("@Puzzle Puzzle Tests", () => {
+    ogsTest("Puzzle should show turn indicator", puzzleTurnIndicatorTest);
+});

--- a/src/views/Puzzle/Puzzle.css
+++ b/src/views/Puzzle/Puzzle.css
@@ -56,6 +56,13 @@
         min-height: auto;
         padding: 0.5rem;
         z-index: 2;
+
+        .game-state {
+            text-align: center;
+            font-size: 1.3rem;
+            font-weight: 700;
+            padding: 0.5rem;
+        }
     }
 
     &.portrait .right-col {

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -696,6 +696,8 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
              * do, here's the next puzzle */
             show_correct = true;
         }
+        const turn_text =
+            this.goban.engine.colorToMove() === "black" ? _("Black to move") : _("White to move");
 
         const have_content: boolean =
             show_correct ||
@@ -721,6 +723,10 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
 
                         {this.frag_undo_reset_buttons()}
 
+                        {!show_correct && !this.state.show_wrong && (
+                            <div className="game-state">{turn_text}</div>
+                        )}
+
                         {(have_content || null) && this.frag_puzzle_content()}
                     </div>
                 )}
@@ -731,6 +737,10 @@ export class _Puzzle extends React.Component<PuzzleProperties, PuzzleState> {
                         <hr />
 
                         {this.frag_undo_reset_buttons()}
+
+                        {!show_correct && !this.state.show_wrong && (
+                            <div className="game-state">{turn_text}</div>
+                        )}
 
                         {(have_content || null) && this.frag_puzzle_content()}
 


### PR DESCRIPTION
Fixes #3159

## Proposed Changes
- Add turn indicator for the puzzles (tsumegos)
- Add e2e test for puzzles

Here are the screenshots (vid) for visual idea:
<img width="713" height="577" alt="Screenshot 2026-04-12 at 12 42 44 PM" src="https://github.com/user-attachments/assets/aa4196c9-430f-4858-8722-012fb148649c" />
<img width="1280" height="757" alt="Screenshot 2026-04-12 at 12 42 24 PM" src="https://github.com/user-attachments/assets/992599d9-b331-4e96-a8e7-999175dd8fcb" />


And here's a video of this in action:

https://github.com/user-attachments/assets/7b473ad3-fb9f-4fe7-a529-380b1c56547e

