### PR TITLE
GameHistoryTable: improved clicking

### DIFF
--- a/src/views/User/GameHistoryTable.css
+++ b/src/views/User/GameHistoryTable.css
@@ -82,6 +82,12 @@
         color: var(--strong-loss);
     }
 
+    .date {
+        a {
+            color: unset;
+        }
+    }
+
     .board_size {
         padding-right: 0.5em;
     }

--- a/src/views/User/GameHistoryTable.tsx
+++ b/src/views/User/GameHistoryTable.tsx
@@ -172,11 +172,12 @@ export function GameHistoryTable(props: GameHistoryProps) {
         ev: React.MouseEvent | React.TouchEvent | React.PointerEvent,
         rows: GroomedGame[],
     ) {
-        if (row.annulled) {
-            return;
-        }
-
         if (selectModeActive) {
+            // "Mass annulment" selection - only for non-annulled games.
+            if (row.annulled) {
+                return;
+            }
+
             if (ev.shiftKey) {
                 if (annulQueue.length > 0 && annulQueue[annulQueue.length - 1]) {
                     window.getSelection()?.removeAllRanges();
@@ -497,7 +498,13 @@ export function GameHistoryTable(props: GameHistoryProps) {
                                 className: (X) =>
                                     "date" +
                                     (X && X.annulled && show_annulled_styling ? " annulled" : ""),
-                                render: (X) => moment(X.date).format("YYYY-MM-DD"),
+                                render: (X) => (
+                                    <span>
+                                        <Link to={X.href} onClick={(e) => handleLinkClick(e)}>
+                                            {moment(X.date).format("YYYY-MM-DD")}
+                                        </Link>
+                                    </span>
+                                ),
                             },
                             {
                                 header: _("Opponent"),


### PR DESCRIPTION
See discussion in https://forums.online-go.com/t/how-do-i-access-an-annulled-game/53686/5

## Proposed Changes

* fix bug that blocks clicking on annulled games
* make date a link to the game for improved interaction (e.g. middle-click, hover to see link preview)
* put date in span to vertically align with other elements

Why just link the date column? Ideally the whole row would be a link. Unfortunately [that is not possible](https://stackoverflow.com/questions/10245279/wrapping-html-table-rows-in-a-tags) without major changes to the HTML. The date is the most notable element that is not already a link and it is very logical and common on the Internet for dates to link to the thing that happened on that date. Also it's relatively far left so it gives people with smaller windows a clickable target that they don't have right now.

Before/after:

<img width="648" height="138" alt="image" src="https://github.com/user-attachments/assets/4150288c-e0a4-4aec-aaa2-ca9dc7940031" />

<img width="648" height="135" alt="image" src="https://github.com/user-attachments/assets/72f10a8f-6a44-4edf-a0fe-cd6852e1574f" />


Note that the alignment in these tables is still not perfect; since game names have a `<span>` within an `<a>` tag, the link underline is messed up:

<img width="379" height="115" alt="image" src="https://github.com/user-attachments/assets/2ddac899-0d7f-4942-8431-9edc05278411" />

That's how it looks on the current site and I'm not fixing that yet.