### PR TITLE
Adjust header alignment on mobile

### DIFF
--- a/src/global_styl/global.css
+++ b/src/global_styl/global.css
@@ -150,6 +150,10 @@ a.primary:active, a.primary:hover, .primary.clickable:hover, .primary.fakelink:h
     margin-bottom: 2rem;
     width: 100%;
 
+    & h2 {
+        white-space: nowrap;
+    }
+
     & .fa-search {
         margin-bottom: 2px;
     }
@@ -164,6 +168,26 @@ a.primary:active, a.primary:hover, .primary.clickable:hover, .primary.fakelink:h
 
         & > a {
             margin: 0 1rem;
+        }
+    }
+
+    @media (max-width: 600px) {
+        flex-direction: column;
+
+        & h2 {
+            margin-bottom: 0.5rem;
+        }
+
+        & > div {
+            padding-top: 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+
+            & > a {
+                margin-left: 0;
+                white-space: nowrap;
+            }
         }
     }
 }

--- a/src/views/LadderList/LadderList.css
+++ b/src/views/LadderList/LadderList.css
@@ -14,6 +14,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+.page-nav {
+    padding: 0 0.5rem;
+    box-sizing: border-box;
+}
+
 .LadderList {
     /* here */
     display: flex;

--- a/src/views/LadderList/LadderList.css
+++ b/src/views/LadderList/LadderList.css
@@ -14,31 +14,30 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-.page-nav {
-    padding: 0 0.5rem;
-    box-sizing: border-box;
-}
-
 .LadderList {
     /* here */
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
+    padding: 0 0.5rem;
 
-    .Card {
-        width: 20rem;
-        max-width: 100dvw;
-        min-height: 30rem;
-        text-align: center;
-    }
+    .ladder-list-container {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: center;
 
-    button {
-        margin-right: 0.5rem;
-    }
+        .Card {
+            width: 20rem;
+            max-width: 100dvw;
+            min-height: 30rem;
+            text-align: center;
+        }
 
-    td.player-column {
-        text-align: left;
+        button {
+            margin-right: 0.5rem;
+        }
+
+        td.player-column {
+            text-align: left;
+        }
     }
 }
 

--- a/src/views/LadderList/LadderList.tsx
+++ b/src/views/LadderList/LadderList.tsx
@@ -81,68 +81,74 @@ export function LadderList(): React.ReactElement {
 
     return (
         <div className="page-width">
-            <div className="page-nav">
-                <h2>
-                    <i className="fa fa-list-ol"></i> {_("Ladders")}
-                </h2>
-                <div>
-                    {ladders.map((ladder, idx) => (
-                        <Link key={idx} to={`/ladder/${ladder.id}`}>
-                            {_(ladder.board_size + "x" + ladder.board_size)}
-                        </Link>
-                    ))}
-                </div>
-            </div>
             <div className="LadderList">
-                {ladders.map((ladder, idx) => (
-                    <Card key={idx}>
-                        <h2>{_(ladder.name)}</h2>
-                        {(ladder.player_rank < 0 || null) && (
-                            <button
-                                className="primary sm"
-                                disabled={user.anonymous}
-                                onClick={() => join(ladder.id)}
-                            >
-                                {_("Join")}
-                            </button>
-                        )}
-                        <Link className="btn primary sm" to={`/ladder/${ladder.id}`}>
-                            {_("Full View") /* translators: View details of the selected ladder */}
-                        </Link>
-
-                        <h4>
-                            {interpolate(_("{{ladder_size}} players"), {
-                                ladder_size: ladder.size,
-                            })}
-                        </h4>
-
-                        <LadderComponent ladderId={ladder.id} />
-                    </Card>
-                ))}
-            </div>
-            {joinedLadders.length > 0 && (
-                <div className="MyLadders">
-                    <h2 style={{ marginLeft: "1rem" }}>
-                        <i className="fa fa-list-ol"></i> {_("My Ladders")}
+                <div className="page-nav">
+                    <h2>
+                        <i className="fa fa-list-ol"></i> {_("Ladders")}
                     </h2>
-                    {joinedLadders.map((ladder, idx) => (
-                        <div className="MyLadders-row" key={idx}>
-                            <span className="player-rank">#{ladder.player_rank}</span>
-                            {ladder.group?.icon ? (
-                                <img
-                                    className="group-icon"
-                                    src={user_uploads_url(ladder.group.icon, 16)}
-                                    title={ladder.group.name}
-                                    alt={ladder.group.name}
-                                />
-                            ) : (
-                                <i className="fa fa-list-ol"></i>
+                    <div>
+                        {ladders.map((ladder, idx) => (
+                            <Link key={idx} to={`/ladder/${ladder.id}`}>
+                                {_(ladder.board_size + "x" + ladder.board_size)}
+                            </Link>
+                        ))}
+                    </div>
+                </div>
+                <div className="ladder-list-container">
+                    {ladders.map((ladder, idx) => (
+                        <Card key={idx}>
+                            <h2>{_(ladder.name)}</h2>
+                            {(ladder.player_rank < 0 || null) && (
+                                <button
+                                    className="primary sm"
+                                    disabled={user.anonymous}
+                                    onClick={() => join(ladder.id)}
+                                >
+                                    {_("Join")}
+                                </button>
                             )}
-                            <Link to={`/ladder/${ladder.id}`}>{ladder.name}</Link>
-                        </div>
+                            <Link className="btn primary sm" to={`/ladder/${ladder.id}`}>
+                                {
+                                    _(
+                                        "Full View",
+                                    ) /* translators: View details of the selected ladder */
+                                }
+                            </Link>
+
+                            <h4>
+                                {interpolate(_("{{ladder_size}} players"), {
+                                    ladder_size: ladder.size,
+                                })}
+                            </h4>
+
+                            <LadderComponent ladderId={ladder.id} />
+                        </Card>
                     ))}
                 </div>
-            )}
+                {joinedLadders.length > 0 && (
+                    <div className="MyLadders">
+                        <h2 style={{ marginLeft: "1rem" }}>
+                            <i className="fa fa-list-ol"></i> {_("My Ladders")}
+                        </h2>
+                        {joinedLadders.map((ladder, idx) => (
+                            <div className="MyLadders-row" key={idx}>
+                                <span className="player-rank">#{ladder.player_rank}</span>
+                                {ladder.group?.icon ? (
+                                    <img
+                                        className="group-icon"
+                                        src={user_uploads_url(ladder.group.icon, 16)}
+                                        title={ladder.group.name}
+                                        alt={ladder.group.name}
+                                    />
+                                ) : (
+                                    <i className="fa fa-list-ol"></i>
+                                )}
+                                <Link to={`/ladder/${ladder.id}`}>{ladder.name}</Link>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
         </div>
     );
 }

--- a/src/views/LadderList/LadderList.tsx
+++ b/src/views/LadderList/LadderList.tsx
@@ -82,7 +82,7 @@ export function LadderList(): React.ReactElement {
     return (
         <div className="page-width">
             <div className="page-nav">
-                <h2 style={{ marginLeft: "1rem" }}>
+                <h2>
                     <i className="fa fa-list-ol"></i> {_("Ladders")}
                 </h2>
                 <div>


### PR DESCRIPTION
Fixes #3546


## Proposed Changes
On mobile we had two problems
1. the icon and header were splitting. This is any easy fix with nowrap
2. the link and searchbar on the right were stacking uncomfortably. This is the harder fix.

For the second, we added some global css which on mobile sticks the link and searchbar below the header. This also impacts LadderList, which needed some minor adjustments to work with the changes. Screenshots below

After:
<img width="315" height="252" alt="image" src="https://github.com/user-attachments/assets/a1601cf5-8437-4804-a7b1-0ccd5d2ec4f6" />
<img width="315" height="252" alt="image" src="https://github.com/user-attachments/assets/52bb330c-1761-4ac8-bc41-e9a224bcb625" />
<img width="315" height="252" alt="image" src="https://github.com/user-attachments/assets/ed966b33-9394-451c-8c0f-262615a13bb0" />

Before:
<img width="315" height="252" alt="image" src="https://github.com/user-attachments/assets/8b2e1d94-be79-4e04-a869-77cb4aebb231" />
<img width="315" height="252" alt="image" src="https://github.com/user-attachments/assets/0840b4d4-f836-4347-9c39-15a84ed7938a" />
<img width="315" height="252" alt="image" src="https://github.com/user-attachments/assets/e4cf855a-1efb-4800-bb3a-275ac25712e8" />


