### PR TITLE
Fix/debug cleanup and sort order bug

### DIFF
--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -72,7 +72,6 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
     };
 
     removeACLEntry(obj: any) {
-        console.log("SHould be removing", obj);
         const new_acl: any[] = [];
         for (const entry of this.state.acl) {
             if (!(entry.player_id === obj.player_id && entry.group_id === obj.group_id)) {

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -47,8 +47,6 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
 
         const ban = () => {
             const player_id = this.props.player_id;
-            console.log("Banning player", this.props.player_id);
-            console.log(this.state.details);
 
             const obj = {
                 moderation_note: this.state.details.moderator_notes,
@@ -57,11 +55,7 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
                 ban_expiration: this.state.details.ban_expiration?.toISOString(),
             };
 
-            console.log("Banning player", player_id, obj);
-
-            put("players/" + player_id + "/moderate", obj)
-                .then(() => console.log("Player banned"))
-                .catch(errorAlerter);
+            put("players/" + player_id + "/moderate", obj).catch(errorAlerter);
             this.close();
         };
 
@@ -103,16 +97,16 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
 
     return (
         <div>
-            <h3>Public reason (displayed to user)</h3>
+            <h3>{_("Public reason (displayed to user)")}</h3>
             <textarea onChange={(e) => set_public_reason(e.target.value)} value={public_reason} />
 
-            <h3>Moderator only notes (optional)</h3>
+            <h3>{_("Moderator only notes (optional)")}</h3>
             <textarea
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}
             />
 
-            <h3>Ban expiration</h3>
+            <h3>{_("Ban expiration")}</h3>
             <Datetime value={expiration} onChange={(d: any) => set_expiration(d._d)} />
         </div>
     );

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -105,8 +105,7 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}
             />
-
-            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
+            <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
             <Datetime value={expiration} onChange={(d: any) => set_expiration(d._d)} />
         </div>
     );

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import Datetime from "react-datetime";
 import { put } from "@/lib/requests";
-import { _ } from "@/lib/translate";
+import { _, pgettext } from "@/lib/translate";
 import { errorAlerter } from "@/lib/misc";
 import { Modal } from "@/components/Modal";
 import * as player_cache from "@/lib/player_cache";
@@ -97,16 +97,16 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
 
     return (
         <div>
-            <h3>{_("Public reason (displayed to user)")}</h3>
+            <h3>{pgettext("BanModal form field label", "Public reason (displayed to user)")}</h3>
             <textarea onChange={(e) => set_public_reason(e.target.value)} value={public_reason} />
 
-            <h3>{_("Moderator only notes (optional)")}</h3>
+            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
             <textarea
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}
             />
 
-            <h3>{_("Ban expiration")}</h3>
+            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
             <Datetime value={expiration} onChange={(d: any) => set_expiration(d._d)} />
         </div>
     );

--- a/src/components/ChatUserList/ChatUserList.tsx
+++ b/src/components/ChatUserList/ChatUserList.tsx
@@ -33,7 +33,7 @@ interface ChatUserCountProperties extends ChatUserListProperties {
 
 export function ChatUserList(props: ChatUserListProperties): React.ReactElement {
     const [user_sort_order, set_user_sort_order] = React.useState<"alpha" | "rank">(
-        preferences.get("chat.user-sort-order") === "rank" ? "alpha" : "rank",
+        preferences.get("chat.user-sort-order") === "rank" ? "rank" : "alpha",
     );
     const [, refresh] = React.useState<number>(0);
     const proxy = React.useRef<ChatChannelProxy | undefined>(undefined);
@@ -42,9 +42,6 @@ export function ChatUserList(props: ChatUserListProperties): React.ReactElement 
         proxy.current = chat_manager.join(props.channel);
         proxy.current.on("join", () => refresh(proxy?.current?.channel.users_by_name.length || 0));
         proxy.current.on("part", () => refresh(proxy?.current?.channel.users_by_name.length || 0));
-        proxy.current.on("join", () => console.log("JOin!"));
-        proxy.current.on("part", () => console.log("Part!"));
-        window.proxy = proxy.current;
         refresh(proxy.current.channel.users_by_name.length);
 
         return () => {

--- a/src/components/DismissableMessages/DismissableMessages.tsx
+++ b/src/components/DismissableMessages/DismissableMessages.tsx
@@ -49,12 +49,9 @@ export function DismissableMessages({
             return;
         }
 
-        console.log("Should dismiss", key);
         delete messages[key];
         data.set("config.dismissable_messages", messages);
-        del(`/api/v1/me/messages/${key}`)
-            .then(() => console.log(`Message ${key} dismissed`))
-            .catch(console.error);
+        del(`/api/v1/me/messages/${key}`).catch(console.error);
     }
 
     return (

--- a/src/components/SGFCollectionModal/SGFCollectionModal.tsx
+++ b/src/components/SGFCollectionModal/SGFCollectionModal.tsx
@@ -130,13 +130,6 @@ export class SGFCollectionModal extends Modal<
         this.setState({ uploading: true });
 
         const user = data.get("user");
-        console.log("DEBUG: Adding game to library", {
-            user_id: user.id,
-            game_id: this.props.gameId,
-            collection_id: parseInt(this.state.selectedCollectionId),
-            name: this.state.fileName,
-            url: `library/${user.id}`,
-        });
 
         post(`library/${user.id}`, {
             game_id: this.props.gameId,

--- a/src/lib/image_resizer.ts
+++ b/src/lib/image_resizer.ts
@@ -27,9 +27,6 @@ export function image_resizer(
         max_height = max_width;
     }
 
-    console.log(file);
-    window.file = file;
-
     const reader = new FileReader();
     const image = new Image();
     const canvas = allocateCanvasOrError();
@@ -77,15 +74,8 @@ export function image_resizer(
                         lastModified: file.lastModified,
                     });
 
-                    console.log(`File size was ${ret.size}.`, ret);
-
                     if (max_file_size && ret.size > max_file_size) {
                         const scale = Math.sqrt(max_file_size / ret.size) * 0.9;
-                        console.log(
-                            `Target size was ${ret.size}. Resizing to ${width * scale}x${
-                                height * scale
-                            } scale = ${scale}`,
-                        );
                         resolve(
                             image_resizer(
                                 ret,

--- a/typings_manual/index.d.ts
+++ b/typings_manual/index.d.ts
@@ -46,7 +46,6 @@ interface Window {
     rounds?: unknown; // Tournament.tsx
     players?: unknown; // Tournament.tsx
     tournament?: unknown; // Tournament.tsx
-    file?: unknown; // image_resizer.ts
     browserHistory: unknown; // ogsHistory.ts
     report_manager: unknown; // report_manager.ts
     sfx: unknown; // sfx.ts
@@ -64,7 +63,6 @@ interface Window {
     GobanEngine: unknown; // configure-goban.ts
     skew_clock: Function; // misc.ts
     notification_manager?: unknown; // NotificationManager.tsx
-    proxy?: unknown; // ChatUserList.tsx
 
     safari?: unknown;
 


### PR DESCRIPTION
OverviewThis Pull Request re-addresses the issues raised by github-actions in the previous implementation (#3605). It focuses on fully cleaning up leftover debug elements, properly defining translations with the mandatory context markers, and pruning dead types.Key Changesi18n & Contextual Translation Fix (src/BanModal.tsx):Updated all newly introduced UI labels to use pgettext("BanModal form field label", ...) instead of bare _() functions to meet the codebase localization rules (CLAUDE.md).Addressed missing contexts for the "Public reason", "Moderator only notes", and "Ban expiration" field labels.Dead Types Cleanup (typings_manual/index.d.ts):Completely removed stale type definitions for file?: unknown; and proxy?: unknown; which became obsolete after removing the respective global window leakages from image_resizer.ts and ChatUserList.tsx.Related Discussion / ReferenceRefers to automated review blockages in online-go/online-go.com#3605.ChecklistCode builds locally without errors.Linter/i18n validation patterns respected (pgettext utilized for new text strings).Unused manual global type definitions safely pruned.
