### PR TITLE
Fix clicking puzzle on mobile to close list and see puzzle

### DIFF
--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -26,7 +26,7 @@ import { rankList } from "@/lib/rank_utils";
 import { GobanRendererConfig, GobanRenderer, PuzzleConfig, PuzzlePlacementSetting } from "goban";
 import type { PlayerCacheEntry } from "@/lib/player_cache";
 import { GobanController } from "@/lib/GobanController";
-import { GobanView, GobanViewRef } from "@/components/GobanView";
+import { goban_view_mode, GobanView, GobanViewRef } from "@/components/GobanView";
 import { Markdown } from "@/components/Markdown";
 import { StarRating } from "@/components/StarRating";
 import { Resizable } from "@/components/Resizable";
@@ -751,6 +751,15 @@ export function Puzzle(): React.ReactElement {
         [withMutation],
     );
 
+    // On mobile the library takeover covers the goban, so picking a puzzle
+    // from it should close it and reveal the puzzle immediately. On desktop
+    // the list sits alongside the board, so it stays open.
+    const closeLibraryOnMobile = React.useCallback(() => {
+        if (goban_view_mode() === "portrait") {
+            gobanViewRef.current?.setActiveTakeover(null);
+        }
+    }, []);
+
     // PuzzleLibrary emits a single-item move with the id of the puzzle that
     // should precede the moved one (after_id === 0 → move to the top).
     const reorderPuzzle = React.useCallback(
@@ -1200,6 +1209,7 @@ export function Puzzle(): React.ReactElement {
                         onRenameCollection={renameCollection}
                         onDeletePuzzle={deletePuzzleFromCollection}
                         onReorderPuzzle={reorderPuzzle}
+                        onSelectPuzzle={closeLibraryOnMobile}
                     />
                 </GobanView.Tab>
 

--- a/src/views/Puzzle/PuzzleLibrary.tsx
+++ b/src/views/Puzzle/PuzzleLibrary.tsx
@@ -46,6 +46,8 @@ interface PuzzleLibraryProps {
     /** Move `moved_id` to sit immediately after `after_id`. `after_id === 0`
      *  moves the puzzle to the top of the list. */
     onReorderPuzzle: (moved_id: number, after_id: number) => void;
+    /** Called when the user clicks a puzzle in the list, before navigation. */
+    onSelectPuzzle?: () => void;
 }
 
 export function PuzzleLibrary({
@@ -57,6 +59,7 @@ export function PuzzleLibrary({
     onRenameCollection,
     onDeletePuzzle,
     onReorderPuzzle,
+    onSelectPuzzle,
 }: PuzzleLibraryProps): React.ReactElement {
     return (
         <div className="PuzzleLibrary">
@@ -76,6 +79,7 @@ export function PuzzleLibrary({
                     can_edit={can_edit}
                     onDeletePuzzle={onDeletePuzzle}
                     onReorderPuzzle={onReorderPuzzle}
+                    onSelectPuzzle={onSelectPuzzle}
                 />
             )}
             {can_edit && (
@@ -182,12 +186,14 @@ function LibraryList({
     can_edit,
     onDeletePuzzle,
     onReorderPuzzle,
+    onSelectPuzzle,
 }: {
     items: PuzzleLibraryItem[];
     current_id?: number;
     can_edit: boolean;
     onDeletePuzzle: (puzzle_id: number) => void;
     onReorderPuzzle: (moved_id: number, after_id: number) => void;
+    onSelectPuzzle?: () => void;
 }): React.ReactElement {
     // Slight activation threshold so clicks on the name link aren't swallowed
     // by drag gesture recognition.
@@ -224,6 +230,7 @@ function LibraryList({
                         current_id={current_id}
                         can_edit={false}
                         onDelete={onDeletePuzzle}
+                        onSelect={onSelectPuzzle}
                     />
                 ))}
             </ul>
@@ -241,6 +248,7 @@ function LibraryList({
                             current_id={current_id}
                             can_edit
                             onDelete={onDeletePuzzle}
+                            onSelect={onSelectPuzzle}
                         />
                     ))}
                 </ul>
@@ -254,11 +262,13 @@ function PuzzleLibraryEntry({
     current_id,
     can_edit,
     onDelete,
+    onSelect,
 }: {
     item: PuzzleLibraryItem;
     current_id?: number;
     can_edit: boolean;
     onDelete: (puzzle_id: number) => void;
+    onSelect?: () => void;
 }): React.ReactElement {
     const sortable = useSortable({ id: item.id, disabled: !can_edit });
     const style: React.CSSProperties = can_edit
@@ -287,7 +297,11 @@ function PuzzleLibraryEntry({
                     <i className="fa fa-bars" />
                 </span>
             )}
-            <Link to={`/puzzle/${item.id}`} className="PuzzleLibrary-entry-link">
+            <Link
+                to={`/puzzle/${item.id}`}
+                className="PuzzleLibrary-entry-link"
+                onClick={() => onSelect?.()}
+            >
                 {item.name}
             </Link>
             {can_edit && (


### PR DESCRIPTION
Makes it so when you click on a puzzle in the puzzle list on mobile, we close the list so the puzzle is visible.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>