### PR TITLE
fix: update border and radius of learning section

### DIFF
--- a/src/views/LearningHub/LearningHub.css
+++ b/src/views/LearningHub/LearningHub.css
@@ -170,16 +170,18 @@
                         }
                     }
                 }
-            }
 
-            &:has(.contents.expanded) .section-header {
-                position: sticky;
-                top: 0;
-                z-index: 10;
-                /*border-top-left-radius: 0.5rem; */
-                /*border-top-right-radius: 0.5rem; */
-                border: 1px solid;
-                border-color: var(--shade4);
+                &:has(+ .contents.collapsed) {
+                    border-radius: 0.5rem;
+                }
+
+                &:has(+ .contents.expanded) {
+                    position: sticky;
+                    top: 0;
+                    z-index: 10;
+                    border: 1px solid;
+                    border-color: var(--shade4);
+                }
             }
 
             /* Collapsible content area with proper card styling */
@@ -187,9 +189,6 @@
                 padding: 1.5rem;
                 background-color: var(--shade5); /* Use shade5 instead of shade6 for compatibility */
                 border-radius: 0 0 0.5rem 0.5rem;
-                border: 1px solid;
-                border-color: var(--shade4);
-                border-top: none;
                 display: grid;
                 /* Use auto-fit with a smaller minimum to allow more flexibility */
                 grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));


### PR DESCRIPTION
Two changes in this PR

1. remove the bottom border from learninghub sections
2. change the border radius to rounded when section is collapsed

Before
<img width="1294" height="648" alt="image" src="https://github.com/user-attachments/assets/e5a941f1-a7ef-40a4-9415-0f4626d0f01e" />

After
<img width="1294" height="648" alt="image" src="https://github.com/user-attachments/assets/4af6fb99-bd3f-49fa-9686-aeb05f7ce965" />

Dark
<img width="1294" height="648" alt="image" src="https://github.com/user-attachments/assets/5f536607-d129-4815-8a33-64ca895154da" />
