### PR TITLE
Drop deprecated tsconfig baseUrl

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,19 +12,15 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "lib": ["es2020", "dom"],
-        "baseUrl": ".",
         "paths": {
-            "@/*": ["src/*"],
-            "goban": ["submodules/goban/src"],
-            "goscorer": ["submodules/goban/src/third_party/goscorer/goscorer"],
-            "react-dynamic-help": ["submodules/react-dynamic-help/src"],
-            "@helpers/*": ["e2e-tests/helpers/*"],
-            "@helpers": ["e2e-tests/helpers"],
-            "@stubs/*": ["src/stubs/*"],
-            "@moderator-ui/*": [
-                "submodules/moderator-ui/*",
-                "src/stubs/moderator-ui/*"
-            ]
+            "@/*": ["./src/*"],
+            "goban": ["./submodules/goban/src"],
+            "goscorer": ["./submodules/goban/src/third_party/goscorer/goscorer"],
+            "react-dynamic-help": ["./submodules/react-dynamic-help/src"],
+            "@helpers/*": ["./e2e-tests/helpers/*"],
+            "@helpers": ["./e2e-tests/helpers"],
+            "@stubs/*": ["./src/stubs/*"],
+            "@moderator-ui/*": ["./submodules/moderator-ui/*", "./src/stubs/moderator-ui/*"]
         },
 
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Proposed Changes

  - Remove `baseUrl` from `tsconfig.json` (flagged as deprecated/unnecessary by the TypeScript language server under `moduleResolution: "bundler"`).
  - Prefix each `paths` entry with `./` so TypeScript resolves them relative to `tsconfig.json`'s directory (required once `baseUrl` is gone; produces `TS5090` otherwise).

Without `baseUrl`, only explicitly-declared `paths` aliases are used for module resolution — no silent shadowing of npm packages by same-named files under the project root.

Verified with `yarn type-check`, `yarn lint`, and `yarn prettier:file tsconfig.json`.