### PR TITLE
dev: serve /img/* from assets/img and pin cdn_release in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ i18n/*.tar.gz
 # Playwright
 /playwright/.cache/
 /playwright/.auth/
+
+# Fixtures dropped by dev-cdn-intercept.spec.ts if a run is killed mid-test
+/assets/img/__probe_*.bin

--- a/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
+++ b/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * OGS's dev server maps assets/img/* to /img/* via a middleware in
+ * vite.config.ts so board textures and other repo assets load from local disk
+ * during development. Two regressions silently break that flow:
+ *
+ *   1. Removing or bypassing the /img/* middleware — asset requests fall
+ *      through to Vite's SPA catch-all and return index.html at HTTP 200,
+ *      which a less strict assertion would happily accept.
+ *   2. Letting the backend's ui/config cdn_release clobber the localhost
+ *      override in src/main.tsx / src/lib/cached.ts — textures start loading
+ *      from the prod CDN, so local changes appear to do nothing.
+ *
+ * The first test fetches a fixture file we create at runtime (so no CDN or
+ * cache can produce a false positive) and verifies the bytes round-trip.
+ * The second seeds localStorage to trigger the cached-config rehydrate path
+ * that previously clobbered cdn_release, then asserts the dev-server pin held.
+ *
+ * This spec is an intentional exception to the "avoid direct API calls" rule
+ * in e2e-tests/CLAUDE.md — it is testing dev-server behavior, not user flows,
+ * and the in-browser `fetch()` + fixture design is the only reliable way to
+ * detect the failure modes above.
+ */
+
+import { expect } from "@playwright/test";
+import { ogsTest } from "@helpers";
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const ASSETS_IMG_DIR = path.resolve(currentDir, "../../assets/img");
+
+ogsTest.describe("@DevServer dev-server /img middleware + cdn_release pin", () => {
+    let fixtureName: string;
+    let fixturePath: string;
+    let expectedSha: string;
+
+    ogsTest.beforeAll(async () => {
+        const token = crypto.randomUUID();
+        fixtureName = `__probe_${token}.bin`;
+        fixturePath = path.join(ASSETS_IMG_DIR, fixtureName);
+        const bytes = Buffer.from(`OGS-MIDDLEWARE-PROBE-${token}`);
+        expectedSha = crypto.createHash("sha256").update(bytes).digest("hex");
+        await fs.writeFile(fixturePath, bytes);
+    });
+
+    ogsTest.afterAll(async () => {
+        await fs.unlink(fixturePath).catch(() => {});
+    });
+
+    ogsTest("/img/* serves fresh bytes from assets/img on disk", async ({ page }) => {
+        await page.goto("/");
+        const result = await page.evaluate(async (name: string) => {
+            const res = await fetch(`/img/${name}`, { cache: "no-store" });
+            const buf = new Uint8Array(await res.arrayBuffer());
+            return { status: res.status, bytes: Array.from(buf) };
+        }, fixtureName);
+
+        expect(result.status).toBe(200);
+        const actualSha = crypto
+            .createHash("sha256")
+            .update(Buffer.from(result.bytes))
+            .digest("hex");
+        expect(actualSha).toBe(expectedSha);
+    });
+
+    ogsTest(
+        "cdn_release stays pinned to the dev server across the cached-config rehydrate path",
+        async ({ browser }) => {
+            const ctx = await browser.newContext();
+            // Seed localStorage to trigger the main.tsx cached-config rehydrate
+            // branch that previously overwrote config.cdn_release on every reload.
+            await ctx.addInitScript(() => {
+                localStorage.setItem(
+                    "ogs.cached.config",
+                    JSON.stringify({
+                        cdn_release: "https://cdn.online-go.com/5.1",
+                        cdn: "https://cdn.online-go.com/",
+                        cdn_host: "cdn.online-go.com",
+                        user: { anonymous: true, id: 0, username: "Guest" },
+                    }),
+                );
+            });
+            const page = await ctx.newPage();
+            await page.goto("/");
+            // Let the debounced cached.refresh.config() call in cached.ts settle.
+            await page.waitForTimeout(5000);
+
+            const { cdnRelease, cdn } = await page.evaluate(() => ({
+                cdnRelease: (
+                    window as unknown as { data: { get: (k: string) => unknown } }
+                ).data?.get?.("config.cdn_release"),
+                cdn: (window as unknown as { data: { get: (k: string) => unknown } }).data?.get?.(
+                    "config.cdn",
+                ),
+            }));
+            await ctx.close();
+
+            expect(cdnRelease).toEqual(expect.stringContaining("localhost"));
+            expect(cdnRelease).not.toEqual(expect.stringContaining("cdn.online-go.com"));
+            expect(cdn).toEqual(expect.stringContaining("localhost"));
+        },
+    );
+});

--- a/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
+++ b/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
@@ -82,6 +82,20 @@ ogsTest.describe("@DevServer dev-server /img middleware + cdn_release pin", () =
         expect(actualSha).toBe(expectedSha);
     });
 
+    ogsTest("/img/* returns 404 on miss (not the SPA fallback)", async ({ page }) => {
+        // If this starts returning 200, someone restored the `next()` path in the
+        // /img middleware and broken textures will silently show as index.html.
+        await page.goto("/");
+        const missed = await page.evaluate(async () => {
+            const res = await fetch(`/img/__does_not_exist_${Date.now()}.jpg`, {
+                cache: "no-store",
+            });
+            return { status: res.status, ct: res.headers.get("content-type") };
+        });
+        expect(missed.status).toBe(404);
+        expect(missed.ct).toMatch(/text\/plain/);
+    });
+
     ogsTest(
         "cdn_release stays pinned to the dev server across the cached-config rehydrate path",
         async ({ browser }) => {

--- a/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
+++ b/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
@@ -38,8 +38,8 @@
  * detect the failure modes above.
  */
 
-import { expect } from "@playwright/test";
-import { ogsTest } from "@helpers";
+import { BrowserContext, expect } from "@playwright/test";
+import { CreateContextOptions, ogsTest } from "@helpers";
 import crypto from "crypto";
 import fs from "fs/promises";
 import path from "path";
@@ -115,8 +115,12 @@ ogsTest.describe("@DevServer dev-server /img middleware + cdn_release pin", () =
 
     ogsTest(
         "cdn_release stays pinned to the dev server across the cached-config rehydrate path",
-        async ({ browser }) => {
-            const ctx = await browser.newContext();
+        async ({
+            createContext,
+        }: {
+            createContext: (options?: CreateContextOptions) => Promise<BrowserContext>;
+        }) => {
+            const ctx = await createContext();
             // Seed localStorage to trigger the main.tsx cached-config rehydrate
             // branch that previously overwrote config.cdn_release on every reload.
             await ctx.addInitScript(() => {
@@ -150,7 +154,6 @@ ogsTest.describe("@DevServer dev-server /img middleware + cdn_release pin", () =
                     "config.cdn",
                 ),
             }));
-            await ctx.close();
 
             expect(cdnRelease).toEqual(expect.stringContaining("localhost"));
             expect(cdnRelease).not.toEqual(expect.stringContaining("cdn.online-go.com"));

--- a/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
+++ b/e2e-tests/dev-server/dev-cdn-intercept.spec.ts
@@ -96,6 +96,23 @@ ogsTest.describe("@DevServer dev-server /img middleware + cdn_release pin", () =
         expect(missed.ct).toMatch(/text\/plain/);
     });
 
+    ogsTest("/img/* falls back to submodules/goban/assets/img (anime theme)", async ({ page }) => {
+        // anime_*.svg only live in the goban submodule, not in the main repo's
+        // assets/img/. Confirms the middleware searches multiple asset roots.
+        await page.goto("/");
+        const anime = await page.evaluate(async () => {
+            const res = await fetch("/img/anime_board.svg", { cache: "no-store" });
+            return {
+                status: res.status,
+                ct: res.headers.get("content-type"),
+                size: (await res.blob()).size,
+            };
+        });
+        expect(anime.status).toBe(200);
+        expect(anime.ct).toMatch(/svg/);
+        expect(anime.size).toBeGreaterThan(100);
+    });
+
     ogsTest(
         "cdn_release stays pinned to the dev server across the cached-config rehydrate path",
         async ({ browser }) => {
@@ -114,9 +131,16 @@ ogsTest.describe("@DevServer dev-server /img middleware + cdn_release pin", () =
                 );
             });
             const page = await ctx.newPage();
-            await page.goto("/");
-            // Let the debounced cached.refresh.config() call in cached.ts settle.
-            await page.waitForTimeout(5000);
+            // Wait deterministically for the async ui/config refresh to complete —
+            // proves the test exercised the full config rehydrate cycle rather than
+            // reading a transient value set synchronously by main.tsx.
+            const [_configResponse] = await Promise.all([
+                page.waitForResponse(
+                    (r) => /\/api\/v\d+\/ui\/config/.test(r.url()) && r.status() === 200,
+                    { timeout: 15_000 },
+                ),
+                page.goto("/"),
+            ]);
 
             const { cdnRelease, cdn } = await page.evaluate(() => ({
                 cdnRelease: (

--- a/src/lib/cached.ts
+++ b/src/lib/cached.ts
@@ -74,19 +74,6 @@ export const cached = {
                         data.set("user", config.user);
                         data.set("config.user", config.user);
                         data.set("config", config);
-                        /* Same rationale as main.tsx: the backend returns a prod
-                         * cdn_release even when served from localhost/uffizzi.
-                         * Re-pin so the vite /img/* middleware can intercept. */
-                        if (
-                            window.cdn_service &&
-                            !window.cdn_service.includes("cdn.online-go.com")
-                        ) {
-                            data.set("config.cdn", window.cdn_service);
-                            data.set(
-                                "config.cdn_release",
-                                window.cdn_service + "/" + (window.ogs_release || ""),
-                            );
-                        }
                         if (cb) {
                             cb();
                         }

--- a/src/lib/cached.ts
+++ b/src/lib/cached.ts
@@ -74,6 +74,19 @@ export const cached = {
                         data.set("user", config.user);
                         data.set("config.user", config.user);
                         data.set("config", config);
+                        /* Same rationale as main.tsx: the backend returns a prod
+                         * cdn_release even when served from localhost/uffizzi.
+                         * Re-pin so the vite /img/* middleware can intercept. */
+                        if (
+                            window.cdn_service &&
+                            !window.cdn_service.includes("cdn.online-go.com")
+                        ) {
+                            data.set("config.cdn", window.cdn_service);
+                            data.set(
+                                "config.cdn_release",
+                                window.cdn_service + "/" + (window.ogs_release || ""),
+                            );
+                        }
                         if (cb) {
                             cb();
                         }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -250,6 +250,14 @@ if (cached_config) {
     }
 }
 
+/* In non-prod environments, the backend's cached/refreshed ui/config includes a
+ * prod cdn_release that bypasses the vite /img/* middleware. Re-pin to the dev
+ * server so asset URLs in themes and views resolve against local disk. */
+if (window.cdn_service && !window.cdn_service.includes("cdn.online-go.com")) {
+    data.set("config.cdn", window.cdn_service);
+    data.set("config.cdn_release", window.cdn_service + "/" + (window.ogs_release || ""));
+}
+
 const user = data.get("config.user"); // guaranteed to return anonymous by the defaults, unless they are logged in
 
 try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -252,8 +252,12 @@ if (cached_config) {
 
 /* In dev, the cached ui/config in localStorage (rehydrated by the loop above)
  * includes a prod cdn_release that bypasses the vite /img/* middleware.
- * Re-pin to the dev server so asset URLs in themes resolve against local disk. */
-if (window.cdn_service && !window.cdn_service.includes("cdn.online-go.com")) {
+ * Re-pin to the dev server so asset URLs in themes resolve against local disk.
+ *
+ * Gated on import.meta.env.DEV — statically replaced at build time, so the
+ * whole block is tree-shaken from production bundles and can never clobber a
+ * server-computed cdn_release in prod or self-hosted deployments. */
+if (import.meta.env.DEV && window.cdn_service) {
     data.set("config.cdn", window.cdn_service);
     data.set("config.cdn_release", window.cdn_service + "/" + (window.ogs_release || ""));
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -250,9 +250,9 @@ if (cached_config) {
     }
 }
 
-/* In non-prod environments, the backend's cached/refreshed ui/config includes a
- * prod cdn_release that bypasses the vite /img/* middleware. Re-pin to the dev
- * server so asset URLs in themes and views resolve against local disk. */
+/* In dev, the cached ui/config in localStorage (rehydrated by the loop above)
+ * includes a prod cdn_release that bypasses the vite /img/* middleware.
+ * Re-pin to the dev server so asset URLs in themes resolve against local disk. */
 if (window.cdn_service && !window.cdn_service.includes("cdn.online-go.com")) {
     data.set("config.cdn", window.cdn_service);
     data.set("config.cdn_release", window.cdn_service + "/" + (window.ogs_release || ""));

--- a/typings_manual/index.d.ts
+++ b/typings_manual/index.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="js-noise.d.ts" />
+/// <reference types="vite/client" />
 
 // Vite worker URL import: `import url from './worker?worker&url'` returns
 // the URL string of the separately-bundled worker script.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -446,6 +446,39 @@ function ogs_vite_middleware(): Plugin {
          */
         configureServer(server: ViteDevServer) {
             return () => {
+                /* Serve assets/img/* at /img/* so board/stone textures referenced via
+                 * the CDN-rewritten base URL resolve against the repo's assets/ dir in dev.
+                 * In production, Makefile.production copies assets/img/ into the CDN staging area. */
+                server.middlewares.use(async (req, res, next) => {
+                    const url = req.originalUrl || "";
+                    const match = url.match(/^\/+img\/([^?#]+)/);
+                    if (!match) {
+                        return next();
+                    }
+                    const rel = path.posix.normalize(match[1]);
+                    if (rel.startsWith("../") || path.isAbsolute(rel)) {
+                        return next();
+                    }
+                    const file = path.resolve(__dirname, "assets/img", rel);
+                    try {
+                        const body = await fs.readFile(file);
+                        const ext = path.extname(file).toLowerCase();
+                        const types: Record<string, string> = {
+                            ".jpg": "image/jpeg",
+                            ".jpeg": "image/jpeg",
+                            ".png": "image/png",
+                            ".svg": "image/svg+xml",
+                            ".webp": "image/webp",
+                            ".gif": "image/gif",
+                        };
+                        res.setHeader("Content-Type", types[ext] || "application/octet-stream");
+                        res.setHeader("Cache-Control", "no-cache");
+                        res.end(body);
+                    } catch {
+                        return next();
+                    }
+                });
+
                 /* Handle our custom index template, serve it for anything that doesn't look like a file */
                 server.middlewares.use(async (req, res, next) => {
                     const url = req.originalUrl || "";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -496,8 +496,10 @@ function ogs_vite_middleware(): Plugin {
                             res.setHeader("Cache-Control", "no-cache");
                             res.end(body);
                             return;
-                        } catch {
-                            /* try next root */
+                        } catch (err) {
+                            const code = (err as NodeJS.ErrnoException).code;
+                            if (code === "ENOENT" || code === "EISDIR") continue;
+                            return next(err);
                         }
                     }
                     send404(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -448,16 +448,27 @@ function ogs_vite_middleware(): Plugin {
             return () => {
                 /* Serve assets/img/* at /img/* so board/stone textures referenced via
                  * the CDN-rewritten base URL resolve against the repo's assets/ dir in dev.
-                 * In production, Makefile.production copies assets/img/ into the CDN staging area. */
+                 * In production, Makefile.production copies assets/img/ into the CDN staging area.
+                 *
+                 * /img/ is treated as a dev-only mount: a miss returns 404 instead of
+                 * falling through to the SPA catch-all (which would 200 + index.html and
+                 * hide the problem). This is safe because /img/ is never used for SPA
+                 * routes; it is reserved for CDN-mirrored repo assets. */
                 server.middlewares.use(async (req, res, next) => {
                     const url = req.originalUrl || "";
                     const match = url.match(/^\/+img\/([^?#]+)/);
                     if (!match) {
                         return next();
                     }
+                    const send404 = (msg: string) => {
+                        res.statusCode = 404;
+                        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+                        res.setHeader("Cache-Control", "no-cache");
+                        res.end(msg);
+                    };
                     const rel = path.posix.normalize(match[1]);
                     if (rel.startsWith("../") || path.isAbsolute(rel)) {
-                        return next();
+                        return send404(`Rejected /img/ path: ${match[1]}\n`);
                     }
                     const file = path.resolve(__dirname, "assets/img", rel);
                     try {
@@ -475,7 +486,11 @@ function ogs_vite_middleware(): Plugin {
                         res.setHeader("Cache-Control", "no-cache");
                         res.end(body);
                     } catch {
-                        return next();
+                        send404(
+                            `Not Found: /img/${rel}\n` +
+                                `This path is served from assets/img/ during dev.\n` +
+                                `Add the file to assets/img/${rel} or check the filename.\n`,
+                        );
                     }
                 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -483,8 +483,6 @@ function ogs_vite_middleware(): Plugin {
                     const rel = match[1];
                     for (const root of assetRoots) {
                         const file = path.resolve(root, rel);
-                        // Canonical path-containment guard — catches "..", "../x", absolute
-                        // paths, and symlinks that would escape the asset root.
                         if (file !== root && !file.startsWith(root + path.sep)) {
                             continue;
                         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -446,14 +446,28 @@ function ogs_vite_middleware(): Plugin {
          */
         configureServer(server: ViteDevServer) {
             return () => {
-                /* Serve assets/img/* at /img/* so board/stone textures referenced via
-                 * the CDN-rewritten base URL resolve against the repo's assets/ dir in dev.
-                 * In production, Makefile.production copies assets/img/ into the CDN staging area.
+                /* Serve /img/* from the repo's asset directories so board/stone textures
+                 * referenced via the CDN-rewritten base URL resolve against local disk in dev.
+                 * Roots are searched in order; the anime_*.svg assets live in the goban
+                 * submodule only, so we need it as a fallback.
+                 * In production, the contents of these directories are mirrored onto the CDN.
                  *
                  * /img/ is treated as a dev-only mount: a miss returns 404 instead of
                  * falling through to the SPA catch-all (which would 200 + index.html and
                  * hide the problem). This is safe because /img/ is never used for SPA
                  * routes; it is reserved for CDN-mirrored repo assets. */
+                const assetRoots = [
+                    path.resolve(__dirname, "assets/img"),
+                    path.resolve(__dirname, "submodules/goban/assets/img"),
+                ];
+                const mimeByExt: Record<string, string> = {
+                    ".jpg": "image/jpeg",
+                    ".jpeg": "image/jpeg",
+                    ".png": "image/png",
+                    ".svg": "image/svg+xml",
+                    ".webp": "image/webp",
+                    ".gif": "image/gif",
+                };
                 server.middlewares.use(async (req, res, next) => {
                     const url = req.originalUrl || "";
                     const match = url.match(/^\/+img\/([^?#]+)/);
@@ -466,32 +480,34 @@ function ogs_vite_middleware(): Plugin {
                         res.setHeader("Cache-Control", "no-cache");
                         res.end(msg);
                     };
-                    const rel = path.posix.normalize(match[1]);
-                    if (rel.startsWith("../") || path.isAbsolute(rel)) {
-                        return send404(`Rejected /img/ path: ${match[1]}\n`);
+                    const rel = match[1];
+                    for (const root of assetRoots) {
+                        const file = path.resolve(root, rel);
+                        // Canonical path-containment guard — catches "..", "../x", absolute
+                        // paths, and symlinks that would escape the asset root.
+                        if (file !== root && !file.startsWith(root + path.sep)) {
+                            continue;
+                        }
+                        try {
+                            const body = await fs.readFile(file);
+                            const ext = path.extname(file).toLowerCase();
+                            res.setHeader(
+                                "Content-Type",
+                                mimeByExt[ext] || "application/octet-stream",
+                            );
+                            res.setHeader("Cache-Control", "no-cache");
+                            res.end(body);
+                            return;
+                        } catch {
+                            /* try next root */
+                        }
                     }
-                    const file = path.resolve(__dirname, "assets/img", rel);
-                    try {
-                        const body = await fs.readFile(file);
-                        const ext = path.extname(file).toLowerCase();
-                        const types: Record<string, string> = {
-                            ".jpg": "image/jpeg",
-                            ".jpeg": "image/jpeg",
-                            ".png": "image/png",
-                            ".svg": "image/svg+xml",
-                            ".webp": "image/webp",
-                            ".gif": "image/gif",
-                        };
-                        res.setHeader("Content-Type", types[ext] || "application/octet-stream");
-                        res.setHeader("Cache-Control", "no-cache");
-                        res.end(body);
-                    } catch {
-                        send404(
-                            `Not Found: /img/${rel}\n` +
-                                `This path is served from assets/img/ during dev.\n` +
-                                `Add the file to assets/img/${rel} or check the filename.\n`,
-                        );
-                    }
+                    send404(
+                        `Not Found: /img/${rel}\n` +
+                            `Looked in:\n` +
+                            assetRoots.map((r) => `  ${r}\n`).join("") +
+                            `Add the file to one of those directories or check the filename.\n`,
+                    );
                 });
 
                 /* Handle our custom index template, serve it for anything that doesn't look like a file */


### PR DESCRIPTION
Images are loaded from CDN, not local dir.  This causes confusion because the assets *are* hosted in the open-source repos.  This PR is a proposal to fix by:

1) redirecting cdn path to the base URL (localhost:8080)
2) telling vite to serve the assets from `assets/img` (in this repo and goban) from `$BASE_URL/img`

### Test plan

- manual: replaced `kaya.jpg` with pink image, check in browser.  Note anime stones (which live in goban repo) show up too.

<img width="323" height="350" alt="Screenshot 2026-04-18 at 10 19 44 PM" src="https://github.com/user-attachments/assets/ac06e1de-7102-41af-8d91-d612e8ee45e1" />
<img width="774" height="777" alt="Screenshot 2026-04-18 at 9 36 01 PM" src="https://github.com/user-attachments/assets/d52af5be-5573-4fa8-a696-ca4b56c3f044" />

- add playwright tests (`yarn test:e2e --grep @DevServer`)