### PR TITLE
Only offer Malicious Report on score-cheating reports

### DIFF
--- a/e2e-tests/cm/cm-file-malicious-report.ts
+++ b/e2e-tests/cm/cm-file-malicious-report.ts
@@ -34,6 +34,9 @@
  * Source-report victim, opponent and source reporter are created dynamically
  * each run. Source reporter is a third-party user (not a game player) — see
  * `setupEscapingSourceGame` for why.
+ *
+ * Also covers a negative guard: the "Malicious Report" option is not offered
+ * against the reporter of a non-score-cheating (escaping) source report.
  */
 
 import type { CreateContextOptions } from "@helpers";
@@ -41,19 +44,22 @@ import { BrowserContext, TestInfo } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 import {
+    captureReportNumber,
     navigateToReport,
     newTestUsername,
     openPlayerDetailsPopover,
     prepareNewUser,
+    reportUser,
     setupSeededCM,
 } from "@helpers/user-utils";
+import { waitForGameViewReady } from "@helpers/game-utils";
 
 import { expectOGSClickableByName } from "@helpers/matchers";
 import { log } from "@helpers/logger";
 import { withReportCountTracking } from "@helpers/report-utils";
 import {
     cancelOwnReport,
-    createSourceEscapingReport,
+    createSourceScoreCheatingReport,
     fileMaliciousReport,
     readOwnReportIds,
     setupEscapingSourceGame,
@@ -66,9 +72,10 @@ export const cmFileMaliciousReportTest = async (
     }: { createContext: (options?: CreateContextOptions) => Promise<BrowserContext> },
     testInfo: TestInfo,
 ) => {
-    const TIMEOUT_MS = 300 * 1000;
+    const TIMEOUT_MS = 420 * 1000;
     // The setup before withReportCountTracking (3 fresh users + game + source
-    // report) is the heaviest part of this test and easily exceeds the
+    // report), plus the negative-guard step (a fourth user + an escaping
+    // report), is the heaviest part of this test and far exceeds the
     // Playwright default 180s when combined with the post-resignation flake
     // budget on the existing reportUser/captureReportNumber helpers. Bump
     // the test-wide timeout up front; withReportCountTracking will also call
@@ -86,17 +93,19 @@ export const cmFileMaliciousReportTest = async (
         "test",
     );
 
-    // Opponent resigns so victim wins; escaping report against the victim is
-    // applicable. The source reporter is created later as a fresh third party.
+    // Opponent resigns so victim wins. The victim not having resigned is also
+    // what makes an escaping report against them applicable — used below for
+    // the negative-guard check. The source reporter is created later as a
+    // fresh third party.
     const gameUrl = await setupEscapingSourceGame(victimPage, opponentPage, opponentUsername);
 
     const { sourceReporterPage, sourceReporterUsername, sourceReportNumber } =
-        await createSourceEscapingReport(
+        await createSourceScoreCheatingReport(
             createContext,
             gameUrl,
             victimUsername,
             "MRFMRep", // cspell:disable-line
-            "E2E test: source escaping report - this is going to be flagged malicious",
+            "E2E test: source score-cheating report - this is going to be flagged malicious",
         );
 
     await withReportCountTracking(
@@ -152,6 +161,47 @@ export const cmFileMaliciousReportTest = async (
             await expect(filerPage.getByText("Thanks for the report!")).toHaveCount(0);
 
             // ========================================
+            // Negative guard: malicious_report is not offered on a
+            // non-score-cheating source
+            // ========================================
+            log(`[MR/file] Negative guard: escaping source does not offer malicious_report`);
+            // The victim did not resign, so an escaping report against them is
+            // applicable.
+            const escReporterUsername = newTestUsername("MRFMEsc"); // cspell:disable-line
+            const { userPage: escReporterPage } = await prepareNewUser(
+                createContext,
+                escReporterUsername,
+                "test",
+            );
+            await escReporterPage.goto(gameUrl);
+            await waitForGameViewReady(escReporterPage);
+            await reportUser(
+                escReporterPage,
+                victimUsername,
+                "escaping",
+                "E2E test: escaping source for the malicious-gate negative check",
+            );
+            const escReportNumber = await captureReportNumber(escReporterPage);
+
+            await navigateToReport(filerPage, escReportNumber);
+            const escReporterLink = filerPage
+                .locator(`a.Player[data-ready="true"]:has-text("${escReporterUsername}")`)
+                .first();
+            await openPlayerDetailsPopover(filerPage, escReporterLink);
+            await (await expectOGSClickableByName(filerPage, /Report$/)).click();
+            await expect(filerPage.getByText("Request Moderator Assistance")).toBeVisible();
+            // The type-picker is populated (escaping is offered) but malicious_report is
+            // NOT offered at all on a non-score-cheating source.
+            await expect(
+                filerPage.locator('.type-picker select option[value="escaping"]'),
+            ).toHaveCount(1);
+            await expect(
+                filerPage.locator('.type-picker select option[value="malicious_report"]'),
+            ).toHaveCount(0);
+            await (await expectOGSClickableByName(filerPage, /^Close$/)).click();
+            await expect(filerPage.getByText("Request Moderator Assistance")).not.toBeVisible();
+
+            // ========================================
             // Test 1: File a malicious_report successfully
             // ========================================
             log(`[MR/file] Test 1: file malicious_report successfully`);
@@ -186,10 +236,10 @@ export const cmFileMaliciousReportTest = async (
                 filerPage.locator(".reported-user").getByText(sourceReporterUsername),
             ).toBeVisible();
 
-            // Source report is unchanged: still escaping, not retyped to malicious.
+            // Source report is unchanged: still score_cheating, not retyped to malicious.
             await navigateToReport(filerPage, sourceReportNumber);
             await expect(filerPage.locator(".report-type-selector")).toContainText(
-                "Stopped Playing",
+                "Score Cheating",
             );
 
             log(`[MR/file] Cleanup`);

--- a/e2e-tests/helpers/malicious-report-utils.ts
+++ b/e2e-tests/helpers/malicious-report-utils.ts
@@ -298,17 +298,15 @@ export async function fileMaliciousReport(
 
 /**
  * Play a short 9x9 game between `victimPage` and `opponentPage`. Opponent
- * resigns, so the victim wins. The victim did NOT resign, which is what the
- * escaping report applicability check requires (it rejects reports against
- * players who resigned).
+ * resigns, so the victim wins.
  *
  * Returns the game URL (read from victimPage after the game ends).
  *
  * Note: this helper deliberately does not have either player file the
- * subsequent escaping report. Doing so from a player's page after resignation
+ * subsequent source report. Doing so from a player's page after resignation
  * is flaky — post-game state (AI processing, dialogs) re-renders the side
  * panel and closes the PlayerDetails popover before the Report button is
- * clicked. The escaping report should be filed by a third-party user from a
+ * clicked. The source report should be filed by a third-party user from a
  * fresh navigation to this URL.
  */
 export async function setupEscapingSourceGame(
@@ -345,7 +343,8 @@ export async function setupEscapingSourceGame(
 
 /**
  * Create a fresh "source reporter" — a third-party user who is not a player in
- * the game — and have them file an escaping report against the victim.
+ * the game — and have them file a score_cheating report against the victim.
+ * The malicious-report gate requires the source report to be score_cheating.
  *
  * Using a fresh user (rather than one of the game players) sidesteps post-game
  * render churn that closes the PlayerDetails popover. See note on
@@ -353,20 +352,20 @@ export async function setupEscapingSourceGame(
  *
  * The caller is expected to have set up the game already and have its URL.
  */
-export interface SourceEscapingReportSetup {
+export interface SourceScoreCheatingReportSetup {
     sourceReporterUsername: string;
     sourceReporterPage: Page;
     sourceReporterContext: BrowserContext;
     sourceReportNumber: string;
 }
 
-export async function createSourceEscapingReport(
+export async function createSourceScoreCheatingReport(
     createContext: (options?: CreateContextOptions) => Promise<BrowserContext>,
     gameUrl: string,
     victimUsername: string,
     rolePrefix: string,
     reporterNote: string,
-): Promise<SourceEscapingReportSetup> {
+): Promise<SourceScoreCheatingReportSetup> {
     const sourceReporterUsername = newTestUsername(rolePrefix);
     log(`[MR] Creating third-party source reporter ${sourceReporterUsername}`);
     const { userPage: sourceReporterPage, userContext: sourceReporterContext } =
@@ -379,11 +378,11 @@ export async function createSourceEscapingReport(
     // dismissing it before reportUser can click the Report button.
     await waitForGameViewReady(sourceReporterPage);
 
-    log(`[MR] Source reporter filing escaping report against ${victimUsername}`);
-    await reportUser(sourceReporterPage, victimUsername, "escaping", reporterNote);
+    log(`[MR] Source reporter filing score-cheating report against ${victimUsername}`);
+    await reportUser(sourceReporterPage, victimUsername, "score_cheating", reporterNote);
 
     const sourceReportNumber = await captureReportNumber(sourceReporterPage);
-    log(`[MR] Source escaping report filed: ${sourceReportNumber}`);
+    log(`[MR] Source score-cheating report filed: ${sourceReportNumber}`);
 
     return {
         sourceReporterUsername,
@@ -397,7 +396,7 @@ export async function createSourceEscapingReport(
  * Full setup of a malicious_report:
  *  1. Create fresh victim, opponent, and source reporter users.
  *  2. Victim and opponent play a short game; opponent resigns (victim wins).
- *  3. Source reporter (third party) files an escaping report against the victim.
+ *  3. Source reporter (third party) files a score_cheating report against the victim.
  *  4. CM filer marks that source report as malicious.
  *
  * Returns both report numbers and the source-reporter / filer pages and
@@ -443,18 +442,18 @@ export async function setupMaliciousReport(
 
     const gameUrl = await setupEscapingSourceGame(victimPage, opponentPage, opponentUsername);
 
-    // Third-party source reporter files an escaping report against the victim
+    // Third-party source reporter files a score_cheating report against the victim
     const {
         sourceReporterUsername,
         sourceReporterPage,
         sourceReporterContext,
         sourceReportNumber,
-    } = await createSourceEscapingReport(
+    } = await createSourceScoreCheatingReport(
         createContext,
         gameUrl,
         victimUsername,
         sourceReporterRolePrefix,
-        "E2E test: filing a bogus escaping report so a CM can mark it malicious.",
+        "E2E test: filing a bogus score-cheating report so a CM can mark it malicious.",
     );
 
     // CM filer marks the source report as malicious

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -111,28 +111,6 @@ Please choose a different type of report, if there is a different problem.`,
     });
 }
 
-// The source-report detail page is the only valid context for filing a
-// malicious_report; its URL becomes the back-link on the new report.
-function getMaliciousReportSourceUrl(): string | null {
-    const match = window.location.pathname.match(/^\/reports-center\/all\/(\d+)/);
-    return match ? `/reports-center/all/${match[1]}` : null;
-}
-
-function checkMaliciousReportApplicability(
-    _game_id?: number,
-    _reported_user_id?: number,
-): Promise<string | null> {
-    if (getMaliciousReportSourceUrl() === null) {
-        return Promise.resolve(
-            pgettext(
-                "Why malicious-report is disabled outside the reports-center view",
-                "Open a report's detail view to file a malicious report against its reporter.",
-            ),
-        );
-    }
-    return Promise.resolve(null);
-}
-
 function checkGameForStallingReportApplicability(
     game_id?: number,
     _reported_user_id?: number,
@@ -206,7 +184,6 @@ export const report_categories: ReportDescription[] = [
         ),
         cm_only: true,
         min_description_length: 1,
-        check_applicability: checkMaliciousReportApplicability,
     },
     {
         type: "sandbagging",
@@ -311,6 +288,7 @@ export function Report(props: ReportProperties): React.ReactElement {
     const [submitting, set_submitting] = React.useState(false);
     const [validating, set_validating] = React.useState(false);
     const [inapplicable_reason, set_inapplicable_reason] = React.useState<string | null>(null);
+    const [source_report_type, set_source_report_type] = React.useState<string | null>(null);
     // Source-report URL snapshot for malicious_report's back-link. Captured at
     // applicability-check time so SPA navigation between selection and submit
     // can't change which report the malicious_report is filed against.
@@ -333,11 +311,29 @@ export function Report(props: ReportProperties): React.ReactElement {
             .catch(() => 0);
     }, [reported_user_id]);
 
+    // When the Report dialog is opened on a report-detail page, fetch that
+    // source report's type once. It gates whether the malicious_report option
+    // is offered (score-cheating only) and provides the malicious_report
+    // back-link URL.
+    React.useEffect(() => {
+        const match = window.location.pathname.match(/^\/reports-center\/all\/(\d+)/);
+        if (!match) {
+            set_source_report_type(null);
+            source_report_url_ref.current = null;
+            return;
+        }
+        const source_id = match[1];
+        source_report_url_ref.current = `/reports-center/all/${source_id}`;
+        get(`moderation/incident/${source_id}`)
+            .then((report: { report_type?: string }) =>
+                set_source_report_type(report?.report_type ?? null),
+            )
+            .catch(() => set_source_report_type(null));
+    }, []);
+
     React.useEffect(() => {
         const needs_game_id_first = category?.game_id_required && !game_id;
         if (category?.check_applicability && !needs_game_id_first) {
-            source_report_url_ref.current =
-                category.type === "malicious_report" ? getMaliciousReportSourceUrl() : null;
             set_validating(true);
             category
                 .check_applicability(game_id, reported_user_id)
@@ -350,7 +346,6 @@ export function Report(props: ReportProperties): React.ReactElement {
                 });
         } else {
             set_inapplicable_reason(null);
-            source_report_url_ref.current = null;
         }
     }, [category, game_id]);
 
@@ -466,7 +461,9 @@ export function Report(props: ReportProperties): React.ReactElement {
     const available_categories = report_categories
         .filter((x) => !x.not_reportable)
         .filter((x) => user.is_moderator || !x.moderator_only)
-        .filter((x) => has_moderator_powers || !x.cm_only);
+        .filter((x) => has_moderator_powers || !x.cm_only)
+        // malicious_report is offered only while viewing a score-cheating report
+        .filter((x) => x.type !== "malicious_report" || source_report_type === "score_cheating");
 
     const more_description_needed =
         category?.min_description_length && note.length < category.min_description_length;

--- a/src/components/Report/Report.tsx
+++ b/src/components/Report/Report.tsx
@@ -289,9 +289,10 @@ export function Report(props: ReportProperties): React.ReactElement {
     const [validating, set_validating] = React.useState(false);
     const [inapplicable_reason, set_inapplicable_reason] = React.useState<string | null>(null);
     const [source_report_type, set_source_report_type] = React.useState<string | null>(null);
-    // Source-report URL snapshot for malicious_report's back-link. Captured at
-    // applicability-check time so SPA navigation between selection and submit
-    // can't change which report the malicious_report is filed against.
+    // Source-report URL snapshot for malicious_report's back-link, set in the
+    // mount effect below from the report-detail path at dialog-open time so SPA
+    // navigation between opening the dialog and submitting can't change which
+    // report the malicious_report is filed against.
     const source_report_url_ref = React.useRef<string | null>(null);
 
     const user = useUser();


### PR DESCRIPTION
Fixes #

## Proposed Changes

- "Malicious Report" now appears in the PlayerDetails → Report type-picker **only** when the CM is viewing a `score_cheating` report; on any other report type it is not offered.
- `Report.tsx` fetches the source report's type once on dialog open (`moderation/incident/<id>`) and gates the malicious-report category on it. Removed the old `checkMaliciousReportApplicability` / `getMaliciousReportSourceUrl` helpers.
- e2e `cm-file-malicious-report` updated: the source report is now `score_cheating`, with a negative guard asserting the option is absent against the reporter of an escaping source.

Backend enforcement (the authoritative gate) is in the paired `online-go/ogs` PR; the ReportsCenter retype-selector change is in the paired `online-go/moderator-ui` PR (same branch name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
