### PR TITLE
Toggle switch for fuzzy stone placement

### DIFF
--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -108,6 +108,7 @@ export function configure_goban() {
         getMoveTreeNumbering: (): "none" | "move-number" | "move-coordinates" =>
             preferences.get("move-tree-numbering"),
         getStoneFontScale: (): number => preferences.get("stone-font-scale"),
+        getFuzzyPlacementEnabled: (): boolean => preferences.get("fuzzy-stone-placement"),
         getCDNReleaseBase: (): string => data.get("config.cdn_release", ""),
         getSoundEnabled: (): boolean => sfx.getVolume("master") > 0,
         getSoundVolume: (): number => sfx.getVolume("master"),

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -83,6 +83,7 @@ export const defaults = {
     "dock-delay": 0, // seconds.
     "double-click-submit-correspondence": false,
     "double-click-submit-live": false,
+    "fuzzy-stone-placement": false,
     "last-move-opacity": 1.0,
     "variation-stone-opacity": 0.6,
     "variation-move-count": 10,

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -94,6 +94,7 @@ export function ThemePreferences(): React.ReactElement | null {
     const [visual_undo_request_indicator, setVisualUndoRequestIndicator] = usePreference(
         "visual-undo-request-indicator",
     );
+    const [fuzzy_stone_placement, setFuzzyStonePlacement] = usePreference("fuzzy-stone-placement");
     const [last_move_opacity, _setLastMoveOpacity] = usePreference("last-move-opacity");
     const [stone_font_scale, _setStoneFontScale] = usePreference("stone-font-scale");
 
@@ -584,6 +585,21 @@ export function ThemePreferences(): React.ReactElement | null {
                         sampleOptions={{ undo: true }}
                     />
                 </div>
+            </PreferenceLine>
+
+            <PreferenceLine
+                title={_("Fuzzy stone placement")}
+                description={_(
+                    "Slightly reduce stone size and shift stones off-center within each intersection.",
+                )}
+            >
+                <Toggle
+                    checked={fuzzy_stone_placement}
+                    onChange={(tf) => {
+                        setFuzzyStonePlacement(tf);
+                        setTimeout(() => refresh((x) => x + 1), 50);
+                    }}
+                />
             </PreferenceLine>
 
             <PreferenceLine title={_("Use old canvas goban renderer")}>


### PR DESCRIPTION
Adds a toggle in Themes and Visuals settings following existing patterns for fuzzy stone placement. Related to https://github.com/online-go/goban/pull/242.