### PR TITLE
feat: improved contrast-ratio for active state of the game history filter button

### DIFF
--- a/src/views/User/GameHistoryFilterPopover.css
+++ b/src/views/User/GameHistoryFilterPopover.css
@@ -20,12 +20,16 @@
     display: inline-block;
 
     .GameHistoryFilterPopover-toggle {
-        &.filter-active {
+        [data-theme="light"] &.filter-active {
             color: var(--primary);
+        }
 
-            .fa-filter {
-                color: var(--primary);
-            }
+        [data-theme="accessible"] &.filter-active {
+            color: var(--primary-light);
+        }
+
+        [data-theme="dark"] &.filter-active {
+            color: var(--primary-light);
         }
     }
 


### PR DESCRIPTION
Improves the contrast ratio of the active state of the game history filter toggle button (in non-light modes). This is especially an issue due to the lighter background of the toggle, as well as the narrowness of the icon.

This change does not bring the button into WCAG compliance but it brings it much closer (from `2.48:1` to `2.7:1`) without needing to define any new css variables. It might be best to do a full pass on contrast in the future, especially on the 'accessibility' site theme in mind.

Note: I also removed an unnecessary css rule that was setting the icon's 'color' when 'color' was already set on the toggle (its parent).