### PR TITLE
Make sure Game Log has loaded before we look at it.

### DIFF
--- a/e2e-tests/games/basic-scoring.ts
+++ b/e2e-tests/games/basic-scoring.ts
@@ -164,6 +164,10 @@ export const basicScoringTest = async (
 
         await expect(cmPage.getByText("E2E test reporting a score cheat")).toBeVisible();
 
+        // Make sure that game log has loaded
+        await expect(cmPage.getByText("No game log entries")).not.toBeVisible();
+
+        // Check that the game ended the way we expected
         const events = await cmPage.locator("tr.entry td.event").allTextContents();
         expect(events[0].trim()).toBe("game ended");
         expect(events[1].trim()).toBe("stone removal stones accepted");


### PR DESCRIPTION
Fixes a reason for pass and score game test failing intermittently

## Proposed Changes

  - Wait till game log is definitely loaded before looking at it
  
