### PR TITLE
Bugfix - filter on wrong type for Malicious Report availability

### DIFF
--- a/e2e-tests/cm/cm-file-malicious-report.ts
+++ b/e2e-tests/cm/cm-file-malicious-report.ts
@@ -245,9 +245,10 @@ export const cmFileMaliciousReportTest = async (
             log(`[MR/file] Cleanup`);
             // Cleanup: the malicious_report we filed never gets resolved
             // in this test, so cancel it so the seeded CM filer doesn't
-            // accumulate pending reports across runs. The source escaping
-            // report is owned by an ephemeral fresh user; we don't bother
-            // cancelling it.
+            // accumulate pending reports across runs. The source
+            // score-cheating report and the negative-guard escaping report
+            // are owned by ephemeral fresh users; we don't bother cancelling
+            // them.
             await cancelOwnReport(filerPage, maliciousReportNumber);
 
             await filerContext.close();

--- a/e2e-tests/cm/cm-malicious-report-escalation.ts
+++ b/e2e-tests/cm/cm-malicious-report-escalation.ts
@@ -215,8 +215,8 @@ export const cmMaliciousReportEscalationTest = async (
             await expect(ack).not.toBeVisible();
 
             // The malicious_report resolved via voting → no pending state
-            // for the seeded filer. Source escaping report is owned by an
-            // ephemeral user, doesn't affect future runs.
+            // for the seeded filer. Source score-cheating report is owned by
+            // an ephemeral user, doesn't affect future runs.
 
             await setup.filerContext.close();
         },

--- a/e2e-tests/cm/cm-malicious-report-queue-visibility.ts
+++ b/e2e-tests/cm/cm-malicious-report-queue-visibility.ts
@@ -24,14 +24,16 @@
  *     in /reports-center (validates termination-server dispatch), and
  *     navigating directly to the report URL does not show vote options
  *     (validates the user_can_moderate gate).
- *  9. The ReportTypeSelector dropdown exposes "Malicious Report" for a CM with
- *     HANDLE_MALICIOUS_REPORT and not for one without it. The same
- *     community_mod_has_power gate also drives the category sidebar in
- *     /reports-center, so the negative case is covered by the sidebar
- *     visibility check in Test 8.
+ *  9. The ReportTypeSelector dropdown never offers "Malicious Report" as a
+ *     retype target — a malicious_report is filed through the PlayerDetails
+ *     -> Report dialog, not by retyping an existing report. The category
+ *     sidebar in /reports-center is still power-gated (a CM without
+ *     HANDLE_MALICIOUS_REPORT does not see the "Malicious report" category),
+ *     which Test 8 covers.
  *
  * Uses init_e2e data:
- * - E2E_CM_MR_FILER (set up by setupMaliciousReport, has HANDLE_ESCAPING too)
+ * - E2E_CM_MR_FILER (set up by setupMaliciousReport; also has
+ *   HANDLE_SCORE_CHEAT to view the score-cheating source, and HANDLE_ESCAPING)
  * - E2E_CM_MR_NO_POWER : CM with HANDLE_STALLING (negative case for Test 8)
  */
 
@@ -64,23 +66,25 @@ export const cmMaliciousReportQueueVisibilityTest = async (
         testInfo,
         async () => {
             // ========================================
-            // Test 9 (positive): filer (HANDLE_MALICIOUS_REPORT + HANDLE_ESCAPING)
-            // views the source escaping report and the type-selector dropdown
-            // includes "Malicious Report" as an option.
+            // Test 9 (type-selector filter): "Malicious Report" is NOT offered
+            // as a retype target, even for the filer who holds
+            // HANDLE_MALICIOUS_REPORT. A malicious_report is filed through the
+            // PlayerDetails -> Report dialog (see cmFileMaliciousReportTest),
+            // never by retyping an existing report.
             // ========================================
-            log(`[MR/queue] Test 9 positive: filer sees "Malicious Report" in type-selector`);
+            log(`[MR/queue] Test 9: "Malicious Report" is not a retype option`);
             await navigateToReport(setup.filerPage, setup.sourceReportNumber);
 
             const typeSelector = setup.filerPage.locator(".report-type-selector");
             await expect(typeSelector).toBeVisible();
-            // Source report's current type is "Stopped Playing", so "Malicious
-            // Report" only appears once the dropdown is opened.
+            // Open the retype dropdown: it lists other report types (e.g.
+            // "Stopped Playing") but must not offer "Malicious Report".
             await typeSelector.click();
-            await expect(
-                setup.filerPage
-                    .locator(".ogs-react-select__menu")
-                    .getByText("Malicious Report", { exact: true }),
-            ).toBeVisible({ timeout: 5000 });
+            const typeMenu = setup.filerPage.locator(".ogs-react-select__menu");
+            await expect(typeMenu.getByText("Stopped Playing", { exact: true })).toBeVisible({
+                timeout: 5000,
+            });
+            await expect(typeMenu.getByText("Malicious Report", { exact: true })).toHaveCount(0);
 
             // ========================================
             // Test 8: NO_POWER CM (HANDLE_STALLING only) cannot see the MR

--- a/e2e-tests/cm/cm-malicious-report-queue-visibility.ts
+++ b/e2e-tests/cm/cm-malicious-report-queue-visibility.ts
@@ -123,7 +123,7 @@ export const cmMaliciousReportQueueVisibilityTest = async (
 
             // Cleanup: the malicious_report doesn't get resolved in this
             // test, so cancel it so the seeded CM filer doesn't accumulate
-            // pending reports. Source escaping report is owned by an
+            // pending reports. Source score-cheating report is owned by an
             // ephemeral fresh user.
             await cancelOwnReport(setup.filerPage, setup.maliciousReportNumber);
 

--- a/e2e-tests/cm/cm-vote-informal-warn-malicious-reporter.ts
+++ b/e2e-tests/cm/cm-vote-informal-warn-malicious-reporter.ts
@@ -120,8 +120,8 @@ export const cmVoteInformalWarnMaliciousReporterTest = async (
             await expect(ack).not.toBeVisible();
 
             // The malicious_report resolved via voting → no pending state
-            // for the seeded filer. Source escaping report is owned by an
-            // ephemeral user, doesn't affect future runs.
+            // for the seeded filer. Source score-cheating report is owned by
+            // an ephemeral user, doesn't affect future runs.
 
             for (const ctx of cmContexts) {
                 await ctx.close();

--- a/e2e-tests/cm/cm-vote-no-malicious-report.ts
+++ b/e2e-tests/cm/cm-vote-no-malicious-report.ts
@@ -115,7 +115,7 @@ export const cmVoteNoMaliciousReportTest = async (
 
             // Cleanup: the malicious_report resolved via voting → no
             // pending state remains on the seeded CM filer. The source
-            // escaping report is still pending but is owned by an
+            // score-cheating report is still pending but is owned by an
             // ephemeral fresh user that never logs back in, so it
             // doesn't surface in any future test run's state.
 

--- a/e2e-tests/cm/cm-vote-warn-malicious-reporter.ts
+++ b/e2e-tests/cm/cm-vote-warn-malicious-reporter.ts
@@ -112,8 +112,8 @@ export const cmVoteWarnMaliciousReporterTest = async (
             await expect(ack).not.toBeVisible();
 
             // The malicious_report resolved via voting → no pending state
-            // remains for the seeded filer. The source escaping report is
-            // owned by an ephemeral fresh user and never affects future
+            // remains for the seeded filer. The source score-cheating report
+            // is owned by an ephemeral fresh user and never affects future
             // runs, so we don't cancel it.
 
             for (const ctx of cmContexts) {


### PR DESCRIPTION
Fixes bug with retyping MR.

## Proposed Changes

The queue-visibility test's Test 9 asserted that the ReportTypeSelector dropdown offers "Malicious Report" — the retype-target behaviour this change removes. Invert it to assert the option is absent while the dropdown still lists other types, matching the shipped behaviour that a malicious_report is filed via the PlayerDetails -> Report dialog, not by retyping. Fix stale 'source escaping report' comments in the sibling vote/escalation tests (the source is now score-cheating).