### PR TITLE
Add custom stone asset variants

### DIFF
--- a/src/components/GobanThemePicker/GobanCustomStoneUrlInput.css
+++ b/src/components/GobanThemePicker/GobanCustomStoneUrlInput.css
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.GobanCustomStoneUrlInput {
+    display: flex;
+    flex-direction: column;
+    width: 365px;
+    max-width: 100%;
+
+    .custom-stone-url-selection {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .customStoneUrlSelector {
+        flex: 1 1 auto;
+        min-width: 0;
+        border: 1px solid;
+    }
+
+    textarea.customStoneUrlSelector {
+        resize: vertical;
+    }
+
+    .color-reset {
+        flex: 0 0 auto;
+        min-width: 2rem;
+        margin: 0;
+        padding: 0.25rem 0.6rem;
+    }
+
+    .canvas-compatibility-note {
+        margin-top: 0.35rem;
+    }
+
+    .add-variations {
+        align-self: flex-start;
+        margin-top: 0.5rem;
+    }
+
+    .variation-help {
+        margin-top: 0.35rem;
+    }
+}

--- a/src/components/GobanThemePicker/GobanCustomStoneUrlInput.css
+++ b/src/components/GobanThemePicker/GobanCustomStoneUrlInput.css
@@ -48,12 +48,12 @@
         margin-top: 0.35rem;
     }
 
-    .add-variations {
+    .add-variants {
         align-self: flex-start;
         margin-top: 0.5rem;
     }
 
-    .variation-help {
+    .variant-help {
         margin-top: 0.35rem;
     }
 }

--- a/src/components/GobanThemePicker/GobanCustomStoneUrlInput.test.tsx
+++ b/src/components/GobanThemePicker/GobanCustomStoneUrlInput.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)  Online-Go.com
+ */
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { GobanCustomStoneUrlInput, parseCustomStoneUrls } from "./GobanCustomStoneUrlInput";
+
+jest.mock("@/lib/hooks", () => ({
+    useData: () => ["enabled", jest.fn()],
+}));
+
+jest.mock("@/lib/translate", () => ({
+    pgettext: (_context: string, message: string) => message,
+}));
+
+describe("GobanCustomStoneUrlInput", () => {
+    test("normalizes URL lines for storage", () => {
+        expect(parseCustomStoneUrls(" first.png \n\nsecond.png\r\nfirst.png\n")).toEqual([
+            "first.png",
+            "second.png",
+        ]);
+    });
+
+    test("uses a compact single-line editor by default", () => {
+        render(<GobanCustomStoneUrlInput color="black" urls={["first.png"]} setUrls={jest.fn()} />);
+
+        expect(screen.getByRole("textbox").tagName).toBe("INPUT");
+        expect(screen.getByRole("button", { name: "Add variations" })).toBeVisible();
+        expect(screen.queryByText("One image URL per line.")).toBeNull();
+    });
+
+    test("preserves draft newlines while emitting normalized URLs", () => {
+        const setUrls = jest.fn();
+        render(<GobanCustomStoneUrlInput color="black" urls={[]} setUrls={setUrls} />);
+        fireEvent.click(screen.getByRole("button", { name: "Add variations" }));
+        const textarea = screen.getByRole("textbox");
+        const draft = "first.png\n\n second.png \n";
+
+        expect(textarea.tagName).toBe("TEXTAREA");
+        fireEvent.change(textarea, { target: { value: draft } });
+
+        expect(textarea).toHaveValue(draft);
+        expect(setUrls).toHaveBeenLastCalledWith(["first.png", "second.png"]);
+    });
+
+    test("resets all URLs and explains canvas compatibility", () => {
+        const setUrls = jest.fn();
+        render(
+            <GobanCustomStoneUrlInput
+                color="white"
+                urls={["first.png", "second.png"]}
+                setUrls={setUrls}
+            />,
+        );
+
+        expect(screen.getByRole("textbox").tagName).toBe("TEXTAREA");
+        expect(screen.getByText("One image URL per line.")).toBeVisible();
+        expect(screen.getByText("The old canvas renderer uses only the first URL.")).toBeVisible();
+        fireEvent.click(screen.getByRole("button", { name: "Reset white stone URLs" }));
+
+        expect(screen.getByRole("textbox")).toHaveValue("");
+        expect(screen.getByRole("textbox").tagName).toBe("INPUT");
+        expect(setUrls).toHaveBeenLastCalledWith([]);
+    });
+});

--- a/src/components/GobanThemePicker/GobanCustomStoneUrlInput.test.tsx
+++ b/src/components/GobanThemePicker/GobanCustomStoneUrlInput.test.tsx
@@ -26,14 +26,14 @@ describe("GobanCustomStoneUrlInput", () => {
         render(<GobanCustomStoneUrlInput color="black" urls={["first.png"]} setUrls={jest.fn()} />);
 
         expect(screen.getByRole("textbox").tagName).toBe("INPUT");
-        expect(screen.getByRole("button", { name: "Add variations" })).toBeVisible();
+        expect(screen.getByRole("button", { name: "Add variants" })).toBeVisible();
         expect(screen.queryByText("One image URL per line.")).toBeNull();
     });
 
     test("preserves draft newlines while emitting normalized URLs", () => {
         const setUrls = jest.fn();
         render(<GobanCustomStoneUrlInput color="black" urls={[]} setUrls={setUrls} />);
-        fireEvent.click(screen.getByRole("button", { name: "Add variations" }));
+        fireEvent.click(screen.getByRole("button", { name: "Add variants" }));
         const textarea = screen.getByRole("textbox");
         const draft = "first.png\n\n second.png \n";
 

--- a/src/components/GobanThemePicker/GobanCustomStoneUrlInput.tsx
+++ b/src/components/GobanThemePicker/GobanCustomStoneUrlInput.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { useData } from "@/lib/hooks";
+import { pgettext } from "@/lib/translate";
+import "./GobanCustomStoneUrlInput.css";
+
+type StoneColor = "black" | "white";
+
+interface GobanCustomStoneUrlInputProperties {
+    color: StoneColor;
+    urls: string[];
+    setUrls: (urls: string[]) => void;
+}
+
+export function parseCustomStoneUrls(value: string): string[] {
+    return Array.from(
+        new Set(
+            value
+                .split(/\r?\n/)
+                .map((url) => url.trim())
+                .filter((url) => url.length > 0),
+        ),
+    );
+}
+
+export function GobanCustomStoneUrlInput({
+    color,
+    urls,
+    setUrls,
+}: GobanCustomStoneUrlInputProperties): React.ReactElement {
+    const serialized_urls = urls.join("\n");
+    const [draft, setDraft] = React.useState(serialized_urls);
+    const last_emitted_urls = React.useRef(serialized_urls);
+    const [variations_open, setVariationsOpen] = React.useState(urls.length > 1);
+    const [canvas_enabled] = useData("experiments.canvas");
+
+    React.useEffect(() => {
+        if (serialized_urls !== last_emitted_urls.current) {
+            last_emitted_urls.current = serialized_urls;
+            setDraft(serialized_urls);
+        }
+    }, [serialized_urls]);
+
+    React.useEffect(() => {
+        if (urls.length > 1) {
+            setVariationsOpen(true);
+        }
+    }, [urls.length]);
+
+    const single_url_placeholder =
+        color === "black"
+            ? pgettext("A URL pointing to a custom black stone image", "Custom black stone URL")
+            : pgettext("A URL pointing to a custom white stone image", "Custom white stone URL");
+    const multiple_urls_placeholder =
+        color === "black"
+            ? pgettext(
+                  "Custom black stone image URLs, one per line",
+                  "Custom black stone URLs, one per line",
+              )
+            : pgettext(
+                  "Custom white stone image URLs, one per line",
+                  "Custom white stone URLs, one per line",
+              );
+    const reset_label =
+        color === "black"
+            ? pgettext("Reset all custom black stone image URLs", "Reset black stone URLs")
+            : pgettext("Reset all custom white stone image URLs", "Reset white stone URLs");
+
+    function updateUrls(value: string): void {
+        setDraft(value);
+        const next_urls = parseCustomStoneUrls(value);
+        last_emitted_urls.current = next_urls.join("\n");
+        setUrls(next_urls);
+    }
+
+    function resetUrls(): void {
+        last_emitted_urls.current = "";
+        setDraft("");
+        setUrls([]);
+        setVariationsOpen(false);
+    }
+
+    return (
+        <div className="GobanCustomStoneUrlInput">
+            <div className="custom-stone-url-selection">
+                {variations_open ? (
+                    <textarea
+                        className="customStoneUrlSelector"
+                        value={draft}
+                        placeholder={multiple_urls_placeholder}
+                        aria-label={multiple_urls_placeholder}
+                        rows={Math.max(2, Math.min(6, draft.split("\n").length))}
+                        onChange={(event) => updateUrls(event.target.value)}
+                    />
+                ) : (
+                    <input
+                        className="customStoneUrlSelector"
+                        type="text"
+                        value={draft}
+                        placeholder={single_url_placeholder}
+                        aria-label={single_url_placeholder}
+                        onFocus={(event) => event.target.select()}
+                        onChange={(event) => updateUrls(event.target.value)}
+                    />
+                )}
+                <button
+                    type="button"
+                    className="color-reset"
+                    title={reset_label}
+                    aria-label={reset_label}
+                    onClick={resetUrls}
+                >
+                    <i className="fa fa-undo" />
+                </button>
+            </div>
+            {!variations_open && (
+                <button
+                    type="button"
+                    className="add-variations"
+                    onClick={() => setVariationsOpen(true)}
+                >
+                    {pgettext("Expand custom stone URL editor", "Add variations")}
+                </button>
+            )}
+            {variations_open && (
+                <small className="variation-help">
+                    {pgettext("Custom stone URL list instructions", "One image URL per line.")}
+                </small>
+            )}
+            {canvas_enabled === "enabled" && urls.length > 1 && (
+                <small className="canvas-compatibility-note">
+                    {pgettext(
+                        "Legacy goban renderer custom stone limitation",
+                        "The old canvas renderer uses only the first URL.",
+                    )}
+                </small>
+            )}
+        </div>
+    );
+}

--- a/src/components/GobanThemePicker/GobanCustomStoneUrlInput.tsx
+++ b/src/components/GobanThemePicker/GobanCustomStoneUrlInput.tsx
@@ -47,7 +47,7 @@ export function GobanCustomStoneUrlInput({
     const serialized_urls = urls.join("\n");
     const [draft, setDraft] = React.useState(serialized_urls);
     const last_emitted_urls = React.useRef(serialized_urls);
-    const [variations_open, setVariationsOpen] = React.useState(urls.length > 1);
+    const [variants_open, setVariantsOpen] = React.useState(urls.length > 1);
     const [canvas_enabled] = useData("experiments.canvas");
 
     React.useEffect(() => {
@@ -59,7 +59,7 @@ export function GobanCustomStoneUrlInput({
 
     React.useEffect(() => {
         if (urls.length > 1) {
-            setVariationsOpen(true);
+            setVariantsOpen(true);
         }
     }, [urls.length]);
 
@@ -93,13 +93,13 @@ export function GobanCustomStoneUrlInput({
         last_emitted_urls.current = "";
         setDraft("");
         setUrls([]);
-        setVariationsOpen(false);
+        setVariantsOpen(false);
     }
 
     return (
         <div className="GobanCustomStoneUrlInput">
             <div className="custom-stone-url-selection">
-                {variations_open ? (
+                {variants_open ? (
                     <textarea
                         className="customStoneUrlSelector"
                         value={draft}
@@ -129,17 +129,17 @@ export function GobanCustomStoneUrlInput({
                     <i className="fa fa-undo" />
                 </button>
             </div>
-            {!variations_open && (
+            {!variants_open && (
                 <button
                     type="button"
-                    className="add-variations"
-                    onClick={() => setVariationsOpen(true)}
+                    className="add-variants"
+                    onClick={() => setVariantsOpen(true)}
                 >
-                    {pgettext("Expand custom stone URL editor", "Add variations")}
+                    {pgettext("Expand custom stone variant URL editor", "Add variants")}
                 </button>
             )}
-            {variations_open && (
-                <small className="variation-help">
+            {variants_open && (
+                <small className="variant-help">
                     {pgettext("Custom stone URL list instructions", "One image URL per line.")}
                 </small>
             )}

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -23,6 +23,7 @@ import { PersistentElement } from "@/components/PersistentElement";
 import { Experiment, Variant, Default } from "../Experiment";
 import { LineText } from "../misc-ui";
 import { GobanCustomBoardGridBackgroundPicker } from "./GobanCustomBoardGridBackgroundPicker";
+import { GobanCustomStoneUrlInput } from "./GobanCustomStoneUrlInput";
 import "./GobanThemePicker.css";
 
 interface GobanThemePickerProperties {
@@ -438,7 +439,7 @@ export function GobanWhiteThemePicker(props: GobanThemePickerProperties): React.
 export function GobanCustomBlackPicker(props: GobanThemePickerProperties): React.ReactElement {
     const size = props.size || 44;
 
-    const [url, _setUrl] = usePreference("goban-theme-custom-black-url");
+    const [urls, setUrls] = usePreference("goban-theme-custom-black-urls");
     const [color, _setColor] = usePreference("goban-theme-custom-black-stone-color");
     const [, refresh] = React.useState(0);
     const theme = Goban.THEMES_SORTED.black.filter((x) => x.theme_name === "Custom")[0];
@@ -458,10 +459,6 @@ export function GobanCustomBlackPicker(props: GobanThemePickerProperties): React
 
     function setColor(ev: React.ChangeEvent<HTMLInputElement>) {
         _setColor(ev.target.value);
-    }
-
-    function setUrl(ev: React.ChangeEvent<HTMLInputElement>) {
-        _setUrl(ev.target.value);
     }
 
     const color_title = pgettext("Custom goban stone color input title", "Black stone color");
@@ -516,23 +513,7 @@ export function GobanCustomBlackPicker(props: GobanThemePickerProperties): React
                 </div>
             </div>
 
-            <div className="custom-url-selection">
-                <input
-                    className="customUrlSelector"
-                    type="text"
-                    value={url}
-                    placeholder={pgettext(
-                        "A URL pointing to a custom black stone image",
-                        "Custom black stone URL",
-                    )}
-                    onFocus={(e) => e.target.select()}
-                    onChange={setUrl}
-                />
-
-                <button className="color-reset" onClick={() => _setUrl("")}>
-                    <i className="fa fa-undo" />
-                </button>
-            </div>
+            <GobanCustomStoneUrlInput color="black" urls={urls} setUrls={setUrls} />
         </div>
     );
 }
@@ -646,7 +627,7 @@ export function GobanBlackThemePicker(props: GobanThemePickerProperties): React.
 export function GobanCustomWhitePicker(props: GobanThemePickerProperties): React.ReactElement {
     const size = props.size || 44;
 
-    const [url, _setUrl] = usePreference("goban-theme-custom-white-url");
+    const [urls, setUrls] = usePreference("goban-theme-custom-white-urls");
     const [color, _setColor] = usePreference("goban-theme-custom-white-stone-color");
     const [, refresh] = React.useState(0);
     const theme = Goban.THEMES_SORTED.white.filter((x) => x.theme_name === "Custom")[0];
@@ -661,10 +642,6 @@ export function GobanCustomWhitePicker(props: GobanThemePickerProperties): React
 
     function setColor(ev: React.ChangeEvent<HTMLInputElement>) {
         _setColor(ev.target.value);
-    }
-
-    function setUrl(ev: React.ChangeEvent<HTMLInputElement>) {
-        _setUrl(ev.target.value);
     }
 
     const color_title = pgettext("Custom goban stone color input title", "White stone color");
@@ -703,23 +680,7 @@ export function GobanCustomWhitePicker(props: GobanThemePickerProperties): React
                 </div>
             </div>
 
-            <div className="custom-url-selection">
-                <input
-                    className="customUrlSelector"
-                    type="text"
-                    value={url}
-                    placeholder={pgettext(
-                        "A URL pointing to a custom white stone image",
-                        "Custom white stone URL",
-                    )}
-                    onFocus={(e) => e.target.select()}
-                    onChange={setUrl}
-                />
-
-                <button className="color-reset" onClick={() => _setUrl("")}>
-                    <i className="fa fa-undo" />
-                </button>
-            </div>
+            <GobanCustomStoneUrlInput color="white" urls={urls} setUrls={setUrls} />
         </div>
     );
 }
@@ -751,9 +712,9 @@ function ThemeSample({
     const [board_bg] = usePreference("goban-theme-custom-board-background");
     const [board_url] = usePreference("goban-theme-custom-board-url");
     const [black_color] = usePreference("goban-theme-custom-black-stone-color");
-    const [black_url] = usePreference("goban-theme-custom-black-url");
+    const [black_urls] = usePreference("goban-theme-custom-black-urls");
     const [white_color] = usePreference("goban-theme-custom-white-stone-color");
-    const [white_url] = usePreference("goban-theme-custom-white-url");
+    const [white_urls] = usePreference("goban-theme-custom-white-urls");
     const [stone_scale] = usePreference("goban-theme-stone-scale");
 
     React.useEffect(() => {
@@ -801,9 +762,9 @@ function ThemeSample({
         board_bg,
         board_url,
         black_color,
-        black_url,
+        black_urls,
         white_color,
-        white_url,
+        white_urls,
         stone_scale,
     ]);
 

--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -134,8 +134,8 @@ export function configure_goban() {
         customBoardLineColor: (): string => preferences.get("goban-theme-custom-board-line"),
         customBoardLabelColor: (): string => preferences.get("goban-theme-custom-board-label"),
         customBoardUrl: (): string => preferences.get("goban-theme-custom-board-url"),
-        customBlackStoneUrl: (): string => preferences.get("goban-theme-custom-black-url"),
-        customWhiteStoneUrl: (): string => preferences.get("goban-theme-custom-white-url"),
+        customBlackStoneUrls: (): string[] => preferences.get("goban-theme-custom-black-urls"),
+        customWhiteStoneUrls: (): string[] => preferences.get("goban-theme-custom-white-urls"),
         addCoordinatesToChatInput: (coordinates: string): void => {
             const chat_input = document.querySelector(".chat-input") as HTMLInputElement;
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -122,9 +122,9 @@ export const defaults = {
     "goban-theme-custom-board-line": "#000000",
     "goban-theme-custom-board-label": blendWithInverseColor("#000000", 0.75),
     "goban-theme-custom-black-stone-color": "#000000",
-    "goban-theme-custom-black-url": "",
+    "goban-theme-custom-black-urls": [] as string[],
     "goban-theme-custom-white-stone-color": "#ffffff",
-    "goban-theme-custom-white-url": "",
+    "goban-theme-custom-white-urls": [] as string[],
     "hide-ranks": false,
     "label-positioning": "all" as LabelPosition,
     "label-positioning-puzzles": "all" as LabelPosition,
@@ -429,9 +429,9 @@ export function watchSelectedThemes(cb: (themes: GobanSelectedThemes) => void) {
         "goban-theme-custom-board-line",
         "goban-theme-custom-board-label",
         "goban-theme-custom-black-stone-color",
-        "goban-theme-custom-black-url",
+        "goban-theme-custom-black-urls",
         "goban-theme-custom-white-stone-color",
-        "goban-theme-custom-white-url",
+        "goban-theme-custom-white-urls",
     ];
 
     for (const key of keys) {
@@ -495,10 +495,42 @@ function migrate() {
     migrate_key("custom.board", "goban-theme-custom-board-background");
     migrate_key("custom.line", "goban-theme-custom-board-line");
     migrate_key("custom.url", "goban-theme-custom-board-url");
-    migrate_key("custom.black_stone_url", "goban-theme-custom-black-url");
-    migrate_key("custom.white_stone_url", "goban-theme-custom-white-url");
-    migrate_key("preferences.goban-theme-black_stone_url", "goban-theme-custom-black-url");
-    migrate_key("preferences.goban-theme-white_stone_url", "goban-theme-custom-white-url");
+
+    function migrateStoneUrls(
+        legacy_keys: string[],
+        target: "goban-theme-custom-black-urls" | "goban-theme-custom-white-urls",
+    ): void {
+        if (get(target).length === 0) {
+            for (const legacy_key of legacy_keys) {
+                const legacy_value = data.get(legacy_key as keyof DataSchema, null);
+                if (typeof legacy_value === "string" && legacy_value.trim()) {
+                    set(target, [legacy_value.trim()]);
+                    break;
+                }
+            }
+        }
+
+        for (const legacy_key of legacy_keys) {
+            data.remove(legacy_key as keyof DataSchema);
+        }
+    }
+
+    migrateStoneUrls(
+        [
+            "preferences.goban-theme-custom-black-url",
+            "custom.black_stone_url",
+            "preferences.goban-theme-black_stone_url",
+        ],
+        "goban-theme-custom-black-urls",
+    );
+    migrateStoneUrls(
+        [
+            "preferences.goban-theme-custom-white-url",
+            "custom.white_stone_url",
+            "preferences.goban-theme-white_stone_url",
+        ],
+        "goban-theme-custom-white-urls",
+    );
 }
 
 try {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -500,18 +500,22 @@ function migrate() {
         legacy_keys: string[],
         target: "goban-theme-custom-black-urls" | "goban-theme-custom-white-urls",
     ): void {
-        if (get(target).length === 0) {
-            for (const legacy_key of legacy_keys) {
-                const legacy_value = data.get(legacy_key as keyof DataSchema, null);
-                if (typeof legacy_value === "string" && legacy_value.trim()) {
-                    set(target, [legacy_value.trim()]);
-                    break;
+        try {
+            if (get(target).length === 0) {
+                for (const legacy_key of legacy_keys) {
+                    const legacy_value = data.get(legacy_key as keyof DataSchema, null);
+                    if (typeof legacy_value === "string" && legacy_value.trim()) {
+                        set(target, [legacy_value.trim()]);
+                        break;
+                    }
                 }
             }
-        }
 
-        for (const legacy_key of legacy_keys) {
-            data.remove(legacy_key as keyof DataSchema);
+            for (const legacy_key of legacy_keys) {
+                data.remove(legacy_key as keyof DataSchema);
+            }
+        } catch (e) {
+            console.log(e);
         }
     }
 


### PR DESCRIPTION
This adds support for multiple custom stone image URLs in the theme picker, allowing users to enter one variation per line. I suggested this at https://github.com/online-go/online-go.com/issues/3608. Existing single-URL preferences are migrated automatically, and the legacy canvas renderer continues to use the first configured image.

The new editor includes translated guidance, reset controls, and component tests.

Default view when zero or one custom stones are set
<img width="913" height="324" alt="image" src="https://github.com/user-attachments/assets/7653a1ac-e115-4ce2-aa3c-343a6e809855" />


Textarea view for multiple stones
<img width="908" height="325" alt="image" src="https://github.com/user-attachments/assets/bc2f7be7-39fc-4119-a39a-5b078c53e4b7" />

The textarea lets user view and set the URL's in bulk. It occupies little space but can be expanded. It also avoids the complexity of building a list-based UX.

It requires https://github.com/online-go/goban/pull/260