### PR TITLE
Animate nav for small screens

### DIFF
--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -226,7 +226,23 @@ header.NavBar {
         overflow-x: hidden;
 
         & > .left {
-            display: none !important;
+            background-color: var(--navbar-background-color);
+            position: absolute;
+            top: var(--navbar-height);
+            bottom: 0;
+            left: 0;
+            padding: 0;
+            z-index: var(--z-nav-menu-menu);
+            overflow-y: auto;
+            overscroll-behavior: contain;
+            visibility: hidden;
+            transform: translateX(calc(-100% - 10px));
+            transition: transform 200ms ease, visibility 0s 200ms;
+
+            & a {
+                opacity: 0;
+                transition: opacity 150ms ease;
+            }
         }
 
         .Menu.desktop-only {
@@ -334,17 +350,14 @@ header.NavBar {
         }
 
         &.hamburger-expanded > .left {
-            display: inline !important;
+            visibility: visible;
+            transform: translateX(0);
+            transition: transform 200ms ease, visibility 0s;
 
-            background-color: var(--navbar-background-color);
-            position: absolute;
-            top: var(--navbar-height);
-            bottom: 0;
-            left: 0;
-            padding: 0;
-            /* max-height: calc(100dvh - var(--navbar-height)) */
-            /* overflow-y: auto; */
-            z-index: var(--z-nav-menu-menu);
+            & a {
+                opacity: 1;
+                transition: opacity 125ms ease-in-out 125ms;
+            }
 
             & > ul {
                 display: flex;

--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -227,6 +227,7 @@ header.NavBar {
 
         & > .left {
             background-color: var(--navbar-background-color);
+            width: 100dvw;
             position: absolute;
             top: var(--navbar-height);
             bottom: 0;


### PR DESCRIPTION
This PR animates opening and closing the smallscreen nav (again similar to what lichess does).

I removed some commented out code here, but I'm suspicious since commented out code is often commented out for a reason. That being said the new CSS as written looks correct on every machine I have access to: instead of toggling display none the nav starts off screen and then slides in and the links fade in. The visibility:hidden should prevent it from being keyboard navigable while offscreen.

Comparing side-by-side I think there are other nice design/CSS about the lichess nav that I _haven't_ done here since it would be more user visible. If there's interest in those I'd be happy to do them either in this PR or in a separate one. Images below


Lila mobile nav:
  1. Nav on lichess only takes 70% width:
    1a. I think this makes it easier for users to close, since there are more places they can click than the tiny x
    1b. This also helps with the illusion of "depth" that the site has where the nav and the site appear at different levels
   2. Items hover nicely with a background
   3. Items are arranged into two columns, which uses up some of the right hand space
   4. Pretty dramatic sizing differences with titles being smaller and bold, the links having icons, and the X being much larger. I probably wouldn't touch those yet unless you'd really like to.

Lichess:
<img width="445" height="874" alt="image" src="https://github.com/user-attachments/assets/79d8e251-bfa8-4b71-b56f-e1cc83d7dcbd" />

OGS:
<img width="553" height="874" alt="image" src="https://github.com/user-attachments/assets/018d5b37-3124-4a65-9756-34eca168c166" />


