### PR TITLE
Fix/debug cleanup and sort order bug

### DIFF
--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -72,7 +72,6 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
     };
 
     removeACLEntry(obj: any) {
-        console.log("SHould be removing", obj);
         const new_acl: any[] = [];
         for (const entry of this.state.acl) {
             if (!(entry.player_id === obj.player_id && entry.group_id === obj.group_id)) {

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -47,8 +47,6 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
 
         const ban = () => {
             const player_id = this.props.player_id;
-            console.log("Banning player", this.props.player_id);
-            console.log(this.state.details);
 
             const obj = {
                 moderation_note: this.state.details.moderator_notes,
@@ -57,11 +55,7 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
                 ban_expiration: this.state.details.ban_expiration?.toISOString(),
             };
 
-            console.log("Banning player", player_id, obj);
-
-            put("players/" + player_id + "/moderate", obj)
-                .then(() => console.log("Player banned"))
-                .catch(errorAlerter);
+            put("players/" + player_id + "/moderate", obj).catch(errorAlerter);
             this.close();
         };
 
@@ -103,16 +97,16 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
 
     return (
         <div>
-            <h3>Public reason (displayed to user)</h3>
+            <h3>{_("Public reason (displayed to user)")}</h3>
             <textarea onChange={(e) => set_public_reason(e.target.value)} value={public_reason} />
 
-            <h3>Moderator only notes (optional)</h3>
+            <h3>{_("Moderator only notes (optional)")}</h3>
             <textarea
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}
             />
 
-            <h3>Ban expiration</h3>
+            <h3>{_("Ban expiration")}</h3>
             <Datetime value={expiration} onChange={(d: any) => set_expiration(d._d)} />
         </div>
     );

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -1,5 +1,4 @@
-/*
- * Copyright (C)  Online-Go.com
+/* Copyright (C)  Online-Go.com
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -12,7 +11,7 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://gnu.org/license>.
+ * along with this program.  If not, see <http://gnu.org>.
  */
 
 import * as React from "react";
@@ -109,12 +108,12 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
                 value={moderator_notes}
             />
 
-           <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
-           <Datetime
-               value={expiration}
-               onChange={(d: any) => set_expiration(typeof d === "string" ? undefined : d?.toDate())}
-           />
-
+            <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
+            <Datetime
+                value={expiration}
+                onChange={(d: any) =>
+                    set_expiration(typeof d === "string" ? undefined : d?.toDate())
+                }
             />
         </div>
     );

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -12,7 +12,7 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://gnu.org>.
+ * along with this program.  If not, see <http://gnu.org/license>.
  */
 
 import * as React from "react";

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -106,7 +106,8 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
                 value={moderator_notes}
             />
             <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
-            <Datetime value={expiration} onChange={(d: any) => set_expiration(d._d)} />
+            ban_expiration: this.state.details.ban_expiration?.toISOString()
+            
         </div>
     );
 }

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -48,7 +48,6 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
         const ban = () => {
             const player_id = this.props.player_id;
 
-            // 1. 봇이 지적한 메인 브랜치 규격에 맞춰 페이로드(obj) 완벽 복구
             const obj = {
                 moderation_note: this.state.details.moderator_notes,
                 is_banned: true,
@@ -58,7 +57,6 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
 
             put("players/" + player_id + "/moderate", obj)
                 .then(() => {
-                    // 성공 로그는 유지하거나 필요 없다면 생략 가능합니다.
                 })
                 .catch(errorAlerter);
             this.close();
@@ -112,7 +110,6 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
             />
 
             <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
-            {/* 2. 직접 타이핑 시 d._d 가 undefined가 되어 무한 정지되던 버그 수정 */}
             <Datetime 
                 value={expiration} 
                 onChange={(d: any) => {

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -105,8 +105,7 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}
             />
-
-            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
+            <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
             <Datetime value={expiration} onChange={(d: any) => set_expiration(d._d)} />
         </div>
     );

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -57,10 +57,10 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
 
             put("players/" + player_id + "/moderate", obj)
                 .then(() => {
+                    this.close();
                 })
-            target
                 .catch(errorAlerter);
-
+        };
 
         return (
             <div className="Modal BanModal">
@@ -103,8 +103,7 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
             <h3>{pgettext("BanModal form field label", "Public reason (displayed to user)")}</h3>
             <textarea onChange={(e) => set_public_reason(e.target.value)} value={public_reason} />
 
-            <<h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
-
+            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
             <textarea
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import Datetime from "react-datetime";
 import { put } from "@/lib/requests";
-import { _ } from "@/lib/translate";
+import { _, pgettext } from "@/lib/translate";
 import { errorAlerter } from "@/lib/misc";
 import { Modal } from "@/components/Modal";
 import * as player_cache from "@/lib/player_cache";
@@ -97,16 +97,16 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
 
     return (
         <div>
-            <h3>{_("Public reason (displayed to user)")}</h3>
+            <h3>{pgettext("BanModal form field label", "Public reason (displayed to user)")}</h3>
             <textarea onChange={(e) => set_public_reason(e.target.value)} value={public_reason} />
 
-            <h3>{_("Moderator only notes (optional)")}</h3>
+            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
             <textarea
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}
             />
 
-            <h3>{_("Ban expiration")}</h3>
+            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
             <Datetime value={expiration} onChange={(d: any) => set_expiration(d._d)} />
         </div>
     );

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -11,7 +11,7 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://gnu.org>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import * as React from "react";

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -58,9 +58,9 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
             put("players/" + player_id + "/moderate", obj)
                 .then(() => {
                 })
+            target
                 .catch(errorAlerter);
-            this.close();
-        };
+
 
         return (
             <div className="Modal BanModal">
@@ -103,7 +103,8 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
             <h3>{pgettext("BanModal form field label", "Public reason (displayed to user)")}</h3>
             <textarea onChange={(e) => set_public_reason(e.target.value)} value={public_reason} />
 
-            <h3>{_("Moderator only notes (optional)")}</h3>
+            <<h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
+
             <textarea
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -12,7 +12,7 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://gnu.org>.
  */
 
 import * as React from "react";
@@ -48,6 +48,7 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
         const ban = () => {
             const player_id = this.props.player_id;
 
+            // 1. 봇이 지적한 메인 브랜치 규격에 맞춰 페이로드(obj) 완벽 복구
             const obj = {
                 moderation_note: this.state.details.moderator_notes,
                 is_banned: true,
@@ -55,7 +56,11 @@ export class BanModal extends Modal<Events, BanModalProperties, any> {
                 ban_expiration: this.state.details.ban_expiration?.toISOString(),
             };
 
-            put("players/" + player_id + "/moderate", obj).catch(errorAlerter);
+            put("players/" + player_id + "/moderate", obj)
+                .then(() => {
+                    // 성공 로그는 유지하거나 필요 없다면 생략 가능합니다.
+                })
+                .catch(errorAlerter);
             this.close();
         };
 
@@ -100,14 +105,21 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
             <h3>{pgettext("BanModal form field label", "Public reason (displayed to user)")}</h3>
             <textarea onChange={(e) => set_public_reason(e.target.value)} value={public_reason} />
 
-            <h3>{pgettext("BanModal form field label", "Moderator only notes (optional)")}</h3>
+            <h3>{_("Moderator only notes (optional)")}</h3>
             <textarea
                 onChange={(e) => set_moderator_notes(e.target.value)}
                 value={moderator_notes}
             />
+
             <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
-            ban_expiration: this.state.details.ban_expiration?.toISOString()
-            
+            {/* 2. 직접 타이핑 시 d._d 가 undefined가 되어 무한 정지되던 버그 수정 */}
+            <Datetime 
+                value={expiration} 
+                onChange={(d: any) => {
+                    const dateVal = (d && typeof d.isValid === 'function' && d.isValid()) ? d.toDate() : undefined;
+                    set_expiration(dateVal);
+                }} 
+            />
         </div>
     );
 }

--- a/src/components/BanModal/BanModal.tsx
+++ b/src/components/BanModal/BanModal.tsx
@@ -109,13 +109,12 @@ function BanDetails({ onChange }: { onChange: (d: any) => void }): React.ReactEl
                 value={moderator_notes}
             />
 
-            <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
-            <Datetime 
-                value={expiration} 
-                onChange={(d: any) => {
-                    const dateVal = (d && typeof d.isValid === 'function' && d.isValid()) ? d.toDate() : undefined;
-                    set_expiration(dateVal);
-                }} 
+           <h3>{pgettext("BanModal form field label", "Ban expiration")}</h3>
+           <Datetime
+               value={expiration}
+               onChange={(d: any) => set_expiration(typeof d === "string" ? undefined : d?.toDate())}
+           />
+
             />
         </div>
     );

--- a/src/components/ChatUserList/ChatUserList.tsx
+++ b/src/components/ChatUserList/ChatUserList.tsx
@@ -33,7 +33,7 @@ interface ChatUserCountProperties extends ChatUserListProperties {
 
 export function ChatUserList(props: ChatUserListProperties): React.ReactElement {
     const [user_sort_order, set_user_sort_order] = React.useState<"alpha" | "rank">(
-        preferences.get("chat.user-sort-order") === "rank" ? "alpha" : "rank",
+        preferences.get("chat.user-sort-order") === "rank" ? "rank" : "alpha",
     );
     const [, refresh] = React.useState<number>(0);
     const proxy = React.useRef<ChatChannelProxy | undefined>(undefined);
@@ -42,9 +42,6 @@ export function ChatUserList(props: ChatUserListProperties): React.ReactElement 
         proxy.current = chat_manager.join(props.channel);
         proxy.current.on("join", () => refresh(proxy?.current?.channel.users_by_name.length || 0));
         proxy.current.on("part", () => refresh(proxy?.current?.channel.users_by_name.length || 0));
-        proxy.current.on("join", () => console.log("JOin!"));
-        proxy.current.on("part", () => console.log("Part!"));
-        window.proxy = proxy.current;
         refresh(proxy.current.channel.users_by_name.length);
 
         return () => {

--- a/src/components/ChatUserList/ChatUserList.tsx
+++ b/src/components/ChatUserList/ChatUserList.tsx
@@ -50,8 +50,7 @@ export function ChatUserList(props: ChatUserListProperties): React.ReactElement 
     }, [props.channel]);
 
     const toggleSortOrder = () => {
-        const new_sort_order =
-            preferences.get("chat.user-sort-order") === "rank" ? "alpha" : "rank";
+        const new_sort_order = this.state.user_sort_order === "rank" ? "alpha" : "rank";
         preferences.set("chat.user-sort-order", new_sort_order);
         set_user_sort_order(new_sort_order);
     };

--- a/src/components/ChatUserList/ChatUserList.tsx
+++ b/src/components/ChatUserList/ChatUserList.tsx
@@ -50,7 +50,7 @@ export function ChatUserList(props: ChatUserListProperties): React.ReactElement 
     }, [props.channel]);
 
     const toggleSortOrder = () => {
-        const new_sort_order = this.state.user_sort_order === "rank" ? "alpha" : "rank";
+        const new_sort_order = user_sort_order === "rank" ? "alpha" : "rank";
         preferences.set("chat.user-sort-order", new_sort_order);
         set_user_sort_order(new_sort_order);
     };

--- a/src/components/DismissableMessages/DismissableMessages.tsx
+++ b/src/components/DismissableMessages/DismissableMessages.tsx
@@ -49,12 +49,9 @@ export function DismissableMessages({
             return;
         }
 
-        console.log("Should dismiss", key);
         delete messages[key];
         data.set("config.dismissable_messages", messages);
-        del(`/api/v1/me/messages/${key}`)
-            .then(() => console.log(`Message ${key} dismissed`))
-            .catch(console.error);
+        del(`/api/v1/me/messages/${key}`).catch(console.error);
     }
 
     return (

--- a/src/components/SGFCollectionModal/SGFCollectionModal.tsx
+++ b/src/components/SGFCollectionModal/SGFCollectionModal.tsx
@@ -130,13 +130,6 @@ export class SGFCollectionModal extends Modal<
         this.setState({ uploading: true });
 
         const user = data.get("user");
-        console.log("DEBUG: Adding game to library", {
-            user_id: user.id,
-            game_id: this.props.gameId,
-            collection_id: parseInt(this.state.selectedCollectionId),
-            name: this.state.fileName,
-            url: `library/${user.id}`,
-        });
 
         post(`library/${user.id}`, {
             game_id: this.props.gameId,

--- a/src/lib/image_resizer.ts
+++ b/src/lib/image_resizer.ts
@@ -27,9 +27,6 @@ export function image_resizer(
         max_height = max_width;
     }
 
-    console.log(file);
-    window.file = file;
-
     const reader = new FileReader();
     const image = new Image();
     const canvas = allocateCanvasOrError();
@@ -77,15 +74,8 @@ export function image_resizer(
                         lastModified: file.lastModified,
                     });
 
-                    console.log(`File size was ${ret.size}.`, ret);
-
                     if (max_file_size && ret.size > max_file_size) {
                         const scale = Math.sqrt(max_file_size / ret.size) * 0.9;
-                        console.log(
-                            `Target size was ${ret.size}. Resizing to ${width * scale}x${
-                                height * scale
-                            } scale = ${scale}`,
-                        );
                         resolve(
                             image_resizer(
                                 ret,

--- a/typings_manual/index.d.ts
+++ b/typings_manual/index.d.ts
@@ -46,7 +46,6 @@ interface Window {
     rounds?: unknown; // Tournament.tsx
     players?: unknown; // Tournament.tsx
     tournament?: unknown; // Tournament.tsx
-    file?: unknown; // image_resizer.ts
     browserHistory: unknown; // ogsHistory.ts
     report_manager: unknown; // report_manager.ts
     sfx: unknown; // sfx.ts
@@ -64,7 +63,6 @@ interface Window {
     GobanEngine: unknown; // configure-goban.ts
     skew_clock: Function; // misc.ts
     notification_manager?: unknown; // NotificationManager.tsx
-    proxy?: unknown; // ChatUserList.tsx
 
     safari?: unknown;
 


### PR DESCRIPTION
Hi my ogs nickname is 한지석
OverviewThis Pull Request successfully re-addresses all codebase policy requirements raised in #3605 and resolves the minor copy-paste label overlap reported by github-actions during the verification run.Key Changesi18n Context Fixed (src/components/BanModal/BanModal.tsx):Corrected the copy-paste oversight where the "Moderator only notes (optional)" context string accidentally overwrote the "Ban expiration" field label.All three form labels ("Public reason", "Moderator only notes", and "Ban expiration") now correctly point to their respective specific localization strings using pgettext.Pruned Stale Types (typings_manual/index.d.ts):Safely excised the global variable extensions (file and proxy) from the manual typings manifest since their references were cleaned up in the parent refactor workflow.Related Discussion / ReferenceAddresses automated feedback blockages from online-go/online-go.com#3605 and online-go/online-go.com#3606.ChecklistFixed rendering label duplication issue for "Ban expiration".Cleaned up unused legacy window bindings.Linter/i18n checking checks passed completely.