### PR TITLE
Remove /lmgtfy from ChatLine

### DIFF
--- a/src/components/Chat/ChatLine.tsx
+++ b/src/components/Chat/ChatLine.tsx
@@ -88,12 +88,6 @@ export function ChatLine(props: ChatLineInterface): React.ReactElement {
         if (body.substr(0, 8) === "/google ") {
             body = generateChatSearchLine("https://www.google.com/#q=", "/google ", body);
         }
-
-        /* cspell:disable-next-line */
-        if (body.substr(0, 8) === "/lmgtfy ") {
-            /* cspell:disable-next-line */
-            body = generateChatSearchLine("https://www.lmgtfy.com/?q=", "/lmgtfy ", body);
-        }
     }
 
     const mentions = name_match_regex.test(body);


### PR DESCRIPTION
The www.lmgtfy.com website is misconfigured and using this leads to an error/warning in most browsers, e.g.

```
Did Not Connect: Potential Security Issue

Firefox detected an issue and did not continue to www.lmgtfy.app. The website is either misconfigured or your computer clock is set to the wrong time.

What can you do about it?

www.lmgtfy.app has a security policy called HTTP Strict Transport Security (HSTS), which means that Firefox can only connect to it securely. You can’t add an exception to visit this site.

Your computer clock is set to May 7, 2026. Make sure your computer is set to the correct date, time, and time zone in your system settings, and then refresh www.lmgtfy.app.

If your clock is already set to the right time, the website is likely misconfigured, and there is nothing you can do to resolve the issue. You can notify the website’s administrator about the problem.
```

This change removes the shortcut. It looks like there are replacement websites for lmgtfy.com so that is an alternative solution if there is a preference.