### PR TITLE
A route for sharing FP logic with agent.

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -97,7 +97,12 @@ import { useData } from "./lib/hooks";
 import { MainSection } from "@/components/MainSection";
 import { AccessibilityMenu } from "@/components/AccessibilityMenu";
 import { RecentlyBlocked } from "@moderator-ui/RecentlyBlocked";
-import { FairPlay, FairPlayActions, FairPlaySearch } from "@moderator-ui/FairPlay";
+import {
+    FairPlay,
+    FairPlayActions,
+    FairPlayLogicDump,
+    FairPlaySearch,
+} from "@moderator-ui/FairPlay";
 
 const LearningHub = React.lazy(() =>
     import("@/views/LearningHub/LearningHub").then((m) => ({
@@ -410,6 +415,7 @@ export const routes = (
                 <Route path="/moderator/fair-play/:id" element={<FairPlay />} />
                 <Route path="/moderator/fair-play-search" element={<FairPlaySearch />} />
                 <Route path="/moderator/fair-play-actions" element={<FairPlayActions />} />
+                <Route path="/moderator/fair-play-logic-dump" element={<FairPlayLogicDump />} />
                 <Route path="/admin/merchant_log" element={<MerchantLog />} />
                 <Route path="/admin/firewall" element={<Firewall />} />
                 <Route path="/admin/flagged_games" element={<FlaggedGames />} />

--- a/src/stubs/moderator-ui/FairPlay/FairPlayLogicDump.tsx
+++ b/src/stubs/moderator-ui/FairPlay/FairPlayLogicDump.tsx
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C)  Online-Go.com
+ */
+
+import * as React from "react";
+
+export function FairPlayLogicDump(): React.ReactElement {
+    return (
+        <div className="FairPlayLogicDump">
+            <p>This feature is not available in the stub implementation.</p>
+        </div>
+    );
+}

--- a/src/stubs/moderator-ui/FairPlay/index.ts
+++ b/src/stubs/moderator-ui/FairPlay/index.ts
@@ -5,4 +5,5 @@
 export * from "./FairPlay";
 export * from "./FairPlayActions";
 export * from "./FairPlayGameSummary";
+export * from "./FairPlayLogicDump";
 export * from "./FairPlaySearch";


### PR DESCRIPTION
Fixes agent wondering how it's working.

## Proposed Changes

  - Route to FP logic dump that we can share.
  

(Note that page is implemented in separate repo, moderator-ui).

Needs: https://github.com/online-go/moderator-ui/pull/48 
