### PR TITLE
Escape rate predictive badge

### DIFF
--- a/e2e-tests/AGENTS.md
+++ b/e2e-tests/AGENTS.md
@@ -21,7 +21,7 @@ When creating e2e tests, note that:
 
 - `prepareNewUser` creates a new user with suitable settings and guaranteed unique name.
 
-- The string argument of `newTestUsername` must be less than 21 characters. This is because OGS username limit is 20 chars and 8 are used for uniquification. It's helpful to have characters identifying which test and which role
+- The string argument of `newTestUsername` is length-checked at call time against a limit derived from the server's 30-char username cap (currently 18 chars, after subtracting the `e2e` prefix, the underscore, the suffix, and worker-index space). The exact value is computed in `helpers/user-utils.ts`; keep the role short and descriptive (e.g. `ERPBAcc`, `LWARNOth`) so the generated username is readable in logs
 
 - Avoid direct API calls - the intent of e2e testing is to test by driving the system as a user does.
 

--- a/e2e-tests/AGENTS.md
+++ b/e2e-tests/AGENTS.md
@@ -4,30 +4,36 @@ This is information for Agents to take into account when working on e2e tests.
 
 When creating e2e tests, note that:
 
--   When writing tests that use UI elements to achieve outcomes, always check the UI code of of the elements you're using to make sure you are using them correctly.
-    -- DO NOT guess how the UI works when developing tests, check how it works in the code.
+- When writing tests that use UI elements to achieve outcomes, always check the UI code of of the elements you're using to make sure you are using them correctly.
+  -- DO NOT guess how the UI works when developing tests, check how it works in the code.
 
--   When entering inputs, include a check to make sure the input was accepted before proceeding to the next action.
+- When entering inputs, include a check to make sure the input was accepted before proceeding to the next action.
 
--   Any actions involving looking at reports should be wrapped in `withIncidentIndicatorLock`, and should check that there are no open reports at the start, so that debug of "already open reports" is easy.
+- Any actions involving looking at reports should be wrapped in `withIncidentIndicatorLock`, and should check that there are no open reports at the start, so that debug of "already open reports" is easy.
 
 (The problem is that tests can fail if the wrong number of reports is open, due to previously failed tests)
 
--   Any actions or assertions using buttons need to use `expectOGSClickable` to find the button, because OGS buttons are implemented in a range of ways.
+- Any actions or assertions using buttons need to use `expectOGSClickable` to find the button, because OGS buttons are implemented in a range of ways.
 
--   Users (user data) can be created either by seeding it or using `prepareNewUser`.
+- Users (user data) can be created either by seeding it or using `prepareNewUser`.
 
--   Seeded data is to be used when we need users with privileges that can only be given by full moderators. We do not have full moderator powers in the test suite.
+- Seeded data is to be used when we need users with privileges that can only be given by full moderators. We do not have full moderator powers in the test suite.
 
--   `prepareNewUser` creates a new user with suitable settings and guaranteed unique name.
+- `prepareNewUser` creates a new user with suitable settings and guaranteed unique name.
 
--   The string argument of `newTestUsername` must be less than 21 characters. This is because OGS username limit is 20 chars and 8 are used for uniquification. It's helpful to have characters identifying which test and which role
+- The string argument of `newTestUsername` must be less than 21 characters. This is because OGS username limit is 20 chars and 8 are used for uniquification. It's helpful to have characters identifying which test and which role
 
--   Avoid direct API calls - the intent of e2e testing is to test by driving the system as a user does.
+- Avoid direct API calls - the intent of e2e testing is to test by driving the system as a user does.
 
--   We do all our testing in English, we don't have to worry about pgettext
+- We do all our testing in English, we don't have to worry about pgettext
 
--   Community Moderation is controlled by MODERATOR_POWERS. This is different to "full moderation", which is controlled by is_moderator.
+- Community Moderation is controlled by MODERATOR_POWERS. This is different to "full moderation", which is controlled by is_moderator.
 
--   When writing tests that use UI elements to achieve outcomes, always check the UI code of of the elements you're using to make sure you are using them correctly.
-    -- DO NOT guess how the UI works when developing tests, check how it works in the code.
+- When writing tests that use UI elements to achieve outcomes, always check the UI code of of the elements you're using to make sure you are using them correctly.
+  -- DO NOT guess how the UI works when developing tests, check how it works in the code.
+
+- The `@Slow` tag in an `ogsTest("@Slow ...", ...)` name is reserved for tests that need a larger-than-default time budget because the behaviour under test takes a long time. The usual case is an explicit long wait — e.g. a 5-minute timeout being verified. A test should not get the tag just because it touches a few UI elements; "long because it does a lot" is normally a smell, not a justification.
+
+    Exception: a test that legitimately needs a long time budget because it builds up a cumulative scenario (e.g. playing several games in sequence to accrue the state under test) may carry `@Slow`. When you do this, raise the test's own `TIMEOUT_MS` accordingly and add a one-line comment in the test file explaining why the tag is present. Otherwise the tag drifts and stops meaning anything.
+
+    When adding a new test alongside one tagged `@Slow`, don't inherit the tag without checking whether _this_ test's behaviour is actually time-gated.

--- a/e2e-tests/cm/cm-escape-rate-display.ts
+++ b/e2e-tests/cm/cm-escape-rate-display.ts
@@ -93,11 +93,19 @@ async function playAndFinishGame(
     accusedUsername: string,
     gameIndex: number,
 ): Promise<void> {
+    // Override defaultChallengeSettings' 2s/2s blitz timing — under a loaded
+    // dev stack the 4-move play sequence can exhaust either player's time
+    // and end the game by timeout rather than pass+accept, leaving the test
+    // waiting forever on the "Pass"/"Accept" buttons. 60s main + 1×10s
+    // byoyomi gives ample headroom while still being "live" speed.
     await createDirectChallenge(reporterPage, accusedUsername, {
         ...defaultChallengeSettings,
         gameName: `E2E ERH Game ${gameIndex}`,
         boardSize: "9x9",
-        speed: "blitz",
+        speed: "live",
+        mainTime: "60",
+        timePerPeriod: "10",
+        periods: "1",
         color: "black",
     });
 

--- a/e2e-tests/cm/cm-escape-rate-display.ts
+++ b/e2e-tests/cm/cm-escape-rate-display.ts
@@ -143,13 +143,14 @@ async function playAndFinishGame(
 
 /**
  * File an escaping report on the current game page, then have 3 CMs
- * vote the specified action to resolve it.
+ * vote the specified action to resolve it. Returns the report number so
+ * the caller can navigate back to verify resolved-report behaviour.
  */
 async function reportAndVote(
     reporterPage: Page,
     cmPages: Page[],
     voteAction: string,
-): Promise<void> {
+): Promise<string> {
     // Report the accused (white) for escaping
     await reportPlayerByColor(
         reporterPage,
@@ -167,6 +168,8 @@ async function reportAndVote(
         const voteButton = await expectOGSClickableByName(cmPage, /Vote$/);
         await voteButton.click();
     }
+
+    return reportNumber;
 }
 
 /**
@@ -268,10 +271,11 @@ export const cmEscapeRateDisplayTest = async (
             // available options to formal-warn only.
             // ========================================
 
+            let lastResolvedReportNumber: string | null = null;
             for (let i = 1; i <= 4; i++) {
                 const voteAction = i <= 2 ? "informal_warn_escaper" : "warn_escaper";
                 await playAndFinishGame(reporterPage, accusedPage, accusedUsername, i);
-                await reportAndVote(reporterPage, cmPages, voteAction);
+                lastResolvedReportNumber = await reportAndVote(reporterPage, cmPages, voteAction);
 
                 // Navigate home to trigger warning dialogs, then dismiss them
                 await accusedPage.goto("/");
@@ -326,6 +330,29 @@ export const cmEscapeRateDisplayTest = async (
             const warningStatus = cmPage.locator(".formal-warning-status");
             await expect(warningStatus).toBeVisible();
             await expect(warningStatus).toContainText("Previously formally warned");
+
+            // ========================================
+            // Resolved-report check: predicted count is not off-by-one
+            // ========================================
+            //
+            // When CMs navigate back to a report that has already been voted
+            // as escaping, the current game's escape warning is in the count.
+            // The serializer must skip predict_escape_rate's +1 so the badge
+            // reflects the actual count, not actual + 1. Without the fix the
+            // predicted count would exceed games-in-window — impossible.
+            //
+            // Report 4 was voted warn_escaper; by its created-time the window
+            // contained games 1-4 (4 games, all ended before the report was
+            // filed) and all four had escape warnings issued (2 informal +
+            // 2 formal). Expected display: "4 escapes in 4 games".
+
+            if (lastResolvedReportNumber === null) {
+                throw new Error("Expected at least one resolved report number");
+            }
+            await navigateToReport(cmPage, lastResolvedReportNumber);
+            const resolvedDetail = cmPage.locator(".escape-rate-detail");
+            await expect(resolvedDetail).toBeVisible({ timeout: 15000 });
+            await expect(resolvedDetail).toContainText("4 escapes in 4 games");
 
             // Close all CM contexts
             for (const ctx of cmContexts) {

--- a/e2e-tests/cm/cm-escape-rate-display.ts
+++ b/e2e-tests/cm/cm-escape-rate-display.ts
@@ -79,7 +79,7 @@ import { playMoves } from "@helpers/game-utils";
 import { expectOGSClickableByName } from "@helpers/matchers";
 import { expect } from "@playwright/test";
 
-import { withReportCountTracking } from "@helpers/report-utils";
+import { dismissWarningDialogs, withReportCountTracking } from "@helpers/report-utils";
 
 const CM_VOTERS = ["E2E_CM_ERH_V1", "E2E_CM_ERH_V2", "E2E_CM_ERH_V3"];
 
@@ -170,50 +170,6 @@ async function reportAndVote(
     }
 
     return reportNumber;
-}
-
-/**
- * Dismiss any warning/ack dialogs that have accumulated on the accused's page.
- * Must be done before the accused can accept the next challenge.
- */
-async function dismissWarningDialogs(page: Page): Promise<void> {
-    // Dismiss formal warnings (require checking "I understand" checkbox)
-    const formalWarning = page.locator("div.AccountWarning");
-    for (let i = 0; i < 10; i++) {
-        try {
-            await formalWarning.waitFor({ state: "visible", timeout: 3000 });
-            const checkbox = formalWarning.locator('input[type="checkbox"]');
-            await checkbox.check();
-            await formalWarning.locator("button.primary").click();
-            await expect(formalWarning).not.toBeVisible();
-        } catch {
-            break;
-        }
-    }
-
-    // Dismiss informal warnings
-    const infoOk = page.locator(".AccountWarningInfo button.primary");
-    for (let i = 0; i < 10; i++) {
-        try {
-            await infoOk.waitFor({ state: "visible", timeout: 3000 });
-            await infoOk.click();
-            await expect(infoOk).not.toBeVisible();
-        } catch {
-            break;
-        }
-    }
-
-    // Dismiss ack dialogs (reporter gets these)
-    const ackOk = page.locator("div.AccountWarningAck button.primary");
-    for (let i = 0; i < 10; i++) {
-        try {
-            await ackOk.waitFor({ state: "visible", timeout: 3000 });
-            await ackOk.click();
-            await expect(ackOk).not.toBeVisible();
-        } catch {
-            break;
-        }
-    }
 }
 
 export const cmEscapeRateDisplayTest = async (

--- a/e2e-tests/cm/cm-escape-rate-display.ts
+++ b/e2e-tests/cm/cm-escape-rate-display.ts
@@ -33,8 +33,9 @@
  * - 1 open escaping report on game 5 (the one we test the display on)
  *
  * Expected display on report 5:
- * - "Escaping too much" badge (red) — 4 escapes in 100-game window > 3% threshold
- * - "4 escapes in 5 games"
+ * - "IF this is escaping:" predictive header
+ * - "5 escapes in 5 games" (4 prior confirmed + 1 current report under judgement)
+ * - "Escaping too much" badge (red) — predicted rate crosses the 3% threshold
  * - "Previously formally warned"
  *
  * Flow:
@@ -199,7 +200,11 @@ export const cmEscapeRateDisplayTest = async (
     const { userPage: accusedPage } = await prepareNewUser(createContext, accusedUsername, "test");
 
     const reporterUsername = newTestUsername("ERHRep"); // cspell:disable-line
-    const { userPage: reporterPage } = await prepareNewUser(createContext, reporterUsername, "test");
+    const { userPage: reporterPage } = await prepareNewUser(
+        createContext,
+        reporterUsername,
+        "test",
+    );
 
     await withReportCountTracking(
         reporterPage,
@@ -271,15 +276,20 @@ export const cmEscapeRateDisplayTest = async (
             const escapeRateInfo = cmPage.locator(".escape-rate-info");
             await expect(escapeRateInfo).toBeVisible({ timeout: 15000 });
 
+            // Verify the predictive header is present
+            const conditionalHeader = cmPage.locator(".escape-rate-conditional-header");
+            await expect(conditionalHeader).toBeVisible();
+            await expect(conditionalHeader).toContainText("IF this is escaping:");
+
             // Verify the badge shows "Escaping too much" (red)
             const badge = cmPage.locator(".escape-rate-badge.escaping-too-much");
             await expect(badge).toBeVisible();
             await expect(badge).toContainText("Escaping too much");
 
-            // Verify rate detail shows correct numbers
+            // Verify rate detail shows the predicted count (4 prior + 1 current = 5)
             const detail = cmPage.locator(".escape-rate-detail");
             await expect(detail).toBeVisible();
-            await expect(detail).toContainText("4 escapes in 5 games");
+            await expect(detail).toContainText("5 escapes in 5 games");
 
             // Verify formal warning status
             const warningStatus = cmPage.locator(".formal-warning-status");

--- a/e2e-tests/cm/cm-escape-rate-display.ts
+++ b/e2e-tests/cm/cm-escape-rate-display.ts
@@ -29,19 +29,26 @@
  * - reporter user - created fresh each run
  * - 5 games between reporter and accused
  * - 4 escaping reports on games 1-4, each resolved by 3 CM votes
- *   (3 informal warnings + 1 formal warning)
+ *   (2 informal warnings then 2 formal warnings)
  * - 1 open escaping report on game 5 (the one we test the display on)
+ *
+ * The 2-then-2 split is dictated by the predictive filter: the badge counts
+ * the report under judgement, so as soon as a player has 2 prior confirmed
+ * escapes, the predicted count for the next report is 3 — over the threshold —
+ * and the informal-warn options are hidden. The test scenario therefore
+ * walks the same staircase a real CM workflow does (2 informals, then formals
+ * once the predictive threshold is reached).
  *
  * Expected display on report 5:
  * - "IF this is escaping:" predictive header
  * - "5 escapes in 5 games" (4 prior confirmed + 1 current report under judgement)
  * - "Escaping too much" badge (red) — predicted rate crosses the 3% threshold
- * - "Previously formally warned"
+ * - "Previously formally warned" (two formal warnings on record by this point)
  *
  * Flow:
  * 1. Play 5 games between reporter and accused (pass+accept to finish each)
- * 2. For games 1-3: file escaping report, 3 CMs vote informal_warn_escaper
- * 3. For game 4: file escaping report, 3 CMs vote warn_escaper (formal)
+ * 2. For games 1-2: file escaping report, 3 CMs vote informal_warn_escaper
+ * 3. For games 3-4: file escaping report, 3 CMs vote warn_escaper (formal)
  * 4. For game 5: file escaping report (left open)
  * 5. CM views report 5 and verifies escape rate display
  */
@@ -58,6 +65,8 @@ import {
     reportPlayerByColor,
     setupSeededCM,
 } from "@helpers/user-utils";
+
+import { log } from "@helpers/logger";
 
 import {
     acceptDirectChallenge,
@@ -113,6 +122,15 @@ async function playAndFinishGame(
     await reporterAccept.click();
 
     await expect(reporterPage.getByText("wins by")).toBeVisible();
+
+    // Five sequential games + reports overload the dev stack: the server's
+    // Game.ended write trails behind the WS phase-finished event the goban
+    // already rendered, so the next escaping report on this game gets
+    // rejected by moderate.py:714-725 (HTTP 400). A deliberate 30 s pause
+    // lets the post-game pipeline (WS → DB write, queue drain) quiesce
+    // before we move on. Heavy but reliable; see e2e-tests/AGENTS.md.
+    log(`[cm-escape-rate-display] Game ${gameIndex} ended — pausing 30 s to quiesce`);
+    await reporterPage.waitForTimeout(30000);
 }
 
 /**
@@ -193,7 +211,14 @@ export const cmEscapeRateDisplayTest = async (
     }: { createContext: (options?: CreateContextOptions) => Promise<BrowserContext> },
     testInfo: TestInfo,
 ) => {
-    const TIMEOUT_MS = 300 * 1000;
+    // Tagged @Slow in cm.spec.ts: this test plays five sequential games and
+    // resolves four reports with three CM votes each to build up the escape
+    // history the display assertion checks. Each game also includes a 30 s
+    // post-game pause so the dev stack can commit Game.ended before the
+    // next escaping report (otherwise moderate.py:714-725 rejects it as
+    // HTTP 400). The cumulative time is genuine setup, not flakiness —
+    // see AGENTS.md for the rule.
+    const TIMEOUT_MS = 720 * 1000;
 
     // Create fresh users
     const accusedUsername = newTestUsername("ERHAcc"); // cspell:disable-line
@@ -223,30 +248,28 @@ export const cmEscapeRateDisplayTest = async (
             }
 
             // ========================================
-            // Games 1-3: Play, report, 3 CMs vote informal_warn_escaper
+            // Games 1-2: Play, report, 3 CMs vote informal_warn_escaper
+            // Games 3-4: Play, report, 3 CMs vote warn_escaper (formal)
+            //
+            // The vote action switches at game 3 because the predictive filter
+            // hides informal-warn options once predicted count >= 3. Games 1-2
+            // each have 0 then 1 prior confirmed escape, so predicted (1, then
+            // 2) stays under threshold and informal is offered. From game 3
+            // onward there are >= 2 prior confirmed escapes, so the predicted
+            // count reaches the 3% threshold and the filter switches the
+            // available options to formal-warn only.
             // ========================================
 
-            for (let i = 1; i <= 3; i++) {
+            for (let i = 1; i <= 4; i++) {
+                const voteAction = i <= 2 ? "informal_warn_escaper" : "warn_escaper";
                 await playAndFinishGame(reporterPage, accusedPage, accusedUsername, i);
-                await reportAndVote(reporterPage, cmPages, "informal_warn_escaper");
+                await reportAndVote(reporterPage, cmPages, voteAction);
 
                 // Navigate home to trigger warning dialogs, then dismiss them
                 await accusedPage.goto("/");
                 await dismissWarningDialogs(accusedPage);
                 await dismissWarningDialogs(reporterPage);
             }
-
-            // ========================================
-            // Game 4: Play, report, 3 CMs vote warn_escaper (formal warning)
-            // ========================================
-
-            await playAndFinishGame(reporterPage, accusedPage, accusedUsername, 4);
-            await reportAndVote(reporterPage, cmPages, "warn_escaper");
-
-            // Dismiss the formal warning on the accused
-            await accusedPage.goto("/");
-            await dismissWarningDialogs(accusedPage);
-            await dismissWarningDialogs(reporterPage);
 
             // ========================================
             // Game 5: Play and file the report we'll test the display on

--- a/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
+++ b/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
@@ -44,6 +44,7 @@ import { BrowserContext, Page, TestInfo } from "@playwright/test";
 
 import {
     captureReportNumber,
+    goToUsersFinishedGame,
     navigateToReport,
     newTestUsername,
     prepareNewUser,
@@ -72,9 +73,10 @@ async function playAndFinishGame(
     accusedUsername: string,
     gameIndex: number,
 ): Promise<void> {
+    const gameName = `E2E ERPB Game ${gameIndex}`;
     await createDirectChallenge(reporterPage, accusedUsername, {
         ...defaultChallengeSettings,
-        gameName: `E2E ERPB Game ${gameIndex}`,
+        gameName,
         boardSize: "9x9",
         speed: "blitz",
         color: "black",
@@ -99,6 +101,14 @@ async function playAndFinishGame(
     await reporterAccept.click();
 
     await expect(reporterPage.getByText("wins by")).toBeVisible();
+
+    // The reporter UI has the goban in "finished" phase, but the server's
+    // Game.ended write may not be committed yet. Filing an escaping report
+    // before that lands gets rejected by moderate.py:714-725 (HTTP 400).
+    // Navigate via the accused's finished-game list — the game only appears
+    // there once the DB has Game.ended set — then load the game page fresh.
+    await goToUsersFinishedGame(reporterPage, accusedUsername, gameName);
+    await expect(reporterPage.locator(".game-state")).toContainText("wins by");
 }
 
 async function reportAndVote(

--- a/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
+++ b/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
@@ -63,7 +63,7 @@ import { playMoves } from "@helpers/game-utils";
 import { expectOGSClickableByName } from "@helpers/matchers";
 import { expect } from "@playwright/test";
 
-import { withReportCountTracking } from "@helpers/report-utils";
+import { dismissWarningDialogs, withReportCountTracking } from "@helpers/report-utils";
 
 const CM_VOTERS = ["E2E_CM_ERH_V1", "E2E_CM_ERH_V2", "E2E_CM_ERH_V3"];
 
@@ -138,43 +138,6 @@ async function reportAndVote(
         await cmPage.locator(`input[value="${voteAction}"]`).click();
         const voteButton = await expectOGSClickableByName(cmPage, /Vote$/);
         await voteButton.click();
-    }
-}
-
-async function dismissWarningDialogs(page: Page): Promise<void> {
-    const formalWarning = page.locator("div.AccountWarning");
-    for (let i = 0; i < 10; i++) {
-        try {
-            await formalWarning.waitFor({ state: "visible", timeout: 3000 });
-            const checkbox = formalWarning.locator('input[type="checkbox"]');
-            await checkbox.check();
-            await formalWarning.locator("button.primary").click();
-            await expect(formalWarning).not.toBeVisible();
-        } catch {
-            break;
-        }
-    }
-
-    const infoOk = page.locator(".AccountWarningInfo button.primary");
-    for (let i = 0; i < 10; i++) {
-        try {
-            await infoOk.waitFor({ state: "visible", timeout: 3000 });
-            await infoOk.click();
-            await expect(infoOk).not.toBeVisible();
-        } catch {
-            break;
-        }
-    }
-
-    const ackOk = page.locator("div.AccountWarningAck button.primary");
-    for (let i = 0; i < 10; i++) {
-        try {
-            await ackOk.waitFor({ state: "visible", timeout: 3000 });
-            await ackOk.click();
-            await expect(ackOk).not.toBeVisible();
-        } catch {
-            break;
-        }
     }
 }
 

--- a/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
+++ b/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
@@ -74,11 +74,19 @@ async function playAndFinishGame(
     gameIndex: number,
 ): Promise<void> {
     const gameName = `E2E ERPB Game ${gameIndex}`;
+    // Override defaultChallengeSettings' 2s/2s blitz timing — under a loaded
+    // dev stack the 4-move play sequence can exhaust either player's time
+    // and end the game by timeout rather than pass+accept, leaving the test
+    // waiting forever on the "Pass"/"Accept" buttons. 60s main + 1×10s
+    // byoyomi gives ample headroom while still being "live" speed.
     await createDirectChallenge(reporterPage, accusedUsername, {
         ...defaultChallengeSettings,
         gameName,
         boardSize: "9x9",
-        speed: "blitz",
+        speed: "live",
+        mainTime: "60",
+        timePerPeriod: "10",
+        periods: "1",
         color: "black",
     });
 
@@ -176,7 +184,7 @@ export const cmEscapeRatePredictiveBorderlineTest = async (
     }: { createContext: (options?: CreateContextOptions) => Promise<BrowserContext> },
     testInfo: TestInfo,
 ) => {
-    const TIMEOUT_MS = 240 * 1000;
+    const TIMEOUT_MS = 360 * 1000;
 
     const accusedUsername = newTestUsername("ERPBAcc"); // cspell:disable-line
     const { userPage: accusedPage } = await prepareNewUser(createContext, accusedUsername, "test");

--- a/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
+++ b/e2e-tests/cm/cm-escape-rate-predictive-borderline.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// cspell:words ERPB
+
+/*
+ * Tests the predictive badge boundary: a player with 2 prior confirmed
+ * escapes (both informal) opens a third escaping report. The predictive
+ * count is 3, which crosses the 3% threshold, so:
+ *   - the badge reads "Escaping too much"
+ *   - the displayed count is "3 escapes in 3 games"
+ *   - formal-warn vote options ARE present
+ *   - informal-warn vote options are NOT present
+ *
+ * Uses init_e2e CM voters from the existing escape-rate display test:
+ *   E2E_CM_ERH_V1, E2E_CM_ERH_V2, E2E_CM_ERH_V3.
+ *
+ * Creates dynamically per run:
+ *   - accused user
+ *   - reporter user
+ *   - 3 games
+ *   - 2 escaping reports on games 1-2 resolved by 3 CMs voting
+ *     informal_warn_escaper
+ *   - 1 open escaping report on game 3 (the one we inspect)
+ */
+
+import type { CreateContextOptions } from "@helpers";
+
+import { BrowserContext, Page, TestInfo } from "@playwright/test";
+
+import {
+    captureReportNumber,
+    navigateToReport,
+    newTestUsername,
+    prepareNewUser,
+    reportPlayerByColor,
+    setupSeededCM,
+} from "@helpers/user-utils";
+
+import {
+    acceptDirectChallenge,
+    createDirectChallenge,
+    defaultChallengeSettings,
+} from "@helpers/challenge-utils";
+
+import { playMoves } from "@helpers/game-utils";
+
+import { expectOGSClickableByName } from "@helpers/matchers";
+import { expect } from "@playwright/test";
+
+import { withReportCountTracking } from "@helpers/report-utils";
+
+const CM_VOTERS = ["E2E_CM_ERH_V1", "E2E_CM_ERH_V2", "E2E_CM_ERH_V3"];
+
+async function playAndFinishGame(
+    reporterPage: Page,
+    accusedPage: Page,
+    accusedUsername: string,
+    gameIndex: number,
+): Promise<void> {
+    await createDirectChallenge(reporterPage, accusedUsername, {
+        ...defaultChallengeSettings,
+        gameName: `E2E ERPB Game ${gameIndex}`,
+        boardSize: "9x9",
+        speed: "blitz",
+        color: "black",
+    });
+
+    await acceptDirectChallenge(accusedPage);
+
+    const goban = reporterPage.locator(".Goban[data-pointers-bound]");
+    await goban.waitFor({ state: "visible" });
+
+    await playMoves(reporterPage, accusedPage, ["D5", "E5", "D6", "E6"], "9x9");
+
+    await reporterPage.getByText("Pass", { exact: true }).click();
+    await accusedPage.getByText("Pass", { exact: true }).click();
+
+    const accusedAccept = accusedPage.getByText("Accept");
+    await expect(accusedAccept).toBeVisible();
+    await accusedAccept.click();
+
+    const reporterAccept = reporterPage.getByText("Accept");
+    await expect(reporterAccept).toBeVisible();
+    await reporterAccept.click();
+
+    await expect(reporterPage.getByText("wins by")).toBeVisible();
+}
+
+async function reportAndVote(
+    reporterPage: Page,
+    cmPages: Page[],
+    voteAction: string,
+): Promise<void> {
+    await reportPlayerByColor(
+        reporterPage,
+        ".white",
+        "escaping",
+        "E2E test: player escaped this game",
+    );
+
+    const reportNumber = await captureReportNumber(reporterPage);
+
+    for (const cmPage of cmPages) {
+        await navigateToReport(cmPage, reportNumber);
+        await cmPage.locator(`input[value="${voteAction}"]`).click();
+        const voteButton = await expectOGSClickableByName(cmPage, /Vote$/);
+        await voteButton.click();
+    }
+}
+
+async function dismissWarningDialogs(page: Page): Promise<void> {
+    const formalWarning = page.locator("div.AccountWarning");
+    for (let i = 0; i < 10; i++) {
+        try {
+            await formalWarning.waitFor({ state: "visible", timeout: 3000 });
+            const checkbox = formalWarning.locator('input[type="checkbox"]');
+            await checkbox.check();
+            await formalWarning.locator("button.primary").click();
+            await expect(formalWarning).not.toBeVisible();
+        } catch {
+            break;
+        }
+    }
+
+    const infoOk = page.locator(".AccountWarningInfo button.primary");
+    for (let i = 0; i < 10; i++) {
+        try {
+            await infoOk.waitFor({ state: "visible", timeout: 3000 });
+            await infoOk.click();
+            await expect(infoOk).not.toBeVisible();
+        } catch {
+            break;
+        }
+    }
+
+    const ackOk = page.locator("div.AccountWarningAck button.primary");
+    for (let i = 0; i < 10; i++) {
+        try {
+            await ackOk.waitFor({ state: "visible", timeout: 3000 });
+            await ackOk.click();
+            await expect(ackOk).not.toBeVisible();
+        } catch {
+            break;
+        }
+    }
+}
+
+export const cmEscapeRatePredictiveBorderlineTest = async (
+    {
+        createContext,
+    }: { createContext: (options?: CreateContextOptions) => Promise<BrowserContext> },
+    testInfo: TestInfo,
+) => {
+    const TIMEOUT_MS = 240 * 1000;
+
+    const accusedUsername = newTestUsername("ERPBAcc"); // cspell:disable-line
+    const { userPage: accusedPage } = await prepareNewUser(createContext, accusedUsername, "test");
+
+    const reporterUsername = newTestUsername("ERPBRep"); // cspell:disable-line
+    const { userPage: reporterPage } = await prepareNewUser(
+        createContext,
+        reporterUsername,
+        "test",
+    );
+
+    await withReportCountTracking(
+        reporterPage,
+        testInfo,
+        async (tracker) => {
+            const cmPages: Page[] = [];
+            const cmContexts: BrowserContext[] = [];
+            for (const cmUser of CM_VOTERS) {
+                const { seededCMPage, seededCMContext } = await setupSeededCM(
+                    createContext,
+                    cmUser,
+                );
+                cmPages.push(seededCMPage);
+                cmContexts.push(seededCMContext);
+            }
+
+            // Games 1-2: file, vote informal_warn_escaper -> 2 prior confirmed escapes.
+            for (let i = 1; i <= 2; i++) {
+                await playAndFinishGame(reporterPage, accusedPage, accusedUsername, i);
+                await reportAndVote(reporterPage, cmPages, "informal_warn_escaper");
+                await accusedPage.goto("/");
+                await dismissWarningDialogs(accusedPage);
+                await dismissWarningDialogs(reporterPage);
+            }
+
+            // Game 3: file but leave open -- this is the report we inspect.
+            await playAndFinishGame(reporterPage, accusedPage, accusedUsername, 3);
+
+            await reportPlayerByColor(
+                reporterPage,
+                ".white",
+                "escaping",
+                "E2E test: player escaped (report 3, borderline)",
+            );
+
+            await tracker.assertCountIncreasedBy(reporterPage, 1);
+
+            const reportNumber = await captureReportNumber(reporterPage);
+
+            const cmPage = cmPages[0];
+            await navigateToReport(cmPage, reportNumber);
+
+            // Header: "IF this is escaping:"
+            const conditionalHeader = cmPage.locator(".escape-rate-conditional-header");
+            await expect(conditionalHeader).toBeVisible({ timeout: 15000 });
+            await expect(conditionalHeader).toContainText("IF this is escaping:");
+
+            // Predicted count: 2 prior + 1 current = 3 in 3 games
+            const detail = cmPage.locator(".escape-rate-detail");
+            await expect(detail).toContainText("3 escapes in 3 games");
+
+            // Badge: "Escaping too much" (red)
+            const badge = cmPage.locator(".escape-rate-badge.escaping-too-much");
+            await expect(badge).toBeVisible();
+            await expect(badge).toContainText("Escaping too much");
+
+            // Formal-warn vote option present
+            const formalVote = cmPage.locator('input[value="warn_escaper"]');
+            await expect(formalVote).toBeVisible();
+
+            // Informal-warn vote options absent
+            const informalVote = cmPage.locator('input[value="informal_warn_escaper"]');
+            await expect(informalVote).toHaveCount(0);
+            const informalAnnulVote = cmPage.locator(
+                'input[value="informal_warn_escaper_and_annul"]',
+            );
+            await expect(informalAnnulVote).toHaveCount(0);
+
+            for (const ctx of cmContexts) {
+                await ctx.close();
+            }
+
+            // Clean up: cancel the open report so we leave a tidy state.
+            await reporterPage.goto("/reports-center");
+            const myReports = reporterPage.getByText("My Own Reports");
+            await expect(myReports).toBeVisible();
+            await myReports.click();
+
+            const cancelButton = await expectOGSClickableByName(reporterPage, /Cancel$/);
+            await cancelButton.click();
+
+            await tracker.assertCountReturnedToInitial(reporterPage);
+        },
+        TIMEOUT_MS,
+    );
+};

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -55,7 +55,7 @@ ogsTest.describe("@CM Community Moderation Tests", () => {
     ogsTest("@Slow Last warning info shown on repeat offender reports", cmLastWarningInfoTest);
     ogsTest("@Slow Escape rate display on escaping reports", cmEscapeRateDisplayTest);
     ogsTest(
-        "@Slow CM sees formal options at the predictive escape-rate boundary",
+        "CM sees formal options at the predictive escape-rate boundary",
         cmEscapeRatePredictiveBorderlineTest,
     );
     ogsTest("Informal warning vote on escaping reports", cmInformalWarnEscaperTest);

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -30,6 +30,7 @@ import { cmVoteEscalateSandbaggingTest } from "./cm-vote-escalate-sandbagging";
 import { cmSandbaggingAssessmentConversionTest } from "./cm-sandbagging-assessment-conversion";
 import { cmLastWarningInfoTest } from "./cm-last-warning-info";
 import { cmEscapeRateDisplayTest } from "./cm-escape-rate-display";
+import { cmEscapeRatePredictiveBorderlineTest } from "./cm-escape-rate-predictive-borderline";
 import { cmInformalWarnEscaperTest } from "./cm-informal-warn-escaper";
 import { cmInformalWarnEscaperAndAnnulTest } from "./cm-informal-warn-escaper-and-annul";
 import { cmEscalatedEscapingAllOptionsTest } from "./cm-escalated-escaping-all-options";
@@ -53,6 +54,10 @@ ogsTest.describe("@CM Community Moderation Tests", () => {
     );
     ogsTest("@Slow Last warning info shown on repeat offender reports", cmLastWarningInfoTest);
     ogsTest("@Slow Escape rate display on escaping reports", cmEscapeRateDisplayTest);
+    ogsTest(
+        "@Slow CM sees formal options at the predictive escape-rate boundary",
+        cmEscapeRatePredictiveBorderlineTest,
+    );
     ogsTest("Informal warning vote on escaping reports", cmInformalWarnEscaperTest);
     ogsTest(
         "Informal warning and annul vote on escaping reports",

--- a/e2e-tests/helpers/report-utils.ts
+++ b/e2e-tests/helpers/report-utils.ts
@@ -204,3 +204,57 @@ export async function withReportCountTracking<T>(
         timeoutMs,
     );
 }
+
+/**
+ * Dismiss any warning/ack dialogs that have accumulated on a user's page.
+ *
+ * After a CM vote that issues a warning the affected player sees a modal
+ * (`.AccountWarning` for formal, `.AccountWarningInfo` for informal); the
+ * reporter sees an acknowledgement modal (`.AccountWarningAck`). These
+ * stack across multiple resolved reports and block subsequent interactions
+ * (e.g. accepting the next challenge), so tests that resolve several
+ * reports in sequence need to drain them between iterations.
+ *
+ * The loop bound of 10 is a defensive cap: in practice there is at most
+ * one dialog per resolved report, but we keep iterating until `waitFor`
+ * times out so the helper is robust to whatever stack depth exists.
+ */
+export async function dismissWarningDialogs(page: Page): Promise<void> {
+    // Dismiss formal warnings (require checking "I understand" checkbox)
+    const formalWarning = page.locator("div.AccountWarning");
+    for (let i = 0; i < 10; i++) {
+        try {
+            await formalWarning.waitFor({ state: "visible", timeout: 3000 });
+            const checkbox = formalWarning.locator('input[type="checkbox"]');
+            await checkbox.check();
+            await formalWarning.locator("button.primary").click();
+            await expect(formalWarning).not.toBeVisible();
+        } catch {
+            break;
+        }
+    }
+
+    // Dismiss informal warnings
+    const infoOk = page.locator(".AccountWarningInfo button.primary");
+    for (let i = 0; i < 10; i++) {
+        try {
+            await infoOk.waitFor({ state: "visible", timeout: 3000 });
+            await infoOk.click();
+            await expect(infoOk).not.toBeVisible();
+        } catch {
+            break;
+        }
+    }
+
+    // Dismiss ack dialogs (reporter gets these)
+    const ackOk = page.locator("div.AccountWarningAck button.primary");
+    for (let i = 0; i < 10; i++) {
+        try {
+            await ackOk.waitFor({ state: "visible", timeout: 3000 });
+            await ackOk.click();
+            await expect(ackOk).not.toBeVisible();
+        } catch {
+            break;
+        }
+    }
+}

--- a/e2e-tests/helpers/user-utils.ts
+++ b/e2e-tests/helpers/user-utils.ts
@@ -59,6 +59,18 @@ import { log } from "./logger";
  * - selectNavMenuItem(): Clicks a specified Nav Menu item & subitem
  */
 
+// Alphabet for the random suffix that uniquifies each test username.
+// Excludes vowels (a, e, i, o, u) so randomly-generated usernames cannot
+// accidentally contain English-word substrings (e.g. "ok") that would
+// collide with Playwright's case-insensitive substring matching in
+// getByRole({ name }) — the bug that caused submitReportForm's OK-button
+// locator to match a player link whose suffix happened to spell "qsok90".
+// 31-char alphabet × 6 positions = 887M combinations, so collision
+// probability against ~1k accumulated test users on a dev stack is
+// ~0.001% per draw — comfortable headroom for realistic stack lifetimes.
+const USERNAME_SUFFIX_ALPHABET = "0123456789bcdfghjklmnpqrstvwxyz";
+const USERNAME_SUFFIX_LEN = 6;
+
 // This is tweaked to provide us with lots of unique usernames but also
 // a decent number of readable user-role characters, within the OGS username 30 character limit
 // on registration.
@@ -66,13 +78,16 @@ export const newTestUsername = (user_role: string) => {
     if (user_role.length > 20) {
         throw new Error("user_role must be 20 characters or less");
     }
-    const timestamp = Date.now().toString(36);
-    // Using 5 chars provides uniqueness roughly every 1.3 seconds
-    // This allows re-running tests with <10 second intervals
-    const midChars = timestamp.slice(-7, -2);
-    // Include worker index to prevent username collisions in parallel execution
+    let suffix = "";
+    for (let i = 0; i < USERNAME_SUFFIX_LEN; i++) {
+        suffix +=
+            USERNAME_SUFFIX_ALPHABET[Math.floor(Math.random() * USERNAME_SUFFIX_ALPHABET.length)];
+    }
+    // Include worker index to keep collisions impossible across parallel workers
+    // (Math.random would already make them vanishingly unlikely, but this is
+    // free and removes the need for a parallel-execution caveat in the math.)
     const workerIndex = process.env.TEST_WORKER_INDEX || "0";
-    return `e2e${user_role}_${midChars}${workerIndex}`;
+    return `e2e${user_role}_${suffix}${workerIndex}`;
 };
 
 // Counter for same-millisecond IPv6 generation

--- a/e2e-tests/helpers/user-utils.ts
+++ b/e2e-tests/helpers/user-utils.ts
@@ -71,12 +71,30 @@ import { log } from "./logger";
 const USERNAME_SUFFIX_ALPHABET = "0123456789bcdfghjklmnpqrstvwxyz";
 const USERNAME_SUFFIX_LEN = 6;
 
+// OGS rejects registration when len(username) > 30 (see Django backend
+// api/views/login.py). Derive the role-length limit from that so the
+// validation can't drift out of sync with the actual server constraint.
+// Worker index is up to 2 digits (TEST_WORKER_INDEX values up to 99);
+// allow for that even though parallel runs are typically 1-2 workers.
+const OGS_USERNAME_MAX_LEN = 30;
+const USERNAME_PREFIX = "e2e";
+const MAX_WORKER_INDEX_DIGITS = 2;
+const MAX_USER_ROLE_LEN =
+    OGS_USERNAME_MAX_LEN -
+    USERNAME_PREFIX.length -
+    1 /* underscore separator */ -
+    USERNAME_SUFFIX_LEN -
+    MAX_WORKER_INDEX_DIGITS;
+
 // This is tweaked to provide us with lots of unique usernames but also
 // a decent number of readable user-role characters, within the OGS username 30 character limit
 // on registration.
 export const newTestUsername = (user_role: string) => {
-    if (user_role.length > 20) {
-        throw new Error("user_role must be 20 characters or less");
+    if (user_role.length > MAX_USER_ROLE_LEN) {
+        throw new Error(
+            `user_role must be ${MAX_USER_ROLE_LEN} characters or less ` +
+                `to keep the generated username within the OGS ${OGS_USERNAME_MAX_LEN}-char limit`,
+        );
     }
     let suffix = "";
     for (let i = 0; i < USERNAME_SUFFIX_LEN; i++) {
@@ -87,7 +105,7 @@ export const newTestUsername = (user_role: string) => {
     // (Math.random would already make them vanishingly unlikely, but this is
     // free and removes the need for a parallel-execution caveat in the math.)
     const workerIndex = process.env.TEST_WORKER_INDEX || "0";
-    return `e2e${user_role}_${suffix}${workerIndex}`;
+    return `${USERNAME_PREFIX}${user_role}_${suffix}${workerIndex}`;
 };
 
 // Counter for same-millisecond IPv6 generation

--- a/e2e-tests/helpers/user-utils.ts
+++ b/e2e-tests/helpers/user-utils.ts
@@ -436,7 +436,14 @@ const submitReportForm = async (page: Page, type: string, notes: string) => {
     await submitButton.click();
 
     await expect(page.getByText("Thanks for the report!")).toBeVisible();
-    const OK = await expectOGSClickableByName(page, "OK");
+    // /^OK$/ rather than "OK": Playwright's getByRole({name}) does
+    // case-insensitive *substring* matching, which collides with
+    // dynamically-generated usernames containing "ok" (e.g. a player link
+    // labelled "e2eFoo_qsok90" matches `name: 'OK'`). The exact-match regex
+    // pins this to the dialog's actual OK button. (A systematic sweep of
+    // expectOGSClickableByName callers for the same problem is worth
+    // doing — separate patch.)
+    const OK = await expectOGSClickableByName(page, /^OK$/);
     // tidy up
     await OK.click();
     await expect(OK).toBeHidden();

--- a/src/models/moderation.d.ts
+++ b/src/models/moderation.d.ts
@@ -173,6 +173,9 @@ declare namespace rest_api {
             escapes_in_window: number | null;
             games_in_window: number | null;
             is_escaping_too_much: boolean | null;
+            predicted_escape_rate: number | null;
+            predicted_escapes_if_confirmed: number | null;
+            predicted_is_escaping_too_much: boolean | null;
             has_prior_formal_warning: boolean | null;
             has_prior_final_warning: boolean | null;
         }


### PR DESCRIPTION
Fixes wrong treatment when "this" report would push the person into the "unacceptable rate".

## Proposed Changes

  - Make the badge show whether it's acceptable _including this one_.
 

Needs https://github.com/online-go/ogs/pull/2417