### PR TITLE
Fix delete button shown on root SGF collection

### DIFF
--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -373,6 +373,9 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
         });
     };
     deleteCollection = () => {
+        if (this.state.collection_id === "0") {
+            return;
+        }
         const parent = this.state.collections![this.state.collection_id].parent;
 
         post(`library/${this.state.player_id}`, {

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -137,7 +137,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
 
         if (this.props.match.params.collection_id !== prev_props.match.params.collection_id) {
             if (this.props.match.params.collection_id) {
-                update.collection_id = parseInt(this.props.match.params.collection_id);
+                update.collection_id = this.props.match.params.collection_id;
             } else {
                 update.collection_id = "0";
             }

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -947,7 +947,7 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
                                                     )}
                                                 </h4>
                                             )}
-                                            {owner && (
+                                            {owner && this.state.collection_id !== "0" && (
                                                 <button
                                                     className="reject"
                                                     onClick={this.deleteCollection}


### PR DESCRIPTION
Fixes #3594. When navigating to the root SGF collection via the breadcrumb, `componentDidUpdate` was storing the result of `parseInt()` into `collection_id` (a `string`). This caused the root collection check `collection_id !== "0"` to pass. The fix removes the `parseInt()` call so `collection_id` stays a `string`. As a follow-on, the repeated `collection_id !== "0"` checks throughout the component could be consolidated into an `isRootCollection` helper, but I'll leave that style decision to another