### PR TITLE
Fix date getting wrapped under Review section on user profile

### DIFF
--- a/src/views/User/User.css
+++ b/src/views/User/User.css
@@ -190,6 +190,7 @@
         width: 7em;
         text-align: left;
         padding-right: 0.5em;
+        white-space: nowrap;
     }
 
     td.banned,


### PR DESCRIPTION
For the mobile screens, the "Date" column under the "Reviews nad Demos" was getting wrapped. 

Before:
<img width="641" height="438" alt="Screenshot 2026-04-13 at 8 00 45 PM" src="https://github.com/user-attachments/assets/a69b4dae-f3f7-4b39-8a4c-ebd5839f6311" />

After my change:
<img width="697" height="449" alt="Screenshot 2026-04-13 at 8 00 52 PM" src="https://github.com/user-attachments/assets/46c0e0d7-f902-4a20-8409-b87b213c06af" />

OGS already had this "unwrap" but it disappeared after some commit.

This issue was recently brought up on the forum [here](https://forums.online-go.com/t/ui-section-reviews-and-demos-below-game-history-android/59795).