### PR TITLE
Add "Hide annulled games" games button to filters

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -209,7 +209,7 @@ export const defaults = {
     "game-history-size-filter": "all",
     "game-history-ranked-filter": "all",
     "game-history-bot-filter": "humans" as "humans" | "bots",
-    "game-history-annulled-filter": "hide" as "all" | "hide",
+    "game-history-annulled-filter": "all" as "all" | "hide",
 
     "help-system-enabled": true,
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -209,6 +209,7 @@ export const defaults = {
     "game-history-size-filter": "all",
     "game-history-ranked-filter": "all",
     "game-history-bot-filter": "humans" as "humans" | "bots",
+    "game-history-annulled-filter": "all",
 
     "help-system-enabled": true,
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -209,7 +209,7 @@ export const defaults = {
     "game-history-size-filter": "all",
     "game-history-ranked-filter": "all",
     "game-history-bot-filter": "humans" as "humans" | "bots",
-    "game-history-annulled-filter": "all",
+    "game-history-annulled-filter": "hide" as "all" | "hide",
 
     "help-system-enabled": true,
 

--- a/src/views/User/GameHistoryFilterPopover.tsx
+++ b/src/views/User/GameHistoryFilterPopover.tsx
@@ -22,6 +22,7 @@ import "./GameHistoryFilterPopover.css";
 export type SizeFilter = "all" | "9x9" | "13x13" | "19x19";
 export type RankedFilter = "all" | "ranked" | "unranked";
 export type BotFilter = "humans" | "bots";
+export type AnnulledFilter = "all" | "hide";
 
 interface GameHistoryFilterPopoverProps {
     sizeFilter: SizeFilter;
@@ -31,6 +32,8 @@ interface GameHistoryFilterPopoverProps {
     botFilter: BotFilter;
     onBotChange: (bot: BotFilter) => void;
     botDisabled?: boolean;
+    annulledFilter: AnnulledFilter;
+    onAnnulledChange: (annulled: AnnulledFilter) => void;
 }
 
 export function GameHistoryFilterPopover(props: GameHistoryFilterPopoverProps) {
@@ -41,7 +44,8 @@ export function GameHistoryFilterPopover(props: GameHistoryFilterPopoverProps) {
     const hasActiveFilter =
         props.sizeFilter !== "all" ||
         (!props.botDisabled && props.botFilter !== "humans") ||
-        (!rankedDisabled && props.rankedFilter !== "all");
+        (!rankedDisabled && props.rankedFilter !== "all") ||
+        props.annulledFilter !== "all";
 
     React.useEffect(() => {
         if (!open) {
@@ -141,6 +145,18 @@ export function GameHistoryFilterPopover(props: GameHistoryFilterPopoverProps) {
                             onClick={() => props.onBotChange("bots")}
                         >
                             {_("Bots")}
+                        </button>
+                    </div>
+                    <div className="btn-group">
+                        <button
+                            className={props.annulledFilter === "hide" ? "primary sm" : "sm"}
+                            onClick={() =>
+                                props.onAnnulledChange(
+                                    props.annulledFilter === "hide" ? "all" : "hide",
+                                )
+                            }
+                        >
+                            {_("Hide Annulled")}
                         </button>
                     </div>
                 </div>

--- a/src/views/User/GameHistoryFilterPopover.tsx
+++ b/src/views/User/GameHistoryFilterPopover.tsx
@@ -156,7 +156,7 @@ export function GameHistoryFilterPopover(props: GameHistoryFilterPopoverProps) {
                                 )
                             }
                         >
-                            {_("Hide Annulled")}
+                            {_("Hide annulled games")}
                         </button>
                     </div>
                 </div>

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -445,7 +445,6 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             ...(effective_bot_filter !== "bots" &&
                                 game_history_ranked_filter !== "all" && {
                                     ranked: game_history_ranked_filter === "ranked",
-                                    annulled: false, // Assume the user wants to filter annulled games
                                 }),
                             ...(game_history_annulled_filter === "hide" && {
                                 annulled: false,

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -42,6 +42,7 @@ import {
     SizeFilter,
     RankedFilter,
     BotFilter,
+    AnnulledFilter,
 } from "./GameHistoryFilterPopover";
 import "./GameHistoryTable.css";
 
@@ -110,6 +111,10 @@ export function GameHistoryTable(props: GameHistoryProps) {
     const [game_history_bot_filter, setGameHistoryBotFilter] = React.useState<BotFilter>(
         preferences.get("game-history-bot-filter"),
     );
+    const [game_history_annulled_filter, setGameHistoryAnnulledFilter] =
+        React.useState<AnnulledFilter>(
+            preferences.get("game-history-annulled-filter") as AnnulledFilter,
+        );
     const effective_bot_filter: BotFilter = props.is_bot ? "bots" : game_history_bot_filter;
     const [hide_flags] = usePreference("moderator.hide-flags");
     const [selectModeActive, setSelectModeActive] = React.useState<boolean>(false);
@@ -234,6 +239,11 @@ export function GameHistoryTable(props: GameHistoryProps) {
     function handleBotChange(bot: BotFilter) {
         setGameHistoryBotFilter(bot);
         preferences.set("game-history-bot-filter", bot);
+    }
+
+    function handleAnnulledChange(annulled: AnnulledFilter) {
+        setGameHistoryAnnulledFilter(annulled);
+        preferences.set("game-history-annulled-filter", annulled);
     }
 
     function game_history_groomer(results: rest_api.Game[]): GroomedGame[] {
@@ -415,6 +425,8 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 botFilter={effective_bot_filter}
                                 onBotChange={handleBotChange}
                                 botDisabled={props.is_bot}
+                                annulledFilter={game_history_annulled_filter}
+                                onAnnulledChange={handleAnnulledChange}
                             />
                         </div>
                     </div>
@@ -435,8 +447,10 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             ...(effective_bot_filter !== "bots" &&
                                 game_history_ranked_filter !== "all" && {
                                     ranked: game_history_ranked_filter === "ranked",
-                                    annulled: false, // Assume the user wants to filter annulled games
                                 }),
+                            ...(game_history_annulled_filter === "hide" && {
+                                annulled: false,
+                            }),
                         }}
                         orderBy={["-ended"]}
                         groom={game_history_groomer}

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -112,9 +112,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
         preferences.get("game-history-bot-filter"),
     );
     const [game_history_annulled_filter, setGameHistoryAnnulledFilter] =
-        React.useState<AnnulledFilter>(
-            preferences.get("game-history-annulled-filter") as AnnulledFilter,
-        );
+        React.useState<AnnulledFilter>(preferences.get("game-history-annulled-filter"));
     const effective_bot_filter: BotFilter = props.is_bot ? "bots" : game_history_bot_filter;
     const [hide_flags] = usePreference("moderator.hide-flags");
     const [selectModeActive, setSelectModeActive] = React.useState<boolean>(false);
@@ -447,6 +445,7 @@ export function GameHistoryTable(props: GameHistoryProps) {
                             ...(effective_bot_filter !== "bots" &&
                                 game_history_ranked_filter !== "all" && {
                                     ranked: game_history_ranked_filter === "ranked",
+                                    annulled: false, // Assume the user wants to filter annulled games
                                 }),
                             ...(game_history_annulled_filter === "hide" && {
                                 annulled: false,


### PR DESCRIPTION
Fixes #
Implemented the proposed feature: https://github.com/online-go/online-go.com/issues/3536

## Proposed Changes

  - Add the button for filterin annulled games.
  - From my point of view, it seems like default behaviour could be hiding the annulled.
