### PR TITLE
Switch to new game history endpoint, add bot/human filter

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -206,6 +206,7 @@ export const defaults = {
 
     "game-history-size-filter": "all",
     "game-history-ranked-filter": "all",
+    "game-history-bot-filter": "humans" as "humans" | "bots",
 
     "help-system-enabled": true,
 

--- a/src/views/User/GameHistoryFilterPopover.css
+++ b/src/views/User/GameHistoryFilterPopover.css
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.GameHistoryFilterPopover {
+    position: relative;
+    display: inline-block;
+
+    .GameHistoryFilterPopover-toggle {
+        &.filter-active {
+            color: var(--primary);
+
+            .fa-filter {
+                color: var(--primary);
+            }
+        }
+    }
+
+    .GameHistoryFilterPopover-panel {
+        position: absolute;
+        top: calc(100% + 4px);
+        right: 0;
+        z-index: 10;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+        padding: 0.75em;
+        border-radius: 4px;
+        background-color: var(--react-select-bg);
+        box-shadow:
+            0 2px 10px 0 rgba(0, 0, 0, 0.16),
+            0 2px 5px 0 rgba(0, 0, 0, 0.15);
+
+        .btn-group {
+            display: flex;
+            justify-content: stretch;
+
+            button {
+                flex: 1;
+                white-space: nowrap;
+            }
+        }
+    }
+}

--- a/src/views/User/GameHistoryFilterPopover.tsx
+++ b/src/views/User/GameHistoryFilterPopover.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { _ } from "@/lib/translate";
+import "./GameHistoryFilterPopover.css";
+
+export type SizeFilter = "all" | "9x9" | "13x13" | "19x19";
+export type RankedFilter = "all" | "ranked" | "unranked";
+export type BotFilter = "humans" | "bots";
+
+interface GameHistoryFilterPopoverProps {
+    sizeFilter: SizeFilter;
+    onSizeChange: (size: SizeFilter) => void;
+    rankedFilter: RankedFilter;
+    onRankedChange: (ranked: RankedFilter) => void;
+    botFilter: BotFilter;
+    onBotChange: (bot: BotFilter) => void;
+    botDisabled?: boolean;
+}
+
+export function GameHistoryFilterPopover(props: GameHistoryFilterPopoverProps) {
+    const [open, setOpen] = React.useState(false);
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
+    const rankedDisabled = props.botFilter === "bots";
+    const hasActiveFilter =
+        props.sizeFilter !== "all" ||
+        (!props.botDisabled && props.botFilter !== "humans") ||
+        (!rankedDisabled && props.rankedFilter !== "all");
+
+    React.useEffect(() => {
+        if (!open) {
+            return;
+        }
+        function handleClickOutside(ev: MouseEvent) {
+            if (containerRef.current && !containerRef.current.contains(ev.target as Node)) {
+                setOpen(false);
+            }
+        }
+        window.addEventListener("click", handleClickOutside);
+        return () => window.removeEventListener("click", handleClickOutside);
+    }, [open]);
+
+    function toggleSize(size: Exclude<SizeFilter, "all">) {
+        props.onSizeChange(props.sizeFilter === size ? "all" : size);
+    }
+
+    function toggleRanked(ranked: Exclude<RankedFilter, "all">) {
+        props.onRankedChange(props.rankedFilter === ranked ? "all" : ranked);
+    }
+
+    return (
+        <div className="GameHistoryFilterPopover" ref={containerRef}>
+            <button
+                type="button"
+                className={
+                    "sm GameHistoryFilterPopover-toggle" + (hasActiveFilter ? " filter-active" : "")
+                }
+                onClick={() => setOpen((v) => !v)}
+                aria-label={_("Filters")}
+                aria-expanded={open}
+            >
+                <i className="fa fa-filter" />
+            </button>
+            {open && (
+                <div className="GameHistoryFilterPopover-panel" role="dialog">
+                    <div className="btn-group">
+                        <button
+                            className={props.sizeFilter === "9x9" ? "primary sm" : "sm"}
+                            onClick={() => toggleSize("9x9")}
+                        >
+                            {_("9x9")}
+                        </button>
+                        <button
+                            className={props.sizeFilter === "13x13" ? "primary sm" : "sm"}
+                            onClick={() => toggleSize("13x13")}
+                        >
+                            {_("13x13")}
+                        </button>
+                        <button
+                            className={props.sizeFilter === "19x19" ? "primary sm" : "sm"}
+                            onClick={() => toggleSize("19x19")}
+                        >
+                            {_("19x19")}
+                        </button>
+                    </div>
+                    <div className="btn-group">
+                        <button
+                            className={
+                                !rankedDisabled && props.rankedFilter === "ranked"
+                                    ? "primary sm"
+                                    : "sm"
+                            }
+                            disabled={rankedDisabled}
+                            onClick={() => toggleRanked("ranked")}
+                        >
+                            {_("Ranked")}
+                        </button>
+                        <button
+                            className={
+                                !rankedDisabled && props.rankedFilter === "unranked"
+                                    ? "primary sm"
+                                    : "sm"
+                            }
+                            disabled={rankedDisabled}
+                            onClick={() => toggleRanked("unranked")}
+                        >
+                            {_("Unranked")}
+                        </button>
+                    </div>
+                    <div className="btn-group">
+                        <button
+                            className={
+                                !props.botDisabled && props.botFilter === "humans"
+                                    ? "primary sm"
+                                    : "sm"
+                            }
+                            disabled={props.botDisabled}
+                            onClick={() => props.onBotChange("humans")}
+                        >
+                            {_("Humans")}
+                        </button>
+                        <button
+                            className={props.botFilter === "bots" ? "primary sm" : "sm"}
+                            disabled={props.botDisabled}
+                            onClick={() => props.onBotChange("bots")}
+                        >
+                            {_("Bots")}
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -37,10 +37,17 @@ import { useUser } from "@/lib/hooks";
 import { GameNameForList } from "@/components/GobanLineSummary";
 import { get } from "@/lib/requests";
 import { MODERATOR_POWERS } from "@/lib/moderation";
+import {
+    GameHistoryFilterPopover,
+    SizeFilter,
+    RankedFilter,
+    BotFilter,
+} from "./GameHistoryFilterPopover";
 import "./GameHistoryTable.css";
 
 interface GameHistoryProps {
     user_id: number;
+    is_bot?: boolean;
 }
 
 interface AnnulmentGamesResponse {
@@ -95,12 +102,15 @@ interface GroomedGame {
 
 export function GameHistoryTable(props: GameHistoryProps) {
     const [player_filter, setPlayerFilter] = React.useState<number>();
-    const [game_history_board_size_filter, setGameHistoryBoardSizeFilter] = React.useState<string>(
-        preferences.get("game-history-size-filter"),
+    const [game_history_board_size_filter, setGameHistoryBoardSizeFilter] =
+        React.useState<SizeFilter>(preferences.get("game-history-size-filter") as SizeFilter);
+    const [game_history_ranked_filter, setGameHistoryRankedFilter] = React.useState<RankedFilter>(
+        preferences.get("game-history-ranked-filter") as RankedFilter,
     );
-    const [game_history_ranked_filter, setGameHistoryRankedFilter] = React.useState<string>(
-        preferences.get("game-history-ranked-filter"),
+    const [game_history_bot_filter, setGameHistoryBotFilter] = React.useState<BotFilter>(
+        preferences.get("game-history-bot-filter"),
     );
+    const effective_bot_filter: BotFilter = props.is_bot ? "bots" : game_history_bot_filter;
     const [hide_flags] = usePreference("moderator.hide-flags");
     const [selectModeActive, setSelectModeActive] = React.useState<boolean>(false);
     const [aiSelectMode, setAiSelectMode] = React.useState<boolean>(false);
@@ -211,18 +221,19 @@ export function GameHistoryTable(props: GameHistoryProps) {
         setIsAnnulQueueModalOpen(false);
     }
 
-    function toggleBoardSizeFilter(size_filter: string) {
-        const new_size_filter =
-            game_history_board_size_filter === size_filter ? "all" : size_filter;
-        setGameHistoryBoardSizeFilter(new_size_filter);
-        preferences.set("game-history-size-filter", new_size_filter);
+    function handleSizeChange(size: SizeFilter) {
+        setGameHistoryBoardSizeFilter(size);
+        preferences.set("game-history-size-filter", size);
     }
 
-    function toggleRankedFilter(ranked_filter: string) {
-        const new_ranked_filter =
-            game_history_ranked_filter === ranked_filter ? "all" : ranked_filter;
-        setGameHistoryRankedFilter(new_ranked_filter);
-        preferences.set("game-history-ranked-filter", new_ranked_filter);
+    function handleRankedChange(ranked: RankedFilter) {
+        setGameHistoryRankedFilter(ranked);
+        preferences.set("game-history-ranked-filter", ranked);
+    }
+
+    function handleBotChange(bot: BotFilter) {
+        setGameHistoryBotFilter(bot);
+        preferences.set("game-history-bot-filter", bot);
     }
 
     function game_history_groomer(results: rest_api.Game[]): GroomedGame[] {
@@ -396,81 +407,36 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                     </button>
                                 </div>
                             ) : null}
-                            <div className="btn-group">
-                                <button
-                                    className={
-                                        game_history_board_size_filter === "9x9"
-                                            ? "primary sm"
-                                            : "sm"
-                                    }
-                                    onClick={() => toggleBoardSizeFilter("9x9")}
-                                >
-                                    {_("9x9")}
-                                </button>
-                                <button
-                                    className={
-                                        game_history_board_size_filter === "13x13"
-                                            ? "primary sm"
-                                            : "sm"
-                                    }
-                                    onClick={() => toggleBoardSizeFilter("13x13")}
-                                >
-                                    {_("13x13")}
-                                </button>
-                                <button
-                                    className={
-                                        game_history_board_size_filter === "19x19"
-                                            ? "primary sm"
-                                            : "sm"
-                                    }
-                                    onClick={() => toggleBoardSizeFilter("19x19")}
-                                >
-                                    {_("19x19")}
-                                </button>
-                            </div>
-                            <div className="btn-group">
-                                <button
-                                    className={
-                                        game_history_ranked_filter === "ranked"
-                                            ? "primary sm"
-                                            : "sm"
-                                    }
-                                    onClick={() => toggleRankedFilter("ranked")}
-                                >
-                                    {_("Ranked")}
-                                </button>
-                                <button
-                                    className={
-                                        game_history_ranked_filter === "unranked"
-                                            ? "primary sm"
-                                            : "sm"
-                                    }
-                                    onClick={() => toggleRankedFilter("unranked")}
-                                >
-                                    {_("Unranked")}
-                                </button>
-                            </div>
+                            <GameHistoryFilterPopover
+                                sizeFilter={game_history_board_size_filter}
+                                onSizeChange={handleSizeChange}
+                                rankedFilter={game_history_ranked_filter}
+                                onRankedChange={handleRankedChange}
+                                botFilter={effective_bot_filter}
+                                onBotChange={handleBotChange}
+                                botDisabled={props.is_bot}
+                            />
                         </div>
                     </div>
                     <PaginatedTable
                         className="GameHistoryTable"
                         name="game-history"
                         method="GET"
-                        source={`players/${props.user_id}/games/`}
+                        source={`players/${props.user_id}/game_history/`}
                         filter={{
-                            source: "play",
-                            ended__isnull: false,
+                            bot_game: effective_bot_filter === "bots",
                             ...(player_filter !== undefined && {
-                                alt_player: player_filter,
+                                opponent: player_filter,
                             }),
                             ...(game_history_board_size_filter !== "all" && {
                                 height: getBoardSize(game_history_board_size_filter),
                                 width: getBoardSize(game_history_board_size_filter),
                             }),
-                            ...(game_history_ranked_filter !== "all" && {
-                                ranked: game_history_ranked_filter === "ranked",
-                                annulled: false, // Assume the user wants to filter annulled games
-                            }),
+                            ...(effective_bot_filter !== "bots" &&
+                                game_history_ranked_filter !== "all" && {
+                                    ranked: game_history_ranked_filter === "ranked",
+                                    annulled: false, // Assume the user wants to filter annulled games
+                                }),
                         }}
                         orderBy={["-ended"]}
                         groom={game_history_groomer}

--- a/src/views/User/User.tsx
+++ b/src/views/User/User.tsx
@@ -539,7 +539,7 @@ export function User(props: { user_id?: number }): React.ReactElement {
                     )}
 
                     <div className="row">
-                        <GameHistoryTable user_id={user.id} />
+                        <GameHistoryTable user_id={user.id} is_bot={user.is_bot} />
                     </div>
 
                     <div className="row">


### PR DESCRIPTION
Switches to the new optimized game history endpoint for faster and complete game history on player profiles. Also adds a human/bot filter for the game history table and collapses the filters under a filter icon dropdown.