### PR TITLE
Scroll chat on keypress

### DIFF
--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -563,6 +563,12 @@ function ChatInput({
 
     const onKeyPress = useCallback(
         (event: React.KeyboardEvent<HTMLTextAreaElement>): boolean | undefined => {
+            const lines = document.querySelector(".chat-lines") as HTMLElement | null;
+            if (lines) {
+                lines.scrollTop = 0;
+                scrolled_to_bottom = true;
+            }
+
             if (!event.shiftKey && event.key === "Enter") {
                 const input = event.target as HTMLTextAreaElement;
                 if (!socket.connected) {

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -563,10 +563,14 @@ function ChatInput({
 
     const onKeyPress = useCallback(
         (event: React.KeyboardEvent<HTMLTextAreaElement>): boolean | undefined => {
-            const lines = document.querySelector(".chat-lines") as HTMLElement | null;
-            if (lines) {
-                lines.scrollTop = 0;
-                scrolled_to_bottom = true;
+            if (event.key.length === 1) {
+                const lines = (event.target as HTMLElement)
+                    .closest(".ChatLog")
+                    ?.querySelector(".chat-lines") as HTMLElement | null;
+                if (lines) {
+                    lines.scrollTop = 0;
+                    scrolled_to_bottom = true;
+                }
             }
 
             if (!event.shiftKey && event.key === "Enter") {

--- a/src/components/Chat/ChatLog.tsx
+++ b/src/components/Chat/ChatLog.tsx
@@ -569,7 +569,6 @@ function ChatInput({
                     ?.querySelector(".chat-lines") as HTMLElement | null;
                 if (lines) {
                     lines.scrollTop = 0;
-                    scrolled_to_bottom = true;
                 }
             }
 


### PR DESCRIPTION
People in chat were talking about sending messages and realizing the conversation had moved on from the message they were looking at. This is *a* fix to the issue and one proposed by the chat, but I'm not sure if it's the best fix.

In this code we add a few lines to `onKeyPress` for the chat input to scroll to the bottom. This means as the user starts typing it will move them, but since that component is autofocused it means that any keypress will move them. I think it would probably be ok but worth thinking about since it would catch like... them switching to another tab using a browser hotkey.

The other options to consider are adding it to send, or being more restrictive about which keyboard events we want to scroll for. Another proposal in the chat is some sort of visual indicator that they've gotten new messages. If chat had that, I think the standard is to click it to scroll the new messages into view. Adding that feature would be a lot more work than this though.

Putting this PR up as is for discussion, can modify it to whatever people think would be best.
