### PR TITLE
Add per-test settle pause (default 5s) to e2e suite.

### DIFF
--- a/e2e-tests/helpers.ts
+++ b/e2e-tests/helpers.ts
@@ -77,3 +77,14 @@ export const ogsTest = base.extend<MultiContextFixtures>({
         }
     },
 });
+
+// Per-test settle delay (ms). Runs after each test so a single local run
+// reports its result immediately and the wait is buried in the time spent
+// looking at the result. Override or disable (set 0) via the env var.
+const PER_TEST_DELAY_MS = Number(process.env.E2E_PER_TEST_DELAY_MS ?? 5000);
+if (PER_TEST_DELAY_MS > 0) {
+    ogsTest.afterEach(async () => {
+        console.log(`Per-test settle: waiting ${PER_TEST_DELAY_MS / 1000}s...`);
+        await new Promise((resolve) => setTimeout(resolve, PER_TEST_DELAY_MS));
+    });
+}


### PR DESCRIPTION
Runs in afterEach so a single local test reports its result first and the wait is buried in time spent looking at it. Configurable via E2E_PER_TEST_DELAY_MS (0 = disabled).

Fixes some flakes.

## Proposed Changes

  - Wait after each e2e test for a moment.
 
Note: if this fixes even one flake, it saves time overall: flakes are expensive retries.

Empiricaly only, it does seem to help in dev, avoiding a new test starting right when AI is spinning up on a game run in a previous test.
