### PR TITLE
Disable pause button in vacation disabled games

### DIFF
--- a/e2e-tests/tournaments/tournament-disable-vacation.ts
+++ b/e2e-tests/tournaments/tournament-disable-vacation.ts
@@ -27,7 +27,8 @@
  * 3. Two players join the tournament
  * 4. The director starts the tournament
  * 5. Games are created
- * 6. Each player navigates to their vacation settings and verifies the
+ * 6. A player navigates to their game and verifies the pause button is hidden
+ * 7. Each player navigates to their vacation settings and verifies the
  *    disable-vacation game warning is displayed
  */
 
@@ -243,6 +244,20 @@ export const tournamentDisableVacationTest = async ({
         player1Page.locator(".TurnIndicator .count.active, .TurnIndicator .count.inactive"),
     ).toBeVisible({ timeout: 60000 });
     log("Turn indicator visible for player 1 - game is active");
+
+    // 7a. Verify the pause button is NOT shown for players in disable-vacation games
+    log("Navigating player 1 to their tournament game to check pause button...");
+    await player1Page.locator(".TurnIndicator").click();
+    await player1Page.waitForURL(/\/game\/\d+/, { timeout: 30000 });
+
+    // Wait for the game board to be ready
+    const goban = player1Page.locator(".Goban[data-pointers-bound]");
+    await goban.waitFor({ state: "visible", timeout: 30000 });
+
+    // The pause button should NOT be visible for a player in a disable-vacation game
+    const pauseLink = player1Page.locator("a").filter({ hasText: "Pause game" });
+    await expect(pauseLink).not.toBeVisible();
+    log("Confirmed: Pause game button is NOT visible for player in disable-vacation game");
 
     log("Checking player 1 vacation settings for disable-vacation warning...");
     await player1Page.goto("/user/settings");

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -465,7 +465,10 @@ export function GameDock({
                     </a>
                 </Tooltip>
             )}
-            {((!review_id && (user_is_player || user_can_intervene) && phase !== "finished") ||
+            {((!review_id &&
+                (user_is_player || user_can_intervene) &&
+                phase !== "finished" &&
+                !(user_is_player && !user_can_intervene && engine.config.disable_vacation)) ||
                 null) && (
                 <Tooltip tooltipRequired={tooltipRequired} title={_("Pause game")}>
                     <a onClick={goban_controller.pauseGame}>


### PR DESCRIPTION
Fixes TDs still wishing that participants wouldn't hold everyone up

## Proposed Changes

  - Disable the Pause button for no-vacation games.


https://github.com/online-go/ogs/pull/2351 implements backend enforcement.
  