### PR TITLE
Allow custom games buttons to expand in other languages

### DIFF
--- a/src/views/LearningHub/LearningHub.css
+++ b/src/views/LearningHub/LearningHub.css
@@ -254,7 +254,7 @@
                 text-decoration: none;
                 width: 100%; /* Make cards responsive to grid cell width */
                 max-width: 23rem; /* But don't exceed original max size */
-                height: 5rem;
+                min-height: 5rem;
                 color: #f9f9f9;
                 border-radius: 0.3rem;
                 text-align: left;

--- a/src/views/LibraryPlayer/LibraryPlayer.css
+++ b/src/views/LibraryPlayer/LibraryPlayer.css
@@ -214,6 +214,11 @@
         align-items: center;
         gap: 1rem;
 
+        button {
+            height: auto;
+            min-height: 2em;
+        }
+
         input[type='text'] {
             min-width: 200px;
             margin: 0;

--- a/src/views/Play/CustomGames.css
+++ b/src/views/Play/CustomGames.css
@@ -96,7 +96,8 @@
     }
 
     button {
-        height: 3rem;
+        height: auto;
+        min-height: 3rem;
         font-size: 1.3rem;
         width: 17rem;
     }


### PR DESCRIPTION
Fixes #3541. I don't know if this should close that issue since I'm sure there are other places this happens. 

The buttons in question have fixed height. Giving them a min-height instead allows them to expand if the translated text is longer than would fit. The `height: auto` is necessary because otherwise `button, a.btn, .btn` sets a height (2em) which is also too small.

<img width="1000" height="437" alt="image" src="https://github.com/user-attachments/assets/e3e3937a-3aaa-4562-a421-f40b24d2859a" />
