### PR TITLE
Fix online-go/ogs#2370: Update how bots are ranked, disable ranked games for bots

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -172,6 +172,11 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             challenge.game.ranked = false;
         }
 
+        // Bot games are never ranked
+        if (this.props.mode === "computer") {
+            challenge.game.ranked = false;
+        }
+
         this.state = {
             conf: {
                 mode: this.props.mode,
@@ -409,6 +414,11 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             this.props.mode === "computer"
         ) {
             challenge.game.name = _("Friendly Match");
+        }
+
+        // Bot games are never ranked - ratings are handled server-side
+        if (this.props.mode === "computer") {
+            challenge.game.ranked = false;
         }
 
         if (!conf.restrict_rank) {
@@ -1228,9 +1238,10 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
                                 type="checkbox"
                                 id="challenge-ranked"
                                 disabled={
-                                    !this.state.challenge.game.ranked &&
-                                    (this.state.challenge.game.private ||
-                                        this.state.challenge.game.rengo)
+                                    this.props.mode === "computer" ||
+                                    (!this.state.challenge.game.ranked &&
+                                        (this.state.challenge.game.private ||
+                                            this.state.challenge.game.rengo))
                                 }
                                 checked={this.state.challenge.game.ranked}
                                 onChange={this.update_ranked}
@@ -1558,7 +1569,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
                 rank: user.ranking,
                 width: this.state.challenge.game.width ?? -1,
                 height: this.state.challenge.game.height ?? -1,
-                ranked: true,
+                ranked: false,
                 handicap: this.state.challenge.game.handicap !== 0,
                 system: this.state.time_control.system,
                 speed: this.state.time_control.speed,

--- a/src/lib/bots.ts
+++ b/src/lib/bots.ts
@@ -230,7 +230,7 @@ export function getAcceptableTimeSetting(
                 ),
             ];
         }
-        if (!options.ranked && bot.config.allow_unranked) {
+        if (!options.ranked && !bot.config.allow_unranked) {
             return [
                 null,
                 llm_pgettext(

--- a/src/views/Play/QuickMatch.tsx
+++ b/src/views/Play/QuickMatch.tsx
@@ -372,7 +372,7 @@ export function QuickMatch(): React.ReactElement {
               };
 
     const playComputer = React.useCallback(() => {
-        const ranked = preferences.get("automatch.bot-ranked");
+        const ranked = false; // Bot games are never ranked
 
         let size = parseInt(board_size);
         if (game_clock === "multiple") {
@@ -515,7 +515,7 @@ export function QuickMatch(): React.ReactElement {
                 rank: user.ranking,
                 width: parseInt(board_size),
                 height: parseInt(board_size),
-                ranked: true,
+                ranked: false,
                 handicap: handicaps === "disabled" ? false : true,
                 system: time_control_system,
                 speed: game_speed,


### PR DESCRIPTION
Addresses online-go/ogs#2370

Automated draft PR created by dev-agent to address: Update how bots are ranked, disable ranked games for bots