### PR TITLE
fix: correct textarea baseline alignment in chat input

### DIFF
--- a/src/components/TabCompleteInput/TabCompleteInput.css
+++ b/src/components/TabCompleteInput/TabCompleteInput.css
@@ -60,4 +60,5 @@
     border-top: none;
     padding: 3px 3px;
     outline: none;
+    vertical-align: bottom;
 }


### PR DESCRIPTION
This PR fixes the textarea alignment issue in the game chat.

After feedback from godeon on the [forum](https://forums.online-go.com/t/how-about-adding-multi-line-input-support-for-chat/59854/7), I noticed that the chat input displays correctly in Firefox but is misaligned in Chrome.

This is caused by differences in how browsers calculate the textarea baseline. I added `vertical-align: bottom` to force the baseline to align at the bottom of the element, restoring proper alignment across browsers.

In Chrome before:
<img width="350" height="45" alt="image" src="https://github.com/user-attachments/assets/7916e2b3-b055-4aea-900c-57aacc8d0924" />

after:
<img width="367" height="36" alt="image" src="https://github.com/user-attachments/assets/863722e0-59c0-44a5-889d-254189047bef" />
