### PR TITLE
Fix tournament mobile CSS

### DIFF
--- a/src/views/Play/Play.css
+++ b/src/views/Play/Play.css
@@ -149,16 +149,6 @@
         border-style: ridge;
     }
 
-    .tab-head {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        justify-content: space-between;
-    }
-
-    .tabs-container {
-        text-align: center;
-    }
 
     .tab {
         cursor: pointer;

--- a/src/views/Play/QuickMatch.css
+++ b/src/views/Play/QuickMatch.css
@@ -609,19 +609,6 @@
         margin-top: 1rem;
     }
 
-    .tab-head {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        align-items: center;
-
-        .tabs-container {
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            margin-bottom: 1rem;
-        }
-    }
 
     .game-speed-buttons {
         padding-left: 1rem !important;


### PR DESCRIPTION
#3544

This PR is potentially a fix for the above issue "Tournament list clips off screen on iOS mobile UI" which describes how the tournament header is weirdly positioned and it's hard to scroll the below table. Because the tab head was wider than the page on mobile because of the leaking CSS, the header centered above it. Worse though, the table had overflow hidden so scrolling high on the page scrolled the tabs and header section, and scrolling lower on the page either did nothing or scrolled the table depending on where.

This should at a minimum help with the listed issue, if not fix it completely.

Before:
<img width="320" height="689" alt="image" src="https://github.com/user-attachments/assets/4d83d10e-4f53-4de5-aad9-d5d84c943eff" />

After:
<img width="320" height="689" alt="image" src="https://github.com/user-attachments/assets/8c503641-704c-47c2-865f-191441c13347" />



