### PR TITLE
feat(TabCompleteInput): support multiline text input

### DIFF
--- a/src/components/Chat/ChatLog.css
+++ b/src/components/Chat/ChatLog.css
@@ -53,12 +53,23 @@
         overflow-y: scroll;
         border-bottom: 1px solid transparent;
         border-bottom-color: var(--shade3);
+        display: flex;
+        flex-direction: column-reverse;
 
         .Player {
             color: var(--fg);
         }
 
         word-wrap: break-word;
+    }
+
+    .chat-lines-spacer {
+        flex: 1;
+    }
+
+    .chat-lines-inner {
+        display: flex;
+        flex-direction: column;
     }
 
     .timestamp {

--- a/src/components/Chat/ChatLog.css
+++ b/src/components/Chat/ChatLog.css
@@ -117,7 +117,7 @@
             font-size: 0.85rem;
         }
 
-        input {
+        .chat-input-wrapper {
             flex: 1;
             overflow: hidden;
         }
@@ -235,7 +235,8 @@
         }
     }
 
-    input {
+    input,
+    textarea {
         background: var(--bg);
         padding: 0.5rem;
     }

--- a/src/components/Chat/ChatLog.css
+++ b/src/components/Chat/ChatLog.css
@@ -134,9 +134,8 @@
     }
 
     .chat-line {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: normal;
+        display: inline;
+        white-space: pre-wrap;
 
         .date {
             font-size: 8pt;

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -549,9 +549,9 @@ function ChatInput({
     }, [channel]);
 
     const onKeyPress = useCallback(
-        (event: React.KeyboardEvent<HTMLInputElement>): boolean | undefined => {
+        (event: React.KeyboardEvent<HTMLTextAreaElement>): boolean | undefined => {
             if (event.charCode === 13) {
-                const input = event.target as HTMLInputElement;
+                const input = event.target as HTMLTextAreaElement;
                 if (!socket.connected) {
                     void alert.fire(_("Connection to server lost"));
                     return false;

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -596,7 +596,6 @@ function ChatInput({
             className={rtl_mode ? "rtl" : ""}
             autoFocus={autoFocus}
             autoComplete={"off"}
-            maxMessageLength={1024}
             placeholder={
                 !user.email_validated
                     ? _("Chat will be enabled once your email address has been validated")

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -557,7 +557,7 @@ function ChatInput({
 
     const onKeyPress = useCallback(
         (event: React.KeyboardEvent<HTMLTextAreaElement>): boolean | undefined => {
-            if (event.key === "Enter") {
+            if (!event.shiftKey && event.key === "Enter") {
                 const input = event.target as HTMLTextAreaElement;
                 if (!socket.connected) {
                     void alert.fire(_("Connection to server lost"));
@@ -596,6 +596,7 @@ function ChatInput({
             className={rtl_mode ? "rtl" : ""}
             autoFocus={autoFocus}
             autoComplete={"off"}
+            maxMessageLength={1024}
             placeholder={
                 !user.email_validated
                     ? _("Chat will be enabled once your email address has been validated")

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -550,7 +550,7 @@ function ChatInput({
 
     const onKeyPress = useCallback(
         (event: React.KeyboardEvent<HTMLTextAreaElement>): boolean | undefined => {
-            if (event.charCode === 13) {
+            if (event.key === "Enter") {
                 const input = event.target as HTMLTextAreaElement;
                 if (!socket.connected) {
                     void alert.fire(_("Connection to server lost"));

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -483,13 +483,13 @@ function ChatLines({
         // Therefore the "is at bottom" check changes from the normal
         //   scrollHeight - scrollTop - 10 < offsetHeight
         // to simply checking whether scrollTop is close to 0.
-        const tf = div.scrollTop > 10;
+        const tf = div.scrollTop > -10;
         if (tf !== scrolled_to_bottom) {
             scrolled_to_bottom = tf;
             div.className =
                 (rtl_mode ? "rtl chat-lines " : "chat-lines ") + (tf ? "autoscrolling" : "");
         }
-        scrolled_to_bottom = div.scrollTop > 10;
+        scrolled_to_bottom = div.scrollTop > -10;
     }, [channel]);
 
     window.requestAnimationFrame(() => {

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -477,13 +477,19 @@ function ChatLines({
             return;
         }
 
-        const tf = div.scrollHeight - div.scrollTop - 10 < div.offsetHeight;
+        // Because chat-log uses flex-direction: column-reverse to achieve
+        // bottom-anchoring, the scroll direction is inverted: scrollTop is 0
+        // when at the bottom, and becomes negative as the user scrolls up.
+        // Therefore the "is at bottom" check changes from the normal
+        //   scrollHeight - scrollTop - 10 < offsetHeight
+        // to simply checking whether scrollTop is close to 0.
+        const tf = div.scrollTop > 10;
         if (tf !== scrolled_to_bottom) {
             scrolled_to_bottom = tf;
             div.className =
                 (rtl_mode ? "rtl chat-lines " : "chat-lines ") + (tf ? "autoscrolling" : "");
         }
-        scrolled_to_bottom = div.scrollHeight - div.scrollTop - 10 < div.offsetHeight;
+        scrolled_to_bottom = div.scrollTop > 10;
     }, [channel]);
 
     window.requestAnimationFrame(() => {
@@ -493,10 +499,10 @@ function ChatLines({
         }
 
         if (scrolled_to_bottom) {
-            div.scrollTop = div.scrollHeight;
+            div.scrollTop = 0;
             setTimeout(() => {
                 try {
-                    div.scrollTop = div.scrollHeight;
+                    div.scrollTop = 0;
                 } catch {
                     // ignore error
                 }

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -513,13 +513,20 @@ function ChatLines({
             onScroll={onScroll}
             onClick={focusInput}
         >
-            {proxy?.channel.chat_log.slice(-500).map((line, idx) => {
-                const ll = last_line;
-                last_line = line;
-                return (
-                    <ChatLine key={line.message.i || `system-${idx}`} line={line} lastLine={ll} />
-                );
-            })}
+            <div className="chat-lines-spacer" />
+            <div className="chat-lines-inner">
+                {proxy?.channel.chat_log.slice(-500).map((line, idx) => {
+                    const ll = last_line;
+                    last_line = line;
+                    return (
+                        <ChatLine
+                            key={line.message.i || `system-${idx}`}
+                            line={line}
+                            lastLine={ll}
+                        />
+                    );
+                })}
+            </div>
         </div>
     );
 }

--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -29,9 +29,6 @@
     top: -25px;
     right: 0;
     width: auto;
-    
-    
-    border: 0.5px solid rgba(245, 166, 35, 0.25);
     padding: 2px 6px;
     border-radius: 4px;
     font-size: 11px;
@@ -42,14 +39,14 @@
 }
 
 .chat-count-warning.warning {
-    background-color: rgba(40, 28, 8, 0.92);
-    backdrop-filter: blur(4px);
-    color: #f5a623;
+    background-color: var(--warning-bg);
+    color: var(--warning-fg);
+    border-color: none;
 }
 .chat-count-warning.error {
-    background-color: #7c2d12;
-    color: #fed7aa;
-    border-color: #7c2d12;
+    background-color: var(--error-boundary-bg);
+    color: var(--error-boundary-fg);
+    border-color: none;
 }
 
 .chat-input-wrapper textarea {

--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -45,11 +45,12 @@
     min-width: 5rem;
     resize: none;
     box-sizing: border-box;
+    font-family: inherit;
+    font-size: inherit;
     line-height: 1.2;
-    outline: none;
     border-left: none;
     border-right: none;
     border-top: none;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    padding: 3px 3px;
+    outline: none;
 }

--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -17,3 +17,34 @@
 .TabCompleteInput {
     /* here */
 }
+
+.chat-input-wrapper {
+    position: relative;
+    width: 100%;
+    overflow: visible;
+}
+
+.chat-count-warning {
+    position: absolute;
+    bottom: 100%;
+    right: 0px;
+    width: calc(100% - 12px);
+    background-color: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+    color: #ff6b6b;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: bold;
+    font-family: monospace;
+    pointer-events: none;
+}
+
+.chat-input-wrapper textarea {
+    width: 100%;
+    min-width: 5rem;
+    resize: none;
+    box-sizing: border-box;
+    line-height: 1.2;
+    outline: none;
+}

--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -50,4 +50,6 @@
     border-left: none;
     border-right: none;
     border-top: none;
+    margin-top: 0px;
+    margin-bottom: 0px;
 }

--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -47,4 +47,7 @@
     box-sizing: border-box;
     line-height: 1.2;
     outline: none;
+    border-left: none;
+    border-right: none;
+    border-top: none;
 }

--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -41,12 +41,10 @@
 .chat-count-warning.warning {
     background-color: var(--warning-bg);
     color: var(--warning-fg);
-    border-color: none;
 }
 .chat-count-warning.error {
     background-color: var(--error-boundary-bg);
     color: var(--error-boundary-fg);
-    border-color: none;
 }
 
 .chat-input-wrapper textarea {

--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -26,18 +26,30 @@
 
 .chat-count-warning {
     position: absolute;
-    bottom: 100%;
-    right: 0px;
-    width: calc(100% - 12px);
-    background-color: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(4px);
-    color: #ff6b6b;
+    top: -25px;
+    right: 0;
+    width: auto;
+    
+    
+    border: 0.5px solid rgba(245, 166, 35, 0.25);
     padding: 2px 6px;
     border-radius: 4px;
-    font-size: 12px;
-    font-weight: bold;
-    font-family: monospace;
+    font-size: 11px;
+    font-family: inherit;
+    text-align: right;
+    box-sizing: border-box;
     pointer-events: none;
+}
+
+.chat-count-warning.warning {
+    background-color: rgba(40, 28, 8, 0.92);
+    backdrop-filter: blur(4px);
+    color: #f5a623;
+}
+.chat-count-warning.error {
+    background-color: #7c2d12;
+    color: #fed7aa;
+    border-color: #7c2d12;
 }
 
 .chat-input-wrapper textarea {

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -23,6 +23,7 @@ interface TabCompleteInputProperties extends React.HTMLProps<HTMLTextAreaElement
     id?: string;
     placeholder?: string;
     disabled?: boolean;
+    maxMessageLength?: number; // optional, undefined means unlimited.
     onKeyPress?: React.KeyboardEventHandler<HTMLTextAreaElement>;
     className?: string;
     onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
@@ -114,11 +115,52 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
         const defaultRef = React.useRef<HTMLTextAreaElement>(null);
         const inputRef = (ref as React.RefObject<HTMLTextAreaElement>) || defaultRef;
         const [lastKey, setLastKey] = React.useState<number>(0);
+        const [charCount, setCharCount] = React.useState<number>(0);
+        const [showWarning, setShowWarning] = React.useState<boolean>(false);
 
         const adjustHeight = React.useCallback((textarea: HTMLTextAreaElement) => {
-            textarea.style.height = "auto";
-            textarea.style.height = `${Math.min(textarea.scrollHeight, 150)}px`;
+            const style = window.getComputedStyle(textarea);
+            const borderY = parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
+            textarea.style.height = "0px";
+            textarea.style.height = `${Math.min(textarea.scrollHeight + borderY, 150)}px`;
         }, []);
+
+        const maxMessageLength = props.maxMessageLength;
+
+        const checkCharCount = React.useCallback(
+            (text: string) => {
+                if (maxMessageLength === undefined) {
+                    setShowWarning(false);
+                    return;
+                }
+
+                const length = text.length;
+                setCharCount(length);
+
+                const remaining = maxMessageLength - length;
+
+                if (remaining < 50) {
+                    setShowWarning(true);
+                } else {
+                    setShowWarning(false);
+                }
+            },
+            [maxMessageLength],
+        );
+
+        React.useEffect(() => {
+            const textarea = inputRef.current;
+            if (!textarea) {
+                return;
+            }
+
+            const observer = new ResizeObserver(() => {
+                adjustHeight(textarea);
+            });
+
+            observer.observe(textarea);
+            return () => observer.disconnect();
+        }, [adjustHeight]);
 
         const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
             if (e.key === "Enter") {
@@ -126,8 +168,8 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
                 props.onKeyPress?.(e);
                 // Reset height after sending
                 if (inputRef.current) {
-                    inputRef.current.style.height = "auto";
                     adjustHeight(inputRef.current);
+                    setShowWarning(false);
                 }
                 return;
             }
@@ -232,20 +274,31 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
 
         const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
             props.onChange?.(e);
-            adjustHeight(inputRef.current);
+            if (inputRef.current) {
+                adjustHeight(inputRef.current);
+            }
+            checkCharCount(inputRef.current.value);
         };
 
         return (
-            <textarea
-                ref={inputRef}
-                enterKeyHint="send"
-                {...props}
-                onKeyDown={handleKeyDown}
-                onFocus={handleFocus}
-                onBlur={handleBlur}
-                onChange={handleChange}
-                rows={1}
-            />
+            <div className="chat-input-wrapper">
+                <textarea
+                    ref={inputRef}
+                    enterKeyHint="send"
+                    {...props}
+                    maxLength={maxMessageLength}
+                    onKeyDown={handleKeyDown}
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
+                    onChange={handleChange}
+                    rows={1}
+                />
+                {showWarning && (
+                    <div className="chat-count-warning">
+                        ⚠ {charCount}/{maxMessageLength} chars
+                    </div>
+                )}
+            </div>
         );
     },
 );

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -17,6 +17,7 @@
 
 import * as React from "react";
 import * as player_cache from "@/lib/player_cache";
+import { maxMessageLength } from "@/lib/chat_manager";
 import "./TabCompleteInput.css";
 import { interpolate, pgettext } from "@/lib/translate";
 
@@ -109,9 +110,6 @@ function matchFullName(input: string, nicknames: string[]): MatchResult {
 function setCaretPosition(input: HTMLTextAreaElement, position: number) {
     input.setSelectionRange(position, position);
 }
-
-// max length support in server is 1024
-const maxMessageLength = 1024;
 
 export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabCompleteInputProperties>(
     (props: TabCompleteInputProperties, ref): React.ReactElement => {

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -19,16 +19,16 @@ import * as React from "react";
 import * as player_cache from "@/lib/player_cache";
 import "./TabCompleteInput.css";
 
-interface TabCompleteInputProperties extends React.HTMLProps<HTMLInputElement> {
+interface TabCompleteInputProperties extends React.HTMLProps<HTMLTextAreaElement> {
     id?: string;
     placeholder?: string;
     disabled?: boolean;
-    onKeyPress?: React.KeyboardEventHandler<HTMLInputElement>;
+    onKeyPress?: React.KeyboardEventHandler<HTMLTextAreaElement>;
     className?: string;
-    onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
+    onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
     autoFocus?: boolean;
     value?: string;
-    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 interface MatchResult {
@@ -105,17 +105,33 @@ function matchFullName(input: string, nicknames: string[]): MatchResult {
     return { value: "", matches };
 }
 
-function setCaretPosition(input: HTMLInputElement, position: number) {
+function setCaretPosition(input: HTMLTextAreaElement, position: number) {
     input.setSelectionRange(position, position);
 }
 
-export const TabCompleteInput = React.forwardRef<HTMLInputElement, TabCompleteInputProperties>(
+export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabCompleteInputProperties>(
     (props: TabCompleteInputProperties, ref): React.ReactElement => {
-        const defaultRef = React.useRef<HTMLInputElement>(null);
-        const inputRef = (ref as React.RefObject<HTMLInputElement>) || defaultRef;
+        const defaultRef = React.useRef<HTMLTextAreaElement>(null);
+        const inputRef = (ref as React.RefObject<HTMLTextAreaElement>) || defaultRef;
         const [lastKey, setLastKey] = React.useState<number>(0);
 
-        const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        const adjustHeight = React.useCallback((textarea: HTMLTextAreaElement) => {
+            textarea.style.height = "auto";
+            textarea.style.height = `${Math.min(textarea.scrollHeight, 150)}px`;
+        }, []);
+
+        const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+            if (e.key === "Enter") {
+                e.preventDefault();
+                props.onKeyPress?.(e);
+                // Reset height after sending
+                if (inputRef.current) {
+                    inputRef.current.style.height = "auto";
+                    adjustHeight(inputRef.current);
+                }
+                return;
+            }
+
             if (e.key === "Tab") {
                 const input = inputRef.current;
                 if (!input) {
@@ -153,7 +169,10 @@ export const TabCompleteInput = React.forwardRef<HTMLInputElement, TabCompleteIn
 
                         input.value = newValue;
                         setCaretPosition(input, newPosition);
-                        props.onChange?.({ target: input } as React.ChangeEvent<HTMLInputElement>);
+                        props.onChange?.({
+                            target: input,
+                        } as React.ChangeEvent<HTMLTextAreaElement>);
+                        adjustHeight(input);
                     }
                 } else if (/( |: )$/.test(text)) {
                     const spaceMatch = text.match(/( |: )$/);
@@ -186,7 +205,10 @@ export const TabCompleteInput = React.forwardRef<HTMLInputElement, TabCompleteIn
 
                         input.value = newValue;
                         setCaretPosition(input, newPosition);
-                        props.onChange?.({ target: input } as React.ChangeEvent<HTMLInputElement>);
+                        props.onChange?.({
+                            target: input,
+                        } as React.ChangeEvent<HTMLTextAreaElement>);
+                        adjustHeight(input);
                     }
                 }
 
@@ -197,7 +219,7 @@ export const TabCompleteInput = React.forwardRef<HTMLInputElement, TabCompleteIn
             props.onKeyPress?.(e);
         };
 
-        const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+        const handleFocus = (e: React.FocusEvent<HTMLTextAreaElement>) => {
             setLastKey(0);
             props.onFocus?.(e);
         };
@@ -208,14 +230,21 @@ export const TabCompleteInput = React.forwardRef<HTMLInputElement, TabCompleteIn
             }
         };
 
+        const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            props.onChange?.(e);
+            adjustHeight(inputRef.current);
+        };
+
         return (
-            <input
+            <textarea
                 ref={inputRef}
                 enterKeyHint="send"
                 {...props}
                 onKeyDown={handleKeyDown}
                 onFocus={handleFocus}
                 onBlur={handleBlur}
+                onChange={handleChange}
+                rows={1}
             />
         );
     },

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -18,6 +18,7 @@
 import * as React from "react";
 import * as player_cache from "@/lib/player_cache";
 import "./TabCompleteInput.css";
+import { interpolate, pgettext } from "@/lib/translate";
 
 interface TabCompleteInputProperties extends React.HTMLProps<HTMLTextAreaElement> {
     id?: string;
@@ -266,8 +267,12 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
                         className={`chat-count-warning ${charCount > maxMessageLength ? "error" : "warning"}`}
                     >
                         {charCount > maxMessageLength
-                            ? `${charCount - maxMessageLength} over limit`
-                            : `${maxMessageLength - charCount} left`}
+                            ? interpolate(pgettext("chat character count", "%d over limit"), [
+                                  charCount - maxMessageLength,
+                              ])
+                            : interpolate(pgettext("chat character count", "%d left"), [
+                                  maxMessageLength - charCount,
+                              ])}
                     </div>
                 )}
                 <textarea

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -148,22 +148,8 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
             [maxMessageLength],
         );
 
-        React.useEffect(() => {
-            const textarea = inputRef.current;
-            if (!textarea) {
-                return;
-            }
-
-            const observer = new ResizeObserver(() => {
-                adjustHeight(textarea);
-            });
-
-            observer.observe(textarea);
-            return () => observer.disconnect();
-        }, [adjustHeight]);
-
         const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-            if (e.key === "Enter") {
+            if (!e.shiftKey && e.key === "Enter") {
                 e.preventDefault();
                 props.onKeyPress?.(e);
                 // Reset height after sending
@@ -276,8 +262,8 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
             props.onChange?.(e);
             if (inputRef.current) {
                 adjustHeight(inputRef.current);
+                checkCharCount(inputRef.current.value);
             }
-            checkCharCount(inputRef.current.value);
         };
 
         return (

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import * as player_cache from "@/lib/player_cache";
-import { maxMessageLength } from "@/lib/chat_manager";
+import { maxMessageLength } from "@/lib/misc";
 import "./TabCompleteInput.css";
 import { interpolate, pgettext } from "@/lib/translate";
 

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -109,6 +109,9 @@ function setCaretPosition(input: HTMLTextAreaElement, position: number) {
     input.setSelectionRange(position, position);
 }
 
+// max length support in server is 1024
+const maxMessageLength = 1024;
+
 export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabCompleteInputProperties>(
     (props: TabCompleteInputProperties, ref): React.ReactElement => {
         const defaultRef = React.useRef<HTMLTextAreaElement>(null);
@@ -124,24 +127,18 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
             textarea.style.height = `${Math.min(textarea.scrollHeight + borderY, 150)}px`;
         }, []);
 
-        // max length support in server is 1024
-        const maxMessageLength = 1024;
+        const checkCharCount = React.useCallback((text: string) => {
+            const length = text.length;
+            setCharCount(length);
 
-        const checkCharCount = React.useCallback(
-            (text: string) => {
-                const length = text.length;
-                setCharCount(length);
+            const remaining = maxMessageLength - length;
 
-                const remaining = maxMessageLength - length;
-
-                if (remaining < 50) {
-                    setShowWarning(true);
-                } else {
-                    setShowWarning(false);
-                }
-            },
-            [maxMessageLength],
-        );
+            if (remaining < 50) {
+                setShowWarning(true);
+            } else {
+                setShowWarning(false);
+            }
+        }, []);
 
         const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
             if (!e.shiftKey && e.key === "Enter") {
@@ -264,6 +261,11 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
 
         return (
             <div className="chat-input-wrapper">
+                {showWarning && (
+                    <div className="chat-count-warning">
+                        ⚠ {charCount}/{maxMessageLength} chars
+                    </div>
+                )}
                 <textarea
                     ref={inputRef}
                     enterKeyHint="send"
@@ -274,11 +276,6 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
                     onChange={handleChange}
                     rows={1}
                 />
-                {showWarning && (
-                    <div className="chat-count-warning">
-                        ⚠ {charCount}/{maxMessageLength} chars
-                    </div>
-                )}
             </div>
         );
     },

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -23,7 +23,6 @@ interface TabCompleteInputProperties extends React.HTMLProps<HTMLTextAreaElement
     id?: string;
     placeholder?: string;
     disabled?: boolean;
-    maxMessageLength?: number; // optional, undefined means unlimited.
     onKeyPress?: React.KeyboardEventHandler<HTMLTextAreaElement>;
     className?: string;
     onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
@@ -125,15 +124,11 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
             textarea.style.height = `${Math.min(textarea.scrollHeight + borderY, 150)}px`;
         }, []);
 
-        const maxMessageLength = props.maxMessageLength;
+        // max length support in server is 1024
+        const maxMessageLength = 1024;
 
         const checkCharCount = React.useCallback(
             (text: string) => {
-                if (maxMessageLength === undefined) {
-                    setShowWarning(false);
-                    return;
-                }
-
                 const length = text.length;
                 setCharCount(length);
 
@@ -155,6 +150,7 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
                 // Reset height after sending
                 if (inputRef.current) {
                     adjustHeight(inputRef.current);
+                    setCharCount(0);
                     setShowWarning(false);
                 }
                 return;
@@ -272,7 +268,6 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
                     ref={inputRef}
                     enterKeyHint="send"
                     {...props}
-                    maxLength={maxMessageLength}
                     onKeyDown={handleKeyDown}
                     onFocus={handleFocus}
                     onBlur={handleBlur}

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -262,8 +262,12 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
         return (
             <div className="chat-input-wrapper">
                 {showWarning && (
-                    <div className="chat-count-warning">
-                        ⚠ {charCount}/{maxMessageLength} chars
+                    <div
+                        className={`chat-count-warning ${charCount > maxMessageLength ? "error" : "warning"}`}
+                    >
+                        {charCount > maxMessageLength
+                            ? `${charCount - maxMessageLength} over limit`
+                            : `${maxMessageLength - charCount} left`}
                     </div>
                 )}
                 <textarea

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -588,13 +588,12 @@ class ChatChannel extends TypedEventEmitter<Events> {
     }
 
     public send(text: string): void {
-        if (text.length > 300) {
-            for (const split_str of string_splitter(text)) {
-                this.send(split_str);
-            }
-            return;
+        for (const split_str of string_splitter(text)) {
+            this.send_(split_str);
         }
-
+        return;
+    }
+    public send_(text: string): void {
         if (this.flood_protection) {
             return;
         }

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -588,12 +588,16 @@ class ChatChannel extends TypedEventEmitter<Events> {
     }
 
     public send(text: string): void {
-        for (const split_str of string_splitter(text)) {
-            this.send_(split_str);
+        if (text.length > 1024) {
+            // TODO: Split logic kept but unreachable
+            // server hard caps all messages at 1024 chars.
+            // Re-enable if per-context limits or chunked sending is restored.
+            for (const split_str of string_splitter(text)) {
+                this.send(split_str);
+            }
+            return;
         }
-        return;
-    }
-    public send_(text: string): void {
+
         if (this.flood_protection) {
             return;
         }

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -29,8 +29,16 @@ import { bounded_rank } from "@/lib/rank_utils";
 import { ActiveTournamentList, GroupList } from "@/lib/types";
 import { _, interpolate } from "@/lib/translate";
 import { getBlocks } from "@/components/BlockPlayer";
-import { insert_into_sorted_list, string_splitter, n2s, Timeout } from "@/lib/misc";
+import {
+    insert_into_sorted_list,
+    sanitizeMessage,
+    string_splitter,
+    n2s,
+    Timeout,
+} from "@/lib/misc";
 import { User } from "goban";
+
+export const maxMessageLength = 1024;
 
 export interface ChatMessage {
     channel: string;
@@ -588,7 +596,8 @@ class ChatChannel extends TypedEventEmitter<Events> {
     }
 
     public send(text: string): void {
-        if (text.length > 1024) {
+        text = sanitizeMessage(text);
+        if (text.length > maxMessageLength) {
             for (const split_str of string_splitter(text)) {
                 this.send(split_str);
             }

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -31,14 +31,13 @@ import { _, interpolate } from "@/lib/translate";
 import { getBlocks } from "@/components/BlockPlayer";
 import {
     insert_into_sorted_list,
+    maxMessageLength,
     sanitizeMessage,
     string_splitter,
     n2s,
     Timeout,
 } from "@/lib/misc";
 import { User } from "goban";
-
-export const maxMessageLength = 1024;
 
 export interface ChatMessage {
     channel: string;

--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -589,9 +589,6 @@ class ChatChannel extends TypedEventEmitter<Events> {
 
     public send(text: string): void {
         if (text.length > 1024) {
-            // TODO: Split logic kept but unreachable
-            // server hard caps all messages at 1024 chars.
-            // Re-enable if per-context limits or chunked sending is restored.
             for (const split_str of string_splitter(text)) {
                 this.send(split_str);
             }

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -386,32 +386,36 @@ export function errorLogger(...args: any[]) {
     }
     console.error(err);
 }
-export function string_splitter(str: string, max_length: number = 200): Array<string> {
-    const words = str.split(/(\W+)/g);
-
+export function string_splitter(str: string, max_length: number = 1024): Array<string> {
+    const paragraphs = str.split("\n");
     const lines: string[] = [];
-    let cur = "";
-    for (let word of words) {
-        while (word.length > max_length) {
-            if (cur !== "") {
-                lines.push(cur);
-                cur = "";
+
+    for (const paragraph of paragraphs) {
+        const words = paragraph.split(/(\W+)/g);
+
+        let cur = "";
+        for (let word of words) {
+            while (word.length > max_length) {
+                if (cur !== "") {
+                    lines.push(cur);
+                    cur = "";
+                }
+
+                lines.push(word.substring(0, max_length - 1) + "-");
+                word = word.substring(max_length - 1);
             }
 
-            lines.push(word.substring(0, max_length - 1) + "-");
-            word = word.substring(max_length - 1);
+            if (cur === "" || (cur + word).length < max_length) {
+                cur += word;
+            } else {
+                lines.push(cur);
+                cur = word;
+            }
         }
 
-        if (cur === "" || (cur + word).length < max_length) {
-            cur += word;
-        } else {
+        if (cur !== "") {
             lines.push(cur);
-            cur = word;
         }
-    }
-
-    if (cur !== "") {
-        lines.push(cur);
     }
 
     return lines;

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -21,6 +21,7 @@ import { browserHistory } from "@/lib/ogsHistory";
 import * as preferences from "@/lib/preferences";
 import { alert } from "@/lib/swal_config";
 import React from "react";
+import { maxMessageLength } from "@/lib/chat_manager";
 
 export type Timeout = ReturnType<typeof setTimeout>;
 
@@ -386,8 +387,23 @@ export function errorLogger(...args: any[]) {
     }
     console.error(err);
 }
-// max length support in server is 1024
-export function string_splitter(str: string, max_length: number = 1024): Array<string> {
+export function sanitizeMessage(text: string): string {
+    let normalized = text.trim();
+
+    if (normalized.length === 0) {
+        return "";
+    }
+
+    normalized = normalized.replace(/[\u200B-\u200D\uFEFF]/g, "");
+    normalized = normalized.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    normalized = normalized.replace(/[^\S\n]+|\n[^\S\n]*/g, (match) =>
+        match.includes("\n") ? "\n" : " ",
+    );
+    normalized = normalized.replace(/\n{3,}/g, "\n\n");
+
+    return normalized;
+}
+export function string_splitter(str: string, max_length: number = maxMessageLength): Array<string> {
     const words = str.split(/(\W+)/g);
 
     const lines: string[] = [];

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -21,7 +21,8 @@ import { browserHistory } from "@/lib/ogsHistory";
 import * as preferences from "@/lib/preferences";
 import { alert } from "@/lib/swal_config";
 import React from "react";
-import { maxMessageLength } from "@/lib/chat_manager";
+
+export const maxMessageLength = 1024;
 
 export type Timeout = ReturnType<typeof setTimeout>;
 

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -386,36 +386,33 @@ export function errorLogger(...args: any[]) {
     }
     console.error(err);
 }
+// max length support in server is 1024
 export function string_splitter(str: string, max_length: number = 1024): Array<string> {
-    const paragraphs = str.split("\n");
+    const words = str.split(/(\W+)/g);
+
     const lines: string[] = [];
-
-    for (const paragraph of paragraphs) {
-        const words = paragraph.split(/(\W+)/g);
-
-        let cur = "";
-        for (let word of words) {
-            while (word.length > max_length) {
-                if (cur !== "") {
-                    lines.push(cur);
-                    cur = "";
-                }
-
-                lines.push(word.substring(0, max_length - 1) + "-");
-                word = word.substring(max_length - 1);
-            }
-
-            if (cur === "" || (cur + word).length < max_length) {
-                cur += word;
-            } else {
+    let cur = "";
+    for (let word of words) {
+        while (word.length > max_length) {
+            if (cur !== "") {
                 lines.push(cur);
-                cur = word;
+                cur = "";
             }
+
+            lines.push(word.substring(0, max_length - 1) + "-");
+            word = word.substring(max_length - 1);
         }
 
-        if (cur !== "") {
+        if (cur === "" || (cur + word).length < max_length) {
+            cur += word;
+        } else {
             lines.push(cur);
+            cur = word;
         }
+    }
+
+    if (cur !== "") {
+        lines.push(cur);
     }
 
     return lines;

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -152,13 +152,12 @@
     .chat-input-container {
         flex-shrink: 0;
         flex-grow: 0;
-        height: 30px;
         flex-basis: 30px;
         display: flex;
         /* max-width: 100%; */
         /* width: 100%; */
-        overflow: hidden;
-        align-items: stretch;
+        overflow: visible;
+        align-items: flex-end;
 
         button {
             flex-shrink: 0;
@@ -171,11 +170,17 @@
             white-space: nowrap;
         }
 
-        input {
+        textarea {
             min-width: 5rem;
             flex-grow: 1;
             flex-shrink: 1;
             width: 5rem;
+            resize: none !important;
+            border-top-left-radius: 0;
+            margin: 0;
+            box-sizing: border-box;
+            box-shadow: none;
+            line-height: 1.2;
         }
 
         .qc-toggle {

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -39,7 +39,7 @@
     }
 
     .chat-log-container {
-        background-color: red !important;
+        /* background-color: red !important; */
         display: flex;
         position: relative;
         flex: 1;
@@ -168,7 +168,7 @@
         display: flex;
         /* max-width: 100%; */
         /* width: 100%; */
-        overflow: hidden;
+        /* overflow: hidden; */
         align-items: flex-end;
         flex-direction: column;
         border-top: 1px solid var(--shade3);
@@ -221,7 +221,6 @@
             /* min-width: 0; */
         }
 
-        /* 右侧按钮组 */
         .chat-toolbar-right {
             display: flex;
             align-items: center;

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -158,10 +158,18 @@
         /* width: 100%; */
         overflow: visible;
         align-items: flex-end;
+        flex-direction: column;
+        border-top: 1px solid var(--shade3);
 
         button {
             flex-shrink: 0;
-            height: 30px;
+            height: 20px;
+            font-size:small;
+            margin-left: 4px;
+            margin-right: 4px;
+            /* box-sizing: border-box; */
+            /* background-color: var(--default-button-dark); */
+            /* border: 3px solid var(--default-button-light); */
         }
 
         .chat-input-chat-log-toggle {
@@ -174,13 +182,42 @@
             min-width: 5rem;
             flex-grow: 1;
             flex-shrink: 1;
-            width: 5rem;
-            resize: none !important;
-            border-top-left-radius: 0;
+            width: 100%;
+            resize: none;
             margin: 0;
             box-sizing: border-box;
-            box-shadow: none;
             line-height: 1.2;
+            border: 4px solid var(--default-button);
+            border-bottom: none;
+            border-radius: 0px 0px 0 0;
+
+            &:focus {
+                outline: none;
+            }
+        }
+
+        .chat-toolbar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            height: 28px;
+            flex-shrink: 0;
+            width: 100%;
+            background-color: var(--default-button);
+        }
+
+        .chat-toolbar-left {
+            display: flex;
+            align-items: center;
+            gap: 0px;
+            /* min-width: 0; */
+        }
+
+        /* 右侧按钮组 */
+        .chat-toolbar-right {
+            display: flex;
+            align-items: center;
+            gap: 0px;
         }
 
         .qc-toggle {
@@ -191,6 +228,7 @@
             background-color: var(--default-button);
             color: var(--default-button-color);
             transition: background-color 0.3s ease;
+            height: 20px;
 
             &:hover, &:focus {
                 text-decoration: none;

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -101,6 +101,7 @@
     .chat-line {
         width: 100%;
         overflow-wrap: break-word;
+        white-space: pre-wrap;
     }
 
     .timestamp {

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -34,18 +34,17 @@
         flex-shrink: 1;
         display: flex;
         width: 100%;
-        max-height: calc(100% - 30px);
+        min-height: 0;
         position: relative;
     }
 
     .chat-log-container {
         background-color: red !important;
-        display: inline-block;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
+        display: flex;
+        position: relative;
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
     }
 
     .ChatUserList {
@@ -61,12 +60,24 @@
     }
 
     .chat-log {
-        height: 100%;
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
         background-color: var(--shade5);
         border-bottom: 1px solid transparent;
-        overflow-y: scroll;
+        display: flex;
+        flex-direction: column-reverse;
     }
 
+    .chat-log-spacer {
+        flex: 1;
+    }
+
+    .chat-log-inner {
+        display: flex;
+        flex-direction: column;
+    }
+    
     .chat-log.autoscrolling {
         border-bottom-color: var(--success);
     }
@@ -152,11 +163,11 @@
     .chat-input-container {
         flex-shrink: 0;
         flex-grow: 0;
-        flex-basis: 30px;
+        /* flex-basis: auto; */
         display: flex;
         /* max-width: 100%; */
         /* width: 100%; */
-        overflow: visible;
+        overflow: hidden;
         align-items: flex-end;
         flex-direction: column;
         border-top: 1px solid var(--shade3);
@@ -190,10 +201,6 @@
             border: 4px solid var(--default-button);
             border-bottom: none;
             border-radius: 0px 0px 0 0;
-
-            &:focus {
-                outline: none;
-            }
         }
 
         .chat-toolbar {

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -34,17 +34,19 @@
         flex-shrink: 1;
         display: flex;
         width: 100%;
+        max-height: calc(100% - 30px);
         min-height: 0;
         position: relative;
     }
 
     .chat-log-container {
         /* background-color: red !important; */
-        display: flex;
-        position: relative;
-        flex: 1;
-        min-height: 0;
-        overflow: hidden;
+        display: inline-block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
     }
 
     .ChatUserList {
@@ -61,8 +63,8 @@
 
     .chat-log {
         flex: 1;
-        min-height: 0;
-        overflow-y: auto;
+        height: 100%;
+        overflow-y: scroll;
         background-color: var(--shade5);
         border-bottom: 1px solid transparent;
         display: flex;
@@ -170,18 +172,12 @@
         /* width: 100%; */
         /* overflow: hidden; */
         align-items: flex-end;
-        flex-direction: column;
+        /* flex-direction: column; */
         border-top: 1px solid var(--shade3);
 
         button {
             flex-shrink: 0;
-            height: 20px;
-            font-size:small;
-            margin-left: 4px;
-            margin-right: 4px;
-            /* box-sizing: border-box; */
-            /* background-color: var(--default-button-dark); */
-            /* border: 3px solid var(--default-button-light); */
+            height: 30px;
         }
 
         .chat-input-chat-log-toggle {
@@ -191,40 +187,10 @@
         }
 
         textarea {
+            min-height: 30px;
             min-width: 5rem;
             flex-grow: 1;
             flex-shrink: 1;
-            width: 100%;
-            resize: none;
-            margin: 0;
-            box-sizing: border-box;
-            line-height: 1.2;
-            border: 4px solid var(--default-button);
-            border-bottom: none;
-            border-radius: 0px 0px 0 0;
-        }
-
-        .chat-toolbar {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            height: 28px;
-            flex-shrink: 0;
-            width: 100%;
-            background-color: var(--default-button);
-        }
-
-        .chat-toolbar-left {
-            display: flex;
-            align-items: center;
-            gap: 0px;
-            /* min-width: 0; */
-        }
-
-        .chat-toolbar-right {
-            display: flex;
-            align-items: center;
-            gap: 0px;
         }
 
         .qc-toggle {
@@ -235,7 +201,7 @@
             background-color: var(--default-button);
             color: var(--default-button-color);
             transition: background-color 0.3s ease;
-            height: 20px;
+            height: 30px;
 
             &:hover, &:focus {
                 text-decoration: none;

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -226,10 +226,10 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
         const chat_log = ref_chat_log.current;
 
         if (chat_log && scrolled_to_bottom.current) {
-            chat_log.scrollTop = chat_log.scrollHeight;
+            chat_log.scrollTop = 0;
             setTimeout(() => {
                 if (chat_log) {
-                    chat_log.scrollTop = chat_log.scrollHeight;
+                    chat_log.scrollTop = 0;
                 }
             }, 100);
         }

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -279,6 +279,20 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
                 />
             )}
             <div className="chat-input-container input-group">
+                {((userIsPlayer && data.get("user").email_validated) || null) && (
+                    <ChatLogToggleButton
+                        selected_chat_log={selected_chat_log}
+                        toggleChatLog={toggleChatLog}
+                        isUserModerator={false}
+                    />
+                )}
+                {((!userIsPlayer && data.get("user").is_moderator) || null) && (
+                    <ChatLogToggleButton
+                        selected_chat_log={selected_chat_log}
+                        toggleChatLog={toggleChatLog}
+                        isUserModerator={true}
+                    />
+                )}
                 <TabCompleteInput
                     className={`chat-input  ${selected_chat_log}`}
                     disabled={user.anonymous || !data.get("user").email_validated}
@@ -309,47 +323,24 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
                     onKeyPress={onKeyPress}
                     onFocus={() => setShowQuickChat(false)}
                 />
-                <div className="chat-toolbar">
-                    <div className="chat-toolbar-left">
-                        {((userIsPlayer && data.get("user").email_validated) || null) && (
-                            <ChatLogToggleButton
-                                selected_chat_log={selected_chat_log}
-                                toggleChatLog={toggleChatLog}
-                                isUserModerator={false}
-                            />
-                        )}
-                        {((!userIsPlayer && data.get("user").is_moderator) || null) && (
-                            <ChatLogToggleButton
-                                selected_chat_log={selected_chat_log}
-                                toggleChatLog={toggleChatLog}
-                                isUserModerator={true}
-                            />
-                        )}
-                    </div>
-
-                    <div className="chat-toolbar-right">
-                        {/* quick chat toggle */}
-                        {userIsPlayer &&
-                        user.email_validated &&
-                        props.game_id &&
-                        selected_chat_log === "main" ? (
-                            <i
-                                className={
-                                    "qc-toggle fa " +
-                                    (show_quick_chat ? "fa-caret-down" : "fa-caret-up")
-                                }
-                                onClick={() => setShowQuickChat(!show_quick_chat)}
-                            />
-                        ) : null}
-
-                        {/* ChatUserCount */}
-                        <ChatUserCount
-                            onClick={togglePlayerList}
-                            active={show_player_list}
-                            channel={channel}
-                        />
-                    </div>
-                </div>
+                {/* quick chat toggle */}
+                {userIsPlayer &&
+                user.email_validated &&
+                props.game_id &&
+                selected_chat_log === "main" ? (
+                    <i
+                        className={
+                            "qc-toggle fa " + (show_quick_chat ? "fa-caret-down" : "fa-caret-up")
+                        }
+                        onClick={() => setShowQuickChat(!show_quick_chat)}
+                    />
+                ) : null}
+                {/* ChatUserCount */}
+                <ChatUserCount
+                    onClick={togglePlayerList}
+                    active={show_player_list}
+                    channel={channel}
+                />
             </div>
         </div>
     );

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -276,23 +276,10 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
                 />
             )}
             <div className="chat-input-container input-group">
-                {((userIsPlayer && data.get("user").email_validated) || null) && (
-                    <ChatLogToggleButton
-                        selected_chat_log={selected_chat_log}
-                        toggleChatLog={toggleChatLog}
-                        isUserModerator={false}
-                    />
-                )}
-                {((!userIsPlayer && data.get("user").is_moderator) || null) && (
-                    <ChatLogToggleButton
-                        selected_chat_log={selected_chat_log}
-                        toggleChatLog={toggleChatLog}
-                        isUserModerator={true}
-                    />
-                )}
                 <TabCompleteInput
                     className={`chat-input  ${selected_chat_log}`}
                     disabled={user.anonymous || !data.get("user").email_validated}
+                    maxMessageLength={1024}
                     placeholder={
                         user.anonymous
                             ? _("Sign in to chat")
@@ -320,22 +307,47 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
                     onKeyPress={onKeyPress}
                     onFocus={() => setShowQuickChat(false)}
                 />
-                {userIsPlayer &&
-                user.email_validated &&
-                props.game_id &&
-                selected_chat_log === "main" ? (
-                    <i
-                        className={
-                            "qc-toggle fa " + (show_quick_chat ? "fa-caret-down" : "fa-caret-up")
-                        }
-                        onClick={() => setShowQuickChat(!show_quick_chat)}
-                    />
-                ) : null}
-                <ChatUserCount
-                    onClick={togglePlayerList}
-                    active={show_player_list}
-                    channel={channel}
-                />
+                <div className="chat-toolbar">
+                    <div className="chat-toolbar-left">
+                        {((userIsPlayer && data.get("user").email_validated) || null) && (
+                            <ChatLogToggleButton
+                                selected_chat_log={selected_chat_log}
+                                toggleChatLog={toggleChatLog}
+                                isUserModerator={false}
+                            />
+                        )}
+                        {((!userIsPlayer && data.get("user").is_moderator) || null) && (
+                            <ChatLogToggleButton
+                                selected_chat_log={selected_chat_log}
+                                toggleChatLog={toggleChatLog}
+                                isUserModerator={true}
+                            />
+                        )}
+                    </div>
+
+                    <div className="chat-toolbar-right">
+                        {/* quick chat toggle */}
+                        {userIsPlayer &&
+                        user.email_validated &&
+                        props.game_id &&
+                        selected_chat_log === "main" ? (
+                            <i
+                                className={
+                                    "qc-toggle fa " +
+                                    (show_quick_chat ? "fa-caret-down" : "fa-caret-up")
+                                }
+                                onClick={() => setShowQuickChat(!show_quick_chat)}
+                            />
+                        ) : null}
+
+                        {/* ChatUserCount */}
+                        <ChatUserCount
+                            onClick={togglePlayerList}
+                            active={show_player_list}
+                            channel={channel}
+                        />
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -207,13 +207,19 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
             return;
         }
 
-        const tf = chat_log.scrollHeight - chat_log.scrollTop - 10 < chat_log.offsetHeight;
+        // Because chat-log uses flex-direction: column-reverse to achieve
+        // bottom-anchoring, the scroll direction is inverted: scrollTop is 0
+        // when at the bottom, and becomes negative as the user scrolls up.
+        // Therefore the "is at bottom" check changes from the normal
+        //   scrollHeight - scrollTop - 10 < offsetHeight
+        // to simply checking whether scrollTop is close to 0.
+        const tf = chat_log.scrollTop > -10;
+
         if (tf !== scrolled_to_bottom.current) {
             scrolled_to_bottom.current = tf;
             chat_log.className = "chat-log " + (tf ? "autoscrolling" : "");
         }
-        scrolled_to_bottom.current =
-            chat_log.scrollHeight - chat_log.scrollTop - 10 < chat_log.offsetHeight;
+        scrolled_to_bottom.current = chat_log.scrollTop > -10;
     };
 
     const autoscroll = () => {

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -187,7 +187,7 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
 
     const onKeyPress = (event: React.KeyboardEvent<HTMLElement>): boolean | void => {
         if (event.key === "Enter") {
-            const input = event.target as HTMLInputElement;
+            const input = event.target as HTMLTextAreaElement;
             if (input.className === "qc-option") {
                 //saveEdit();
                 console.warn("Quick chat editing not implemented");
@@ -195,6 +195,7 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
             } else {
                 goban.sendChat(input.value, selected_chat_log);
                 input.value = "";
+                input.style.height = "auto";
                 return false;
             }
         }
@@ -384,7 +385,7 @@ export function QuickChat(props: QuickChatProperties): React.ReactElement {
 
     const onKeyPress = (event: React.KeyboardEvent<HTMLElement>) => {
         if (event.key === "Enter") {
-            const input = event.target as HTMLInputElement;
+            const input = event.target as HTMLTextAreaElement;
             if (input.className === "qc-option") {
                 saveEdit();
                 event.preventDefault();

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -186,7 +186,7 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
     }, []);
 
     const onKeyPress = (event: React.KeyboardEvent<HTMLElement>): boolean | void => {
-        if (event.key === "Enter") {
+        if (!event.shiftKey && event.key === "Enter") {
             const input = event.target as HTMLTextAreaElement;
             if (input.className === "qc-option") {
                 //saveEdit();

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -19,6 +19,7 @@ import * as data from "@/lib/data";
 import * as preferences from "@/lib/preferences";
 import * as React from "react";
 import { LineText } from "@/components/misc-ui";
+import { sanitizeMessage } from "@/lib/misc";
 import { Link } from "react-router-dom";
 import { _, pgettext, interpolate, current_language, moment } from "@/lib/translate";
 import { Player } from "@/components/Player";
@@ -193,7 +194,7 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
                 console.warn("Quick chat editing not implemented");
                 event.preventDefault();
             } else {
-                goban.sendChat(input.value, selected_chat_log);
+                goban.sendChat(sanitizeMessage(input.value), selected_chat_log);
                 input.value = "";
                 input.style.height = "auto";
                 return false;

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -251,19 +251,22 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
                         className="chat-log autoscrolling"
                         onScroll={updateScrollPosition}
                     >
-                        {chat_lines.current.map((line: ChatLine) => {
-                            const ll = last_line;
-                            last_line = line;
-                            return (
-                                <GameChatLine
-                                    key={line.chat_id}
-                                    line={line}
-                                    last_line={ll}
-                                    game_id={props.game_id}
-                                    review_id={props.review_id}
-                                />
-                            );
-                        })}
+                        <div className="chat-log-spacer" />
+                        <div className="chat-log-inner">
+                            {chat_lines.current.map((line: ChatLine) => {
+                                const ll = last_line;
+                                last_line = line;
+                                return (
+                                    <GameChatLine
+                                        key={line.chat_id}
+                                        line={line}
+                                        last_line={ll}
+                                        game_id={props.game_id}
+                                        review_id={props.review_id}
+                                    />
+                                );
+                            })}
+                        </div>
                     </div>
                 </div>
                 {(show_player_list || null) && <ChatUserList channel={channel} />}

--- a/src/views/Game/GameChat.tsx
+++ b/src/views/Game/GameChat.tsx
@@ -282,7 +282,6 @@ export function GameChat(props: GameChatProperties): React.ReactElement {
                 <TabCompleteInput
                     className={`chat-input  ${selected_chat_log}`}
                     disabled={user.anonymous || !data.get("user").email_validated}
-                    maxMessageLength={1024}
                     placeholder={
                         user.anonymous
                             ? _("Sign in to chat")

--- a/src/views/Group/Group.css
+++ b/src/views/Group/Group.css
@@ -69,10 +69,16 @@
         }
     }
 
-    input {
+    textarea {
         width: 100%;
         margin-top: 1rem;
         margin-bottom: 1rem;
+    }
+
+    .chat-input-wrapper textarea {
+        width: 100%;
+        margin-top: 0;
+        margin-bottom: 0;
     }
 
     .pad {

--- a/src/views/Group/Group.css
+++ b/src/views/Group/Group.css
@@ -69,7 +69,7 @@
         }
     }
 
-    textarea {
+    input {
         width: 100%;
         margin-top: 1rem;
         margin-bottom: 1rem;


### PR DESCRIPTION
This PR adds multi-line input support for the chat input box, improving the experience when composing longer messages.

My changes mainly include the following three points:

1. Replace <input> with <textarea>
2. Auto-height adjustment (max 150px, min 1 line)
3. CSS layout fixes to prevent chat log from covering input box

<img width="456" height="107" alt="image" src="https://github.com/user-attachments/assets/e8041a08-1260-4bf6-9c28-4ac238f84109" />


This is an early draft. I'd like to confirm if this direction is worth pursuing.