### PR TITLE
Add stone scale theme setting

### DIFF
--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -693,7 +693,8 @@ function ThemeSample({
     const [stone_scale] = usePreference("goban-theme-stone-scale");
 
     React.useEffect(() => {
-        if (!div.current) {
+        const host = div.current;
+        if (!host) {
             return;
         }
 
@@ -719,14 +720,17 @@ function ThemeSample({
             theme.placeWhiteStoneSVG(g, undefined, white_stones[0], cx, cy, radius);
         }
 
-        div.current.appendChild(svg);
+        host.replaceChildren(svg);
 
         return () => {
-            div.current?.removeChild(svg);
+            if (host.contains(svg)) {
+                host.removeChild(svg);
+            }
         };
     }, [
-        div,
-        div.current,
+        theme,
+        color,
+        size,
         black,
         white,
         board,

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -690,6 +690,7 @@ function ThemeSample({
     const [black_url] = usePreference("goban-theme-custom-black-url");
     const [white_color] = usePreference("goban-theme-custom-white-stone-color");
     const [white_url] = usePreference("goban-theme-custom-white-url");
+    const [stone_scale] = usePreference("goban-theme-stone-scale");
 
     React.useEffect(() => {
         if (!div.current) {
@@ -698,7 +699,7 @@ function ThemeSample({
 
         const cx = size / 2;
         const cy = size / 2;
-        const radius = (size / 2) * 0.95;
+        const radius = (size / 2) * 0.95 * stone_scale;
 
         const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
         svg.setAttribute("width", size.toFixed(0));
@@ -735,6 +736,7 @@ function ThemeSample({
         black_url,
         white_color,
         white_url,
+        stone_scale,
     ]);
 
     return <div ref={div} />;

--- a/src/lib/preferences.test.ts
+++ b/src/lib/preferences.test.ts
@@ -16,11 +16,51 @@
  */
 
 import * as preferences from "@/lib/preferences";
+import * as data from "@/lib/data";
+
+const TEST_USER: rest_api.UserConfig = {
+    anonymous: false,
+    id: 123,
+    username: "test_user",
+    registration_date: "2022-05-10 11:03:24.299562+00:00",
+    ratings: {
+        version: 5,
+        overall: { rating: 1500, deviation: 350, volatility: 0.06 },
+    },
+    country: "un",
+    professional: false,
+    ranking: 23,
+    provisional: 0,
+    can_create_tournaments: true,
+    is_moderator: false,
+    is_superuser: false,
+    moderator_powers: 0,
+    offered_moderator_powers: 0,
+    is_tournament_moderator: false,
+    supporter: true,
+    supporter_level: 4,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "https://secure.gravatar.com/avatar/8d809ecc50408afc399a4cb7c8fd4510?s=32&d=retro",
+    email: "",
+    email_validated: false,
+    is_announcer: false,
+    last_supporter_trial: "",
+};
 
 describe("last-move crosshair preferences", () => {
     test("defaults are disabled, blue, thickness 0.1", () => {
         expect(preferences.get("accessibility.last-move-crosshair")).toBe(false);
         expect(preferences.get("accessibility.last-move-crosshair-color")).toBe("#1e6bff");
         expect(preferences.get("accessibility.last-move-crosshair-thickness")).toBe(0.1);
+    });
+});
+
+describe("stone scale preferences", () => {
+    test("defaults to normal size and is included in selected goban themes", () => {
+        data.set("user", TEST_USER);
+
+        expect(preferences.get("goban-theme-stone-scale")).toBe(1.0);
+        expect(preferences.getSelectedThemes()["stone-scale"]).toBe(1.0);
     });
 });

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -101,6 +101,7 @@ export const defaults = {
     //"goban-theme-white_stone_url": null as null | string,
     "goban-theme-removal-graphic": "square" as "square" | "x",
     "goban-theme-removal-scale": 0.9,
+    "goban-theme-stone-scale": 1.0,
     "goban-theme-stone-shadows": "default" as ShadowTheme,
     "goban-theme-custom-black-shadow-color": "#000000",
     "goban-theme-custom-black-shadow-gradient": "rotate(45) scale(1.10 1.0) translate(0.05 -0.50)",
@@ -354,6 +355,7 @@ export function getSelectedThemes(): GobanSelectedThemes {
     let black = get("goban-theme-black") || (default_plain ? "Plain" : "Slate");
     const removal_graphic = get("goban-theme-removal-graphic");
     const removal_scale = get("goban-theme-removal-scale");
+    const stone_scale = get("goban-theme-stone-scale");
     const stone_shadows = get("goban-theme-stone-shadows");
     const custom_black_shadow_color = get("goban-theme-custom-black-shadow-color");
     const custom_black_shadow_gradient = get("goban-theme-custom-black-shadow-gradient");
@@ -380,6 +382,7 @@ export function getSelectedThemes(): GobanSelectedThemes {
         black: black,
         "removal-graphic": removal_graphic as any,
         "removal-scale": removal_scale,
+        "stone-scale": Number.isFinite(stone_scale) && stone_scale > 0 ? stone_scale : 1.0,
         "stone-shadows": stone_shadows,
         "custom-shadow-config": {
             black: {
@@ -412,6 +415,7 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
         "goban-theme-white",
         "goban-theme-removal-graphic",
         "goban-theme-removal-scale",
+        "goban-theme-stone-scale",
         "goban-theme-stone-shadows",
         "goban-theme-custom-black-shadow-color",
         "goban-theme-custom-black-shadow-gradient",

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -97,6 +97,7 @@ export function ThemePreferences(): React.ReactElement | null {
     const [fuzzy_stone_placement, setFuzzyStonePlacement] = usePreference("fuzzy-stone-placement");
     const [last_move_opacity, _setLastMoveOpacity] = usePreference("last-move-opacity");
     const [stone_font_scale, _setStoneFontScale] = usePreference("stone-font-scale");
+    const [stone_scale, _setStoneScale] = usePreference("goban-theme-stone-scale");
 
     const [variation_stone_opacity, _setVariationStoneOpacity] =
         usePreference("variation-stone-opacity");
@@ -141,6 +142,14 @@ export function ThemePreferences(): React.ReactElement | null {
         }
     }
 
+    function setStoneScale(ev: React.ChangeEvent<HTMLInputElement>) {
+        const value = parseFloat(ev.target.value);
+
+        if (value >= 0.5 && value <= 1.5) {
+            _setStoneScale(value);
+        }
+    }
+
     function setLastMoveOpacity(ev: React.ChangeEvent<HTMLInputElement>) {
         const value = parseFloat(ev.target.value);
 
@@ -165,6 +174,7 @@ export function ThemePreferences(): React.ReactElement | null {
         (enable_svg ? "svg" : "canvas") +
         board_labeling +
         label_positioning +
+        stone_scale +
         stone_font_scale +
         //stone_removal_graphic +
         //removal_scale +
@@ -364,6 +374,44 @@ export function ThemePreferences(): React.ReactElement | null {
                     </PreferenceLine>
                 </>
             )}
+            <PreferenceLine
+                title={_("Stone scale")}
+                description={_("Adjust the size of stones on the board.")}
+            >
+                <div className="with-sample-goban">
+                    <div className="left">
+                        <input
+                            type="range"
+                            step="0.05"
+                            min="0.5"
+                            max="1.5"
+                            onChange={setStoneScale}
+                            value={stone_scale}
+                        />
+                        <span>{stone_scale}</span>
+                    </div>
+
+                    <MiniGoban
+                        className="inline"
+                        key={stone_scale + "" + _refresh}
+                        json={{
+                            width: 3,
+                            height: 1,
+                            moves: [
+                                { x: 0, y: 0 },
+                                { x: 1, y: 0 },
+                                { x: 2, y: 0 },
+                            ],
+                        }}
+                        noLink={true}
+                        width={2}
+                        height={1}
+                        displayWidth={80}
+                        labels_positioning={"none"}
+                        sampleOptions={{}}
+                    />
+                </div>
+            </PreferenceLine>
             <PreferenceLine
                 title={_("Stone font scale")}
                 description={_("Adjust the size of the font used to display symbols on stones.")}

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -397,11 +397,10 @@ export function ThemePreferences(): React.ReactElement | null {
                         json={{
                             width: 3,
                             height: 1,
-                            moves: [
-                                { x: 0, y: 0 },
-                                { x: 1, y: 0 },
-                                { x: 2, y: 0 },
-                            ],
+                            initial_state: {
+                                black: "aaca", // cspell: disable-line
+                                white: "ba", // cspell: disable-line
+                            },
                         }}
                         noLink={true}
                         width={2}


### PR DESCRIPTION
This adds a new setting for the stone scaling, as I suggested at https://github.com/online-go/online-go.com/issues/3608

<img width="494" height="122" alt="image" src="https://github.com/user-attachments/assets/adfcd05e-c5c6-45ea-b4d5-ba20c7d61f53" />

It also fixes a regression from ce49240bfe. The stone url edits weren't updating the stone preview. That path imperatively appended SVG nodes and tried to clean them up via `div.current`, so URL edits could leave the old SVG definition visible.

The fix is make the preview container own a single SVG. `ThemeSample` now captures the host element, rebuilds the SVG when theme inputs change, and uses `replaceChildren(svg)` so custom stone URL edits replace the stale `<defs>` image reference immediately.

See also https://github.com/online-go/goban/pull/258