### PR TITLE
Custom board label color

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.css
+++ b/src/components/GobanThemePicker/GobanThemePicker.css
@@ -109,6 +109,30 @@
 }
 
 .GobanCustomBoardPicker {
+    .custom-board-theme-set {
+        flex-direction: column;
+        align-items: center;
+        gap: 0.25rem;
+    }
+
+    .custom-board-color-row {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+
+        .color-reset {
+            margin-top: 0;
+        }
+    }
+
+    .custom-board-grid-label-row {
+        input[type="color"]:first-child {
+            margin-left: 0;
+        }
+    }
+
     .custom-board-advanced {
         display: flex;
         flex-direction: column;

--- a/src/components/GobanThemePicker/GobanThemePicker.css
+++ b/src/components/GobanThemePicker/GobanThemePicker.css
@@ -110,25 +110,46 @@
 
 .GobanCustomBoardPicker {
     .custom-board-theme-set {
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
         align-items: center;
-        gap: 0.25rem;
-    }
+        column-gap: clamp(0.75rem, 2vw, 1rem);
+        width: 365px;
+        max-width: 100%;
 
-    .custom-board-color-row {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
+        .select-custom {
+            min-width: 0;
+        }
+
+        .custom-board-color-controls {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            align-items: center;
+            min-width: 0;
+        }
+
+        .custom-board-color-control {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.25rem;
+            min-width: 0;
+        }
+
+        input[type="color"] {
+            flex: 1 1 auto;
+            margin-left: 0;
+            min-width: 1.5rem;
+            max-width: var(--custom-board-color-input-width);
+            width: 100%;
+        }
 
         .color-reset {
+            flex: 0 0 auto;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             margin-top: 0;
-        }
-    }
-
-    .custom-board-grid-label-row {
-        input[type="color"]:first-child {
             margin-left: 0;
         }
     }

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import { _, pgettext } from "@/lib/translate";
-import { Goban, GobanTheme /*, GobanThemeBackgroundCSS */ } from "goban";
+import { blendWithInverseColor, Goban, GobanTheme /*, GobanThemeBackgroundCSS */ } from "goban";
 import { getSelectedThemes, usePreference } from "@/lib/preferences";
 import { PersistentElement } from "@/components/PersistentElement";
 import { Experiment, Variant, Default } from "../Experiment";
@@ -121,6 +121,7 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
     const size = props.size || 44;
 
     const [line_color, _setLineColor] = usePreference("goban-theme-custom-board-line");
+    const [label_color, _setLabelColor] = usePreference("goban-theme-custom-board-label");
     const [background_color, _setBackgroundColor] = usePreference(
         "goban-theme-custom-board-background",
     );
@@ -136,6 +137,9 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
     );
 
     const inputStyle = { height: `${size}px`, width: `${size * 1.5}px` };
+    const background_color_title = pgettext("Custom board theme color input title", "Board color");
+    const line_color_title = pgettext("Custom board theme color input title", "Grid color");
+    const label_color_title = pgettext("Custom board theme color input title", "Label color");
 
     if (!theme) {
         requestAnimationFrame(() => refresh((x) => x + 1));
@@ -145,7 +149,7 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
         sample_canvas.current = document.createElement("canvas");
         renderSampleBoard(sample_canvas.current, theme, size);
         refresh((x) => x + 1);
-    }, [theme, size, background_color, line_color, background_image]);
+    }, [theme, size, background_color, line_color, label_color, background_image]);
 
     function setBackgroundColor(ev: React.ChangeEvent<HTMLInputElement>) {
         _setBackgroundColor(ev.target.value);
@@ -153,6 +157,10 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
 
     function setLineColor(ev: React.ChangeEvent<HTMLInputElement>) {
         _setLineColor(ev.target.value);
+    }
+
+    function setLabelColor(ev: React.ChangeEvent<HTMLInputElement>) {
+        _setLabelColor(ev.target.value);
     }
 
     function setBackgroundImage(ev: React.ChangeEvent<HTMLInputElement>) {
@@ -170,38 +178,66 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
             </LineText>
 
             <div className="GobanThemePicker">
-                <div className="theme-set">
-                    <div className="select-custom">
-                        <div
-                            key={theme.theme_name}
-                            title={_(theme.theme_name)}
-                            className={"selector" + (selected.board === "Custom" ? " active" : "")}
-                            style={theme.styles}
-                            onClick={() => setBoard("Custom")}
-                        >
-                            {sample_canvas && <PersistentElement elt={sample_canvas.current} />}
+                <div className="theme-set custom-board-theme-set">
+                    <div className="custom-board-color-row">
+                        <div className="select-custom">
+                            <div
+                                key={theme.theme_name}
+                                title={_(theme.theme_name)}
+                                className={
+                                    "selector" + (selected.board === "Custom" ? " active" : "")
+                                }
+                                style={theme.styles}
+                                onClick={() => setBoard("Custom")}
+                            >
+                                {sample_canvas && <PersistentElement elt={sample_canvas.current} />}
+                            </div>
                         </div>
+
+                        <input
+                            type="color"
+                            style={inputStyle}
+                            value={background_color}
+                            title={background_color_title}
+                            aria-label={background_color_title}
+                            onChange={setBackgroundColor}
+                        />
+                        <button
+                            className="color-reset"
+                            onClick={() => _setBackgroundColor("#DCB35C")}
+                        >
+                            <i className="fa fa-undo" />
+                        </button>
                     </div>
 
-                    <input
-                        type="color"
-                        style={inputStyle}
-                        value={background_color}
-                        onChange={setBackgroundColor}
-                    />
-                    <button className="color-reset" onClick={() => _setBackgroundColor("#DCB35C")}>
-                        <i className="fa fa-undo" />
-                    </button>
+                    <div className="custom-board-color-row custom-board-grid-label-row">
+                        <input
+                            type="color"
+                            style={inputStyle}
+                            value={line_color}
+                            title={line_color_title}
+                            aria-label={line_color_title}
+                            onChange={setLineColor}
+                        />
+                        <button className="color-reset" onClick={() => _setLineColor("#000000")}>
+                            <i className="fa fa-undo" />
+                        </button>
 
-                    <input
-                        type="color"
-                        style={inputStyle}
-                        value={line_color}
-                        onChange={setLineColor}
-                    />
-                    <button className="color-reset" onClick={() => _setLineColor("#000000")}>
-                        <i className="fa fa-undo" />
-                    </button>
+                        <input
+                            type="color"
+                            style={inputStyle}
+                            value={label_color}
+                            title={label_color_title}
+                            aria-label={label_color_title}
+                            onChange={setLabelColor}
+                        />
+                        <button
+                            className="color-reset"
+                            onClick={() => _setLabelColor(blendWithInverseColor(line_color, 0.75))}
+                        >
+                            <i className="fa fa-undo" />
+                        </button>
+                    </div>
                 </div>
             </div>
 
@@ -418,6 +454,8 @@ export function GobanCustomBlackPicker(props: GobanThemePickerProperties): React
         _setUrl(ev.target.value);
     }
 
+    const color_title = pgettext("Custom goban stone color input title", "Black stone color");
+
     const custom_board = Goban.THEMES_SORTED.board.filter((x) => x.theme_name === "Custom")[0];
 
     const active_standard_board_theme = Goban.THEMES_SORTED.board.filter(
@@ -454,7 +492,14 @@ export function GobanCustomBlackPicker(props: GobanThemePickerProperties): React
                         </div>
                     </div>
 
-                    <input type="color" style={inputStyle} value={color} onChange={setColor} />
+                    <input
+                        type="color"
+                        style={inputStyle}
+                        value={color}
+                        title={color_title}
+                        aria-label={color_title}
+                        onChange={setColor}
+                    />
                     <button className="color-reset" onClick={() => _setColor("")}>
                         <i className="fa fa-undo" />
                     </button>
@@ -612,6 +657,8 @@ export function GobanCustomWhitePicker(props: GobanThemePickerProperties): React
         _setUrl(ev.target.value);
     }
 
+    const color_title = pgettext("Custom goban stone color input title", "White stone color");
+
     return (
         <div className="GobanCustomStonePicker">
             <LineText className="customize">
@@ -632,7 +679,14 @@ export function GobanCustomWhitePicker(props: GobanThemePickerProperties): React
                         </div>
                     </div>
 
-                    <input type="color" style={inputStyle} value={color} onChange={setColor} />
+                    <input
+                        type="color"
+                        style={inputStyle}
+                        value={color}
+                        title={color_title}
+                        aria-label={color_title}
+                        onChange={setColor}
+                    />
                     <button className="color-reset" onClick={() => _setColor("")}>
                         <i className="fa fa-undo" />
                     </button>

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -136,7 +136,10 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
         () => !!background_image || Object.values(grid_backgrounds).some((url) => !!url),
     );
 
-    const inputStyle = { height: `${size}px`, width: `${size * 1.5}px` };
+    const inputStyle: React.CSSProperties & { "--custom-board-color-input-width": string } = {
+        "--custom-board-color-input-width": `${size * 1.5}px`,
+        height: `${size}px`,
+    };
     const background_color_title = pgettext("Custom board theme color input title", "Board color");
     const line_color_title = pgettext("Custom board theme color input title", "Grid color");
     const label_color_title = pgettext("Custom board theme color input title", "Label color");
@@ -179,64 +182,71 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
 
             <div className="GobanThemePicker">
                 <div className="theme-set custom-board-theme-set">
-                    <div className="custom-board-color-row">
-                        <div className="select-custom">
-                            <div
-                                key={theme.theme_name}
-                                title={_(theme.theme_name)}
-                                className={
-                                    "selector" + (selected.board === "Custom" ? " active" : "")
-                                }
-                                style={theme.styles}
-                                onClick={() => setBoard("Custom")}
-                            >
-                                {sample_canvas && <PersistentElement elt={sample_canvas.current} />}
-                            </div>
-                        </div>
-
-                        <input
-                            type="color"
-                            style={inputStyle}
-                            value={background_color}
-                            title={background_color_title}
-                            aria-label={background_color_title}
-                            onChange={setBackgroundColor}
-                        />
-                        <button
-                            className="color-reset"
-                            onClick={() => _setBackgroundColor("#DCB35C")}
+                    <div className="select-custom">
+                        <div
+                            key={theme.theme_name}
+                            title={_(theme.theme_name)}
+                            className={"selector" + (selected.board === "Custom" ? " active" : "")}
+                            style={theme.styles}
+                            onClick={() => setBoard("Custom")}
                         >
-                            <i className="fa fa-undo" />
-                        </button>
+                            {sample_canvas && <PersistentElement elt={sample_canvas.current} />}
+                        </div>
                     </div>
 
-                    <div className="custom-board-color-row custom-board-grid-label-row">
-                        <input
-                            type="color"
-                            style={inputStyle}
-                            value={line_color}
-                            title={line_color_title}
-                            aria-label={line_color_title}
-                            onChange={setLineColor}
-                        />
-                        <button className="color-reset" onClick={() => _setLineColor("#000000")}>
-                            <i className="fa fa-undo" />
-                        </button>
+                    <div className="custom-board-color-controls">
+                        <div className="custom-board-color-control">
+                            <input
+                                type="color"
+                                style={inputStyle}
+                                value={background_color}
+                                title={background_color_title}
+                                aria-label={background_color_title}
+                                onChange={setBackgroundColor}
+                            />
+                            <button
+                                className="color-reset"
+                                onClick={() => _setBackgroundColor("#DCB35C")}
+                            >
+                                <i className="fa fa-undo" />
+                            </button>
+                        </div>
 
-                        <input
-                            type="color"
-                            style={inputStyle}
-                            value={label_color}
-                            title={label_color_title}
-                            aria-label={label_color_title}
-                            onChange={setLabelColor}
-                        />
-                        <button
-                            className="color-reset"
-                            onClick={() => _setLabelColor(blendWithInverseColor(line_color, 0.75))}
-                        >
-                            <i className="fa fa-undo" />
-                        </button>
+                        <div className="custom-board-color-control">
+                            <input
+                                type="color"
+                                style={inputStyle}
+                                value={line_color}
+                                title={line_color_title}
+                                aria-label={line_color_title}
+                                onChange={setLineColor}
+                            />
+                            <button
+                                className="color-reset"
+                                onClick={() => _setLineColor("#000000")}
+                            >
+                                <i className="fa fa-undo" />
+                            </button>
+                        </div>
+
+                        <div className="custom-board-color-control">
+                            <input
+                                type="color"
+                                style={inputStyle}
+                                value={label_color}
+                                title={label_color_title}
+                                aria-label={label_color_title}
+                                onChange={setLabelColor}
+                            />
+                            <button
+                                className="color-reset"
+                                onClick={() =>
+                                    _setLabelColor(blendWithInverseColor(line_color, 0.75))
+                                }
+                            >
+                                <i className="fa fa-undo" />
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -132,6 +132,7 @@ export function configure_goban() {
         customWhiteTextColor: (): string => preferences.get("goban-theme-custom-black-stone-color"),
         customBoardColor: (): string => preferences.get("goban-theme-custom-board-background"),
         customBoardLineColor: (): string => preferences.get("goban-theme-custom-board-line"),
+        customBoardLabelColor: (): string => preferences.get("goban-theme-custom-board-label"),
         customBoardUrl: (): string => preferences.get("goban-theme-custom-board-url"),
         customBlackStoneUrl: (): string => preferences.get("goban-theme-custom-black-url"),
         customWhiteStoneUrl: (): string => preferences.get("goban-theme-custom-white-url"),

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -25,6 +25,7 @@ import {
     ShadowTheme,
     CustomBoardGridBackgrounds,
     emptyCustomBoardGridBackgrounds,
+    blendWithInverseColor,
 } from "goban";
 import * as React from "react";
 import { current_language } from "@/lib/translate";
@@ -118,6 +119,7 @@ export const defaults = {
         ...emptyCustomBoardGridBackgrounds,
     } as CustomBoardGridBackgrounds,
     "goban-theme-custom-board-line": "#000000",
+    "goban-theme-custom-board-label": blendWithInverseColor("#000000", 0.75),
     "goban-theme-custom-black-stone-color": "#000000",
     "goban-theme-custom-black-url": "",
     "goban-theme-custom-white-stone-color": "#ffffff",
@@ -421,6 +423,7 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
         "goban-theme-custom-board-url",
         "goban-theme-custom-board-grid-backgrounds",
         "goban-theme-custom-board-line",
+        "goban-theme-custom-board-label",
         "goban-theme-custom-black-stone-color",
         "goban-theme-custom-black-url",
         "goban-theme-custom-white-stone-color",


### PR DESCRIPTION
This adds a new setting for the label color, as I suggested at #3608 

The UX looks better when all pickers remain on a single line.

I did not keep the inherited defaults because they were designed for two color pickers: fixed input width, left margins per input, and reset-button top margin. With three pickers those defaults either overflow or need fragile hand tuning. The new rules make the layout express those constraints: one preview, three equal controls, default-size inputs when possible, responsive shrinking when needed.

Now that there are three colors, as a side improvement I added titles to the inputs. The coding is mostly done with Codex.

Tested on the desktop and mobile views.

<img width="487" height="285" alt="image" src="https://github.com/user-attachments/assets/dcafcb68-5e93-4715-b3f8-0efdd050a040" />

Also see https://github.com/online-go/goban/pull/257