### PR TITLE
fix: cap group banner image at 100% width

### DIFF
--- a/src/views/Group/Group.css
+++ b/src/views/Group/Group.css
@@ -19,7 +19,7 @@
         text-align: center;
 
         img {
-            max-width: 100dvw;
+            max-width: 100%;
             max-height: 20dvh;
         }
 


### PR DESCRIPTION
Fixes #3598
