### PR TITLE
Fix empty collections

### DIFF
--- a/e2e-tests/puzzles/empty-collection-redirect.ts
+++ b/e2e-tests/puzzles/empty-collection-redirect.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { BrowserContext, expect } from "@playwright/test";
+import { log } from "@helpers/logger";
+import { CreateContextOptions, load } from "@helpers";
+import { newTestUsername, prepareNewUser } from "@helpers/user-utils";
+import { expectOGSClickableByName } from "@helpers/matchers";
+
+/**
+ * An empty puzzle collection has no starting puzzle, so the
+ * /puzzle-collection/:id resolver can't forward to a puzzle. The owner should
+ * land in the new-puzzle editor bound to the collection (ready to add the
+ * first puzzle) rather than being bounced back to the puzzle catalog.
+ *
+ * Covers both entry points:
+ *  - creating a new collection from the "My puzzles" list
+ *  - clicking a still-empty collection row in that list
+ */
+export const emptyCollectionRedirectTest = async ({
+    createContext,
+}: {
+    createContext: (options?: CreateContextOptions) => Promise<BrowserContext>;
+}) => {
+    log("=== Empty Puzzle Collection Redirect Test ===");
+
+    const username = newTestUsername("pzl-emptycol");
+    const { userPage } = await prepareNewUser(createContext, username, "test123");
+
+    // Navigate to "My puzzles" as a user would: catalog -> My puzzles link
+    await load(userPage, "/puzzles");
+    const myPuzzlesLink = await expectOGSClickableByName(userPage, /My puzzles/);
+    await myPuzzlesLink.click();
+    await expect(userPage).toHaveURL(/\/puzzle-collections\/\d+/, { timeout: 10000 });
+    log("On puzzle collection list page");
+
+    // Create a new (empty) collection
+    const newCollectionButton = await expectOGSClickableByName(userPage, /New puzzle collection/);
+    await newCollectionButton.click();
+
+    // Use the unique username in the name to avoid collisions on retry
+    const collectionName = `Collection ${username}`;
+    const swalInput = userPage.locator(".swal2-input");
+    await expect(swalInput).toBeVisible({ timeout: 5000 });
+    await swalInput.fill(collectionName);
+    await expect(swalInput).toHaveValue(collectionName);
+    await userPage.locator(".swal2-confirm").click();
+
+    // We should land in the new-puzzle editor bound to the new collection,
+    // not back on the puzzle catalog
+    await expect(userPage).toHaveURL(/\/puzzle\/new\?collection_id=\d+/, { timeout: 15000 });
+    log("Creating a collection landed on the new-puzzle editor");
+
+    const setupButton = userPage.locator("button.active", { hasText: "Setup" });
+    await expect(setupButton).toBeVisible({ timeout: 15000 });
+
+    // The editor's collection dropdown should have the new collection selected
+    const collectionId = new URL(userPage.url()).searchParams.get("collection_id");
+    if (!collectionId) {
+        throw new Error("Expected collection_id query parameter on the editor URL");
+    }
+    const collectionSelect = userPage.locator("select").filter({
+        has: userPage.locator('option:has-text("Select collection")'),
+    });
+    await expect(collectionSelect).toBeVisible();
+    await expect(collectionSelect).toHaveValue(collectionId);
+    log(`Editor pre-bound to new collection ${collectionId}`);
+
+    // Clicking the still-empty collection in "My puzzles" should land the
+    // owner in the same editor, not on the catalog
+    await load(userPage, "/puzzles");
+    const myPuzzlesLinkAgain = await expectOGSClickableByName(userPage, /My puzzles/);
+    await myPuzzlesLinkAgain.click();
+    await expect(userPage).toHaveURL(/\/puzzle-collections\/\d+/, { timeout: 10000 });
+
+    const collectionRow = userPage.locator("tr", { hasText: collectionName });
+    await expect(collectionRow).toBeVisible({ timeout: 10000 });
+    // Click the collection name text rather than the row in general: the name
+    // cell also contains a Player link, and other cells could reorder
+    await collectionRow.locator("td.name").getByText(collectionName).click();
+
+    await expect(userPage).toHaveURL(new RegExp(`/puzzle/new\\?collection_id=${collectionId}`), {
+        timeout: 15000,
+    });
+    await expect(userPage.locator("button.active", { hasText: "Setup" })).toBeVisible({
+        timeout: 15000,
+    });
+    log("Visiting the empty collection landed on the new-puzzle editor");
+
+    log("=== Empty Puzzle Collection Redirect Test Complete ===");
+};

--- a/e2e-tests/puzzles/empty-collection-redirect.ts
+++ b/e2e-tests/puzzles/empty-collection-redirect.ts
@@ -23,13 +23,16 @@ import { expectOGSClickableByName } from "@helpers/matchers";
 
 /**
  * An empty puzzle collection has no starting puzzle, so the
- * /puzzle-collection/:id resolver can't forward to a puzzle. The owner should
- * land in the new-puzzle editor bound to the collection (ready to add the
- * first puzzle) rather than being bounced back to the puzzle catalog.
+ * /puzzle-collection/:id resolver can't forward to a puzzle. Instead of
+ * bouncing the user back to the puzzle catalog, it should show the collection
+ * page (the same PuzzleLibrary list used in the puzzle view's library panel)
+ * with no entries, from which the owner can add the first puzzle.
  *
  * Covers both entry points:
- *  - creating a new collection from the "My puzzles" list
- *  - clicking a still-empty collection row in that list
+ *  - creating a new collection from the "My puzzles" list (goes straight to
+ *    the new-puzzle editor bound to the collection)
+ *  - clicking a still-empty collection row in that list (shows the empty
+ *    collection page, whose "New puzzle" link leads to the editor)
  */
 export const emptyCollectionRedirectTest = async ({
     createContext,
@@ -80,8 +83,8 @@ export const emptyCollectionRedirectTest = async ({
     await expect(collectionSelect).toHaveValue(collectionId);
     log(`Editor pre-bound to new collection ${collectionId}`);
 
-    // Clicking the still-empty collection in "My puzzles" should land the
-    // owner in the same editor, not on the catalog
+    // Clicking the still-empty collection in "My puzzles" should show the
+    // empty collection page, not bounce to the catalog
     await load(userPage, "/puzzles");
     const myPuzzlesLinkAgain = await expectOGSClickableByName(userPage, /My puzzles/);
     await myPuzzlesLinkAgain.click();
@@ -93,13 +96,27 @@ export const emptyCollectionRedirectTest = async ({
     // cell also contains a Player link, and other cells could reorder
     await collectionRow.locator("td.name").getByText(collectionName).click();
 
+    await expect(userPage).toHaveURL(new RegExp(`/puzzle-collection/${collectionId}`), {
+        timeout: 15000,
+    });
+    await expect(userPage.locator(".PuzzleLibrary-title")).toHaveText(collectionName, {
+        timeout: 15000,
+    });
+    await expect(userPage.getByText("This collection doesn't have any puzzles yet.")).toBeVisible();
+    log("Visiting the empty collection landed on the empty collection page");
+
+    // The owner's "New puzzle" link should lead to the editor bound to the
+    // collection
+    const newPuzzleLink = await expectOGSClickableByName(userPage, /New puzzle$/);
+    await newPuzzleLink.click();
+
     await expect(userPage).toHaveURL(new RegExp(`/puzzle/new\\?collection_id=${collectionId}`), {
         timeout: 15000,
     });
     await expect(userPage.locator("button.active", { hasText: "Setup" })).toBeVisible({
         timeout: 15000,
     });
-    log("Visiting the empty collection landed on the new-puzzle editor");
+    log("New puzzle link from the empty collection page landed on the editor");
 
     log("=== Empty Puzzle Collection Redirect Test Complete ===");
 };

--- a/e2e-tests/puzzles/puzzles.spec.ts
+++ b/e2e-tests/puzzles/puzzles.spec.ts
@@ -17,7 +17,12 @@
 
 import { ogsTest } from "@helpers";
 import { puzzleTurnIndicatorTest } from "./puzzle-turn-indicator";
+import { emptyCollectionRedirectTest } from "./empty-collection-redirect";
 
 ogsTest.describe("@Puzzle Puzzle Tests", () => {
     ogsTest("Puzzle should show turn indicator", puzzleTurnIndicatorTest);
+    ogsTest(
+        "Empty puzzle collection should land its owner in the puzzle editor",
+        emptyCollectionRedirectTest,
+    );
 });

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -795,11 +795,14 @@ export function Puzzle(): React.ReactElement {
                             );
                             setState({ puzzle_collection_summary: remaining });
                             // If the user just deleted the current puzzle,
-                            // navigate somewhere sensible.
+                            // navigate somewhere sensible: the next puzzle, or
+                            // the now-empty collection's page.
                             if (puzzle_id === s.id) {
                                 const next = remaining[0]?.id;
                                 if (next) {
                                     browserHistory.push(`/puzzle/${next}`);
+                                } else if (s.collection?.id) {
+                                    browserHistory.push(`/puzzle-collection/${s.collection.id}`);
                                 } else {
                                     browserHistory.push("/puzzles/");
                                 }
@@ -1019,13 +1022,15 @@ export function Puzzle(): React.ReactElement {
                         .then(() => {
                             // Jump to the next remaining puzzle in the
                             // collection if there is one, otherwise the
-                            // user's puzzle list.
+                            // now-empty collection's page.
                             const s = stateRef.current;
                             const remaining = s.puzzle_collection_summary.filter(
                                 (p) => p.id !== s.id,
                             );
                             if (remaining[0]?.id) {
                                 browserHistory.push(`/puzzle/${remaining[0].id}?view-collection=1`);
+                            } else if (s.collection?.id) {
+                                browserHistory.push(`/puzzle-collection/${s.collection.id}`);
                             } else {
                                 browserHistory.push("/puzzles/");
                             }

--- a/src/views/Puzzle/PuzzleLibrary.css
+++ b/src/views/Puzzle/PuzzleLibrary.css
@@ -62,6 +62,12 @@
         }
     }
 
+    .PuzzleLibrary-empty {
+        padding: 0.75rem 0;
+        color: var(--shade1);
+        font-style: italic;
+    }
+
     .PuzzleLibrary-list {
         list-style: none;
         margin: 0;

--- a/src/views/Puzzle/PuzzleLibrary.tsx
+++ b/src/views/Puzzle/PuzzleLibrary.tsx
@@ -65,13 +65,19 @@ export function PuzzleLibrary({
                 can_edit={can_edit}
                 onRenameCollection={onRenameCollection}
             />
-            <LibraryList
-                items={items}
-                current_id={current_id}
-                can_edit={can_edit}
-                onDeletePuzzle={onDeletePuzzle}
-                onReorderPuzzle={onReorderPuzzle}
-            />
+            {items.length === 0 ? (
+                <div className="PuzzleLibrary-empty">
+                    {_("This collection doesn't have any puzzles yet.")}
+                </div>
+            ) : (
+                <LibraryList
+                    items={items}
+                    current_id={current_id}
+                    can_edit={can_edit}
+                    onDeletePuzzle={onDeletePuzzle}
+                    onReorderPuzzle={onReorderPuzzle}
+                />
+            )}
             {can_edit && (
                 <div className="PuzzleLibrary-footer">
                     <Link

--- a/src/views/PuzzleCollection/PuzzleCollection.css
+++ b/src/views/PuzzleCollection/PuzzleCollection.css
@@ -15,11 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ogsTest } from "@helpers";
-import { puzzleTurnIndicatorTest } from "./puzzle-turn-indicator";
-import { emptyCollectionRedirectTest } from "./empty-collection-redirect";
+.PuzzleCollection {
+    display: flex;
+    justify-content: center;
+    padding: 2rem 1rem;
 
-ogsTest.describe("@Puzzle Puzzle Tests", () => {
-    ogsTest("Puzzle should show turn indicator", puzzleTurnIndicatorTest);
-    ogsTest("Empty puzzle collection should show its collection page", emptyCollectionRedirectTest);
-});
+    .PuzzleCollection-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        width: 100%;
+        max-width: 28rem;
+    }
+
+    .PuzzleCollection-browse {
+        text-align: center;
+    }
+}

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { Navigate, useParams } from "react-router-dom";
 import { get } from "@/lib/requests";
 import { errorAlerter } from "@/lib/misc";
+import * as data from "@/lib/data";
 
 /**
  * Legacy /puzzle-collection/:collection_id route. Collections no longer have
@@ -26,6 +27,11 @@ import { errorAlerter } from "@/lib/misc";
  * library/settings panels. This component just resolves the collection's
  * starting puzzle and redirects; the `?view-collection=1` query tells the
  * Puzzle view to open the library panel on mount.
+ *
+ * An empty collection has no starting puzzle to land on, so its owner is sent
+ * to the new-puzzle editor pre-bound to the collection (the same URL shape the
+ * library panel's "New puzzle" button uses); anyone else falls back to the
+ * puzzle catalog.
  */
 export function PuzzleCollection(): React.ReactElement | null {
     const { collection_id } = useParams<{ collection_id: string }>();
@@ -35,7 +41,13 @@ export function PuzzleCollection(): React.ReactElement | null {
         get(`puzzles/collections/${collection_id}`)
             .then((collection) => {
                 const start_id = collection?.starting_puzzle?.id;
-                setTarget(start_id ? `/puzzle/${start_id}?view-collection=1` : "/puzzles/");
+                if (start_id) {
+                    setTarget(`/puzzle/${start_id}?view-collection=1`);
+                } else if (collection?.owner?.id === data.get("user")?.id) {
+                    setTarget(`/puzzle/new?collection_id=${collection_id}`);
+                } else {
+                    setTarget("/puzzles/");
+                }
             })
             .catch(errorAlerter);
     }, [collection_id]);

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -16,44 +16,90 @@
  */
 
 import * as React from "react";
-import { Navigate, useParams } from "react-router-dom";
-import { get } from "@/lib/requests";
+import { Link, Navigate, useParams } from "react-router-dom";
+import { get, put } from "@/lib/requests";
 import { errorAlerter } from "@/lib/misc";
+import { _ } from "@/lib/translate";
 import * as data from "@/lib/data";
+import { PuzzleLibrary } from "@/views/Puzzle/PuzzleLibrary";
+import "./PuzzleCollection.css";
 
 /**
- * Legacy /puzzle-collection/:collection_id route. Collections no longer have
- * a dedicated edit page — collection management lives inside the Puzzle view's
- * library/settings panels. This component just resolves the collection's
- * starting puzzle and redirects; the `?view-collection=1` query tells the
- * Puzzle view to open the library panel on mount.
+ * /puzzle-collection/:collection_id route. Collections no longer have a
+ * dedicated edit page — collection management lives inside the Puzzle view's
+ * library/settings panels — so when the collection has puzzles this just
+ * resolves the starting puzzle and redirects; the `?view-collection=1` query
+ * tells the Puzzle view to open the library panel on mount.
  *
- * An empty collection has no starting puzzle to land on, so its owner is sent
- * to the new-puzzle editor pre-bound to the collection (the same URL shape the
- * library panel's "New puzzle" button uses); anyone else falls back to the
- * puzzle catalog.
+ * An empty collection has no puzzle to land on, so we render the same
+ * PuzzleLibrary list standalone (with no entries). Owners and moderators get
+ * the library's usual rename control and "New puzzle" link, so a brand-new
+ * collection is immediately manageable.
  */
 export function PuzzleCollection(): React.ReactElement | null {
     const { collection_id } = useParams<{ collection_id: string }>();
     const [target, setTarget] = React.useState<string | null>(null);
+    const [collection, setCollection] = React.useState<rest_api.PuzzleCollection | null>(null);
 
     React.useEffect(() => {
+        setTarget(null);
+        setCollection(null);
         get(`puzzles/collections/${collection_id}`)
-            .then((collection) => {
-                const start_id = collection?.starting_puzzle?.id;
-                if (start_id) {
-                    setTarget(`/puzzle/${start_id}?view-collection=1`);
-                } else if (collection?.owner?.id === data.get("user")?.id) {
-                    setTarget(`/puzzle/new?collection_id=${collection_id}`);
+            .then((fetched: rest_api.PuzzleCollection) => {
+                if (fetched?.starting_puzzle?.id) {
+                    setTarget(`/puzzle/${fetched.starting_puzzle.id}?view-collection=1`);
                 } else {
-                    setTarget("/puzzles/");
+                    window.document.title = fetched.name;
+                    setCollection(fetched);
                 }
             })
             .catch(errorAlerter);
     }, [collection_id]);
 
-    if (!target) {
+    const renameCollection = React.useCallback((new_name: string) => {
+        setCollection((current) => {
+            if (!current) {
+                return current;
+            }
+            const prev_name = current.name;
+            // Optimistic update; server PUT fails → revert.
+            put(`puzzles/collections/${current.id}`, { name: new_name }).catch((err) => {
+                setCollection((latest) => (latest ? { ...latest, name: prev_name } : latest));
+                errorAlerter(err);
+            });
+            window.document.title = new_name;
+            return { ...current, name: new_name };
+        });
+    }, []);
+
+    if (target) {
+        return <Navigate to={target} replace />;
+    }
+
+    if (!collection) {
         return null;
     }
-    return <Navigate to={target} replace />;
+
+    const user = data.get("user");
+    const can_edit = collection.owner.id === user.id || !!user?.is_moderator;
+
+    return (
+        <div className="PuzzleCollection">
+            <div className="PuzzleCollection-panel">
+                <PuzzleLibrary
+                    collection_id={collection.id}
+                    collection_name={collection.name}
+                    items={[]}
+                    can_edit={can_edit}
+                    // Unreachable with no items; PuzzleLibrary requires them.
+                    onDeletePuzzle={() => undefined}
+                    onReorderPuzzle={() => undefined}
+                    onRenameCollection={renameCollection}
+                />
+                <Link className="PuzzleCollection-browse" to="/puzzles/">
+                    {_("Browse puzzles")}
+                </Link>
+            </div>
+        </div>
+    );
 }

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -56,21 +56,23 @@ export function PuzzleCollection(): React.ReactElement | null {
             .catch(errorAlerter);
     }, [collection_id]);
 
-    const renameCollection = React.useCallback((new_name: string) => {
-        setCollection((current) => {
-            if (!current) {
-                return current;
+    const renameCollection = React.useCallback(
+        (new_name: string) => {
+            if (!collection) {
+                return;
             }
-            const prev_name = current.name;
+            const prev_name = collection.name;
             // Optimistic update; server PUT fails → revert.
-            put(`puzzles/collections/${current.id}`, { name: new_name }).catch((err) => {
+            setCollection({ ...collection, name: new_name });
+            window.document.title = new_name;
+            put(`puzzles/collections/${collection.id}`, { name: new_name }).catch((err) => {
                 setCollection((latest) => (latest ? { ...latest, name: prev_name } : latest));
+                window.document.title = prev_name;
                 errorAlerter(err);
             });
-            window.document.title = new_name;
-            return { ...current, name: new_name };
-        });
-    }, []);
+        },
+        [collection],
+    );
 
     if (target) {
         return <Navigate to={target} replace />;

--- a/src/views/PuzzleCollection/PuzzleCollectionList.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollectionList.tsx
@@ -169,7 +169,10 @@ export function PuzzleCollectionList(): React.ReactElement {
                         price: "0.00",
                     })
                         .then((res) => {
-                            navigateTo(`/puzzle-collection/${res.id}`);
+                            // The new collection is empty, so skip the
+                            // /puzzle-collection/ redirect resolver and go
+                            // straight to the new-puzzle editor bound to it.
+                            navigateTo(`/puzzle/new?collection_id=${res.id}`);
                         })
                         .catch(errorAlerter);
                 }


### PR DESCRIPTION
Fixes can't put puzzles in new collections because new collections redirect back to catalog

## Proposed Changes

  - Show empty collections as empty collections
  - e2e test 
  

Note: this regressed during the major refactor here:

> commit dcdb2064e — "Add GobanView and switch Puzzle system to use it" (Apr 24, 2026, author ogsai)
