### PR TITLE
fix(joseki): explorer now properly removes placed stones when resetting

### DIFF
--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -701,9 +701,9 @@ export function Joseki(): React.ReactElement {
     // ---- Goban initialization ----
     function initializeGoban(initial_position?: string) {
         // Skip destroy/recreate if the goban already exists and we have no
-        // initial_position to load. This avoids a redundant teardown of the
+        // last_click set. This avoids a redundant teardown of the
         // eagerly-created goban on first mount.
-        if (goban_ref.current != null && !initial_position) {
+        if (goban_ref.current != null && !last_click.current) {
             return;
         }
 

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -701,9 +701,10 @@ export function Joseki(): React.ReactElement {
     // ---- Goban initialization ----
     function initializeGoban(initial_position?: string) {
         // Skip destroy/recreate if the goban already exists and we have no
-        // last_click set. This avoids a redundant teardown of the
-        // eagerly-created goban on first mount.
-        if (goban_ref.current != null && !last_click.current) {
+        // initial_position to load and we just completed the first mount
+        // (detected by checking last_click). This avoids a redundant teardown
+        // of the eagerly-created goban on first mount.
+        if (goban_ref.current != null && !initial_position && !last_click.current) {
             return;
         }
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/online-go/online-go.com/commit/b402605bd0ab6a9b7f766215285a358c8c54c1c3 which caused stones to not be cleared from the Joseki Explorer when using the "fast backwards" button to reset the board.

## Cause

The old version avoided destroying the Goban on first mount by checking if the `initial_position` wasn't unset. However, this check generates a false-positive _whenever_ the Goban is being reset as those are also cases where we don't specify an initial position. This means that it is not properly destroyed when one tries to manually reset the board.

## Proposed Changes

Switched to checking if `last_click.current` is set (instead of `initial_position`) as the only time that could be `undefined` is when the component has just mounted.