### PR TITLE
fix: paginated tables now bring you to page 1 when filters change

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -127,6 +127,11 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
         if (!force && last.length && softEquals(last, cur)) {
             return;
         }
+        const last_filter = last[3];
+        if (!softEquals(last_filter, filter)) {
+            setPage(1);
+        }
+
         last_loaded.current = cur;
 
         if (loading) {
@@ -174,9 +179,6 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
             })
             .catch((err) => {
                 console.error(err);
-                if (err.status === 404) {
-                    setPage(1);
-                }
                 setLoading(false);
                 if (load_again.current) {
                     load_again.current = false;

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -128,11 +128,14 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
             return;
         }
         const last_filter = last[3];
-        if (!softEquals(last_filter, filter)) {
-            setPage(1);
-        }
-
         last_loaded.current = cur;
+
+        if (last_filter && !softEquals(last_filter, filter)) {
+            setPage(1);
+            setLoading(false); // avoids loading-overlay flashing twice
+            setLoadAgainRefresh(load_again_refresh + 1);
+            return;
+        }
 
         if (loading) {
             load_again.current = true;

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -130,15 +130,15 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
         const last_filter = last[3];
         last_loaded.current = cur;
 
-        if (last_filter && !softEquals(last_filter, filter)) {
-            setPage(1);
-            setLoading(false); // avoids loading-overlay flashing twice
-            setLoadAgainRefresh(load_again_refresh + 1);
+        if (loading) {
+            load_again.current = true;
             return;
         }
 
-        if (loading) {
+        if (last_filter && !softEquals(last_filter, filter)) {
+            setPage(1);
             load_again.current = true;
+            setLoadAgainRefresh(load_again_refresh + 1);
             return;
         }
 

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -149,7 +149,7 @@ function request(method: Method): RequestFunction {
                         } else {
                             console.error(res.status, url, data);
                             console.error(traceback.stack);
-                            reject(res);
+                            reject(data);
                         }
                     };
 

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -144,7 +144,7 @@ function request(method: Method): RequestFunction {
                     }
 
                     const onJson = (data: any) => {
-                        if (res.status >= 200 && res.status < 300) {
+                        if (res.ok) {
                             resolve(data);
                         } else {
                             console.error(res.status, url, data);
@@ -157,13 +157,7 @@ function request(method: Method): RequestFunction {
                         reject(res.statusText);
                     };
 
-                    const data_or_promise = res.json();
-
-                    if (data_or_promise instanceof Promise) {
-                        data_or_promise.then(onJson).catch(errorHandler);
-                    } else {
-                        onJson(data_or_promise);
-                    }
+                    res.json().then(onJson).catch(errorHandler);
                 })
                 .catch((err) => {
                     delete requests_in_flight[request_id];

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -149,7 +149,7 @@ function request(method: Method): RequestFunction {
                         } else {
                             console.error(res.status, url, data);
                             console.error(traceback.stack);
-                            reject(data);
+                            reject(res);
                         }
                     };
 


### PR DESCRIPTION
Aims to fix a bug introduced in https://github.com/online-go/online-go.com/commit/0679486fba0b2ad7d19c317c02ce0315ceb4f616 which causes the `PaginatedTable` component (used in a player profile's `GameHistoryTable` for example) to break when selecting a filter that doesn't result in enough pages to accommodate your current page selection.

## Cause

The commit noted above introduced the `onJson` function which brought with it a meaning change to behavior. Specifically, when the response status is not in the 2xx range, the parsed JSON is still returned. This is different to how it worked before this where the `Response` would be returned. In the case of (at least) `PaginatedTable` this resulted in said broken behavior. This is because, in it's `refresh()` function, it has fallback code to run `SetPage(1)` if the promise returned from `ajax_loader()` rejects. The issue is that this is conditional on `err.status === 404` which is never true given that `err` is the JSON body of the response so `err.status` is `undefined`.

## Changes

> **Note:** Much of the below section is outdated, see my follow up comment

My tentative change is to revert the behavior in `onJson` to return the `Response` when the it doesn't have a 2xx status. I recognize however that the entire point of https://github.com/online-go/online-go.com/commit/0679486fba0b2ad7d19c317c02ce0315ceb4f616 was to pass along readable error messages instead of just an error code. An approach could be to return an object which includes both the readable error as well as the raw response. For example we could (exclusively in the error status code case) do `data.status = res.status` or something similar. This would allow us to check the status code within `PaginatedTable`. I'm a bit hesitant with both approaches here given that `lib/requests` is used in so many files meaning it may be hard to audit for breakages. Of course, an alternative would be to make the fix locally in `PaginatedTable` but that might be tricky to do in a clean way... Please let me know how you'd recommend proceeding.

## Reproduction:

1. Navigate to some player's profile.
2. Apply some filter to their game history.
3. Note how many pages are available (let's call this amount N).
4. Remove all filters.
5. Navigate to page N+1 or greater and apply those same filters.
6. Note the filters don't correctly apply until you navigate to page N or earlier.

**For example:** If you only have two pages of 13x13 games then, without filters applied, navigate to page 3 and filter to 13x13.