### PR TITLE
Refactor Joseki comments from a takeover panel to an inline toggle below the explore pane, and remove the comments button from the actions panel

### DIFF
--- a/src/components/GobanView/GobanView.css
+++ b/src/components/GobanView/GobanView.css
@@ -65,6 +65,17 @@
         overflow: hidden;
     }
 
+    .GobanView-header {
+        flex-shrink: 0;
+        padding: 0.6rem 0.875rem;
+        font-size: 1.5rem;
+        font-weight: 600;
+        text-align: center;
+        color: var(--fg);
+        background: var(--shade4);
+        border-bottom: 1px solid var(--shade3);
+    }
+
     .GobanView-sidebar-content {
         flex-grow: 1;
         overflow-y: auto;

--- a/src/components/GobanView/GobanView.tsx
+++ b/src/components/GobanView/GobanView.tsx
@@ -66,6 +66,10 @@ interface GobanViewProps {
      *  class is added to the GobanView root so portrait CSS can leave room
      *  for it above the tab bar. */
     customSlider?: React.ReactNode;
+    /** Optional title bar rendered at the top of the sidebar (landscape) or
+     *  above the goban (portrait). Stays visible across takeovers so
+     *  consumers can use it to label the current view. */
+    header?: React.ReactNode;
     ref?: React.Ref<GobanViewRef>;
 }
 
@@ -106,6 +110,7 @@ function GobanViewComponent({
     children,
     defaultActiveTakeover,
     customSlider,
+    header,
     ref,
 }: GobanViewProps): React.ReactElement {
     const { tabs, others } = React.useMemo(() => partitionChildren(children), [children]);
@@ -302,6 +307,7 @@ function GobanViewComponent({
                             (className ? ` ${className}` : "")
                         }
                     >
+                        {header && <div className="GobanView-header">{header}</div>}
                         <div className="GobanView-center">
                             <GobanContainer onResize={onResize} />
                         </div>
@@ -334,6 +340,7 @@ function GobanViewComponent({
                         <GobanContainer onResize={onResize} />
                     </div>
                     <div className="GobanView-sidebar">
+                        {header && <div className="GobanView-header">{header}</div>}
                         <div className="GobanView-sidebar-content">
                             {inlinePanels.map((t) => renderPanel(t, isInlineVisible(t)))}
                             {takeoverPanels.map((t) => renderPanel(t, activeTakeover === t.id))}

--- a/src/views/Joseki/ExplorePane.tsx
+++ b/src/views/Joseki/ExplorePane.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 
-import { _, pgettext } from "@/lib/translate";
+import { _ } from "@/lib/translate";
 import { AutoTranslate } from "@/components/AutoTranslate";
 import { applyJosekiMarkdown } from "./joseki-utils";
 
@@ -27,31 +27,6 @@ export interface ExploreProps {
     description: string;
     position_type: string;
     see_also: number[];
-    /** Lowercased category string (e.g. "ideal", "good", "mistake", "trick",
-     *  "question") when a documented pass continuation exists at this
-     *  position; false otherwise. */
-    pass_available: boolean | string;
-    onExploreTenuki: () => void;
-}
-
-function tenukiMessage(category: string): string | null {
-    switch (category) {
-        // Ideal / good show only the button — colored border carries the meaning.
-        case "ideal":
-        case "good":
-            return null;
-        case "mistake":
-            return pgettext("Joseki: tenuki outcome label", "Tenuki would be a mistake here.");
-        case "trick":
-            return pgettext("Joseki: tenuki outcome label", "Tenuki would be a trick move here.");
-        case "question":
-            return pgettext("Joseki: tenuki outcome label", "Tenuki is questioned here.");
-        default:
-            return pgettext(
-                "Joseki: tenuki outcome label",
-                "A tenuki continuation is documented here.",
-            );
-    }
 }
 
 export function ExplorePane(props: ExploreProps): React.ReactElement {
@@ -59,9 +34,6 @@ export function ExplorePane(props: ExploreProps): React.ReactElement {
 
     // Onboarding hint shown only at root with no curated description.
     const show_root_hint = props.position_id === "root" && !props.description;
-
-    const tenuki_category = typeof props.pass_available === "string" ? props.pass_available : null;
-    const tenuki_msg = tenuki_category ? tenukiMessage(tenuki_category) : null;
 
     return (
         <div className="explore-pane">
@@ -86,14 +58,6 @@ export function ExplorePane(props: ExploreProps): React.ReactElement {
                                 {node}
                             </Link>
                         ))}
-                    </div>
-                )}
-                {tenuki_category && (
-                    <div className="joseki-tenuki-info">
-                        {tenuki_msg && <span className="joseki-tenuki-message">{tenuki_msg}</span>}
-                        <button className="joseki-tenuki-explore" onClick={props.onExploreTenuki}>
-                            {pgettext("Joseki: explore the tenuki continuation", "Explore tenuki")}
-                        </button>
                     </div>
                 )}
             </div>

--- a/src/views/Joseki/Joseki.css
+++ b/src/views/Joseki/Joseki.css
@@ -39,22 +39,34 @@
         }
     }
 
-    .joseki-tenuki-info {
-        display: flex;
-        flex-wrap: wrap;
+    .Joseki-tenuki-button {
+        flex-shrink: 0;
+        padding: 0.15rem 0.6rem;
+        height: var(--thumb-size);
+        display: inline-flex;
         align-items: center;
-        gap: 0.5rem;
-        padding-top: 0.25rem;
-        font-size: 0.9rem;
-    }
+        font-size: 0.8rem;
+        line-height: 1;
+        border-left-width: 0.25rem;
+        border-left-style: solid;
 
-    .joseki-tenuki-message {
-        color: var(--fg);
+        &.tenuki-border-gray {
+            border-left-color: color-mix(in srgb, var(--shade2) 50%, transparent);
+        }
+        &.tenuki-border-green {
+            border-left-color: #00830080;
+        }
+        &.tenuki-border-yellow {
+            border-left-color: #c79a0080;
+        }
+        &.tenuki-border-red {
+            border-left-color: #b3001e80;
+        }
     }
 
     .Joseki-throbber-overlay {
         position: absolute;
-        right: 0.5rem;
+        right: 0;
         top: 50%;
         transform: translateY(-50%);
         pointer-events: none;
@@ -114,6 +126,13 @@
         font-size: 0.85rem;
         color: var(--shade1);
         font-style: italic;
+    }
+
+    .joseki-filter-actions {
+        margin-top: auto;
+        display: flex;
+        justify-content: flex-end;
+        padding-top: 0.5rem;
     }
 
     /* ---- Empty/root onboarding hint ---- */
@@ -393,14 +412,6 @@
         min-height: 0;
         overflow-y: auto;
 
-        .play-prompt {
-            font-size: 1.5rem;
-            font-weight: 600;
-            text-align: center;
-            padding: 1.5rem 0.5rem;
-            color: var(--fg);
-        }
-
         .fa {
             margin-right: 0.4rem;
             min-width: 1.25rem;
@@ -414,6 +425,15 @@
         .fa-times {
             color: red;
         }
+    }
+
+    .play-prompt {
+        flex-shrink: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+        text-align: center;
+        padding: 1rem 0.5rem;
+        color: var(--fg);
     }
 
     /* ---- Edit pane ---- */

--- a/src/views/Joseki/Joseki.css
+++ b/src/views/Joseki/Joseki.css
@@ -155,7 +155,17 @@
         }
     }
 
-    /* ---- Comments takeover ---- */
+    /* ---- Comments ---- */
+
+    .joseki-inline-comments {
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        max-height: 24rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid var(--shade4);
+    }
 
     .discussion-container {
         flex-grow: 1;

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -166,13 +166,6 @@ export function Joseki(): React.ReactElement {
 
     const gobanViewRef = React.useRef<GobanViewRef>(null);
     const moreActionsPopoverRef = React.useRef<PopOver | null>(null);
-    // Tracks how many history.forward() steps are available because the
-    // user just walked back via the move bar (or browser back). Reset to
-    // zero whenever a new push happens (forward exploration). Browser-
-    // initiated forward/back can desync this slightly; the worst case is
-    // the move-bar forward briefly falls back to placing a best_move
-    // instead of replaying the redo entry.
-    const forward_history_count = React.useRef(0);
     const goban_div = React.useMemo(() => {
         const div = document.createElement("div");
         div.className = "Goban";
@@ -331,20 +324,17 @@ export function Joseki(): React.ReactElement {
             renderCurrentJosekiPosition();
         }
 
-        // Keep the URL aligned with the loaded position. Push for forward
-        // navigation (stone clicks from a /joseki/<id> URL move on to a
-        // new /joseki/<id>) so each move gets its own history entry; replace
-        // for the initial /joseki → /joseki/<root> settle; skip when the
-        // URL already matches (popstate-driven loads).
+        // Keep the URL aligned with the loaded position via replaceState
+        // only — joseki is a sub-app with its own internal navigation
+        // (move_trace / trace_index), so we deliberately do not pollute
+        // the browser's history with one entry per stone click. Browser
+        // back leaves the joseki view, which is the expected behavior;
+        // in-page navigation goes through backOneMove / forwardOneMove
+        // and never touches window.history.
         const new_url = "/joseki/" + position.node_id;
         const old_pathname = window.location.pathname;
         if (old_pathname !== new_url) {
-            if (old_pathname.startsWith("/joseki/")) {
-                window.history.pushState({}, "", new_url);
-                forward_history_count.current = 0;
-            } else {
-                window.history.replaceState({}, "", new_url);
-            }
+            window.history.replaceState({}, "", new_url);
         }
     }
 
@@ -555,23 +545,29 @@ export function Joseki(): React.ReactElement {
                 set_move_string(ms); // trigger re-render to clear highlight class
                 goban_ref.current!.enableStonePlacement();
             } else if (S.current.current_move_category !== "new") {
-                const stepping_back_to = previous_position_ref.current.node_id as string;
-                fetchNextMovesFor(stepping_back_to);
-                trace_index.current--;
-                if (trace_index.current === -1) {
-                    trace_index.current = 0;
-                    move_trace.current.unshift(stepping_back_to);
-                } else if (
-                    move_trace.current[trace_index.current] !== stepping_back_to &&
-                    move_trace.current[trace_index.current] !== "root"
-                ) {
-                    console.log(
-                        "** whoa, move trace out of sync",
-                        move_trace.current[trace_index.current],
-                        stepping_back_to,
-                    );
-                    trace_index.current = 0;
-                    move_trace.current = [stepping_back_to];
+                const parent_node_id = previous_position_ref.current?.node_id;
+                if (parent_node_id === undefined) {
+                    // At the root of the joseki tree; nothing to back to.
+                    goban_ref.current!.enableStonePlacement();
+                } else {
+                    const stepping_back_to = parent_node_id + "";
+                    fetchNextMovesFor(stepping_back_to);
+                    trace_index.current--;
+                    if (trace_index.current === -1) {
+                        trace_index.current = 0;
+                        move_trace.current.unshift(stepping_back_to);
+                    } else if (
+                        move_trace.current[trace_index.current] !== stepping_back_to &&
+                        move_trace.current[trace_index.current] !== "root"
+                    ) {
+                        console.log(
+                            "** whoa, move trace out of sync",
+                            move_trace.current[trace_index.current],
+                            stepping_back_to,
+                        );
+                        trace_index.current = 0;
+                        move_trace.current = [stepping_back_to];
+                    }
                 }
             } else {
                 const play = ".root." + ms.replace(/,/g, ".");
@@ -808,11 +804,24 @@ export function Joseki(): React.ReactElement {
         if (S.current.throb) {
             return;
         }
-        // Drive back through the browser history. Each forward move was
-        // pushed by processNewJosekiPosition, so popstate / location effect
-        // takes care of reloading the previous position.
-        forward_history_count.current++;
-        window.history.back();
+        if (back_stepping.current) {
+            return;
+        }
+        const goban = goban_ref.current;
+        if (!goban || goban.engine.cur_move.move_number === 0) {
+            return;
+        }
+        // Step back on the goban's own move tree; the back_stepping flag
+        // routes the resulting onBoardUpdate into processPlacement's
+        // recovery branch, which fetches the parent's metadata and adjusts
+        // trace_index / move_trace. We deliberately do NOT touch
+        // window.history here — the move bar is in-view navigation only and
+        // must never escape the joseki view. (history.back() from a deep-
+        // linked /joseki/<id> would otherwise jump back to whatever
+        // non-joseki page the user came from, which is the "back sent me
+        // home" symptom.)
+        back_stepping.current = true;
+        goban.showPrevious();
     }
 
     function backOneMoveKey() {
@@ -825,33 +834,18 @@ export function Joseki(): React.ReactElement {
         if (S.current.throb) {
             return;
         }
-        // Redo a back via browser history when one is available.
-        if (forward_history_count.current > 0) {
-            forward_history_count.current--;
-            window.history.forward();
+        // Forward only retraces a branch the user actually walked — we
+        // deliberately do not auto-place a "best next move" when at the
+        // leaf of the trace.
+        if (trace_index.current >= move_trace.current.length - 1) {
             return;
         }
-        // At the leaf of explored history — pick the best next move and
-        // place it. processNewJosekiPosition will push the resulting URL.
-        if (next_moves_ref.current.length > 0) {
-            const best_move = next_moves_ref.current.reduce(
-                (
-                    prev_move: { [key: string]: string | number },
-                    next_move: { [key: string]: string | number },
-                ) =>
-                    (prev_move.variation_label as string) > (next_move.variation_label as string) &&
-                    next_move.placement !== "pass"
-                        ? next_move
-                        : prev_move,
-            );
-            doPlacement(best_move.placement as string);
+        const target_id = move_trace.current[trace_index.current + 1];
+        const cached = cached_positions_ref.current[target_id];
+        if (!cached || typeof cached.placement !== "string") {
+            return;
         }
-    }
-
-    function forwardOneMoveKey() {
-        if (S.current.mode !== PageMode.Play) {
-            forwardOneMove();
-        }
+        doPlacement(cached.placement);
     }
 
     function doPlacement(placement: string) {
@@ -865,6 +859,12 @@ export function Joseki(): React.ReactElement {
                 console.warn(e);
             }
             on_board_update_ref.current();
+        }
+    }
+
+    function forwardOneMoveKey() {
+        if (S.current.mode !== PageMode.Play) {
+            forwardOneMove();
         }
     }
 
@@ -1080,9 +1080,12 @@ export function Joseki(): React.ReactElement {
         }
         // Mirror the move-bar buttons' direction gating: Play mode
         // restricts navigation to back-after-mistake and never forward.
-        // Without this guard the slider could drag past those rules.
-        const can_step_back = mode !== PageMode.Play || played_mistake.current;
-        const can_step_fwd = mode !== PageMode.Play;
+        // Also gate on what backOneMove / forwardOneMove will actually
+        // do — otherwise the slider can drag to an unreachable target
+        // and park indefinitely calling a no-op handler.
+        const can_step_back = (mode !== PageMode.Play || played_mistake.current) && current > 0;
+        const can_step_fwd =
+            mode !== PageMode.Play && trace_index.current < move_trace.current.length - 1;
         if (current < slider_target) {
             if (can_step_fwd) {
                 forwardOneMove();
@@ -1127,12 +1130,16 @@ export function Joseki(): React.ReactElement {
     function renderMoveControls() {
         const goban = goban_ref.current;
         const move_number = goban?.engine.cur_move.move_number ?? 0;
-        const knob_max = Math.max(move_number, move_trace.current.length - 1, 1);
+        // Slider range covers the visited branch: 0 (root) → current
+        // move_number → current + (trace entries forward of current). At a
+        // freshly loaded root with no trace this collapses to 0, making the
+        // <input> degenerate (un-draggable) — the CSS denominator already
+        // applies its own Math.max(..., 1) so --move-frac stays defined.
+        const knob_max = move_number + (move_trace.current.length - 1 - trace_index.current);
         const at_start = move_number === 0;
-        const can_back = mode !== PageMode.Play || played_mistake.current;
+        const can_back = (mode !== PageMode.Play || played_mistake.current) && move_number > 0;
         const can_forward =
-            mode !== PageMode.Play &&
-            (next_moves_ref.current.length > 0 || forward_history_count.current > 0);
+            mode !== PageMode.Play && trace_index.current < move_trace.current.length - 1;
 
         return (
             <div
@@ -1169,9 +1176,9 @@ export function Joseki(): React.ReactElement {
                         className="MoveNumberSlider-input"
                         type="range"
                         min={0}
-                        max={Math.max(knob_max, 1)}
+                        max={knob_max}
                         value={slider_target ?? move_number}
-                        disabled={mode === PageMode.Play}
+                        disabled={mode === PageMode.Play || knob_max === 0}
                         onChange={(e) => {
                             const v = parseInt(e.target.value, 10);
                             if (!isNaN(v)) {

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -107,6 +107,47 @@ try {
     console.log(e);
 }
 
+function tenukiBorderClass(pass_available: boolean | string): string {
+    if (typeof pass_available !== "string") {
+        return "tenuki-border-gray";
+    }
+    switch (pass_available) {
+        case "ideal":
+        case "good":
+            return "tenuki-border-green";
+        case "trick":
+        case "question":
+            return "tenuki-border-yellow";
+        case "mistake":
+            return "tenuki-border-red";
+        default:
+            return "tenuki-border-gray";
+    }
+}
+
+function tenukiButtonTitle(pass_available: boolean | string): string {
+    if (typeof pass_available !== "string") {
+        return pgettext(
+            "Joseki: tooltip when no documented tenuki continuation exists at this position",
+            "No documented tenuki continuation here — playing one creates a new variation.",
+        );
+    }
+    switch (pass_available) {
+        case "ideal":
+            return pgettext("Joseki tenuki tooltip", "Tenuki is an ideal continuation here.");
+        case "good":
+            return pgettext("Joseki tenuki tooltip", "Tenuki is a good continuation here.");
+        case "mistake":
+            return pgettext("Joseki tenuki tooltip", "Tenuki would be a mistake here.");
+        case "trick":
+            return pgettext("Joseki tenuki tooltip", "Tenuki would be a trick move here.");
+        case "question":
+            return pgettext("Joseki tenuki tooltip", "Tenuki is questioned here.");
+        default:
+            return pgettext("Joseki tenuki tooltip", "A tenuki continuation is documented here.");
+    }
+}
+
 export function Joseki(): React.ReactElement {
     const { pos } = useParams<{ pos: string }>();
     const location = useLocation();
@@ -163,6 +204,7 @@ export function Joseki(): React.ReactElement {
     const [share_confirmed, set_share_confirmed] = React.useState(false);
 
     const [show_comments, set_show_comments] = React.useState(false);
+    const [filter_takeover_active, set_filter_takeover_active] = React.useState(false);
 
     const gobanViewRef = React.useRef<GobanViewRef>(null);
     const moreActionsPopoverRef = React.useRef<PopOver | null>(null);
@@ -1154,7 +1196,7 @@ export function Joseki(): React.ReactElement {
                     disabled={at_start}
                     title={pgettext("Move navigation: reset to root", "Reset to root")}
                 >
-                    <i className="fa fa-fast-backward" />
+                    <i className="fa fa-refresh" />
                 </button>
                 <button
                     className="MoveNumberSlider-button"
@@ -1192,6 +1234,9 @@ export function Joseki(): React.ReactElement {
                             {slider_target ?? move_number}
                         </span>
                     </div>
+                    <div className="Joseki-throbber-overlay" aria-hidden="true">
+                        <Throbber throb={throb} />
+                    </div>
                 </div>
                 <button
                     className="MoveNumberSlider-button"
@@ -1201,9 +1246,26 @@ export function Joseki(): React.ReactElement {
                 >
                     <i className="fa fa-step-forward" />
                 </button>
-                <div className="Joseki-throbber-overlay" aria-hidden="true">
-                    <Throbber throb={throb} />
-                </div>
+                <button
+                    className={
+                        "Joseki-tenuki-button " +
+                        (mode === PageMode.Play
+                            ? "tenuki-border-gray"
+                            : tenukiBorderClass(pass_available))
+                    }
+                    onClick={doPass}
+                    disabled={throb}
+                    title={
+                        mode === PageMode.Play
+                            ? pgettext(
+                                  "Joseki tenuki tooltip (play mode hides the outcome)",
+                                  "Tenuki",
+                              )
+                            : tenukiButtonTitle(pass_available)
+                    }
+                >
+                    {pgettext("Joseki: play a tenuki (skip) move from this position", "Tenuki")}
+                </button>
             </div>
         );
     }
@@ -1327,8 +1389,6 @@ export function Joseki(): React.ReactElement {
                 position_type={current_move_category}
                 see_also={see_also}
                 position_id={current_node_id as string}
-                pass_available={pass_available}
-                onExploreTenuki={doPass}
             />
         );
     }
@@ -1347,6 +1407,16 @@ export function Joseki(): React.ReactElement {
         : current_move_category === "new" && mode === PageMode.Explore
           ? _("Save new position")
           : _("Edit");
+
+    const joseki_header = filter_takeover_active
+        ? pgettext("Joseki view title: the filter takeover is open", "Filter")
+        : mode === PageMode.Play
+          ? pgettext("Joseki view title: play mode", "Play Joseki")
+          : mode === PageMode.Edit
+            ? pgettext("Joseki view title: edit mode", "Edit Joseki")
+            : mode === PageMode.Admin
+              ? pgettext("Joseki view title: admin mode", "Admin")
+              : pgettext("Joseki view title: default explore mode", "Explore Joseki");
 
     function openMoreActions(event?: React.MouseEvent<HTMLButtonElement>) {
         if (!event) {
@@ -1393,6 +1463,7 @@ export function Joseki(): React.ReactElement {
             controller={controller_ref.current!}
             className="Joseki"
             customSlider={renderMoveControls()}
+            header={joseki_header}
         >
             <KBShortcut shortcut="home" action={resetBoard} />
             <KBShortcut shortcut="left" action={backOneMoveKey} />
@@ -1402,6 +1473,7 @@ export function Joseki(): React.ReactElement {
                 id="joseki-filter"
                 type="takeover"
                 disabled={mode !== PageMode.Explore}
+                onToggle={set_filter_takeover_active}
                 icon={
                     <span className="joseki-tab-icon-with-badge">
                         <i className="fa fa-filter" />
@@ -1424,6 +1496,17 @@ export function Joseki(): React.ReactElement {
                     <p className="joseki-filter-hint">
                         {_("Tag “Joseki: Done” narrows results to verified joseki sequences.")}
                     </p>
+                    <div className="joseki-filter-actions">
+                        <button
+                            className="joseki-filter-apply primary"
+                            onClick={() => gobanViewRef.current?.setActiveTakeover(null)}
+                        >
+                            {pgettext(
+                                "Joseki filter: dismiss the filter panel (filter changes apply automatically as you make them)",
+                                "Apply",
+                            )}
+                        </button>
+                    </div>
                 </div>
             </GobanView.Tab>
 
@@ -1431,6 +1514,7 @@ export function Joseki(): React.ReactElement {
                 id="joseki-comments-toggle"
                 type="action"
                 active={show_comments}
+                disabled={mode === PageMode.Play}
                 icon={
                     <span className="joseki-tab-icon-with-badge">
                         <i className="fa fa-comment-o" />

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -162,6 +162,8 @@ export function Joseki(): React.ReactElement {
 
     const [share_confirmed, set_share_confirmed] = React.useState(false);
 
+    const [show_comments, set_show_comments] = React.useState(false);
+
     const gobanViewRef = React.useRef<GobanViewRef>(null);
     const moreActionsPopoverRef = React.useRef<PopOver | null>(null);
     // Tracks how many history.forward() steps are available because the
@@ -1018,7 +1020,7 @@ export function Joseki(): React.ReactElement {
                     saved_filter
                         ? saved_filter
                         : {
-                              tags: joseki_tags_ref.current ? [joseki_tags_ref.current[0]] : [],
+                              tags: [],
                               contributor: undefined,
                               source: undefined,
                           },
@@ -1047,13 +1049,8 @@ export function Joseki(): React.ReactElement {
     }, [location, pos]);
 
     React.useEffect(() => {
-        if (
-            show_comments_requested.current &&
-            gobanViewRef.current &&
-            current_node_id &&
-            current_node_id !== "root"
-        ) {
-            gobanViewRef.current.setActiveTakeover("joseki-comments");
+        if (show_comments_requested.current && current_node_id && current_node_id !== "root") {
+            set_show_comments(true);
             show_comments_requested.current = false;
         }
     }, [current_node_id]);
@@ -1342,7 +1339,7 @@ export function Joseki(): React.ReactElement {
         ? _("Edit (database is locked)")
         : current_move_category === "new" && mode === PageMode.Explore
           ? _("Save new position")
-          : _("Edit position");
+          : _("Edit");
 
     function openMoreActions(event?: React.MouseEvent<HTMLButtonElement>) {
         if (!event) {
@@ -1366,8 +1363,6 @@ export function Joseki(): React.ReactElement {
                     user_can_administer={user_can_administer}
                     db_locked_down={db_locked_down}
                     edit_label={edit_label}
-                    comment_count={current_comment_count}
-                    onOpenComments={open("joseki-comments")}
                     onOpenChanges={open("joseki-changes")}
                     onOpenEdit={open("joseki-edit")}
                     onOpenAdmin={open("joseki-admin")}
@@ -1399,6 +1394,7 @@ export function Joseki(): React.ReactElement {
             <GobanView.Tab
                 id="joseki-filter"
                 type="takeover"
+                disabled={mode !== PageMode.Explore}
                 icon={
                     <span className="joseki-tab-icon-with-badge">
                         <i className="fa fa-filter" />
@@ -1425,17 +1421,20 @@ export function Joseki(): React.ReactElement {
             </GobanView.Tab>
 
             <GobanView.Tab
-                id="joseki-comments"
-                type="takeover"
-                icon="comment-o"
+                id="joseki-comments-toggle"
+                type="action"
+                active={show_comments}
+                icon={
+                    <span className="joseki-tab-icon-with-badge">
+                        <i className="fa fa-comment-o" />
+                        {!!current_comment_count && (
+                            <span className="joseki-tab-badge">{current_comment_count}</span>
+                        )}
+                    </span>
+                }
                 title={_("Comments")}
-                hideFromBar
-            >
-                <CommentsPanel
-                    position_id={current_node_id as string}
-                    can_comment={user_can_comment}
-                />
-            </GobanView.Tab>
+                onClick={() => set_show_comments((s) => !s)}
+            />
 
             <GobanView.Tab
                 id="joseki-changes"
@@ -1525,6 +1524,14 @@ export function Joseki(): React.ReactElement {
 
             <GobanView.Tab id="joseki-explore" type="always">
                 {renderExplorePane()}
+                {show_comments && current_node_id && current_node_id !== "root" && (
+                    <div className="joseki-inline-comments">
+                        <CommentsPanel
+                            position_id={current_node_id}
+                            can_comment={user_can_comment}
+                        />
+                    </div>
+                )}
                 {renderPositionDetails()}
             </GobanView.Tab>
         </GobanView>

--- a/src/views/Joseki/JosekiActionsPanel.css
+++ b/src/views/Joseki/JosekiActionsPanel.css
@@ -70,18 +70,3 @@
         }
     }
 }
-
-.JosekiActionsPanel-count {
-    flex-shrink: 0;
-    min-width: 1.1rem;
-    height: 1.1rem;
-    padding: 0 0.3rem;
-    border-radius: 0.55rem;
-    background: var(--primary);
-    color: var(--colored-background-fg);
-    font-size: 0.7rem;
-    line-height: 1.1rem;
-    font-variant-numeric: tabular-nums;
-    font-weight: 600;
-    text-align: center;
-}

--- a/src/views/Joseki/JosekiActionsPanel.tsx
+++ b/src/views/Joseki/JosekiActionsPanel.tsx
@@ -24,8 +24,6 @@ interface JosekiActionsPanelProps {
     user_can_administer: boolean;
     db_locked_down: boolean;
     edit_label: string;
-    comment_count?: number;
-    onOpenComments: () => void;
     onOpenChanges: () => void;
     onOpenEdit: () => void;
     onOpenAdmin: () => void;
@@ -42,14 +40,6 @@ export function JosekiActionsPanel(props: JosekiActionsPanelProps): React.ReactE
 
     return (
         <div className="JosekiActionsPanel">
-            <button className="JosekiActionsPanel-item" onClick={wrap(props.onOpenComments)}>
-                <i className="fa fa-comment-o" />
-                <span>{_("Comments")}</span>
-                {!!props.comment_count && (
-                    <span className="JosekiActionsPanel-count">{props.comment_count}</span>
-                )}
-            </button>
-
             <button className="JosekiActionsPanel-item" onClick={wrap(props.onOpenChanges)}>
                 <i className="fa fa-history" />
                 <span>{_("Position changes")}</span>

--- a/src/views/Joseki/PlayPane.tsx
+++ b/src/views/Joseki/PlayPane.tsx
@@ -61,12 +61,17 @@ export function PlayPane(props: PlayProps): React.ReactElement {
         }
     }, []);
 
+    const last_type = props.move_type_sequence[props.move_type_sequence.length - 1]?.type;
+    // It's the user's turn at the start of a session and after each
+    // computer reply. After a "good" the computer is about to move; after
+    // "bad" the user is in the mistake state; after "complete" the joseki
+    // is finished.
+    const show_your_move = props.move_type_sequence.length === 0 || last_type === "computer";
+
     return (
         <div className="play-columns">
+            {show_your_move && <div className="play-prompt">{_("Your move...")}</div>}
             <div className="play-dashboard">
-                {props.move_type_sequence.length === 0 && (
-                    <div className="play-prompt">{_("Your move...")}</div>
-                )}
                 {props.move_type_sequence.map((move_type, id) => (
                     <div key={id}>
                         {iconFor(move_type["type"])}


### PR DESCRIPTION
@GreenAsJade 