### PR TITLE
fix(anti-stall): only show stalling estimate to the predicted winner

### DIFF
--- a/src/views/Game/AntiGrief.test.tsx
+++ b/src/views/Game/AntiGrief.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C)  Online-Go.com
+ * Copyright (C)  Benjamin P. Jones
+ */
+
+import { AntiGrief } from "./AntiGrief";
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import * as data from "@/lib/data";
+import { MemoryRouter as Router } from "react-router-dom";
+import { GobanControllerContext } from "./goban_context";
+import { OgsHelpProvider } from "@/components/OgsHelpProvider";
+import { GobanController } from "../../lib/GobanController";
+
+const BLACK_PLAYER_ID = 123;
+const WHITE_PLAYER_ID = 456;
+const SPECTATOR_ID = 789;
+
+const TEST_USER = {
+    anonymous: false,
+    id: BLACK_PLAYER_ID,
+    username: "test_user",
+    registration_date: "2022-05-10 11:03:24.299562+00:00",
+    ratings: {
+        version: 5,
+        overall: { rating: 1500, deviation: 350, volatility: 0.06 },
+    },
+    country: "un",
+    professional: false,
+    ranking: 23,
+    provisional: 0,
+    can_create_tournaments: true,
+    is_moderator: false,
+    is_superuser: false,
+    moderator_powers: 0,
+    offered_moderator_powers: 0,
+    is_tournament_moderator: false,
+    supporter: true,
+    supporter_level: 4,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "",
+    email: "",
+    email_validated: false,
+    is_announcer: false,
+    last_supporter_trial: "",
+} as const;
+
+// Mirrors the `game/:id/stalling_score_estimate` message the server sends when
+// it thinks the game is over but a player keeps playing useless moves.
+function stallingScoreEstimate(predicted_winner: "black" | "white") {
+    return {
+        move_number: 0,
+        predicted_winner,
+        game_id: 1234,
+        removed: "",
+        score: 50.5,
+        win_rate: predicted_winner === "black" ? 0.98 : 0.02,
+        ownership: [],
+    };
+}
+
+function makeController(predicted_winner: "black" | "white"): GobanController {
+    return new GobanController({
+        game_id: 1234,
+        // AntiStalling reads engine.config.black_player_id / white_player_id.
+        // The nested `players` shape alone does not populate those, which
+        // silently makes every viewer a non-player -- so set both explicitly.
+        black_player_id: BLACK_PLAYER_ID,
+        white_player_id: WHITE_PLAYER_ID,
+        players: {
+            black: { id: BLACK_PLAYER_ID, username: "black_player" },
+            white: { id: WHITE_PLAYER_ID, username: "white_player" },
+        },
+        stalling_score_estimate: stallingScoreEstimate(predicted_winner),
+    } as any);
+}
+
+function WrapTest(props: { controller: GobanController; children: any }): React.ReactElement {
+    const { controller } = props;
+    return (
+        <OgsHelpProvider>
+            <Router>
+                <GobanControllerContext.Provider value={controller}>
+                    {props.children}
+                </GobanControllerContext.Provider>
+            </Router>
+        </OgsHelpProvider>
+    );
+}
+
+function renderAs(user: rest_api.UserConfig, predicted_winner: "black" | "white") {
+    data.set("user", user);
+    render(
+        <WrapTest controller={makeController(predicted_winner)}>
+            <AntiGrief />
+        </WrapTest>,
+    );
+}
+
+const ACCEPT_BUTTON = "Accept predicted winner and end game";
+
+test("Shows the stalling estimate to the player predicted to win", () => {
+    renderAs({ ...TEST_USER, id: BLACK_PLAYER_ID }, "black");
+
+    expect(screen.getByText(ACCEPT_BUTTON)).toBeDefined();
+});
+
+test("Does not show the stalling estimate to the player who is behind", () => {
+    // White is losing here. Prompting them to end the game is just a resign
+    // button by another name, which is not what this feature is for.
+    renderAs({ ...TEST_USER, id: WHITE_PLAYER_ID }, "black");
+
+    expect(screen.queryByText(ACCEPT_BUTTON)).toBeNull();
+});
+
+test("Does not show the stalling estimate to the player who is behind as black", () => {
+    // Same as above with the colours swapped, so the test would fail if the
+    // component hardcoded a colour rather than comparing against the estimate.
+    renderAs({ ...TEST_USER, id: BLACK_PLAYER_ID }, "white");
+
+    expect(screen.queryByText(ACCEPT_BUTTON)).toBeNull();
+});
+
+test("Shows the stalling estimate to a non-player moderator", () => {
+    renderAs({ ...TEST_USER, id: SPECTATOR_ID, is_moderator: true }, "black");
+
+    expect(screen.getByText(ACCEPT_BUTTON)).toBeDefined();
+});
+
+test("Does not show the stalling estimate to a spectator", () => {
+    renderAs({ ...TEST_USER, id: SPECTATOR_ID }, "black");
+
+    expect(screen.queryByText(ACCEPT_BUTTON)).toBeNull();
+});

--- a/src/views/Game/AntiGrief.tsx
+++ b/src/views/Game/AntiGrief.tsx
@@ -286,12 +286,12 @@ function AntiStalling(): React.ReactElement | null {
     const user = useUser();
     const goban_controller = useGobanController();
     const goban = goban_controller.goban;
-    const [estimate, setEstimate] = React.useState<any>(null);
+    const [estimate, setEstimate] = React.useState<StallingScoreEstimate | null>(null);
     const [phase, setPhase] = React.useState(goban?.engine?.phase);
 
     React.useEffect(() => {
         const onScoreEstimate = (estimate?: StallingScoreEstimate) => {
-            setEstimate(estimate);
+            setEstimate(estimate ?? null);
         };
 
         onScoreEstimate(goban.config?.stalling_score_estimate);
@@ -314,11 +314,18 @@ function AntiStalling(): React.ReactElement | null {
         return null;
     }
 
-    if (
-        user.id !== goban?.engine?.config?.black_player_id &&
-        user.id !== goban?.engine?.config?.white_player_id &&
-        !user.is_moderator
-    ) {
+    const is_black = user.id === goban?.engine?.config?.black_player_id;
+    const is_white = user.id === goban?.engine?.config?.white_player_id;
+    const is_player = is_black || is_white;
+
+    if (!is_player && !user.is_moderator) {
+        return null;
+    }
+
+    // Only the player who is predicted to win is offered this. The player who
+    // is behind shouldn't be nudged into ending the game -- that's what the
+    // resign button is for.
+    if (is_player && (is_black ? "black" : "white") !== estimate.predicted_winner) {
         return null;
     }
 


### PR DESCRIPTION
This seems to be a relatively uncontroversial modification of the stalling system.  See discussion in https://forums.online-go.com/t/can-we-please-get-rid-of-ai-interrupting-a-game-and-ending-it/55280/115

## Proposed Changes

  - The `AntiStalling` card gated visibility on "is this user a player in this game", so **both** players saw the predicted winner and the *"Accept predicted winner and end game"* button — including the player predicted to lose. Prompting the player who is behind to end the game is effectively a resign button by another name, which isn't what the anti-stalling feature is for.
  - Gate on the viewing player's color instead: a player only sees the card when their color matches `estimate.predicted_winner`. Non-player moderators still see it for either color.
  - `any` -> `StallingScoreEstimate | null` so the new color comparison is type-checked.
  - Add `AntiGrief.test.tsx` covering the visibility matrix.

NOTE: This is a **client-side visibility change only**. The `sendPreventStalling` path is now unreachable from the UI for the losing player, but it isn't blocked server-side — this change could easily belong server side, but I'm submitting here because it's the open source repo.

## Testing

I tried to test in-browser, but couldn't trigger Anti-stall on the beta server because the AI server is currently dead. Here was my attempt: https://beta.online-go.com/game/20986

I added a jsdom test suite to simulate the anti-stall message and verify when the messages are shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)