### PR TITLE
Ignore Enter during IME composition in chat input

### DIFF
--- a/src/components/TabCompleteInput/TabCompleteInput.test.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TabCompleteInput } from "./TabCompleteInput";
+
+describe("TabCompleteInput", () => {
+    it("fires onKeyPress and prevents default on a plain Enter", () => {
+        const onKeyPress = jest.fn();
+        render(<TabCompleteInput onKeyPress={onKeyPress} />);
+
+        const input = screen.getByRole("textbox");
+        const sent = fireEvent.keyDown(input, { key: "Enter" });
+
+        expect(onKeyPress).toHaveBeenCalledTimes(1);
+        // preventDefault was called, so fireEvent returns false
+        expect(sent).toBe(false);
+    });
+
+    it("does not fire onKeyPress on Enter while IME is composing (isComposing)", () => {
+        const onKeyPress = jest.fn();
+        render(<TabCompleteInput onKeyPress={onKeyPress} />);
+
+        const input = screen.getByRole("textbox");
+        // Confirming a Japanese / Chinese / Korean IME candidate also produces
+        // a keydown Enter — but with isComposing === true. The chat input must
+        // not send the message in this case, and must not preventDefault
+        // (otherwise the IME confirmation itself would be swallowed).
+        const sent = fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+        expect(onKeyPress).not.toHaveBeenCalled();
+        expect(sent).toBe(true);
+    });
+
+    it("does not fire onKeyPress on Enter while IME is composing (keyCode 229 fallback)", () => {
+        const onKeyPress = jest.fn();
+        render(<TabCompleteInput onKeyPress={onKeyPress} />);
+
+        const input = screen.getByRole("textbox");
+        // Older Safari fires keydown with keyCode === 229 during IME
+        // composition without setting isComposing. Guard against this too.
+        const sent = fireEvent.keyDown(input, { key: "Enter", keyCode: 229 });
+
+        expect(onKeyPress).not.toHaveBeenCalled();
+        expect(sent).toBe(true);
+    });
+});

--- a/src/components/TabCompleteInput/TabCompleteInput.tsx
+++ b/src/components/TabCompleteInput/TabCompleteInput.tsx
@@ -140,6 +140,14 @@ export const TabCompleteInput = React.forwardRef<HTMLTextAreaElement, TabComplet
         }, []);
 
         const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+            // Don't act on Enter while an IME composition is in progress
+            // (e.g. confirming Japanese / Chinese / Korean candidates).
+            // keyCode === 229 is the legacy "IME process" code, kept as a
+            // fallback for browsers that don't reliably set isComposing on
+            // keydown.
+            if (e.nativeEvent.isComposing || e.keyCode === 229) {
+                return;
+            }
             if (!e.shiftKey && e.key === "Enter") {
                 e.preventDefault();
                 props.onKeyPress?.(e);


### PR DESCRIPTION
Fixes #3581

## Proposed Changes

  - Skip `onKeyPress` in `TabCompleteInput.handleKeyDown` when the keydown is an IME composition event (`e.nativeEvent.isComposing` or legacy `keyCode === 229`), so confirming a Japanese/Chinese/Korean IME candidate with Enter no longer submits the chat message.
  - Add `TabCompleteInput.test.tsx` covering: plain Enter still sends (and `preventDefault`s), IME-composing Enter is ignored (via `isComposing`), and the Safari `keyCode === 229` fallback is also ignored.
  - Centralized fix: both `GameChat` and `ChatLog` paths go through `TabCompleteInput`, so this single guard fixes the entire chat input surface.