### PR TITLE
puzzles: Fix up drag and drop support for owners on mobile

### DIFF
--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -47,6 +47,8 @@ type TransformationOptions = "x" | "h" | "v" | "color" | "zoom";
 interface PuzzleCollectionInfo {
     id: number;
     name: string;
+    /** Absent on the /puzzle/new path, where no collection is chosen yet. */
+    owner?: rest_api.MinimalPlayerDetail;
     position_transform_enabled?: boolean;
     color_transform_enabled?: boolean;
     private?: boolean;
@@ -751,9 +753,7 @@ export function Puzzle(): React.ReactElement {
         [withMutation],
     );
 
-    // On mobile the library takeover covers the goban, so picking a puzzle
-    // from it should close it and reveal the puzzle immediately. On desktop
-    // the list sits alongside the board, so it stays open.
+    // The portrait takeover covers the goban; the landscape sidebar doesn't.
     const closeLibraryOnMobile = React.useCallback(() => {
         if (goban_view_mode() === "portrait") {
             gobanViewRef.current?.setActiveTakeover(null);
@@ -1140,8 +1140,10 @@ export function Puzzle(): React.ReactElement {
             (!goban!.engine.cur_move.parent && !!goban!.engine.puzzle_description);
 
         const user = data.get("user");
-        const is_owner = loadedState.owner.id === user.id;
-        const is_owner_or_mod = is_owner || !!user?.is_moderator;
+        // Every puzzle and collection mutation is collection-owner-only
+        // server side, moderators included.
+        const is_collection_owner =
+            !!playState.collection.owner && playState.collection.owner.id === user.id;
         const has_prev = findSiblingPuzzleId(state.puzzle_collection_summary, state.id, -1) !== 0;
         const has_next = findSiblingPuzzleId(state.puzzle_collection_summary, state.id, 1) !== 0;
         const at_start = !goban!.engine.cur_move.parent;
@@ -1181,6 +1183,7 @@ export function Puzzle(): React.ReactElement {
                         color_transform_enabled={!!playState.collection.color_transform_enabled}
                         label_positioning={state.label_positioning}
                         owner_id={loadedState.owner.id}
+                        is_collection_owner={is_collection_owner}
                         collection_id={playState.collection.id}
                         collection_private={!!playState.collection.private}
                         onToggleTransformX={toggle_transform_x}
@@ -1205,7 +1208,7 @@ export function Puzzle(): React.ReactElement {
                         collection_name={playState.collection.name}
                         current_id={state.id}
                         items={state.puzzle_collection_summary}
-                        can_edit={is_owner_or_mod}
+                        can_edit={is_collection_owner}
                         onRenameCollection={renameCollection}
                         onDeletePuzzle={deletePuzzleFromCollection}
                         onReorderPuzzle={reorderPuzzle}
@@ -1213,7 +1216,7 @@ export function Puzzle(): React.ReactElement {
                     />
                 </GobanView.Tab>
 
-                {is_owner_or_mod && (
+                {is_collection_owner && (
                     <GobanView.Tab
                         id="puzzle-edit"
                         icon="pencil"

--- a/src/views/Puzzle/PuzzleLibrary.css
+++ b/src/views/Puzzle/PuzzleLibrary.css
@@ -93,11 +93,19 @@
 
     .PuzzleLibrary-entry-handle {
         flex-shrink: 0;
-        padding: 0.5rem 0.25rem;
+        padding: 0rem 0.25rem;
         color: var(--shade2);
         cursor: grab;
         user-select: none;
         touch-action: none;
+
+        i {
+            font-size: 1.25rem !important;
+            margin: 0.25rem 0.1rem;
+        }
+        &:first-child {
+            margin-left: 0.25rem;
+        }
 
         &:active {
             cursor: grabbing;
@@ -136,6 +144,12 @@
     .PuzzleLibrary-footer {
         padding-top: 0.5rem;
         border-top: 1px solid var(--shade3);
+    }
+
+    /* The portrait takeover is full width, so keep the handle out of the
+       phone's edge-swipe strip. */
+    .GobanView.portrait & .PuzzleLibrary-entry-handle {
+        margin-left: 0.75rem;
     }
 
     .PuzzleLibrary-new-puzzle {

--- a/src/views/Puzzle/PuzzleLibrary.tsx
+++ b/src/views/Puzzle/PuzzleLibrary.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { _ } from "@/lib/translate";
 import {
+    closestCenter,
     DndContext,
     DragEndEvent,
     MouseSensor,
@@ -237,8 +238,10 @@ function LibraryList({
         );
     }
 
+    // closestCenter rather than the default rectIntersection, which drops
+    // short drags in a dense list as no-ops.
     return (
-        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={items} strategy={verticalListSortingStrategy}>
                 <ul className="PuzzleLibrary-list">
                     {items.map((item) => (
@@ -294,7 +297,8 @@ function PuzzleLibraryEntry({
                     {...sortable.attributes}
                     {...sortable.listeners}
                 >
-                    <i className="fa fa-bars" />
+                    <i className="fa fa-ellipsis-v"></i>
+                    <i className="fa fa-ellipsis-v"></i>
                 </span>
             )}
             <Link

--- a/src/views/Puzzle/PuzzleSettings.tsx
+++ b/src/views/Puzzle/PuzzleSettings.tsx
@@ -34,6 +34,8 @@ interface PuzzleSettingsProps {
     color_transform_enabled: boolean;
     label_positioning: string;
     owner_id?: number;
+    /** Gates the collection settings — see the server's owner-only checks. */
+    is_collection_owner?: boolean;
     /** Collection info — optional because the new-puzzle flow has none. */
     collection_id?: number;
     collection_private?: boolean;
@@ -71,6 +73,7 @@ export function PuzzleSettings({
     color_transform_enabled,
     label_positioning,
     owner_id,
+    is_collection_owner,
     collection_id,
     collection_private,
     onToggleTransformX,
@@ -92,11 +95,10 @@ export function PuzzleSettings({
     const [debug, setDebug] = React.useState(false);
 
     const user = data.get("user");
-    const is_owner = !!user && user.id === owner_id;
-    const is_owner_or_mod = !!user && (user.is_moderator || user.id === owner_id);
-    const show_debug_toggle = is_owner_or_mod;
-    const show_collection_settings = is_owner_or_mod && collection_id !== undefined;
-    const show_acl = is_owner && collection_id !== undefined;
+    // The debug rows are local-only; the collection settings hit the server,
+    // which accepts the collection's owner alone.
+    const show_debug_toggle = !!user && (user.is_moderator || user.id === owner_id);
+    const show_collection_settings = !!is_collection_owner && collection_id !== undefined;
 
     const handleRandomizeTransform = (checked: boolean) => {
         preferences.set("puzzle.randomize.transform", checked);
@@ -257,7 +259,7 @@ export function PuzzleSettings({
                 <>
                     <h3 className="PuzzleSettings-heading">{_("Puzzle Collection Settings")}</h3>
                     <ul className="PuzzleSettings-list">{collection_rows.map(renderToggleRow)}</ul>
-                    {collection_private && show_acl && (
+                    {collection_private && (
                         <div className="PuzzleSettings-subsection">
                             <h4 className="PuzzleSettings-subheading">{_("Access control")}</h4>
                             <PuzzleCollectionAcl collection_id={collection_id} />

--- a/src/views/PuzzleCollection/PuzzleCollection.tsx
+++ b/src/views/PuzzleCollection/PuzzleCollection.tsx
@@ -32,8 +32,8 @@ import "./PuzzleCollection.css";
  * tells the Puzzle view to open the library panel on mount.
  *
  * An empty collection has no puzzle to land on, so we render the same
- * PuzzleLibrary list standalone (with no entries). Owners and moderators get
- * the library's usual rename control and "New puzzle" link, so a brand-new
+ * PuzzleLibrary list standalone (with no entries). The owner gets the
+ * library's usual rename control and "New puzzle" link, so a brand-new
  * collection is immediately manageable.
  */
 export function PuzzleCollection(): React.ReactElement | null {
@@ -83,7 +83,8 @@ export function PuzzleCollection(): React.ReactElement | null {
     }
 
     const user = data.get("user");
-    const can_edit = collection.owner.id === user.id || !!user?.is_moderator;
+    // Renaming and adding puzzles are owner-only server side.
+    const can_edit = collection.owner.id === user.id;
 
     return (
         <div className="PuzzleCollection">


### PR DESCRIPTION
Fixes drag and drop support to rearrange puzzles in puzzle collections


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>