### PR TITLE
Expose board background settings per board size

### DIFF
--- a/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.css
+++ b/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.css
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.GobanCustomBoardGridBackgroundPicker {
+    max-width: 100%;
+
+    .grid-background-url-selection {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        max-width: 100%;
+    }
+
+    .grid-background-url-row {
+        display: grid;
+        grid-template-columns: minmax(8rem, auto) minmax(12rem, 1fr) auto;
+        gap: 0.35rem;
+        align-items: center;
+        max-width: 100%;
+    }
+
+    .gridBackgroundUrlSelector {
+        min-width: 0;
+        border: 1px solid;
+    }
+
+    .color-reset {
+        margin-left: 0;
+        margin-right: 0;
+        padding-right: 0;
+        padding-left: 0;
+
+        .fa-undo {
+            margin-left: 0 !important;
+            margin-right: 0 !important;
+            padding-right: 0;
+            padding-left: 0;
+        }
+    }
+}

--- a/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.tsx
+++ b/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.tsx
@@ -59,12 +59,28 @@ export function GobanCustomBoardGridBackgroundPicker(): React.ReactElement {
     const [grid_backgrounds, setGridBackgrounds] = usePreference(
         "goban-theme-custom-board-grid-backgrounds",
     );
+    const grid_backgrounds_ref = React.useRef(grid_backgrounds);
+
+    React.useEffect(() => {
+        grid_backgrounds_ref.current = grid_backgrounds;
+    }, [grid_backgrounds]);
 
     function setGridBackground(size: keyof CustomBoardGridBackgrounds, url: string): void {
-        setGridBackgrounds({
-            ...grid_backgrounds,
+        /*
+         * usePreference setters currently accept concrete values, not React
+         * functional updates. Making this a normal functional update would mean
+         * widening that shared hook interface for one component, so keep the
+         * latest value locally instead. Updating the ref synchronously preserves
+         * batched multi-field edits, such as browser autofill updating several
+         * URLs in the same render.
+         */
+        const next_grid_backgrounds = {
+            ...grid_backgrounds_ref.current,
             [size]: url,
-        });
+        };
+
+        grid_backgrounds_ref.current = next_grid_backgrounds;
+        setGridBackgrounds(next_grid_backgrounds);
     }
 
     return (

--- a/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.tsx
+++ b/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { pgettext } from "@/lib/translate";
+import { usePreference } from "@/lib/preferences";
+import type { CustomBoardGridBackgrounds } from "goban";
+import { LineText } from "../misc-ui";
+import "./GobanCustomBoardGridBackgroundPicker.css";
+
+const grid_background_sizes: (keyof CustomBoardGridBackgrounds)[] = ["9", "13", "19"];
+
+function getGridBackgroundLabel(size: keyof CustomBoardGridBackgrounds): string {
+    switch (size) {
+        case "9":
+            return pgettext("Custom board baked-grid background URL", "9x9 grid background URL");
+        case "13":
+            return pgettext("Custom board baked-grid background URL", "13x13 grid background URL");
+        case "19":
+            return pgettext("Custom board baked-grid background URL", "19x19 grid background URL");
+    }
+}
+
+function getResetGridBackgroundLabel(size: keyof CustomBoardGridBackgrounds): string {
+    switch (size) {
+        case "9":
+            return pgettext(
+                "Reset custom board baked-grid background URL",
+                "Reset 9x9 grid background",
+            );
+        case "13":
+            return pgettext(
+                "Reset custom board baked-grid background URL",
+                "Reset 13x13 grid background",
+            );
+        case "19":
+            return pgettext(
+                "Reset custom board baked-grid background URL",
+                "Reset 19x19 grid background",
+            );
+    }
+}
+
+export function GobanCustomBoardGridBackgroundPicker(): React.ReactElement {
+    const [grid_backgrounds, setGridBackgrounds] = usePreference(
+        "goban-theme-custom-board-grid-backgrounds",
+    );
+
+    function setGridBackground(size: keyof CustomBoardGridBackgrounds, url: string): void {
+        setGridBackgrounds({
+            ...grid_backgrounds,
+            [size]: url,
+        });
+    }
+
+    return (
+        <div className="GobanCustomBoardGridBackgroundPicker">
+            <LineText className="customize">
+                {pgettext("Customize custom board baked-grid backgrounds", "Grid backgrounds")}
+            </LineText>
+
+            <div className="grid-background-url-selection">
+                {grid_background_sizes.map((size) => {
+                    const label = getGridBackgroundLabel(size);
+                    const input_id = `custom-board-grid-background-${size}`;
+                    return (
+                        <div className="grid-background-url-row" key={size}>
+                            <label htmlFor={input_id}>{label}</label>
+                            <input
+                                id={input_id}
+                                className="gridBackgroundUrlSelector"
+                                type="text"
+                                value={grid_backgrounds[size]}
+                                placeholder={label}
+                                onFocus={(e) => e.target.select()}
+                                onChange={(e) => setGridBackground(size, e.target.value)}
+                            />
+                            <button
+                                type="button"
+                                className="color-reset"
+                                title={getResetGridBackgroundLabel(size)}
+                                aria-label={getResetGridBackgroundLabel(size)}
+                                onClick={() => setGridBackground(size, "")}
+                            >
+                                <i className="fa fa-undo" />
+                            </button>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -22,6 +22,7 @@ import { getSelectedThemes, usePreference } from "@/lib/preferences";
 import { PersistentElement } from "@/components/PersistentElement";
 import { Experiment, Variant, Default } from "../Experiment";
 import { LineText } from "../misc-ui";
+import { GobanCustomBoardGridBackgroundPicker } from "./GobanCustomBoardGridBackgroundPicker";
 import "./GobanThemePicker.css";
 
 interface GobanThemePickerProperties {
@@ -217,6 +218,8 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
                     <i className="fa fa-undo" />
                 </button>
             </div>
+
+            <GobanCustomBoardGridBackgroundPicker />
         </div>
     );
 }

--- a/src/global_styl/01_variables.css
+++ b/src/global_styl/01_variables.css
@@ -48,6 +48,8 @@
     --turn-indicator-size: 1.5rem;
 
     /* Z-indices */
+    --z-goban-grid-layer: 5;
+    --z-goban-grid-background-layer: 8;
     --z-goban-shadow-layer: 10;
     --z-goban-stone-layer: 20;
     --z-goban-pen-layer: 30;

--- a/src/global_styl/01_variables.css
+++ b/src/global_styl/01_variables.css
@@ -48,6 +48,13 @@
     --turn-indicator-size: 1.5rem;
 
     /* Z-indices */
+    /*
+     * Canvas goban uses both a vector grid layer and an optional themed image
+     * layer containing a baked-in grid. The image layer intentionally sits above
+     * the vector grid so a loaded themed asset hides it, while shadows, stones,
+     * pen marks, and messages remain above both. If the image URL fails, the
+     * vector grid below it is still visible.
+     */
     --z-goban-grid-layer: 5;
     --z-goban-grid-background-layer: 8;
     --z-goban-shadow-layer: 10;

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -23,6 +23,8 @@ import {
     JGOFTimeControlSpeed,
     Size,
     ShadowTheme,
+    CustomBoardGridBackgrounds,
+    emptyCustomBoardGridBackgrounds,
 } from "goban";
 import * as React from "react";
 import { current_language } from "@/lib/translate";
@@ -103,6 +105,15 @@ export const defaults = {
     "goban-theme-custom-white-shadow-gradient": "rotate(45) scale(1.10 1.0) translate(0.05 -0.50)",
     "goban-theme-custom-board-background": "#DCB35C",
     "goban-theme-custom-board-url": "",
+    /*
+     * V1 baked-grid board assets are compactly stored as one URL per board size. The goban
+     * renderer maps these into a structured asset descriptor so future variants can add
+     * small margins, baked coordinates, coordinate origins, or numbering formats without
+     * changing the meaning of these saved URLs.
+     */
+    "goban-theme-custom-board-grid-backgrounds": {
+        ...emptyCustomBoardGridBackgrounds,
+    } as CustomBoardGridBackgrounds,
     "goban-theme-custom-board-line": "#000000",
     "goban-theme-custom-black-stone-color": "#000000",
     "goban-theme-custom-black-url": "",
@@ -345,6 +356,7 @@ export function getSelectedThemes(): GobanSelectedThemes {
     const custom_black_shadow_gradient = get("goban-theme-custom-black-shadow-gradient");
     const custom_white_shadow_color = get("goban-theme-custom-white-shadow-color");
     const custom_white_shadow_gradient = get("goban-theme-custom-white-shadow-gradient");
+    const custom_board_grid_backgrounds = get("goban-theme-custom-board-grid-backgrounds");
 
     if (!(board in Goban.THEMES["board"])) {
         board = default_plain ? "Plain" : "Kaya";
@@ -376,6 +388,7 @@ export function getSelectedThemes(): GobanSelectedThemes {
                 gradientTransform: custom_white_shadow_gradient,
             },
         },
+        "custom-board-grid-backgrounds": custom_board_grid_backgrounds,
     };
 }
 
@@ -403,6 +416,7 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
         "goban-theme-custom-white-shadow-gradient",
         "goban-theme-custom-board-background",
         "goban-theme-custom-board-url",
+        "goban-theme-custom-board-grid-backgrounds",
         "goban-theme-custom-board-line",
         "goban-theme-custom-black-stone-color",
         "goban-theme-custom-black-url",


### PR DESCRIPTION
This depends on the goban renderer support in: https://github.com/online-go/goban/pull/252. For motivation see the screenshots of themed boards in that PR.

The changes are made with Codex. I've reviewed them and closely steered the technical design.

The existing custom board background URL remains the default background. This PR adds three optional URLs for baked-grid board assets:
- 9x9
- 13x13
- 19x19

If a matching baked-grid URL is absent, invalid, or not applicable to the current board, rendering falls back to the default custom board background and
vector grid.

## Screenshots
<img width="765" height="733" alt="image" src="https://github.com/user-attachments/assets/1cfe4352-9c12-4bea-b856-47dadd8bdfd9" />

## What this PR enables
This is of the themes I made and plan to release as Creative Commons once OGS supports backgrounds per board size.
<img width="721" height="728" alt="image" src="https://github.com/user-attachments/assets/ed480dca-48cc-407c-8b44-7ba50b2f200a" />

It relies on two features:
- Backgrounds per board size that this PR adds
- Stone variants. Sabaki themes support it, and I plan to open a follow-up PR to OGS with that too.


## Details

- Adds `goban-theme-custom-board-grid-backgrounds` preference.
- Adds a custom board grid background URL picker to the Goban theme picker.
- Passes the optional grid background map through selected goban themes.
- Adds z-index variables for the new goban grid and baked-grid background layers.
- Leaves existing custom board settings backward-compatible.

## Compatibility

Existing customized boards are unaffected:
- `goban-theme-custom-board-url` keeps its current meaning.
- The new preference defaults to empty URLs.
- Boards without a matching baked-grid asset use the existing board/vector-grid rendering.

## Testing
I followed the testing recommendations in the CONTRIBUTION doc, and separately from that tested for graceful degradation when the asset URL's become unavailable.