### PR TITLE
Css challengelist

### DIFF
--- a/src/views/Play/ChallengeLists.tsx
+++ b/src/views/Play/ChallengeLists.tsx
@@ -224,7 +224,7 @@ export function RengoList(props: RengoComponentProps): React.ReactElement {
 
     if (!anyChallengesToShow(filter, list)) {
         return (
-            <table id="rengo-table">
+            <table className="rengo-table">
                 <tbody>
                     <tr key="none-available">
                         <td colSpan={11}>
@@ -250,25 +250,35 @@ export function RengoList(props: RengoComponentProps): React.ReactElement {
     const corr_list = list.filter((c) => !isLiveGame(c.time_control_parameters, c.width, c.height));
 
     return (
-        <table id="rengo-table">
-            <tbody>
-                <tr className="challenge-row">
-                    <td className="cell break" colSpan={11}>
-                        {_("Rengo Live")}
-                    </td>
-                </tr>
-                {anyChallengesToShow(filter, live_list) && <RengoListHeaders />}
-                <RengoChallengeManagementList {...props} list={live_list} key="live" />
+        <>
+            <table className="rengo-table">
+                <thead>
+                    <tr className="challenge-row">
+                        <td className="cell break" colSpan={11}>
+                            {_("Rengo Live")}
+                        </td>
+                    </tr>
+                    {anyChallengesToShow(filter, live_list) && <RengoListHeaders />}
+                </thead>
+                <tbody>
+                    <RengoChallengeManagementList {...props} list={live_list} />
+                </tbody>
+            </table>
 
-                <tr className="challenge-row">
-                    <td className="cell break" colSpan={11}>
-                        {_("Rengo Correspondence")}
-                    </td>
-                </tr>
-                {anyChallengesToShow(filter, corr_list) && <RengoListHeaders />}
-                <RengoChallengeManagementList {...props} list={corr_list} key="corr" />
-            </tbody>
-        </table>
+            <table className="rengo-table">
+                <thead>
+                    <tr className="challenge-row">
+                        <td className="cell break" colSpan={11}>
+                            {_("Rengo Correspondence")}
+                        </td>
+                    </tr>
+                    {anyChallengesToShow(filter, corr_list) && <RengoListHeaders />}
+                </thead>
+                <tbody>
+                    <RengoChallengeManagementList {...props} list={corr_list} />
+                </tbody>
+            </table>
+        </>
     );
 }
 

--- a/src/views/Play/ChallengeLists.tsx
+++ b/src/views/Play/ChallengeLists.tsx
@@ -224,21 +224,25 @@ export function RengoList(props: RengoComponentProps): React.ReactElement {
 
     if (!anyChallengesToShow(filter, list)) {
         return (
-            <tr key="none-available">
-                <td colSpan={9}>
-                    <div className="ineligible">
-                        {
-                            filter.showIneligible
-                                ? _(
-                                      "(none)",
-                                  ) /* translators: There are no challenges in the system, nothing to list here */
-                                : _(
-                                      "(none available)",
-                                  ) /* translators: There are no challenges that this person is eligible for */
-                        }
-                    </div>
-                </td>
-            </tr>
+            <table id="rengo-table">
+                <tbody>
+                    <tr key="none-available">
+                        <td colSpan={11}>
+                            <div className="ineligible">
+                                {
+                                    filter.showIneligible
+                                        ? _(
+                                              "(none)",
+                                          ) /* translators: There are no challenges in the system, nothing to list here */
+                                        : _(
+                                              "(none available)",
+                                          ) /* translators: There are no challenges that this person is eligible for */
+                                }
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         );
     }
 
@@ -246,23 +250,25 @@ export function RengoList(props: RengoComponentProps): React.ReactElement {
     const corr_list = list.filter((c) => !isLiveGame(c.time_control_parameters, c.width, c.height));
 
     return (
-        <>
-            <tr className="challenge-row">
-                <td className="cell break" colSpan={11}>
-                    {_("Rengo Live")}
-                </td>
-            </tr>
-            {anyChallengesToShow(filter, live_list) && <RengoListHeaders />}
-            <RengoChallengeManagementList {...props} list={live_list} key="live" />
+        <table id="rengo-table">
+            <tbody>
+                <tr className="challenge-row">
+                    <td className="cell break" colSpan={11}>
+                        {_("Rengo Live")}
+                    </td>
+                </tr>
+                {anyChallengesToShow(filter, live_list) && <RengoListHeaders />}
+                <RengoChallengeManagementList {...props} list={live_list} key="live" />
 
-            <tr className="challenge-row">
-                <td className="cell break" colSpan={11}>
-                    {_("Rengo Correspondence")}
-                </td>
-            </tr>
-            {anyChallengesToShow(filter, corr_list) && <RengoListHeaders />}
-            <RengoChallengeManagementList {...props} list={corr_list} key="corr" />
-        </>
+                <tr className="challenge-row">
+                    <td className="cell break" colSpan={11}>
+                        {_("Rengo Correspondence")}
+                    </td>
+                </tr>
+                {anyChallengesToShow(filter, corr_list) && <RengoListHeaders />}
+                <RengoChallengeManagementList {...props} list={corr_list} key="corr" />
+            </tbody>
+        </table>
     );
 }
 

--- a/src/views/Play/ChallengeLists.tsx
+++ b/src/views/Play/ChallengeLists.tsx
@@ -248,19 +248,19 @@ export function RengoList(props: RengoComponentProps): React.ReactElement {
     return (
         <>
             <tr className="challenge-row">
-                <td className="cell">{_("Live:")}</td>
+                <td className="cell break" colSpan={11}>
+                    {_("Rengo Live")}
+                </td>
             </tr>
+            {anyChallengesToShow(filter, live_list) && <RengoListHeaders />}
             <RengoChallengeManagementList {...props} list={live_list} key="live" />
 
             <tr className="challenge-row">
-                <td className="cell" colSpan={10}>
-                    <hr />
+                <td className="cell break" colSpan={11}>
+                    {_("Rengo Correspondence")}
                 </td>
             </tr>
-
-            <tr className="challenge-row">
-                <td className="cell">{_("Correspondence:")}</td>
-            </tr>
+            {anyChallengesToShow(filter, corr_list) && <RengoListHeaders />}
             <RengoChallengeManagementList {...props} list={corr_list} key="corr" />
         </>
     );

--- a/src/views/Play/ChallengeLists.tsx
+++ b/src/views/Play/ChallengeLists.tsx
@@ -325,7 +325,7 @@ function RengoManageListItem(props: RengoComponentProps): React.ReactElement {
 
     return (
         <tr className={"challenge-row rengo-management-row"}>
-            <td className="cell" colSpan={10}>
+            <td className="cell" colSpan={11}>
                 <Card className="rengo-management-list-item">
                     <div className="rengo-management-header">
                         <span>{challenge.name}</span>

--- a/src/views/Play/ChallengeLists.tsx
+++ b/src/views/Play/ChallengeLists.tsx
@@ -453,7 +453,7 @@ function RengoListItem(props: RengoComponentProps): React.ReactElement {
             >
                 {challenge.width}x{challenge.height}
             </td>
-            <td>{shortShortTimeControl(challenge.time_control_parameters)}</td>
+            <td className="cell">{shortShortTimeControl(challenge.time_control_parameters)}</td>
             <td className="cell">{rengo_casual_mode_text}</td>
             <td className="cell">{rengo_auto_start_text}</td>
             <td className="cell">{challenge.rengo_participants.length}</td>

--- a/src/views/Play/CustomGames.tsx
+++ b/src/views/Play/CustomGames.tsx
@@ -35,13 +35,7 @@ import { allocateCanvasOrError } from "goban";
 import { Challenge, ChallengeFilter, ChallengeFilterKey } from "@/lib/challenge_utils";
 //import { challenge } from "@/components/ChallengeModal";
 import { useUser } from "@/lib/hooks";
-import {
-    CellBreaks,
-    ChallengeList,
-    ChallengeListHeaders,
-    RengoList,
-    RengoListHeaders,
-} from "./ChallengeLists";
+import { CellBreaks, ChallengeList, ChallengeListHeaders, RengoList } from "./ChallengeLists";
 //import { PlayContext } from "./context";
 import { anyChallengesToShow, challenge_sort, time_per_move_challenge_sort } from "./utils";
 //import { CreatedChallengeInfo } from "@/lib/types";
@@ -635,7 +629,7 @@ export function CustomGames(): React.ReactElement {
 
                                 <div className="challenge-row">
                                     <span className="cell break">{_("Short Games")}</span>
-                                    <CellBreaks width={8} />
+                                    <CellBreaks width={9} />
                                 </div>
 
                                 {anyChallengesToShow(filter, live_list) ? (
@@ -657,7 +651,7 @@ export function CustomGames(): React.ReactElement {
                                             "Daily Correspondence",
                                         )}
                                     </span>
-                                    <CellBreaks width={8} />
+                                    <CellBreaks width={9} />
                                 </div>
 
                                 {anyChallengesToShow(filter, correspondence_list) ? (
@@ -670,15 +664,8 @@ export function CustomGames(): React.ReactElement {
                             </div>
                             {filter.showRengo && (
                                 <div id="challenge-list">
-                                    <div className="challenge-row" style={{ marginTop: "1em" }}>
-                                        <span className="cell break">{_("Rengo")}</span>
-                                    </div>
                                     <table id="rengo-table">
-                                        <thead>
-                                            {anyChallengesToShow(filter, rengo_list) ? (
-                                                <RengoListHeaders />
-                                            ) : null}
-                                        </thead>
+                                        <thead></thead>
                                         <tbody>
                                             <RengoList
                                                 filter={filter}

--- a/src/views/Play/CustomGames.tsx
+++ b/src/views/Play/CustomGames.tsx
@@ -664,19 +664,14 @@ export function CustomGames(): React.ReactElement {
                             </div>
                             {filter.showRengo && (
                                 <div id="challenge-list">
-                                    <table id="rengo-table">
-                                        <thead></thead>
-                                        <tbody>
-                                            <RengoList
-                                                filter={filter}
-                                                list={rengo_list}
-                                                show_in_rengo_management_pane={
-                                                    show_in_rengo_management_pane
-                                                }
-                                                rengo_manage_pane_lock={rengo_manage_pane_lock}
-                                            />
-                                        </tbody>
-                                    </table>
+                                    <RengoList
+                                        filter={filter}
+                                        list={rengo_list}
+                                        show_in_rengo_management_pane={
+                                            show_in_rengo_management_pane
+                                        }
+                                        rengo_manage_pane_lock={rengo_manage_pane_lock}
+                                    />
                                 </div>
                             )}
                         </div>

--- a/src/views/Play/Play.css
+++ b/src/views/Play/Play.css
@@ -67,6 +67,11 @@
         .btn {
             padding-bottom: 0; /* override default that makes these look bottom heavy */
         }
+
+        .btn.success {
+            min-width: 6.0em;
+        }
+
     }
 
     .rengo-management-list-item {

--- a/src/views/Play/Play.css
+++ b/src/views/Play/Play.css
@@ -129,6 +129,7 @@
 
     #rengo-table {
         width: 100%;
+        border-collapse: collapse;
     }
 
     .MiniGoban {
@@ -211,31 +212,26 @@
         cursor: help;
     }
 
-    /* Flex to escape from the containing table formats */
     .challenge-row {
-        padding-top: 0.2em;
-        padding-bottom: 0.2em;
         display: table-row;
         font-size: 0.85em;
         white-space: nowrap;
 
         .head {
-            padding-left: 0.5em;
+            padding: 0.7em 0.5em;
             display: table-cell;
             text-align: left;
-            font-weight: bold;
+            font-weight: 400;
             font-size: 0.8em;
-        }
-
-        .head.time-control-header {
-            /* padding-left: 4em; */
-            text-align: left;
+            color: var(--shade1);
+            border-bottom: 1px solid var(--shade4);
         }
 
         .cell {
-            padding-left: 0.5em;
+            padding: 0.4em 0.5em;
             display: table-cell;
             text-align: left;
+            border-bottom: 1px solid var(--shade4);
             position: relative;
         }
 
@@ -275,8 +271,12 @@
         }
 
         .break {
-            border-top: 1px solid #888;
-            border-bottom: 1px solid #888;
+            padding-top: 1.5em;
+            padding-bottom: 0.3em;
+            font-weight: bold;
+            font-size: 0.9em;
+            color: var(--shade1);
+            border-bottom: 1px solid var(--shade3);
         }
 
         .bold {

--- a/src/views/Play/Play.css
+++ b/src/views/Play/Play.css
@@ -132,7 +132,7 @@
         padding-top: 1rem;
     }
 
-    #rengo-table {
+    .rengo-table {
         width: 100%;
         border-collapse: collapse;
     }


### PR DESCRIPTION
This PR:

1. Makes css changes to the challengelist to make it look a bit more like a table and give it breathing room
2. Splits Rengo into "Rengo Live" and "Rengo Correspondence" visually
3. Fixes minor other styling problems (line under header was the wrong length, one cell was missing the cell css class)

Side by side with ordinary ogs. Individual cells have a bit more padding
<img width="1759" height="748" alt="Screenshot 2026-04-26 at 7 22 46 AM" src="https://github.com/user-attachments/assets/55a7c197-6728-4dbf-8c73-acd70c7719e7" />

Rengo update: split it into two visual tables without changing the underlying js.
<img width="1764" height="314" alt="Screenshot 2026-04-26 at 7 25 14 AM" src="https://github.com/user-attachments/assets/0b99ee03-ac4f-4fb4-90f2-071031e3f720" />

Mobile screenshot. Counterintuitively giving it a bit more space might make it easier to read and easier to click buttons on mobile.

<img width="992" height="671" alt="Screenshot 2026-04-26 at 7 24 05 AM" src="https://github.com/user-attachments/assets/60afb09b-727c-4c23-8be6-ef876293523d" />

