### PR TITLE
Revise tolerable

### DIFF
--- a/e2e-tests/cm/cm-call-stalled-game-warns-staller.ts
+++ b/e2e-tests/cm/cm-call-stalled-game-warns-staller.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// cspell:words STALL
+
+/*
+ * Resolving a STALLING report via "call the game for black" must warn the
+ * accused as a STALLER, not an escaper. Guards the warn_escaper -> warn_staller
+ * fix in voted_call_stalled_game_for_black/white (moderation.py:1211,1225):
+ * before that fix this test fails, because the accused receives a beginner
+ * ESCAPER warning.
+ *
+ * Flow:
+ *  - Reporter (black) and accused (white) start a live game; play 2 moves so a
+ *    stalling report is applicable, and leave the game in progress.
+ *  - Reporter files a stalling report on the accused.
+ *  - 3 CMs (stalling power) vote call_stalled_game_for_black; consensus decides
+ *    the game for black and warns white.
+ *  - The accused's warning is the beginner STALLER message, not an escaper one.
+ *
+ * Uses init_e2e seeded CMs E2E_CM_STALL_V1/V2/V3 (stalling power).
+ */
+
+import type { CreateContextOptions } from "@helpers";
+
+import { BrowserContext, TestInfo } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+import {
+    captureReportNumber,
+    navigateToReport,
+    newTestUsername,
+    prepareNewUser,
+    reportPlayerByColor,
+    setupSeededCM,
+} from "@helpers/user-utils";
+
+import {
+    acceptDirectChallenge,
+    createDirectChallenge,
+    defaultChallengeSettings,
+} from "@helpers/challenge-utils";
+
+import { playMoves, waitForGameViewReady } from "@helpers/game-utils";
+import { expectOGSClickableByName } from "@helpers/matchers";
+import { dismissWarningDialogs, withReportCountTracking } from "@helpers/report-utils";
+
+const CM_VOTERS = ["E2E_CM_STALL_V1", "E2E_CM_STALL_V2", "E2E_CM_STALL_V3"];
+
+export const cmCallStalledGameWarnsStallerTest = async (
+    {
+        createContext,
+    }: { createContext: (options?: CreateContextOptions) => Promise<BrowserContext> },
+    testInfo: TestInfo,
+) => {
+    const TIMEOUT_MS = 180 * 1000;
+
+    const accusedUsername = newTestUsername("STALLAcc"); // cspell:disable-line
+    const { userPage: accusedPage } = await prepareNewUser(createContext, accusedUsername, "test");
+
+    const reporterUsername = newTestUsername("STALLRep"); // cspell:disable-line
+    const { userPage: reporterPage } = await prepareNewUser(
+        createContext,
+        reporterUsername,
+        "test",
+    );
+
+    await withReportCountTracking(
+        reporterPage,
+        testInfo,
+        async (tracker) => {
+            // Live game: generous main time so it stays in progress through
+            // three CM votes (a timeout would end it as an escape, not a stall).
+            await createDirectChallenge(reporterPage, accusedUsername, {
+                ...defaultChallengeSettings,
+                gameName: "E2E STALL call-game",
+                boardSize: "9x9",
+                speed: "live",
+                mainTime: "300",
+                timePerPeriod: "30",
+                periods: "5",
+                color: "black",
+            });
+            await acceptDirectChallenge(accusedPage);
+
+            const goban = reporterPage.locator(".Goban[data-pointers-bound]");
+            await goban.waitFor({ state: "visible" });
+
+            // Two moves make a stalling report applicable (moves.length >= 2);
+            // the game is left in progress.
+            await playMoves(reporterPage, accusedPage, ["D5", "E5"], "9x9");
+
+            // AI review does not render mid-game.
+            await waitForGameViewReady(reporterPage, { aiReviewExpected: false });
+
+            // File the stalling report on white (the accused). Note >= 20 chars.
+            await reportPlayerByColor(
+                reporterPage,
+                ".white",
+                "stalling",
+                "E2E test: white is stalling the end of this live game",
+            );
+            await tracker.assertCountIncreasedBy(reporterPage, 1);
+            const reportNumber = await captureReportNumber(reporterPage);
+
+            // 3 CMs vote to call the game for black — consensus resolves it.
+            for (const cmUser of CM_VOTERS) {
+                const { seededCMPage, seededCMContext } = await setupSeededCM(
+                    createContext,
+                    cmUser,
+                );
+                await navigateToReport(seededCMPage, reportNumber);
+                await seededCMPage.locator(`input[value="call_stalled_game_for_black"]`).click();
+                const voteButton = await expectOGSClickableByName(seededCMPage, /Vote$/);
+                await voteButton.click();
+                await seededCMContext.close();
+            }
+
+            // Surface the warning on the accused's client.
+            await accusedPage.goto("/");
+
+            // The accused is warned as a STALLER (beginner variant for a new
+            // account), never as an escaper.
+            const stallerWarning = accusedPage.locator(
+                "div.AccountWarning .canned-message.warn_beginner_staller",
+            );
+            await expect(stallerWarning).toBeVisible({ timeout: 15000 });
+            await expect(stallerWarning).toContainText("delayed the end of game");
+
+            await expect(accusedPage.locator(".canned-message.warn_beginner_escaper")).toHaveCount(
+                0,
+            );
+            await expect(accusedPage.locator(".canned-message.warn_escaper")).toHaveCount(0);
+
+            // Dismiss so the account is left clean; the report is already
+            // resolved by consensus, so the reporter's count returns to initial.
+            await dismissWarningDialogs(accusedPage);
+            await tracker.assertCountReturnedToInitial(reporterPage);
+        },
+        TIMEOUT_MS,
+    );
+};

--- a/e2e-tests/cm/cm-escape-rate-display.ts
+++ b/e2e-tests/cm/cm-escape-rate-display.ts
@@ -302,9 +302,9 @@ export const cmEscapeRateDisplayTest = async (
             // reflects the actual count, not actual + 1. Without the fix the
             // predicted count would exceed games-in-window — impossible.
             //
-            // Report 4 was voted warn_escaper; by its created-time the window
-            // contained games 1-4 (4 games, all ended before the report was
-            // filed) and all four had escape warnings issued (2 informal +
+            // Report 4 was voted warn_escaper; anchored to game 4's completion
+            // time the window contains games 1-4 (game 5 ended later, so it is
+            // excluded) and all four had escape warnings issued (2 informal +
             // 2 formal). Expected display: "4 escapes in 4 games".
 
             if (lastResolvedReportNumber === null) {

--- a/e2e-tests/cm/cm-escape-rate-display.ts
+++ b/e2e-tests/cm/cm-escape-rate-display.ts
@@ -59,122 +59,23 @@ import { BrowserContext, Page, TestInfo } from "@playwright/test";
 
 import {
     captureReportNumber,
-    navigateToReport,
     newTestUsername,
+    navigateToReport,
     prepareNewUser,
     reportPlayerByColor,
     setupSeededCM,
 } from "@helpers/user-utils";
 
-import { log } from "@helpers/logger";
-
-import {
-    acceptDirectChallenge,
-    createDirectChallenge,
-    defaultChallengeSettings,
-} from "@helpers/challenge-utils";
-
-import { playMoves, waitForGameViewReady } from "@helpers/game-utils";
+import { waitForGameViewReady } from "@helpers/game-utils";
 
 import { expectOGSClickableByName } from "@helpers/matchers";
 import { expect } from "@playwright/test";
 
 import { dismissWarningDialogs, withReportCountTracking } from "@helpers/report-utils";
 
+import { playAndFinishGame, reportAndVote } from "./escape-rate-helpers";
+
 const CM_VOTERS = ["E2E_CM_ERH_V1", "E2E_CM_ERH_V2", "E2E_CM_ERH_V3"];
-
-/**
- * Play a 9x9 game between reporter (black) and accused (white),
- * ending by pass+accept. Returns the game URL.
- */
-async function playAndFinishGame(
-    reporterPage: Page,
-    accusedPage: Page,
-    accusedUsername: string,
-    gameIndex: number,
-): Promise<void> {
-    // Override defaultChallengeSettings' 2s/2s blitz timing — under a loaded
-    // dev stack the 4-move play sequence can exhaust either player's time
-    // and end the game by timeout rather than pass+accept, leaving the test
-    // waiting forever on the "Pass"/"Accept" buttons. 60s main + 1×10s
-    // byoyomi gives ample headroom while still being "live" speed.
-    await createDirectChallenge(reporterPage, accusedUsername, {
-        ...defaultChallengeSettings,
-        gameName: `E2E ERH Game ${gameIndex}`,
-        boardSize: "9x9",
-        speed: "live",
-        mainTime: "60",
-        timePerPeriod: "10",
-        periods: "1",
-        color: "black",
-    });
-
-    await acceptDirectChallenge(accusedPage);
-
-    const goban = reporterPage.locator(".Goban[data-pointers-bound]");
-    await goban.waitFor({ state: "visible" });
-
-    // Play a few moves (need >= 2 for escaping report applicability)
-    await playMoves(reporterPage, accusedPage, ["D5", "E5", "D6", "E6"], "9x9");
-
-    // End the game: both pass, both accept scoring
-    await reporterPage.getByText("Pass", { exact: true }).click();
-    await accusedPage.getByText("Pass", { exact: true }).click();
-
-    const accusedAccept = accusedPage.getByText("Accept");
-    await expect(accusedAccept).toBeVisible();
-    await accusedAccept.click();
-
-    const reporterAccept = reporterPage.getByText("Accept");
-    await expect(reporterAccept).toBeVisible();
-    await reporterAccept.click();
-
-    await expect(reporterPage.getByText("wins by")).toBeVisible();
-
-    // Five sequential games + reports overload the dev stack: the server's
-    // Game.ended write trails behind the WS phase-finished event the goban
-    // already rendered, so the next escaping report on this game gets
-    // rejected by moderate.py:714-725 (HTTP 400). A deliberate 30 s pause
-    // lets the post-game pipeline (WS → DB write, queue drain) quiesce
-    // before we move on. Heavy but reliable; see e2e-tests/AGENTS.md.
-    log(`[cm-escape-rate-display] Game ${gameIndex} ended — pausing 30 s to quiesce`);
-    await reporterPage.waitForTimeout(30000);
-}
-
-/**
- * File an escaping report on the current game page, then have 3 CMs
- * vote the specified action to resolve it. Returns the report number so
- * the caller can navigate back to verify resolved-report behaviour.
- */
-async function reportAndVote(
-    reporterPage: Page,
-    cmPages: Page[],
-    voteAction: string,
-): Promise<string> {
-    // Wait for the post-game view to settle (PlayerCard avatars, AIReview)
-    // before opening PlayerDetails.
-    await waitForGameViewReady(reporterPage);
-
-    // Report the accused (white) for escaping
-    await reportPlayerByColor(
-        reporterPage,
-        ".white",
-        "escaping",
-        "E2E test: player escaped this game",
-    );
-
-    const reportNumber = await captureReportNumber(reporterPage);
-
-    // 3 CMs vote to reach consensus
-    for (const cmPage of cmPages) {
-        await navigateToReport(cmPage, reportNumber);
-        await cmPage.locator(`input[value="${voteAction}"]`).click();
-        const voteButton = await expectOGSClickableByName(cmPage, /Vote$/);
-        await voteButton.click();
-    }
-
-    return reportNumber;
-}
 
 export const cmEscapeRateDisplayTest = async (
     {

--- a/e2e-tests/cm/cm-escape-rate-game-anchor.ts
+++ b/e2e-tests/cm/cm-escape-rate-game-anchor.ts
@@ -45,16 +45,12 @@ import { BrowserContext, Page, TestInfo } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 import {
-    captureReportNumber,
     navigateToReport,
     newTestUsername,
     prepareNewUser,
-    reportPlayerByColor,
     setupSeededCM,
 } from "@helpers/user-utils";
 
-import { waitForGameViewReady } from "@helpers/game-utils";
-import { expectOGSClickableByName } from "@helpers/matchers";
 import { dismissWarningDialogs, withReportCountTracking } from "@helpers/report-utils";
 
 import { playAndFinishGame, reportAndVote } from "./escape-rate-helpers";
@@ -69,7 +65,7 @@ export const cmEscapeRateGameAnchorTest = async (
 ) => {
     // @Slow: plays two sequential games with a 30 s post-game quiesce each
     // (so Game.ended commits before the next escaping report — otherwise
-    // moderate.py rejects it HTTP 400) plus one CM-voted resolution. The time
+    // moderate.py rejects it HTTP 400) plus two CM-voted resolutions. The time
     // is cumulative setup, not flakiness; see e2e-tests/CLAUDE.md.
     const TIMEOUT_MS = 360 * 1000;
 
@@ -121,19 +117,21 @@ export const cmEscapeRateGameAnchorTest = async (
             await dismissWarningDialogs(accusedPage);
             await dismissWarningDialogs(reporterPage);
 
-            // Now file the report on game G and leave it pending.
+            // Report game G and resolve it by CM vote (rather than leaving it
+            // pending and cancelling it): the window is anchored to G's
+            // completion time whether the report is pending or resolved, so
+            // this still discriminates, and the test never leaves an open
+            // report on its normal path. Resolving as escaping puts a warning
+            // on G, so under the game anchor G's window is {G} with 1 escape;
+            // the old report anchor would include H too and show 2.
             await reporterPage.goto(gGameUrl);
-            await waitForGameViewReady(reporterPage);
-            await reportPlayerByColor(
-                reporterPage,
-                ".white",
-                "escaping",
-                "E2E ERGA: game G (left pending)",
-            );
-            await tracker.assertCountIncreasedBy(reporterPage, 1);
-            const reportG = await captureReportNumber(reporterPage);
+            const reportG = await reportAndVote(reporterPage, cmPages, "informal_warn_escaper");
 
-            // Inspect report G.
+            await accusedPage.goto("/");
+            await dismissWarningDialogs(accusedPage);
+            await dismissWarningDialogs(reporterPage);
+
+            // Inspect the resolved report G.
             const cmPage = cmPages[0];
             await navigateToReport(cmPage, reportG);
 
@@ -153,10 +151,6 @@ export const cmEscapeRateGameAnchorTest = async (
                 await ctx.close();
             }
 
-            // Clean up: cancel the pending report on G.
-            await reporterPage.goto("/reports-center/my_reports");
-            const cancelButton = await expectOGSClickableByName(reporterPage, /Cancel$/);
-            await cancelButton.click();
             await tracker.assertCountReturnedToInitial(reporterPage);
         },
         TIMEOUT_MS,

--- a/e2e-tests/cm/cm-escape-rate-game-anchor.ts
+++ b/e2e-tests/cm/cm-escape-rate-game-anchor.ts
@@ -24,9 +24,11 @@
  * own report is resolved first.
  *
  * Scenario:
- *  - Play game G, report it, leave it pending (the game under inspection).
+ *  - Play game G (the game under inspection), but do not report it yet.
  *  - Play game H (ends after G), report it, 3 CMs vote informal_warn_escaper
- *    so H carries an escape warning.
+ *    so H carries an escape warning and is fully resolved.
+ *  - Only now report game G and leave it pending — so H ends after G but
+ *    before G's report is filed.
  *  - View report G as a CM.
  *
  * Game-anchored (correct): G's window is games ended <= G.ended = {G}. H is
@@ -96,9 +98,31 @@ export const cmEscapeRateGameAnchorTest = async (
                 cmContexts.push(seededCMContext);
             }
 
-            // Game G — ends first; reported and left pending. This is the game
-            // whose escape-rate display we inspect.
+            // Game G — the game whose escape-rate display we inspect. It ends
+            // first, but its report is filed LAST (after game H resolves) so
+            // that H ends after G yet before G's report — the one interval
+            // where the report-anchored and game-anchored windows diverge.
             await playAndFinishGame(reporterPage, accusedPage, accusedUsername, 1);
+            const gGameUrl = reporterPage.url();
+
+            await accusedPage.goto("/");
+            await dismissWarningDialogs(accusedPage);
+            await dismissWarningDialogs(reporterPage);
+
+            // Game H — ends AFTER G; reported and resolved as escaping so it
+            // carries an escape warning. The game-anchored window (<= G.ended)
+            // excludes H, but the old report-anchored window (< report.created)
+            // would include it because H ends before G's report is filed. That
+            // difference is what this test discriminates.
+            await playAndFinishGame(reporterPage, accusedPage, accusedUsername, 2);
+            await reportAndVote(reporterPage, cmPages, "informal_warn_escaper");
+
+            await accusedPage.goto("/");
+            await dismissWarningDialogs(accusedPage);
+            await dismissWarningDialogs(reporterPage);
+
+            // Now file the report on game G and leave it pending.
+            await reporterPage.goto(gGameUrl);
             await waitForGameViewReady(reporterPage);
             await reportPlayerByColor(
                 reporterPage,
@@ -109,19 +133,6 @@ export const cmEscapeRateGameAnchorTest = async (
             await tracker.assertCountIncreasedBy(reporterPage, 1);
             const reportG = await captureReportNumber(reporterPage);
 
-            await accusedPage.goto("/");
-            await dismissWarningDialogs(accusedPage);
-            await dismissWarningDialogs(reporterPage);
-
-            // Game H — ends AFTER G; reported and resolved as escaping so it
-            // carries an escape warning at inspection time.
-            await playAndFinishGame(reporterPage, accusedPage, accusedUsername, 2);
-            await reportAndVote(reporterPage, cmPages, "informal_warn_escaper");
-
-            await accusedPage.goto("/");
-            await dismissWarningDialogs(accusedPage);
-            await dismissWarningDialogs(reporterPage);
-
             // Inspect report G.
             const cmPage = cmPages[0];
             await navigateToReport(cmPage, reportG);
@@ -130,8 +141,9 @@ export const cmEscapeRateGameAnchorTest = async (
             await expect(escapeRateInfo).toBeVisible({ timeout: 15000 });
 
             // Game-anchored: H (ended after G) is excluded, so G's window is
-            // {G} alone. Old report-anchored behaviour would show
-            // "2 escapes in 2 games".
+            // {G} alone -> "1 escapes in 1 games". The old report-anchored
+            // window would include H (it ended before G's report was filed) and
+            // show "2 escapes in 2 games".
             const detail = cmPage.locator(".escape-rate-detail");
             await expect(detail).toBeVisible();
             await expect(detail).toContainText(/1 escapes? in 1 games?/);

--- a/e2e-tests/cm/cm-escape-rate-game-anchor.ts
+++ b/e2e-tests/cm/cm-escape-rate-game-anchor.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// cspell:words ERGA
+
+/*
+ * Proves the escape-rate window is anchored to the reported game's completion
+ * time, not the report's filing time. A game the player escaped AFTER the
+ * reported game must not count toward the reported game's rate — even when its
+ * own report is resolved first.
+ *
+ * Scenario:
+ *  - Play game G, report it, leave it pending (the game under inspection).
+ *  - Play game H (ends after G), report it, 3 CMs vote informal_warn_escaper
+ *    so H carries an escape warning.
+ *  - View report G as a CM.
+ *
+ * Game-anchored (correct): G's window is games ended <= G.ended = {G}. H is
+ *   excluded. Predictive display: "1 escapes in 1 games".
+ * Report-anchored (old bug): G's window is {G, H}; H's warning counts, giving
+ *   "2 escapes in 2 games".
+ *
+ * Uses init_e2e seeded CMs E2E_CM_ERGA_V1/V2/V3 (escaping power).
+ */
+
+import type { CreateContextOptions } from "@helpers";
+
+import { BrowserContext, Page, TestInfo } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+import {
+    captureReportNumber,
+    navigateToReport,
+    newTestUsername,
+    prepareNewUser,
+    reportPlayerByColor,
+    setupSeededCM,
+} from "@helpers/user-utils";
+
+import { waitForGameViewReady } from "@helpers/game-utils";
+import { expectOGSClickableByName } from "@helpers/matchers";
+import { dismissWarningDialogs, withReportCountTracking } from "@helpers/report-utils";
+
+import { playAndFinishGame, reportAndVote } from "./escape-rate-helpers";
+
+const CM_VOTERS = ["E2E_CM_ERGA_V1", "E2E_CM_ERGA_V2", "E2E_CM_ERGA_V3"];
+
+export const cmEscapeRateGameAnchorTest = async (
+    {
+        createContext,
+    }: { createContext: (options?: CreateContextOptions) => Promise<BrowserContext> },
+    testInfo: TestInfo,
+) => {
+    // @Slow: plays two sequential games with a 30 s post-game quiesce each
+    // (so Game.ended commits before the next escaping report — otherwise
+    // moderate.py rejects it HTTP 400) plus one CM-voted resolution. The time
+    // is cumulative setup, not flakiness; see e2e-tests/CLAUDE.md.
+    const TIMEOUT_MS = 360 * 1000;
+
+    const accusedUsername = newTestUsername("ERGAAcc"); // cspell:disable-line
+    const { userPage: accusedPage } = await prepareNewUser(createContext, accusedUsername, "test");
+
+    const reporterUsername = newTestUsername("ERGARep"); // cspell:disable-line
+    const { userPage: reporterPage } = await prepareNewUser(
+        createContext,
+        reporterUsername,
+        "test",
+    );
+
+    await withReportCountTracking(
+        reporterPage,
+        testInfo,
+        async (tracker) => {
+            const cmPages: Page[] = [];
+            const cmContexts: BrowserContext[] = [];
+            for (const cmUser of CM_VOTERS) {
+                const { seededCMPage, seededCMContext } = await setupSeededCM(
+                    createContext,
+                    cmUser,
+                );
+                cmPages.push(seededCMPage);
+                cmContexts.push(seededCMContext);
+            }
+
+            // Game G — ends first; reported and left pending. This is the game
+            // whose escape-rate display we inspect.
+            await playAndFinishGame(reporterPage, accusedPage, accusedUsername, 1);
+            await waitForGameViewReady(reporterPage);
+            await reportPlayerByColor(
+                reporterPage,
+                ".white",
+                "escaping",
+                "E2E ERGA: game G (left pending)",
+            );
+            await tracker.assertCountIncreasedBy(reporterPage, 1);
+            const reportG = await captureReportNumber(reporterPage);
+
+            await accusedPage.goto("/");
+            await dismissWarningDialogs(accusedPage);
+            await dismissWarningDialogs(reporterPage);
+
+            // Game H — ends AFTER G; reported and resolved as escaping so it
+            // carries an escape warning at inspection time.
+            await playAndFinishGame(reporterPage, accusedPage, accusedUsername, 2);
+            await reportAndVote(reporterPage, cmPages, "informal_warn_escaper");
+
+            await accusedPage.goto("/");
+            await dismissWarningDialogs(accusedPage);
+            await dismissWarningDialogs(reporterPage);
+
+            // Inspect report G.
+            const cmPage = cmPages[0];
+            await navigateToReport(cmPage, reportG);
+
+            const escapeRateInfo = cmPage.locator(".escape-rate-info");
+            await expect(escapeRateInfo).toBeVisible({ timeout: 15000 });
+
+            // Game-anchored: H (ended after G) is excluded, so G's window is
+            // {G} alone. Old report-anchored behaviour would show
+            // "2 escapes in 2 games".
+            const detail = cmPage.locator(".escape-rate-detail");
+            await expect(detail).toBeVisible();
+            await expect(detail).toContainText(/1 escapes? in 1 games?/);
+            await expect(detail).not.toContainText("2 escapes");
+
+            for (const ctx of cmContexts) {
+                await ctx.close();
+            }
+
+            // Clean up: cancel the pending report on G.
+            await reporterPage.goto("/reports-center/my_reports");
+            const cancelButton = await expectOGSClickableByName(reporterPage, /Cancel$/);
+            await cancelButton.click();
+            await tracker.assertCountReturnedToInitial(reporterPage);
+        },
+        TIMEOUT_MS,
+    );
+};

--- a/e2e-tests/cm/cm-escaping-one-at-a-time.ts
+++ b/e2e-tests/cm/cm-escaping-one-at-a-time.ts
@@ -32,8 +32,10 @@
  * 1. Reporter plays two games with accused, both end
  * 2. Reporter files escaping reports on both games
  * 3. CM1 navigates to reports center — only sees one escaping report
- * 4. All 3 CMs vote to resolve the first report
- * 5. CM1 now sees the second report
+ * 4. CM1 votes on the first report; the second must NOT leak into their queue
+ *    while the first is still pending (only CM1 has voted — no consensus yet)
+ * 5. CM2 and CM3 vote to resolve the first report
+ * 6. CM1 now sees the second report
  */
 
 import type { CreateContextOptions } from "@helpers";
@@ -197,16 +199,43 @@ export const cmEscapingOneAtATimeTest = async (
                 `CM1 queue count is ${expectedAfterFiling} (baseline ${baselineCount} + 1, not +2)`,
             );
 
+            const voteAction = "no_escaping";
+
+            // ========================================
+            // Phase 1.5: CM1 votes on report 1, but consensus is NOT reached.
+            // Report 2 must not leak into CM1's queue. Once a CM votes,
+            // community_mod_can_handle() hides the voted report from
+            // getVisibleReports(), so the one-at-a-time serialization has to
+            // anchor on the still-pending report from the full active set, not
+            // the CM-visible set. Anchoring on the visible set lets report 2
+            // leak in the moment CM1 votes.
+            // ========================================
+
+            log("CM1 votes on report 1 (partial consensus)...");
+            await navigateToReport(cm1Page, reportNumber1);
+            await cm1Page.locator(`input[value="${voteAction}"]`).click();
+            const cm1VoteButton = await expectOGSClickableByName(cm1Page, /Vote$/);
+            await cm1VoteButton.click();
+
+            // Report 1 is now hidden from CM1 (they voted) but still pending, so
+            // report 2 stays suppressed: CM1's queue count returns to baseline,
+            // not baseline + 1.
+            await expect
+                .poll(async () => parseInt((await cmCountEl.textContent()) || "0", 10), {
+                    timeout: 15000,
+                })
+                .toBe(baselineCount);
+            log("Report 2 did not leak into CM1's queue after the partial vote");
+
             await cm1Context.close();
 
             // ========================================
             // Phase 2: Resolve the first report with 3 CM votes
             // ========================================
 
-            log("Resolving report 1 with 3 CM votes...");
-            const voteAction = "no_escaping";
+            log("CM2 and CM3 vote to reach consensus on report 1 (CM1 already voted)...");
 
-            for (let i = 0; i < CM_VOTERS.length; i++) {
+            for (let i = 1; i < CM_VOTERS.length; i++) {
                 const { seededCMPage: cmPage, seededCMContext: cmContext } = await setupSeededCM(
                     createContext,
                     CM_VOTERS[i],

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -30,6 +30,7 @@ import { cmVoteEscalateSandbaggingTest } from "./cm-vote-escalate-sandbagging";
 import { cmSandbaggingAssessmentConversionTest } from "./cm-sandbagging-assessment-conversion";
 import { cmLastWarningInfoTest } from "./cm-last-warning-info";
 import { cmEscapeRateDisplayTest } from "./cm-escape-rate-display";
+import { cmEscapeRateGameAnchorTest } from "./cm-escape-rate-game-anchor";
 import { cmEscapeRatePredictiveBorderlineTest } from "./cm-escape-rate-predictive-borderline";
 import { cmInformalWarnEscaperTest } from "./cm-informal-warn-escaper";
 import { cmInformalWarnEscaperAndAnnulTest } from "./cm-informal-warn-escaper-and-annul";
@@ -60,6 +61,10 @@ ogsTest.describe("@CM Community Moderation Tests", () => {
     );
     ogsTest("@Slow Last warning info shown on repeat offender reports", cmLastWarningInfoTest);
     ogsTest("@Slow Escape rate display on escaping reports", cmEscapeRateDisplayTest);
+    ogsTest(
+        "@Slow Escape rate window is anchored to the reported game",
+        cmEscapeRateGameAnchorTest,
+    );
     ogsTest(
         "CM sees formal options at the predictive escape-rate boundary",
         cmEscapeRatePredictiveBorderlineTest,

--- a/e2e-tests/cm/cm.spec.ts
+++ b/e2e-tests/cm/cm.spec.ts
@@ -43,6 +43,7 @@ import { cmVoteWarnMaliciousReporterTest } from "./cm-vote-warn-malicious-report
 import { cmVoteInformalWarnMaliciousReporterTest } from "./cm-vote-informal-warn-malicious-reporter";
 import { cmMaliciousReportQueueVisibilityTest } from "./cm-malicious-report-queue-visibility";
 import { cmMaliciousReportEscalationTest } from "./cm-malicious-report-escalation";
+import { cmCallStalledGameWarnsStallerTest } from "./cm-call-stalled-game-warns-staller";
 
 ogsTest.describe("@CM Community Moderation Tests", () => {
     ogsTest("CM Vote on own report", cmVoteOnOwnReportTest);
@@ -92,4 +93,8 @@ ogsTest.describe("@CM Community Moderation Tests", () => {
         cmMaliciousReportQueueVisibilityTest,
     );
     ogsTest("Malicious report escalation flow", cmMaliciousReportEscalationTest);
+    ogsTest(
+        "CM call-stalled-game warns the staller, not the escaper",
+        cmCallStalledGameWarnsStallerTest,
+    );
 });

--- a/e2e-tests/cm/escape-rate-helpers.ts
+++ b/e2e-tests/cm/escape-rate-helpers.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { log } from "@helpers/logger";
+import {
+    acceptDirectChallenge,
+    createDirectChallenge,
+    defaultChallengeSettings,
+} from "@helpers/challenge-utils";
+import { playMoves, waitForGameViewReady } from "@helpers/game-utils";
+import { captureReportNumber, navigateToReport, reportPlayerByColor } from "@helpers/user-utils";
+import { expectOGSClickableByName } from "@helpers/matchers";
+
+/**
+ * Play a 9x9 game between reporter (black) and accused (white),
+ * ending by pass+accept. Returns the game URL.
+ */
+export async function playAndFinishGame(
+    reporterPage: Page,
+    accusedPage: Page,
+    accusedUsername: string,
+    gameIndex: number,
+): Promise<void> {
+    // Override defaultChallengeSettings' 2s/2s blitz timing — under a loaded
+    // dev stack the 4-move play sequence can exhaust either player's time
+    // and end the game by timeout rather than pass+accept, leaving the test
+    // waiting forever on the "Pass"/"Accept" buttons. 60s main + 1×10s
+    // byoyomi gives ample headroom while still being "live" speed.
+    await createDirectChallenge(reporterPage, accusedUsername, {
+        ...defaultChallengeSettings,
+        gameName: `E2E ERH Game ${gameIndex}`,
+        boardSize: "9x9",
+        speed: "live",
+        mainTime: "60",
+        timePerPeriod: "10",
+        periods: "1",
+        color: "black",
+    });
+
+    await acceptDirectChallenge(accusedPage);
+
+    const goban = reporterPage.locator(".Goban[data-pointers-bound]");
+    await goban.waitFor({ state: "visible" });
+
+    // Play a few moves (need >= 2 for escaping report applicability)
+    await playMoves(reporterPage, accusedPage, ["D5", "E5", "D6", "E6"], "9x9");
+
+    // End the game: both pass, both accept scoring
+    await reporterPage.getByText("Pass", { exact: true }).click();
+    await accusedPage.getByText("Pass", { exact: true }).click();
+
+    const accusedAccept = accusedPage.getByText("Accept");
+    await expect(accusedAccept).toBeVisible();
+    await accusedAccept.click();
+
+    const reporterAccept = reporterPage.getByText("Accept");
+    await expect(reporterAccept).toBeVisible();
+    await reporterAccept.click();
+
+    await expect(reporterPage.getByText("wins by")).toBeVisible();
+
+    // Five sequential games + reports overload the dev stack: the server's
+    // Game.ended write trails behind the WS phase-finished event the goban
+    // already rendered, so the next escaping report on this game gets
+    // rejected by moderate.py:714-725 (HTTP 400). A deliberate 30 s pause
+    // lets the post-game pipeline (WS → DB write, queue drain) quiesce
+    // before we move on. Heavy but reliable; see e2e-tests/AGENTS.md.
+    log(`[cm-escape-rate-display] Game ${gameIndex} ended — pausing 30 s to quiesce`);
+    await reporterPage.waitForTimeout(30000);
+}
+
+/**
+ * File an escaping report on the current game page, then have 3 CMs
+ * vote the specified action to resolve it. Returns the report number so
+ * the caller can navigate back to verify resolved-report behaviour.
+ */
+export async function reportAndVote(
+    reporterPage: Page,
+    cmPages: Page[],
+    voteAction: string,
+): Promise<string> {
+    // Wait for the post-game view to settle (PlayerCard avatars, AIReview)
+    // before opening PlayerDetails.
+    await waitForGameViewReady(reporterPage);
+
+    // Report the accused (white) for escaping
+    await reportPlayerByColor(
+        reporterPage,
+        ".white",
+        "escaping",
+        "E2E test: player escaped this game",
+    );
+
+    const reportNumber = await captureReportNumber(reporterPage);
+
+    // 3 CMs vote to reach consensus
+    for (const cmPage of cmPages) {
+        await navigateToReport(cmPage, reportNumber);
+        await cmPage.locator(`input[value="${voteAction}"]`).click();
+        const voteButton = await expectOGSClickableByName(cmPage, /Vote$/);
+        await voteButton.click();
+    }
+
+    return reportNumber;
+}

--- a/src/lib/report_manager.test.ts
+++ b/src/lib/report_manager.test.ts
@@ -35,9 +35,10 @@ jest.mock("@/lib/preferences", () => ({
     get: jest.fn(() => undefined),
     watch: jest.fn(),
 }));
-jest.mock("@/lib/report_util", () => ({
-    community_mod_can_handle: () => true,
-}));
+// @/lib/report_util is deliberately NOT mocked: getVisibleReports() relies on
+// the real community_mod_can_handle(), which hides a report from a CM once they
+// have voted on it (for non-escalated reports). That is the exact interaction
+// the serialization must survive, so mocking it away would hide the bug.
 jest.mock("@/lib/translate", () => ({
     pgettext: (_ctx: string, s: string) => s,
 }));
@@ -53,8 +54,9 @@ const CM_ID = 1000;
 jest.mock("@/lib/data", () => ({
     get: (key: string) => {
         if (key === "user") {
-            // any non-zero moderator_powers; community_mod_can_handle is mocked true
-            return { id: 1000, is_moderator: false, moderator_powers: 1 };
+            // HANDLE_ESCAPING power (0b010) so the real community_mod_can_handle
+            // grants this CM escaping reports they have not voted on
+            return { id: 1000, is_moderator: false, moderator_powers: 0b010 };
         }
         if (key === "ignored-reports") {
             return {};

--- a/src/lib/report_manager.test.ts
+++ b/src/lib/report_manager.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Unit tests for ReportManager.moderationQueue escaping-report serialization.
+ *
+ * A community moderator must see only the oldest active escaping report per
+ * reported player at a time, and must not have a newer report leak in after
+ * they have voted on the oldest one (which resolves only on CM consensus).
+ */
+
+// Module mocks: importing report_manager runs the singleton constructor and
+// pulls in several collaborators at module load. Stub them so the import is
+// side-effect-free under jsdom. The last group is only touched by methods this
+// test does not call; trivial stubs keep their (potentially React-heavy)
+// import graphs out of the test.
+jest.mock("@/lib/sockets", () => ({
+    socket: { on: jest.fn(), connected: false },
+}));
+jest.mock("@/lib/preferences", () => ({
+    get: jest.fn(() => undefined),
+    watch: jest.fn(),
+}));
+jest.mock("@/lib/report_util", () => ({
+    community_mod_can_handle: () => true,
+}));
+jest.mock("@/lib/translate", () => ({
+    pgettext: (_ctx: string, s: string) => s,
+}));
+jest.mock("@/lib/swal_config", () => ({ alert: { fire: jest.fn() } }));
+jest.mock("@/lib/toast", () => ({ toast: jest.fn() }));
+jest.mock("@/components/Notifications", () => ({ emitNotification: jest.fn() }));
+jest.mock("@/lib/ogsHistory", () => ({ browserHistory: { push: jest.fn() } }));
+jest.mock("@/lib/requests", () => ({ get: jest.fn(), post: jest.fn() }));
+
+// CM user id. Kept as a literal inside the data factory too (the factory is
+// hoisted and cannot safely close over a non-`mock`-prefixed const).
+const CM_ID = 1000;
+jest.mock("@/lib/data", () => ({
+    get: (key: string) => {
+        if (key === "user") {
+            // any non-zero moderator_powers; community_mod_can_handle is mocked true
+            return { id: 1000, is_moderator: false, moderator_powers: 1 };
+        }
+        if (key === "ignored-reports") {
+            return {};
+        }
+        return undefined;
+    },
+    set: jest.fn(),
+    watch: jest.fn(),
+}));
+
+import { report_manager } from "./report_manager";
+
+function escapingReport(id: number, reportedUserId: number, votedByCM: boolean) {
+    return {
+        id,
+        report_type: "escaping",
+        reported_user: { id: reportedUserId },
+        reporting_user: { id: 2000 }, // not the CM, so it is not "our own" report
+        moderator: undefined, // unclaimed
+        escalated: false,
+        voters: votedByCM ? [{ voter_id: CM_ID, updated: "2026-07-16T00:00:00Z" }] : [],
+    } as any;
+}
+
+describe("moderationQueue escaping serialization", () => {
+    it("suppresses a newer escaping report after the CM voted on the older one", () => {
+        const older = escapingReport(1, 500, /* votedByCM */ true);
+        const newer = escapingReport(2, 500, /* votedByCM */ false);
+        report_manager.sorted_active_incident_reports = [older, newer];
+
+        const queue = report_manager.moderationQueue();
+        const ids = queue.map((r) => r.id);
+
+        // The CM has done their part on report 1 (awaiting other CMs), so they
+        // see nothing for this player until report 1 resolves. Report 2 must
+        // not leak in.
+        expect(ids).not.toContain(2);
+        expect(ids).not.toContain(1); // already voted -> removed at the end
+    });
+
+    it("shows only the oldest when none are voted yet", () => {
+        const older = escapingReport(10, 501, /* votedByCM */ false);
+        const newer = escapingReport(11, 501, /* votedByCM */ false);
+        report_manager.sorted_active_incident_reports = [older, newer];
+
+        const ids = report_manager.moderationQueue().map((r) => r.id);
+        expect(ids).toContain(10);
+        expect(ids).not.toContain(11);
+    });
+});

--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -195,18 +195,20 @@ class ReportManager extends EventEmitter<Events> {
             return [];
         }
 
-        const queue = this.getVisibleReports().filter(
-            (r) => this.userCanModerate(user, r) && !this.userAlreadyVoted(user, r),
-        );
+        // Reports this user is allowed to act on. Kept separate from the
+        // already-voted filter (applied last) so the escaping serialization
+        // below sees reports the CM has voted on but that have not yet
+        // resolved.
+        let moderatable = this.getVisibleReports().filter((r) => this.userCanModerate(user, r));
 
         // For community moderators, only show one escaping report per reported
-        // user at a time. This prevents CMs from being overwhelmed by multiple
-        // reports against the same player — they should resolve the oldest one
-        // before seeing the next.
+        // user at a time: they must resolve the oldest before seeing the next.
+        // Computed over the full moderatable set — before the already-voted
+        // filter — so a report this CM has already voted on still suppresses
+        // newer reports on the same player until consensus resolves it.
         if (user.moderator_powers && !user.is_moderator) {
-            // Find the oldest (lowest id) escaping report per reported user
             const oldest_escaping_by_user = new Map<number, number>();
-            for (const report of queue) {
+            for (const report of moderatable) {
                 if (report.report_type === "escaping" && report.reported_user?.id) {
                     const user_id = report.reported_user.id;
                     const existing = oldest_escaping_by_user.get(user_id);
@@ -215,7 +217,7 @@ class ReportManager extends EventEmitter<Events> {
                     }
                 }
             }
-            return queue.filter((report) => {
+            moderatable = moderatable.filter((report) => {
                 if (report.report_type === "escaping" && report.reported_user?.id) {
                     return oldest_escaping_by_user.get(report.reported_user.id) === report.id;
                 }
@@ -223,7 +225,8 @@ class ReportManager extends EventEmitter<Events> {
             });
         }
 
-        return queue;
+        // Finally, drop reports this user has already voted on.
+        return moderatable.filter((r) => !this.userAlreadyVoted(user, r));
     }
 
     public getMyReports(): ReportNotification[] {

--- a/src/lib/report_manager.tsx
+++ b/src/lib/report_manager.tsx
@@ -195,21 +195,22 @@ class ReportManager extends EventEmitter<Events> {
             return [];
         }
 
-        // Reports this user is allowed to act on. Kept separate from the
-        // already-voted filter (applied last) so the escaping serialization
-        // below sees reports the CM has voted on but that have not yet
-        // resolved.
-        let moderatable = this.getVisibleReports().filter((r) => this.userCanModerate(user, r));
+        const queue = this.getVisibleReports().filter(
+            (r) => this.userCanModerate(user, r) && !this.userAlreadyVoted(user, r),
+        );
 
         // For community moderators, only show one escaping report per reported
         // user at a time: they must resolve the oldest before seeing the next.
-        // Computed over the full moderatable set — before the already-voted
-        // filter — so a report this CM has already voted on still suppresses
-        // newer reports on the same player until consensus resolves it.
+        // The anchor (oldest active escaping report per player) is computed from
+        // ALL active reports, not just the ones visible to this CM. Once a CM
+        // votes on a report, community_mod_can_handle() hides it from their view
+        // (getVisibleReports), but it is still the pending report that must
+        // resolve first — so anchoring on the visible set would let the next
+        // report leak in the moment they vote.
         if (user.moderator_powers && !user.is_moderator) {
             const oldest_escaping_by_user = new Map<number, number>();
-            for (const report of moderatable) {
-                if (report.report_type === "escaping" && report.reported_user?.id) {
+            for (const report of this.sorted_active_incident_reports) {
+                if (report?.report_type === "escaping" && report.reported_user?.id) {
                     const user_id = report.reported_user.id;
                     const existing = oldest_escaping_by_user.get(user_id);
                     if (existing === undefined || report.id < existing) {
@@ -217,7 +218,7 @@ class ReportManager extends EventEmitter<Events> {
                     }
                 }
             }
-            moderatable = moderatable.filter((report) => {
+            return queue.filter((report) => {
                 if (report.report_type === "escaping" && report.reported_user?.id) {
                     return oldest_escaping_by_user.get(report.reported_user.id) === report.id;
                 }
@@ -225,8 +226,7 @@ class ReportManager extends EventEmitter<Events> {
             });
         }
 
-        // Finally, drop reports this user has already voted on.
-        return moderatable.filter((r) => !this.userAlreadyVoted(user, r));
+        return queue;
     }
 
     public getMyReports(): ReportNotification[] {


### PR DESCRIPTION
Fixes two issues contributing to unstable tolerable escaping assessment:
 - Wrong window calculation (backend : https://github.com/online-go/ogs/pull/2424 )
 - Serialize treatment of escaping reports per user
