### PR TITLE
Sharing goban themes

### DIFF
--- a/docs/goban-theme-json.md
+++ b/docs/goban-theme-json.md
@@ -17,17 +17,23 @@ opacity, variation display, undo indicators, and accessibility settings are excl
 
 ## Effective theme settings
 
-The selected `theme` is authoritative. A built-in board theme such as `Kaya` supplies its
-own background, grid, and label colors, so its exported `board` object contains only the
-selected theme name. The `custom` object is required when the selected theme is `Custom`
-and is rejected when a built-in theme is selected.
+The JSON stores only the settings that currently affect how the goban looks.
 
-Black and white stones follow the same rule independently. Custom shadow colors and
-gradients are included only when the selected shadow style is `custom`.
+For example, a built-in board theme such as `Kaya` already defines its background, grid,
+and label colors. When `Kaya` is selected, the exported `board` object therefore contains
+only the theme name. When `Custom` is selected, the `custom` object is required and
+contains the custom board settings. A `custom` object is not allowed for a built-in theme.
 
-This makes the document a portable description of the effective goban appearance rather
-than a backup of dormant theme-editor settings. Importing a built-in selection resets its
-inactive Custom settings to the documented defaults.
+Black and white stones follow the same rule separately: each stone color can use either a
+built-in theme or `Custom`. Custom shadow colors and gradients are exported only when the
+selected shadow style is `custom`.
+
+Unused Custom settings are not preserved. For example, if someone configured a custom
+board and later selected `Kaya`, the old custom settings are not exported. Importing that
+theme resets the unused Custom settings to their documented defaults.
+
+In short, the document describes what the goban looks like now. It is not a backup of
+every setting previously entered in the theme editor.
 
 ## Replacement and defaults
 

--- a/docs/goban-theme-json.md
+++ b/docs/goban-theme-json.md
@@ -1,0 +1,61 @@
+# Goban theme JSON
+
+OGS goban theme JSON is a public, versioned format intended for sharing themes in
+places such as the OGS forums. It is deliberately separate from the private
+`preferences.*` keys stored by the web client.
+
+The current format discriminator is `online-go.com/goban-theme`, and its current version
+is `1`. Exported documents contain:
+
+- the effective selected board, black-stone, and white-stone theme names;
+- the complete Custom board and Custom stone configuration, even when it is dormant;
+- global stone scale and shadow settings; and
+- fuzzy stone placement.
+
+Personal presentation choices such as coordinates, removal markers, font scale, marker
+opacity, variation display, undo indicators, and accessibility settings are excluded.
+
+## Selected themes and Custom details
+
+The selected `theme` is authoritative. A board theme such as `Kaya` supplies its own
+background, grid, and label colors. The adjacent `custom` values are stored but remain
+dormant until the selected board theme is changed to `Custom`.
+
+Black and white stones follow the same rule independently. Built-in stone themes supply
+their own artwork and marker colors. A stone's `custom` colors and image URLs become
+active only when that stone's selected theme is `Custom`. Import never infers `Custom`
+from the presence of custom details.
+
+Keeping dormant details in the document lets a shared theme preserve the author's whole
+Custom setup without creating unsupported hybrids such as Kaya with an overridden grid.
+
+## Replacement and defaults
+
+Import replaces every setting in the shareable scope after the complete document has
+been parsed, migrated, and validated. It never merges with the recipient's corresponding
+settings. This matters for forward compatibility: when a later format adds a setting,
+an older theme must receive the new version's documented default instead of accidentally
+retaining an unrelated value from the importing device.
+
+Current preference/reset defaults are defined independently from the portable migration
+chain. Some defaults are concrete values, some are automatic sentinels, and some are
+derived—for example, the default board-label color is computed from the grid color.
+
+## Adding a format version
+
+Persisted-setting migrations and portable-theme migrations solve different problems:
+
+- persisted migrations rename or reshape private browser/account storage keys;
+- portable migrations preserve JSON that may remain in forum posts indefinitely.
+
+When the public shape, meaning, or normalized defaults change:
+
+1. Increment the portable format version.
+2. Add a pure, directional migration from the preceding version.
+3. Fill every newly introduced field with the target version's documented default.
+4. Explicitly map renamed or removed built-in theme identifiers.
+5. Keep the old types and migration tests so every supported version can migrate
+   sequentially to the current format.
+
+Never call persisted preference migrations from the portable migration chain, and never
+rely on renderer fallback behavior to repair a portable document.

--- a/docs/goban-theme-json.md
+++ b/docs/goban-theme-json.md
@@ -8,26 +8,26 @@ The current format discriminator is `online-go.com/goban-theme`, and its current
 is `1`. Exported documents contain:
 
 - the effective selected board, black-stone, and white-stone theme names;
-- the complete Custom board and Custom stone configuration, even when it is dormant;
+- Custom board and stone configuration only for selections currently using `Custom`;
 - global stone scale and shadow settings; and
 - fuzzy stone placement.
 
 Personal presentation choices such as coordinates, removal markers, font scale, marker
 opacity, variation display, undo indicators, and accessibility settings are excluded.
 
-## Selected themes and Custom details
+## Effective theme settings
 
-The selected `theme` is authoritative. A board theme such as `Kaya` supplies its own
-background, grid, and label colors. The adjacent `custom` values are stored but remain
-dormant until the selected board theme is changed to `Custom`.
+The selected `theme` is authoritative. A built-in board theme such as `Kaya` supplies its
+own background, grid, and label colors, so its exported `board` object contains only the
+selected theme name. The `custom` object is required when the selected theme is `Custom`
+and is rejected when a built-in theme is selected.
 
-Black and white stones follow the same rule independently. Built-in stone themes supply
-their own artwork and marker colors. A stone's `custom` colors and image URLs become
-active only when that stone's selected theme is `Custom`. Import never infers `Custom`
-from the presence of custom details.
+Black and white stones follow the same rule independently. Custom shadow colors and
+gradients are included only when the selected shadow style is `custom`.
 
-Keeping dormant details in the document lets a shared theme preserve the author's whole
-Custom setup without creating unsupported hybrids such as Kaya with an overridden grid.
+This makes the document a portable description of the effective goban appearance rather
+than a backup of dormant theme-editor settings. Importing a built-in selection resets its
+inactive Custom settings to the documented defaults.
 
 ## Replacement and defaults
 

--- a/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.tsx
+++ b/src/components/GobanThemePicker/GobanCustomBoardGridBackgroundPicker.tsx
@@ -19,10 +19,13 @@ import * as React from "react";
 import { pgettext, interpolate } from "@/lib/translate";
 import { usePreference } from "@/lib/preferences";
 import type { CustomBoardGridBackgrounds } from "goban";
+import { createGobanThemePreferenceDefaults } from "@/lib/goban_theme_defaults";
 import { LineText } from "../misc-ui";
 import "./GobanCustomBoardGridBackgroundPicker.css";
 
 const grid_background_sizes: (keyof CustomBoardGridBackgrounds)[] = ["9", "13", "19"];
+const default_grid_backgrounds =
+    createGobanThemePreferenceDefaults()["goban-theme-custom-board-grid-backgrounds"];
 
 // Compact label shown next to each input, e.g. "9×9".
 function getGridSizeLabel(size: keyof CustomBoardGridBackgrounds): string {
@@ -109,7 +112,9 @@ export function GobanCustomBoardGridBackgroundPicker(): React.ReactElement {
                                 className="color-reset"
                                 title={reset_label}
                                 aria-label={reset_label}
-                                onClick={() => setGridBackground(size, "")}
+                                onClick={() =>
+                                    setGridBackground(size, default_grid_backgrounds[size])
+                                }
                             >
                                 <i className="fa fa-undo" />
                             </button>

--- a/src/components/GobanThemePicker/GobanCustomStoneUrlInput.tsx
+++ b/src/components/GobanThemePicker/GobanCustomStoneUrlInput.tsx
@@ -18,9 +18,11 @@
 import * as React from "react";
 import { useData } from "@/lib/hooks";
 import { pgettext } from "@/lib/translate";
+import { createGobanThemePreferenceDefaults } from "@/lib/goban_theme_defaults";
 import "./GobanCustomStoneUrlInput.css";
 
 type StoneColor = "black" | "white";
+const theme_defaults = createGobanThemePreferenceDefaults();
 
 interface GobanCustomStoneUrlInputProperties {
     color: StoneColor;
@@ -90,9 +92,13 @@ export function GobanCustomStoneUrlInput({
     }
 
     function resetUrls(): void {
+        const default_urls =
+            color === "black"
+                ? theme_defaults["goban-theme-custom-black-urls"]
+                : theme_defaults["goban-theme-custom-white-urls"];
         last_emitted_urls.current = "";
         setDraft("");
-        setUrls([]);
+        setUrls([...default_urls]);
         setVariantsOpen(false);
     }
 

--- a/src/components/GobanThemePicker/GobanThemePicker.tsx
+++ b/src/components/GobanThemePicker/GobanThemePicker.tsx
@@ -17,14 +17,20 @@
 
 import * as React from "react";
 import { _, pgettext } from "@/lib/translate";
-import { blendWithInverseColor, Goban, GobanTheme /*, GobanThemeBackgroundCSS */ } from "goban";
+import { Goban, GobanTheme /*, GobanThemeBackgroundCSS */ } from "goban";
 import { getSelectedThemes, usePreference } from "@/lib/preferences";
+import {
+    createGobanThemePreferenceDefaults,
+    defaultGobanLabelColor,
+} from "@/lib/goban_theme_defaults";
 import { PersistentElement } from "@/components/PersistentElement";
 import { Experiment, Variant, Default } from "../Experiment";
 import { LineText } from "../misc-ui";
 import { GobanCustomBoardGridBackgroundPicker } from "./GobanCustomBoardGridBackgroundPicker";
 import { GobanCustomStoneUrlInput } from "./GobanCustomStoneUrlInput";
 import "./GobanThemePicker.css";
+
+const theme_defaults = createGobanThemePreferenceDefaults();
 
 interface GobanThemePickerProperties {
     size?: number;
@@ -207,7 +213,11 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
                             />
                             <button
                                 className="color-reset"
-                                onClick={() => _setBackgroundColor("#DCB35C")}
+                                onClick={() =>
+                                    _setBackgroundColor(
+                                        theme_defaults["goban-theme-custom-board-background"],
+                                    )
+                                }
                             >
                                 <i className="fa fa-undo" />
                             </button>
@@ -224,7 +234,9 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
                             />
                             <button
                                 className="color-reset"
-                                onClick={() => _setLineColor("#000000")}
+                                onClick={() =>
+                                    _setLineColor(theme_defaults["goban-theme-custom-board-line"])
+                                }
                             >
                                 <i className="fa fa-undo" />
                             </button>
@@ -241,9 +253,7 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
                             />
                             <button
                                 className="color-reset"
-                                onClick={() =>
-                                    _setLabelColor(blendWithInverseColor(line_color, 0.75))
-                                }
+                                onClick={() => _setLabelColor(defaultGobanLabelColor(line_color))}
                             >
                                 <i className="fa fa-undo" />
                             </button>
@@ -278,7 +288,14 @@ export function GobanCustomBoardPicker(props: GobanThemePickerProperties): React
                                 onChange={setBackgroundImage}
                             />
 
-                            <button className="color-reset" onClick={() => _setBackgroundImage("")}>
+                            <button
+                                className="color-reset"
+                                onClick={() =>
+                                    _setBackgroundImage(
+                                        theme_defaults["goban-theme-custom-board-url"],
+                                    )
+                                }
+                            >
                                 <i className="fa fa-undo" />
                             </button>
                         </div>
@@ -521,7 +538,14 @@ export function GobanCustomBlackPicker(props: GobanThemePickerProperties): React
                                 aria-label={color_title}
                                 onChange={setColor}
                             />
-                            <button className="color-reset" onClick={() => _setColor("")}>
+                            <button
+                                className="color-reset"
+                                onClick={() =>
+                                    _setColor(
+                                        theme_defaults["goban-theme-custom-black-stone-color"],
+                                    )
+                                }
+                            >
                                 <i className="fa fa-undo" />
                             </button>
                         </span>
@@ -534,7 +558,14 @@ export function GobanCustomBlackPicker(props: GobanThemePickerProperties): React
                                 aria-label={marker_color_title}
                                 onChange={(ev) => setMarkerColor(ev.target.value)}
                             />
-                            <button className="color-reset" onClick={() => setMarkerColor("")}>
+                            <button
+                                className="color-reset"
+                                onClick={() =>
+                                    setMarkerColor(
+                                        theme_defaults["goban-theme-custom-black-text-color"],
+                                    )
+                                }
+                            >
                                 <i className="fa fa-undo" />
                             </button>
                         </span>
@@ -717,7 +748,14 @@ export function GobanCustomWhitePicker(props: GobanThemePickerProperties): React
                                 aria-label={color_title}
                                 onChange={setColor}
                             />
-                            <button className="color-reset" onClick={() => _setColor("")}>
+                            <button
+                                className="color-reset"
+                                onClick={() =>
+                                    _setColor(
+                                        theme_defaults["goban-theme-custom-white-stone-color"],
+                                    )
+                                }
+                            >
                                 <i className="fa fa-undo" />
                             </button>
                         </span>
@@ -730,7 +768,14 @@ export function GobanCustomWhitePicker(props: GobanThemePickerProperties): React
                                 aria-label={marker_color_title}
                                 onChange={(ev) => setMarkerColor(ev.target.value)}
                             />
-                            <button className="color-reset" onClick={() => setMarkerColor("")}>
+                            <button
+                                className="color-reset"
+                                onClick={() =>
+                                    setMarkerColor(
+                                        theme_defaults["goban-theme-custom-white-text-color"],
+                                    )
+                                }
+                            >
                                 <i className="fa fa-undo" />
                             </button>
                         </span>

--- a/src/lib/goban_theme_defaults.ts
+++ b/src/lib/goban_theme_defaults.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+    blendWithInverseColor,
+    CustomBoardGridBackgrounds,
+    emptyCustomBoardGridBackgrounds,
+    ShadowTheme,
+} from "goban";
+
+export interface GobanThemePreferenceDefaults {
+    "fuzzy-stone-placement": boolean;
+    "goban-theme-black": string | null;
+    "goban-theme-board": string | null;
+    "goban-theme-white": string | null;
+    "goban-theme-stone-scale": number;
+    "goban-theme-stone-shadows": ShadowTheme;
+    "goban-theme-custom-black-shadow-color": string;
+    "goban-theme-custom-black-shadow-gradient": string;
+    "goban-theme-custom-white-shadow-color": string;
+    "goban-theme-custom-white-shadow-gradient": string;
+    "goban-theme-custom-board-background": string;
+    "goban-theme-custom-board-url": string;
+    "goban-theme-custom-board-grid-backgrounds": CustomBoardGridBackgrounds;
+    "goban-theme-custom-board-line": string;
+    "goban-theme-custom-board-label": string;
+    "goban-theme-custom-black-stone-color": string;
+    "goban-theme-custom-black-text-color": string;
+    "goban-theme-custom-black-urls": string[];
+    "goban-theme-custom-white-stone-color": string;
+    "goban-theme-custom-white-text-color": string;
+    "goban-theme-custom-white-urls": string[];
+}
+
+export const DEFAULT_GOBAN_BOARD_COLOR = "#DCB35C";
+export const DEFAULT_GOBAN_GRID_COLOR = "#000000";
+export const DEFAULT_BLACK_STONE_COLOR = "#000000";
+export const DEFAULT_WHITE_STONE_COLOR = "#ffffff";
+export const DEFAULT_SHADOW_COLOR = "#000000";
+export const DEFAULT_SHADOW_GRADIENT = "rotate(45) scale(1.10 1.0) translate(0.05 -0.50)";
+
+export function defaultGobanLabelColor(grid_color: string): string {
+    return blendWithInverseColor(grid_color, 0.75);
+}
+
+/**
+ * The current reset contract for shareable goban theme preferences.
+ *
+ * Keep this separate from portable-theme migrations: persisted preference migrations
+ * deal with private storage keys, while portable migrations deal with a public JSON
+ * contract. A future portable schema version may snapshot these values when it adds a
+ * field, but both the current UI and a newly-created preference store use this function.
+ */
+export function createGobanThemePreferenceDefaults(): GobanThemePreferenceDefaults {
+    return {
+        "fuzzy-stone-placement": false,
+        "goban-theme-black": null,
+        "goban-theme-board": null,
+        "goban-theme-white": null,
+        "goban-theme-stone-scale": 1.0,
+        "goban-theme-stone-shadows": "default",
+        "goban-theme-custom-black-shadow-color": DEFAULT_SHADOW_COLOR,
+        "goban-theme-custom-black-shadow-gradient": DEFAULT_SHADOW_GRADIENT,
+        "goban-theme-custom-white-shadow-color": DEFAULT_SHADOW_COLOR,
+        "goban-theme-custom-white-shadow-gradient": DEFAULT_SHADOW_GRADIENT,
+        "goban-theme-custom-board-background": DEFAULT_GOBAN_BOARD_COLOR,
+        "goban-theme-custom-board-url": "",
+        "goban-theme-custom-board-grid-backgrounds": {
+            ...emptyCustomBoardGridBackgrounds,
+        },
+        "goban-theme-custom-board-line": DEFAULT_GOBAN_GRID_COLOR,
+        "goban-theme-custom-board-label": defaultGobanLabelColor(DEFAULT_GOBAN_GRID_COLOR),
+        "goban-theme-custom-black-stone-color": DEFAULT_BLACK_STONE_COLOR,
+        "goban-theme-custom-black-text-color": "",
+        "goban-theme-custom-black-urls": [],
+        "goban-theme-custom-white-stone-color": DEFAULT_WHITE_STONE_COLOR,
+        "goban-theme-custom-white-text-color": "",
+        "goban-theme-custom-white-urls": [],
+    };
+}

--- a/src/lib/goban_theme_json.test.ts
+++ b/src/lib/goban_theme_json.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C)  Online-Go.com
+ */
+
+import * as data from "@/lib/data";
+import * as preferences from "@/lib/preferences";
+import {
+    getGobanThemeConfig,
+    importGobanTheme,
+    parseGobanTheme,
+    resetShareableGobanTheme,
+    serializeGobanTheme,
+} from "@/lib/goban_theme_json";
+import {
+    createGobanThemePreferenceDefaults,
+    defaultGobanLabelColor,
+} from "@/lib/goban_theme_defaults";
+
+const TEST_USER = {
+    anonymous: true,
+    id: 0,
+    username: "anonymous",
+} as rest_api.UserConfig;
+
+describe("goban theme JSON", () => {
+    beforeEach(() => {
+        data.set("user", TEST_USER);
+        resetShareableGobanTheme();
+        preferences.set("goban-theme-board", "Kaya");
+        preferences.set("goban-theme-black", "Slate");
+        preferences.set("goban-theme-white", "Shell");
+    });
+
+    test("uses centralized and independently allocated theme defaults", () => {
+        const first = createGobanThemePreferenceDefaults();
+        const second = createGobanThemePreferenceDefaults();
+
+        expect(first["goban-theme-custom-board-label"]).toBe(
+            defaultGobanLabelColor(first["goban-theme-custom-board-line"]),
+        );
+        expect(first["goban-theme-custom-board-grid-backgrounds"]).not.toBe(
+            second["goban-theme-custom-board-grid-backgrounds"],
+        );
+        expect(first["goban-theme-custom-black-urls"]).not.toBe(
+            second["goban-theme-custom-black-urls"],
+        );
+    });
+
+    test("round trips the selected themes and complete custom configuration", () => {
+        preferences.set("goban-theme-custom-board-line", "#123456");
+        preferences.set("goban-theme-custom-board-label", "#abcdef");
+        preferences.set("goban-theme-custom-board-grid-backgrounds", {
+            "9": "https://example.com/9.png",
+            "13": "",
+            "19": "https://example.com/19.png",
+        });
+        preferences.set("goban-theme-custom-black-urls", [
+            "https://example.com/black-1.png",
+            "https://example.com/black-2.png",
+        ]);
+        preferences.set("goban-theme-stone-scale", 1.2);
+        preferences.set("fuzzy-stone-placement", true);
+
+        const exported = getGobanThemeConfig();
+        const parsed = parseGobanTheme(JSON.stringify(exported));
+
+        expect(parsed).toEqual(exported);
+        expect(parsed.board.theme).toBe("Kaya");
+        expect(parsed.board.custom.gridColor).toBe("#123456");
+        expect(parsed.board.custom.gridBackgroundImageUrls["13x13"]).toBeNull();
+        expect(parsed.stones.black.custom.imageUrls).toHaveLength(2);
+        expect(parsed.stones.scale).toBe(1.2);
+        expect(parsed.fuzzyPlacement).toBe(true);
+    });
+
+    test("stores dormant custom values without selecting Custom", () => {
+        const theme = getGobanThemeConfig();
+        theme.board.theme = "Kaya";
+        theme.board.custom.gridColor = "#884400";
+        theme.board.custom.labelColor = "#663300";
+        theme.stones.black.theme = "Slate";
+        theme.stones.black.custom.color = "#112233";
+
+        importGobanTheme(JSON.stringify(theme));
+
+        expect(preferences.get("goban-theme-board")).toBe("Kaya");
+        expect(preferences.get("goban-theme-custom-board-line")).toBe("#884400");
+        expect(preferences.get("goban-theme-custom-board-label")).toBe("#663300");
+        expect(preferences.get("goban-theme-black")).toBe("Slate");
+        expect(preferences.get("goban-theme-custom-black-stone-color")).toBe("#112233");
+
+        preferences.set("goban-theme-board", "Custom");
+        preferences.set("goban-theme-black", "Custom");
+        expect(preferences.getSelectedThemes().board).toBe("Custom");
+        expect(preferences.getSelectedThemes().black).toBe("Custom");
+        expect(preferences.get("goban-theme-custom-board-line")).toBe("#884400");
+        expect(preferences.get("goban-theme-custom-black-stone-color")).toBe("#112233");
+    });
+
+    test("does not change excluded personal theme preferences", () => {
+        preferences.set("label-positioning", "bottom-right");
+        preferences.set("last-move-opacity", 0.4);
+        preferences.set("stone-font-scale", 0.8);
+
+        importGobanTheme(serializeGobanTheme());
+
+        expect(preferences.get("label-positioning")).toBe("bottom-right");
+        expect(preferences.get("last-move-opacity")).toBe(0.4);
+        expect(preferences.get("stone-font-scale")).toBe(0.8);
+    });
+
+    test("rejects invalid documents before writing any preferences", () => {
+        const theme = getGobanThemeConfig();
+        const invalid = {
+            ...theme,
+            board: {
+                ...theme.board,
+                custom: {
+                    ...theme.board.custom,
+                    gridColor: "not-a-color",
+                },
+            },
+        };
+        preferences.set("goban-theme-custom-board-line", "#010203");
+
+        expect(() => importGobanTheme(JSON.stringify(invalid))).toThrow("$.board.custom.gridColor");
+        expect(preferences.get("goban-theme-custom-board-line")).toBe("#010203");
+    });
+
+    test("rejects unknown fields and newer versions", () => {
+        const theme = getGobanThemeConfig();
+
+        expect(() => parseGobanTheme(JSON.stringify({ ...theme, unexpected: true }))).toThrow(
+            "$.unexpected",
+        );
+        expect(() => parseGobanTheme(JSON.stringify({ ...theme, version: 2 }))).toThrow(
+            "newer version of OGS",
+        );
+    });
+});

--- a/src/lib/goban_theme_json.test.ts
+++ b/src/lib/goban_theme_json.test.ts
@@ -47,6 +47,10 @@ describe("goban theme JSON", () => {
     });
 
     test("round trips the selected themes and complete custom configuration", () => {
+        preferences.set("goban-theme-board", "Custom");
+        preferences.set("goban-theme-black", "Custom");
+        preferences.set("goban-theme-white", "Custom");
+        preferences.set("goban-theme-stone-shadows", "custom");
         preferences.set("goban-theme-custom-board-line", "#123456");
         preferences.set("goban-theme-custom-board-label", "#abcdef");
         preferences.set("goban-theme-custom-board-grid-backgrounds", {
@@ -65,36 +69,37 @@ describe("goban theme JSON", () => {
         const parsed = parseGobanTheme(JSON.stringify(exported));
 
         expect(parsed).toEqual(exported);
-        expect(parsed.board.theme).toBe("Kaya");
-        expect(parsed.board.custom.gridColor).toBe("#123456");
-        expect(parsed.board.custom.gridBackgroundImageUrls["13x13"]).toBeNull();
-        expect(parsed.stones.black.custom.imageUrls).toHaveLength(2);
+        expect(parsed.board.theme).toBe("Custom");
+        expect(parsed.board.custom?.gridColor).toBe("#123456");
+        expect(parsed.board.custom?.gridBackgroundImageUrls["13x13"]).toBeNull();
+        expect(parsed.stones.black.custom?.imageUrls).toHaveLength(2);
+        expect(parsed.shadows.black).toBeDefined();
         expect(parsed.stones.scale).toBe(1.2);
         expect(parsed.fuzzyPlacement).toBe(true);
     });
 
-    test("stores dormant custom values without selecting Custom", () => {
+    test("omits inactive custom settings and resets them to defaults on import", () => {
+        preferences.set("goban-theme-custom-board-line", "#884400");
+        preferences.set("goban-theme-custom-black-stone-color", "#112233");
+        preferences.set("goban-theme-custom-black-shadow-color", "#223344");
         const theme = getGobanThemeConfig();
-        theme.board.theme = "Kaya";
-        theme.board.custom.gridColor = "#884400";
-        theme.board.custom.labelColor = "#663300";
-        theme.stones.black.theme = "Slate";
-        theme.stones.black.custom.color = "#112233";
+
+        expect(theme.board).toEqual({ theme: "Kaya" });
+        expect(theme.stones.black).toEqual({ theme: "Slate" });
+        expect(theme.shadows).toEqual({ style: "default" });
 
         importGobanTheme(JSON.stringify(theme));
 
-        expect(preferences.get("goban-theme-board")).toBe("Kaya");
-        expect(preferences.get("goban-theme-custom-board-line")).toBe("#884400");
-        expect(preferences.get("goban-theme-custom-board-label")).toBe("#663300");
-        expect(preferences.get("goban-theme-black")).toBe("Slate");
-        expect(preferences.get("goban-theme-custom-black-stone-color")).toBe("#112233");
-
-        preferences.set("goban-theme-board", "Custom");
-        preferences.set("goban-theme-black", "Custom");
-        expect(preferences.getSelectedThemes().board).toBe("Custom");
-        expect(preferences.getSelectedThemes().black).toBe("Custom");
-        expect(preferences.get("goban-theme-custom-board-line")).toBe("#884400");
-        expect(preferences.get("goban-theme-custom-black-stone-color")).toBe("#112233");
+        const defaults = createGobanThemePreferenceDefaults();
+        expect(preferences.get("goban-theme-custom-board-line")).toBe(
+            defaults["goban-theme-custom-board-line"],
+        );
+        expect(preferences.get("goban-theme-custom-black-stone-color")).toBe(
+            defaults["goban-theme-custom-black-stone-color"],
+        );
+        expect(preferences.get("goban-theme-custom-black-shadow-color")).toBe(
+            defaults["goban-theme-custom-black-shadow-color"],
+        );
     });
 
     test("does not change excluded personal theme preferences", () => {
@@ -110,13 +115,14 @@ describe("goban theme JSON", () => {
     });
 
     test("rejects invalid documents before writing any preferences", () => {
+        preferences.set("goban-theme-board", "Custom");
         const theme = getGobanThemeConfig();
         const invalid = {
             ...theme,
             board: {
                 ...theme.board,
                 custom: {
-                    ...theme.board.custom,
+                    ...theme.board.custom!,
                     gridColor: "not-a-color",
                 },
             },
@@ -125,6 +131,29 @@ describe("goban theme JSON", () => {
 
         expect(() => importGobanTheme(JSON.stringify(invalid))).toThrow("$.board.custom.gridColor");
         expect(preferences.get("goban-theme-custom-board-line")).toBe("#010203");
+    });
+
+    test("rejects custom settings for an inactive built-in theme", () => {
+        const theme = getGobanThemeConfig();
+        const invalid = {
+            ...theme,
+            board: {
+                theme: "Kaya",
+                custom: {
+                    backgroundColor: "#dcb35c",
+                    gridColor: "#000000",
+                    labelColor: "#bfbfbf",
+                    backgroundImageUrl: null,
+                    gridBackgroundImageUrls: {
+                        "9x9": null,
+                        "13x13": null,
+                        "19x19": null,
+                    },
+                },
+            },
+        };
+
+        expect(() => parseGobanTheme(JSON.stringify(invalid))).toThrow("$.board.custom");
     });
 
     test("rejects unknown fields and newer versions", () => {

--- a/src/lib/goban_theme_json.ts
+++ b/src/lib/goban_theme_json.ts
@@ -47,7 +47,12 @@ interface CustomStoneTheme {
 
 interface StoneThemeSelection {
     theme: string;
-    custom: CustomStoneTheme;
+    custom?: CustomStoneTheme;
+}
+
+interface BoardThemeSelection {
+    theme: string;
+    custom?: CustomBoardTheme;
 }
 
 interface ShadowThemeConfig {
@@ -58,10 +63,7 @@ interface ShadowThemeConfig {
 export interface GobanThemeConfigV1 {
     format: typeof GOBAN_THEME_FORMAT;
     version: typeof GOBAN_THEME_VERSION;
-    board: {
-        theme: string;
-        custom: CustomBoardTheme;
-    };
+    board: BoardThemeSelection;
     stones: {
         scale: number;
         black: StoneThemeSelection;
@@ -69,8 +71,8 @@ export interface GobanThemeConfigV1 {
     };
     shadows: {
         style: ShadowTheme;
-        black: ShadowThemeConfig;
-        white: ShadowThemeConfig;
+        black?: ShadowThemeConfig;
+        white?: ShadowThemeConfig;
     };
     fuzzyPlacement: boolean;
 }
@@ -98,63 +100,86 @@ function customStoneColor(value: string, fallback: string): string {
 export function getGobanThemeConfig(): GobanThemeConfigV1 {
     const selected = preferences.getSelectedThemes();
     const grid_backgrounds = preferences.get("goban-theme-custom-board-grid-backgrounds");
+    const shadow_style = preferences.get("goban-theme-stone-shadows");
 
     return {
         format: GOBAN_THEME_FORMAT,
         version: GOBAN_THEME_VERSION,
         board: {
             theme: selected.board,
-            custom: {
-                backgroundColor: preferences.get("goban-theme-custom-board-background"),
-                gridColor: preferences.get("goban-theme-custom-board-line"),
-                labelColor: preferences.get("goban-theme-custom-board-label"),
-                backgroundImageUrl: nullableString(preferences.get("goban-theme-custom-board-url")),
-                gridBackgroundImageUrls: {
-                    "9x9": nullableString(grid_backgrounds["9"]),
-                    "13x13": nullableString(grid_backgrounds["13"]),
-                    "19x19": nullableString(grid_backgrounds["19"]),
-                },
-            },
+            ...(selected.board === "Custom"
+                ? {
+                      custom: {
+                          backgroundColor: preferences.get("goban-theme-custom-board-background"),
+                          gridColor: preferences.get("goban-theme-custom-board-line"),
+                          labelColor: preferences.get("goban-theme-custom-board-label"),
+                          backgroundImageUrl: nullableString(
+                              preferences.get("goban-theme-custom-board-url"),
+                          ),
+                          gridBackgroundImageUrls: {
+                              "9x9": nullableString(grid_backgrounds["9"]),
+                              "13x13": nullableString(grid_backgrounds["13"]),
+                              "19x19": nullableString(grid_backgrounds["19"]),
+                          },
+                      },
+                  }
+                : {}),
         },
         stones: {
             scale: preferences.get("goban-theme-stone-scale"),
             black: {
                 theme: selected.black,
-                custom: {
-                    color: customStoneColor(
-                        preferences.get("goban-theme-custom-black-stone-color"),
-                        DEFAULT_BLACK_STONE_COLOR,
-                    ),
-                    markerColor: nullableString(
-                        preferences.get("goban-theme-custom-black-text-color"),
-                    ),
-                    imageUrls: [...preferences.get("goban-theme-custom-black-urls")],
-                },
+                ...(selected.black === "Custom"
+                    ? {
+                          custom: {
+                              color: customStoneColor(
+                                  preferences.get("goban-theme-custom-black-stone-color"),
+                                  DEFAULT_BLACK_STONE_COLOR,
+                              ),
+                              markerColor: nullableString(
+                                  preferences.get("goban-theme-custom-black-text-color"),
+                              ),
+                              imageUrls: [...preferences.get("goban-theme-custom-black-urls")],
+                          },
+                      }
+                    : {}),
             },
             white: {
                 theme: selected.white,
-                custom: {
-                    color: customStoneColor(
-                        preferences.get("goban-theme-custom-white-stone-color"),
-                        DEFAULT_WHITE_STONE_COLOR,
-                    ),
-                    markerColor: nullableString(
-                        preferences.get("goban-theme-custom-white-text-color"),
-                    ),
-                    imageUrls: [...preferences.get("goban-theme-custom-white-urls")],
-                },
+                ...(selected.white === "Custom"
+                    ? {
+                          custom: {
+                              color: customStoneColor(
+                                  preferences.get("goban-theme-custom-white-stone-color"),
+                                  DEFAULT_WHITE_STONE_COLOR,
+                              ),
+                              markerColor: nullableString(
+                                  preferences.get("goban-theme-custom-white-text-color"),
+                              ),
+                              imageUrls: [...preferences.get("goban-theme-custom-white-urls")],
+                          },
+                      }
+                    : {}),
             },
         },
         shadows: {
-            style: preferences.get("goban-theme-stone-shadows"),
-            black: {
-                color: preferences.get("goban-theme-custom-black-shadow-color"),
-                gradientTransform: preferences.get("goban-theme-custom-black-shadow-gradient"),
-            },
-            white: {
-                color: preferences.get("goban-theme-custom-white-shadow-color"),
-                gradientTransform: preferences.get("goban-theme-custom-white-shadow-gradient"),
-            },
+            style: shadow_style,
+            ...(shadow_style === "custom"
+                ? {
+                      black: {
+                          color: preferences.get("goban-theme-custom-black-shadow-color"),
+                          gradientTransform: preferences.get(
+                              "goban-theme-custom-black-shadow-gradient",
+                          ),
+                      },
+                      white: {
+                          color: preferences.get("goban-theme-custom-white-shadow-color"),
+                          gradientTransform: preferences.get(
+                              "goban-theme-custom-white-shadow-gradient",
+                          ),
+                      },
+                  }
+                : {}),
         },
         fuzzyPlacement: preferences.get("fuzzy-stone-placement"),
     };
@@ -276,10 +301,11 @@ function customStoneAt(value: unknown, path: string): CustomStoneTheme {
 
 function stoneAt(value: unknown, color: "black" | "white", path: string): StoneThemeSelection {
     const object = objectAt(value, path);
-    exactKeys(object, ["theme", "custom"], path);
+    const theme = themeAt(object.theme, color, `${path}.theme`);
+    exactKeys(object, theme === "Custom" ? ["theme", "custom"] : ["theme"], path);
     return {
-        theme: themeAt(object.theme, color, `${path}.theme`),
-        custom: customStoneAt(object.custom, `${path}.custom`),
+        theme,
+        ...(theme === "Custom" ? { custom: customStoneAt(object.custom, `${path}.custom`) } : {}),
     };
 }
 
@@ -342,28 +368,33 @@ export function parseGobanTheme(json: string): GobanThemeConfigV1 {
     exactKeys(migrated, ["format", "version", "board", "stones", "shadows", "fuzzyPlacement"], "$");
 
     const board = objectAt(migrated.board, "$.board");
-    exactKeys(board, ["theme", "custom"], "$.board");
-    const custom_board = objectAt(board.custom, "$.board.custom");
-    exactKeys(
-        custom_board,
-        [
-            "backgroundColor",
-            "gridColor",
-            "labelColor",
-            "backgroundImageUrl",
-            "gridBackgroundImageUrls",
-        ],
-        "$.board.custom",
-    );
-    const grid_backgrounds = objectAt(
-        custom_board.gridBackgroundImageUrls,
-        "$.board.custom.gridBackgroundImageUrls",
-    );
-    exactKeys(
-        grid_backgrounds,
-        ["9x9", "13x13", "19x19"],
-        "$.board.custom.gridBackgroundImageUrls",
-    );
+    const board_theme = themeAt(board.theme, "board", "$.board.theme");
+    exactKeys(board, board_theme === "Custom" ? ["theme", "custom"] : ["theme"], "$.board");
+    let custom_board: JsonObject | undefined;
+    let grid_backgrounds: JsonObject | undefined;
+    if (board_theme === "Custom") {
+        custom_board = objectAt(board.custom, "$.board.custom");
+        exactKeys(
+            custom_board,
+            [
+                "backgroundColor",
+                "gridColor",
+                "labelColor",
+                "backgroundImageUrl",
+                "gridBackgroundImageUrls",
+            ],
+            "$.board.custom",
+        );
+        grid_backgrounds = objectAt(
+            custom_board.gridBackgroundImageUrls,
+            "$.board.custom.gridBackgroundImageUrls",
+        );
+        exactKeys(
+            grid_backgrounds,
+            ["9x9", "13x13", "19x19"],
+            "$.board.custom.gridBackgroundImageUrls",
+        );
+    }
 
     const stones = objectAt(migrated.stones, "$.stones");
     exactKeys(stones, ["scale", "black", "white"], "$.stones");
@@ -380,7 +411,6 @@ export function parseGobanTheme(json: string): GobanThemeConfigV1 {
     }
 
     const shadows = objectAt(migrated.shadows, "$.shadows");
-    exactKeys(shadows, ["style", "black", "white"], "$.shadows");
     const shadow_styles: readonly ShadowTheme[] = [
         "none",
         "low",
@@ -399,6 +429,12 @@ export function parseGobanTheme(json: string): GobanThemeConfigV1 {
             pgettext("Goban theme JSON validation error", "is not a supported shadow style"),
         );
     }
+    const shadow_style = shadows.style as ShadowTheme;
+    exactKeys(
+        shadows,
+        shadow_style === "custom" ? ["style", "black", "white"] : ["style"],
+        "$.shadows",
+    );
     if (typeof migrated.fuzzyPlacement !== "boolean") {
         throw new GobanThemeValidationError(
             "$.fuzzyPlacement",
@@ -410,33 +446,37 @@ export function parseGobanTheme(json: string): GobanThemeConfigV1 {
         format: GOBAN_THEME_FORMAT,
         version: GOBAN_THEME_VERSION,
         board: {
-            theme: themeAt(board.theme, "board", "$.board.theme"),
-            custom: {
-                backgroundColor: colorAt(
-                    custom_board.backgroundColor,
-                    "$.board.custom.backgroundColor",
-                ),
-                gridColor: colorAt(custom_board.gridColor, "$.board.custom.gridColor"),
-                labelColor: colorAt(custom_board.labelColor, "$.board.custom.labelColor"),
-                backgroundImageUrl: nullableStringAt(
-                    custom_board.backgroundImageUrl,
-                    "$.board.custom.backgroundImageUrl",
-                ),
-                gridBackgroundImageUrls: {
-                    "9x9": nullableStringAt(
-                        grid_backgrounds["9x9"],
-                        "$.board.custom.gridBackgroundImageUrls.9x9",
-                    ),
-                    "13x13": nullableStringAt(
-                        grid_backgrounds["13x13"],
-                        "$.board.custom.gridBackgroundImageUrls.13x13",
-                    ),
-                    "19x19": nullableStringAt(
-                        grid_backgrounds["19x19"],
-                        "$.board.custom.gridBackgroundImageUrls.19x19",
-                    ),
-                },
-            },
+            theme: board_theme,
+            ...(custom_board && grid_backgrounds
+                ? {
+                      custom: {
+                          backgroundColor: colorAt(
+                              custom_board.backgroundColor,
+                              "$.board.custom.backgroundColor",
+                          ),
+                          gridColor: colorAt(custom_board.gridColor, "$.board.custom.gridColor"),
+                          labelColor: colorAt(custom_board.labelColor, "$.board.custom.labelColor"),
+                          backgroundImageUrl: nullableStringAt(
+                              custom_board.backgroundImageUrl,
+                              "$.board.custom.backgroundImageUrl",
+                          ),
+                          gridBackgroundImageUrls: {
+                              "9x9": nullableStringAt(
+                                  grid_backgrounds["9x9"],
+                                  "$.board.custom.gridBackgroundImageUrls.9x9",
+                              ),
+                              "13x13": nullableStringAt(
+                                  grid_backgrounds["13x13"],
+                                  "$.board.custom.gridBackgroundImageUrls.13x13",
+                              ),
+                              "19x19": nullableStringAt(
+                                  grid_backgrounds["19x19"],
+                                  "$.board.custom.gridBackgroundImageUrls.19x19",
+                              ),
+                          },
+                      },
+                  }
+                : {}),
         },
         stones: {
             scale: stones.scale,
@@ -444,50 +484,99 @@ export function parseGobanTheme(json: string): GobanThemeConfigV1 {
             white: stoneAt(stones.white, "white", "$.stones.white"),
         },
         shadows: {
-            style: shadows.style as ShadowTheme,
-            black: shadowAt(shadows.black, "$.shadows.black"),
-            white: shadowAt(shadows.white, "$.shadows.white"),
+            style: shadow_style,
+            ...(shadow_style === "custom"
+                ? {
+                      black: shadowAt(shadows.black, "$.shadows.black"),
+                      white: shadowAt(shadows.white, "$.shadows.white"),
+                  }
+                : {}),
         },
         fuzzyPlacement: migrated.fuzzyPlacement,
     };
 }
 
 export function applyGobanTheme(theme: GobanThemeConfigV1): void {
+    const defaults = createGobanThemePreferenceDefaults();
+    const custom_board = theme.board.custom;
+    const custom_black = theme.stones.black.custom;
+    const custom_white = theme.stones.white.custom;
+    const custom_black_shadow = theme.shadows.black;
+    const custom_white_shadow = theme.shadows.white;
+
     preferences.set("goban-theme-board", theme.board.theme);
-    preferences.set("goban-theme-custom-board-background", theme.board.custom.backgroundColor);
-    preferences.set("goban-theme-custom-board-line", theme.board.custom.gridColor);
-    preferences.set("goban-theme-custom-board-label", theme.board.custom.labelColor);
-    preferences.set("goban-theme-custom-board-url", theme.board.custom.backgroundImageUrl ?? "");
+    preferences.set(
+        "goban-theme-custom-board-background",
+        custom_board?.backgroundColor ?? defaults["goban-theme-custom-board-background"],
+    );
+    preferences.set(
+        "goban-theme-custom-board-line",
+        custom_board?.gridColor ?? defaults["goban-theme-custom-board-line"],
+    );
+    preferences.set(
+        "goban-theme-custom-board-label",
+        custom_board?.labelColor ?? defaults["goban-theme-custom-board-label"],
+    );
+    preferences.set(
+        "goban-theme-custom-board-url",
+        custom_board?.backgroundImageUrl ?? defaults["goban-theme-custom-board-url"],
+    );
     preferences.set("goban-theme-custom-board-grid-backgrounds", {
-        "9": theme.board.custom.gridBackgroundImageUrls["9x9"] ?? "",
-        "13": theme.board.custom.gridBackgroundImageUrls["13x13"] ?? "",
-        "19": theme.board.custom.gridBackgroundImageUrls["19x19"] ?? "",
+        "9":
+            custom_board?.gridBackgroundImageUrls["9x9"] ??
+            defaults["goban-theme-custom-board-grid-backgrounds"]["9"],
+        "13":
+            custom_board?.gridBackgroundImageUrls["13x13"] ??
+            defaults["goban-theme-custom-board-grid-backgrounds"]["13"],
+        "19":
+            custom_board?.gridBackgroundImageUrls["19x19"] ??
+            defaults["goban-theme-custom-board-grid-backgrounds"]["19"],
     });
     preferences.set("goban-theme-black", theme.stones.black.theme);
-    preferences.set("goban-theme-custom-black-stone-color", theme.stones.black.custom.color);
+    preferences.set(
+        "goban-theme-custom-black-stone-color",
+        custom_black?.color ?? defaults["goban-theme-custom-black-stone-color"],
+    );
     preferences.set(
         "goban-theme-custom-black-text-color",
-        theme.stones.black.custom.markerColor ?? "",
+        custom_black?.markerColor ?? defaults["goban-theme-custom-black-text-color"],
     );
-    preferences.set("goban-theme-custom-black-urls", [...theme.stones.black.custom.imageUrls]);
+    preferences.set(
+        "goban-theme-custom-black-urls",
+        custom_black ? [...custom_black.imageUrls] : [...defaults["goban-theme-custom-black-urls"]],
+    );
     preferences.set("goban-theme-white", theme.stones.white.theme);
-    preferences.set("goban-theme-custom-white-stone-color", theme.stones.white.custom.color);
+    preferences.set(
+        "goban-theme-custom-white-stone-color",
+        custom_white?.color ?? defaults["goban-theme-custom-white-stone-color"],
+    );
     preferences.set(
         "goban-theme-custom-white-text-color",
-        theme.stones.white.custom.markerColor ?? "",
+        custom_white?.markerColor ?? defaults["goban-theme-custom-white-text-color"],
     );
-    preferences.set("goban-theme-custom-white-urls", [...theme.stones.white.custom.imageUrls]);
+    preferences.set(
+        "goban-theme-custom-white-urls",
+        custom_white ? [...custom_white.imageUrls] : [...defaults["goban-theme-custom-white-urls"]],
+    );
     preferences.set("goban-theme-stone-scale", theme.stones.scale);
     preferences.set("goban-theme-stone-shadows", theme.shadows.style);
-    preferences.set("goban-theme-custom-black-shadow-color", theme.shadows.black.color);
+    preferences.set(
+        "goban-theme-custom-black-shadow-color",
+        custom_black_shadow?.color ?? defaults["goban-theme-custom-black-shadow-color"],
+    );
     preferences.set(
         "goban-theme-custom-black-shadow-gradient",
-        theme.shadows.black.gradientTransform,
+        custom_black_shadow?.gradientTransform ??
+            defaults["goban-theme-custom-black-shadow-gradient"],
     );
-    preferences.set("goban-theme-custom-white-shadow-color", theme.shadows.white.color);
+    preferences.set(
+        "goban-theme-custom-white-shadow-color",
+        custom_white_shadow?.color ?? defaults["goban-theme-custom-white-shadow-color"],
+    );
     preferences.set(
         "goban-theme-custom-white-shadow-gradient",
-        theme.shadows.white.gradientTransform,
+        custom_white_shadow?.gradientTransform ??
+            defaults["goban-theme-custom-white-shadow-gradient"],
     );
     preferences.set("fuzzy-stone-placement", theme.fuzzyPlacement);
 }

--- a/src/lib/goban_theme_json.ts
+++ b/src/lib/goban_theme_json.ts
@@ -1,0 +1,506 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Goban, ShadowTheme } from "goban";
+import * as preferences from "@/lib/preferences";
+import { pgettext } from "@/lib/translate";
+import {
+    createGobanThemePreferenceDefaults,
+    DEFAULT_BLACK_STONE_COLOR,
+    DEFAULT_WHITE_STONE_COLOR,
+} from "@/lib/goban_theme_defaults";
+
+export const GOBAN_THEME_FORMAT = "online-go.com/goban-theme";
+export const GOBAN_THEME_VERSION = 1;
+
+interface CustomBoardTheme {
+    backgroundColor: string;
+    gridColor: string;
+    labelColor: string;
+    backgroundImageUrl: string | null;
+    gridBackgroundImageUrls: {
+        "9x9": string | null;
+        "13x13": string | null;
+        "19x19": string | null;
+    };
+}
+
+interface CustomStoneTheme {
+    color: string;
+    markerColor: string | null;
+    imageUrls: string[];
+}
+
+interface StoneThemeSelection {
+    theme: string;
+    custom: CustomStoneTheme;
+}
+
+interface ShadowThemeConfig {
+    color: string;
+    gradientTransform: string;
+}
+
+export interface GobanThemeConfigV1 {
+    format: typeof GOBAN_THEME_FORMAT;
+    version: typeof GOBAN_THEME_VERSION;
+    board: {
+        theme: string;
+        custom: CustomBoardTheme;
+    };
+    stones: {
+        scale: number;
+        black: StoneThemeSelection;
+        white: StoneThemeSelection;
+    };
+    shadows: {
+        style: ShadowTheme;
+        black: ShadowThemeConfig;
+        white: ShadowThemeConfig;
+    };
+    fuzzyPlacement: boolean;
+}
+
+type JsonObject = Record<string, unknown>;
+
+export class GobanThemeValidationError extends Error {
+    constructor(
+        public readonly path: string,
+        message: string,
+    ) {
+        super(`${path}: ${message}`);
+        this.name = "GobanThemeValidationError";
+    }
+}
+
+function nullableString(value: string): string | null {
+    return value.trim() ? value : null;
+}
+
+function customStoneColor(value: string, fallback: string): string {
+    return value || fallback;
+}
+
+export function getGobanThemeConfig(): GobanThemeConfigV1 {
+    const selected = preferences.getSelectedThemes();
+    const grid_backgrounds = preferences.get("goban-theme-custom-board-grid-backgrounds");
+
+    return {
+        format: GOBAN_THEME_FORMAT,
+        version: GOBAN_THEME_VERSION,
+        board: {
+            theme: selected.board,
+            custom: {
+                backgroundColor: preferences.get("goban-theme-custom-board-background"),
+                gridColor: preferences.get("goban-theme-custom-board-line"),
+                labelColor: preferences.get("goban-theme-custom-board-label"),
+                backgroundImageUrl: nullableString(preferences.get("goban-theme-custom-board-url")),
+                gridBackgroundImageUrls: {
+                    "9x9": nullableString(grid_backgrounds["9"]),
+                    "13x13": nullableString(grid_backgrounds["13"]),
+                    "19x19": nullableString(grid_backgrounds["19"]),
+                },
+            },
+        },
+        stones: {
+            scale: preferences.get("goban-theme-stone-scale"),
+            black: {
+                theme: selected.black,
+                custom: {
+                    color: customStoneColor(
+                        preferences.get("goban-theme-custom-black-stone-color"),
+                        DEFAULT_BLACK_STONE_COLOR,
+                    ),
+                    markerColor: nullableString(
+                        preferences.get("goban-theme-custom-black-text-color"),
+                    ),
+                    imageUrls: [...preferences.get("goban-theme-custom-black-urls")],
+                },
+            },
+            white: {
+                theme: selected.white,
+                custom: {
+                    color: customStoneColor(
+                        preferences.get("goban-theme-custom-white-stone-color"),
+                        DEFAULT_WHITE_STONE_COLOR,
+                    ),
+                    markerColor: nullableString(
+                        preferences.get("goban-theme-custom-white-text-color"),
+                    ),
+                    imageUrls: [...preferences.get("goban-theme-custom-white-urls")],
+                },
+            },
+        },
+        shadows: {
+            style: preferences.get("goban-theme-stone-shadows"),
+            black: {
+                color: preferences.get("goban-theme-custom-black-shadow-color"),
+                gradientTransform: preferences.get("goban-theme-custom-black-shadow-gradient"),
+            },
+            white: {
+                color: preferences.get("goban-theme-custom-white-shadow-color"),
+                gradientTransform: preferences.get("goban-theme-custom-white-shadow-gradient"),
+            },
+        },
+        fuzzyPlacement: preferences.get("fuzzy-stone-placement"),
+    };
+}
+
+export function serializeGobanTheme(): string {
+    return JSON.stringify(getGobanThemeConfig(), null, 2);
+}
+
+function objectAt(value: unknown, path: string): JsonObject {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new GobanThemeValidationError(
+            path,
+            pgettext("Goban theme JSON validation error", "must be an object"),
+        );
+    }
+    return value as JsonObject;
+}
+
+function exactKeys(object: JsonObject, keys: readonly string[], path: string): void {
+    const expected = new Set(keys);
+    for (const key of Object.keys(object)) {
+        if (!expected.has(key)) {
+            throw new GobanThemeValidationError(
+                `${path}.${key}`,
+                pgettext("Goban theme JSON validation error", "is not supported"),
+            );
+        }
+    }
+    for (const key of keys) {
+        if (!(key in object)) {
+            throw new GobanThemeValidationError(
+                `${path}.${key}`,
+                pgettext("Goban theme JSON validation error", "is required"),
+            );
+        }
+    }
+}
+
+function stringAt(value: unknown, path: string): string {
+    if (typeof value !== "string") {
+        throw new GobanThemeValidationError(
+            path,
+            pgettext("Goban theme JSON validation error", "must be a string"),
+        );
+    }
+    return value;
+}
+
+function nonemptyStringAt(value: unknown, path: string): string {
+    const result = stringAt(value, path);
+    if (!result.trim()) {
+        throw new GobanThemeValidationError(
+            path,
+            pgettext("Goban theme JSON validation error", "must not be empty"),
+        );
+    }
+    return result;
+}
+
+function nullableStringAt(value: unknown, path: string): string | null {
+    if (value === null) {
+        return null;
+    }
+    const result = stringAt(value, path).trim();
+    return result || null;
+}
+
+function colorAt(value: unknown, path: string): string {
+    const result = stringAt(value, path);
+    if (!/^#[0-9a-f]{6}$/i.test(result)) {
+        throw new GobanThemeValidationError(
+            path,
+            pgettext("Goban theme JSON validation error", "must be a six-digit hex color"),
+        );
+    }
+    return result;
+}
+
+function nullableColorAt(value: unknown, path: string): string | null {
+    if (value === null) {
+        return null;
+    }
+    return colorAt(value, path);
+}
+
+function themeAt(value: unknown, color: "board" | "black" | "white", path: string): string {
+    const theme = nonemptyStringAt(value, path);
+    if (!Object.prototype.hasOwnProperty.call(Goban.THEMES[color], theme)) {
+        throw new GobanThemeValidationError(
+            path,
+            pgettext("Goban theme JSON validation error", "is not an available theme"),
+        );
+    }
+    return theme;
+}
+
+function stringArrayAt(value: unknown, path: string): string[] {
+    if (!Array.isArray(value)) {
+        throw new GobanThemeValidationError(
+            path,
+            pgettext("Goban theme JSON validation error", "must be an array"),
+        );
+    }
+    return Array.from(
+        new Set(value.map((entry, index) => nonemptyStringAt(entry, `${path}[${index}]`).trim())),
+    );
+}
+
+function customStoneAt(value: unknown, path: string): CustomStoneTheme {
+    const object = objectAt(value, path);
+    exactKeys(object, ["color", "markerColor", "imageUrls"], path);
+    return {
+        color: colorAt(object.color, `${path}.color`),
+        markerColor: nullableColorAt(object.markerColor, `${path}.markerColor`),
+        imageUrls: stringArrayAt(object.imageUrls, `${path}.imageUrls`),
+    };
+}
+
+function stoneAt(value: unknown, color: "black" | "white", path: string): StoneThemeSelection {
+    const object = objectAt(value, path);
+    exactKeys(object, ["theme", "custom"], path);
+    return {
+        theme: themeAt(object.theme, color, `${path}.theme`),
+        custom: customStoneAt(object.custom, `${path}.custom`),
+    };
+}
+
+function shadowAt(value: unknown, path: string): ShadowThemeConfig {
+    const object = objectAt(value, path);
+    exactKeys(object, ["color", "gradientTransform"], path);
+    return {
+        color: colorAt(object.color, `${path}.color`),
+        gradientTransform: stringAt(object.gradientTransform, `${path}.gradientTransform`),
+    };
+}
+
+function migratePortableTheme(value: unknown): unknown {
+    const root = objectAt(value, "$");
+    if (root.format !== GOBAN_THEME_FORMAT) {
+        throw new GobanThemeValidationError(
+            "$.format",
+            pgettext("Goban theme JSON validation error", "has an unsupported format identifier"),
+        );
+    }
+    if (typeof root.version !== "number" || !Number.isInteger(root.version)) {
+        throw new GobanThemeValidationError(
+            "$.version",
+            pgettext("Goban theme JSON validation error", "must be an integer"),
+        );
+    }
+    if (root.version > GOBAN_THEME_VERSION) {
+        throw new GobanThemeValidationError(
+            "$.version",
+            pgettext("Goban theme JSON validation error", "was created by a newer version of OGS"),
+        );
+    }
+    if (root.version < 1) {
+        throw new GobanThemeValidationError(
+            "$.version",
+            pgettext("Goban theme JSON validation error", "is not supported"),
+        );
+    }
+
+    /*
+     * Add sequential, pure migrations here as the public format evolves. Portable
+     * migrations must not call preferences.migrate(): that function changes OGS's
+     * private persisted-key layout, while this function preserves forum-posted JSON.
+     */
+    return root;
+}
+
+export function parseGobanTheme(json: string): GobanThemeConfigV1 {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(json) as unknown;
+    } catch {
+        throw new GobanThemeValidationError(
+            "$",
+            pgettext("Goban theme JSON validation error", "is not valid JSON"),
+        );
+    }
+
+    const migrated = objectAt(migratePortableTheme(parsed), "$");
+    exactKeys(migrated, ["format", "version", "board", "stones", "shadows", "fuzzyPlacement"], "$");
+
+    const board = objectAt(migrated.board, "$.board");
+    exactKeys(board, ["theme", "custom"], "$.board");
+    const custom_board = objectAt(board.custom, "$.board.custom");
+    exactKeys(
+        custom_board,
+        [
+            "backgroundColor",
+            "gridColor",
+            "labelColor",
+            "backgroundImageUrl",
+            "gridBackgroundImageUrls",
+        ],
+        "$.board.custom",
+    );
+    const grid_backgrounds = objectAt(
+        custom_board.gridBackgroundImageUrls,
+        "$.board.custom.gridBackgroundImageUrls",
+    );
+    exactKeys(
+        grid_backgrounds,
+        ["9x9", "13x13", "19x19"],
+        "$.board.custom.gridBackgroundImageUrls",
+    );
+
+    const stones = objectAt(migrated.stones, "$.stones");
+    exactKeys(stones, ["scale", "black", "white"], "$.stones");
+    if (
+        typeof stones.scale !== "number" ||
+        !Number.isFinite(stones.scale) ||
+        stones.scale < 0.5 ||
+        stones.scale > 1.5
+    ) {
+        throw new GobanThemeValidationError(
+            "$.stones.scale",
+            pgettext("Goban theme JSON validation error", "must be a number from 0.5 to 1.5"),
+        );
+    }
+
+    const shadows = objectAt(migrated.shadows, "$.shadows");
+    exactKeys(shadows, ["style", "black", "white"], "$.shadows");
+    const shadow_styles: readonly ShadowTheme[] = [
+        "none",
+        "low",
+        "mid",
+        "high",
+        "custom",
+        "default",
+        "anime",
+    ];
+    if (
+        typeof shadows.style !== "string" ||
+        !shadow_styles.includes(shadows.style as ShadowTheme)
+    ) {
+        throw new GobanThemeValidationError(
+            "$.shadows.style",
+            pgettext("Goban theme JSON validation error", "is not a supported shadow style"),
+        );
+    }
+    if (typeof migrated.fuzzyPlacement !== "boolean") {
+        throw new GobanThemeValidationError(
+            "$.fuzzyPlacement",
+            pgettext("Goban theme JSON validation error", "must be a boolean"),
+        );
+    }
+
+    return {
+        format: GOBAN_THEME_FORMAT,
+        version: GOBAN_THEME_VERSION,
+        board: {
+            theme: themeAt(board.theme, "board", "$.board.theme"),
+            custom: {
+                backgroundColor: colorAt(
+                    custom_board.backgroundColor,
+                    "$.board.custom.backgroundColor",
+                ),
+                gridColor: colorAt(custom_board.gridColor, "$.board.custom.gridColor"),
+                labelColor: colorAt(custom_board.labelColor, "$.board.custom.labelColor"),
+                backgroundImageUrl: nullableStringAt(
+                    custom_board.backgroundImageUrl,
+                    "$.board.custom.backgroundImageUrl",
+                ),
+                gridBackgroundImageUrls: {
+                    "9x9": nullableStringAt(
+                        grid_backgrounds["9x9"],
+                        "$.board.custom.gridBackgroundImageUrls.9x9",
+                    ),
+                    "13x13": nullableStringAt(
+                        grid_backgrounds["13x13"],
+                        "$.board.custom.gridBackgroundImageUrls.13x13",
+                    ),
+                    "19x19": nullableStringAt(
+                        grid_backgrounds["19x19"],
+                        "$.board.custom.gridBackgroundImageUrls.19x19",
+                    ),
+                },
+            },
+        },
+        stones: {
+            scale: stones.scale,
+            black: stoneAt(stones.black, "black", "$.stones.black"),
+            white: stoneAt(stones.white, "white", "$.stones.white"),
+        },
+        shadows: {
+            style: shadows.style as ShadowTheme,
+            black: shadowAt(shadows.black, "$.shadows.black"),
+            white: shadowAt(shadows.white, "$.shadows.white"),
+        },
+        fuzzyPlacement: migrated.fuzzyPlacement,
+    };
+}
+
+export function applyGobanTheme(theme: GobanThemeConfigV1): void {
+    preferences.set("goban-theme-board", theme.board.theme);
+    preferences.set("goban-theme-custom-board-background", theme.board.custom.backgroundColor);
+    preferences.set("goban-theme-custom-board-line", theme.board.custom.gridColor);
+    preferences.set("goban-theme-custom-board-label", theme.board.custom.labelColor);
+    preferences.set("goban-theme-custom-board-url", theme.board.custom.backgroundImageUrl ?? "");
+    preferences.set("goban-theme-custom-board-grid-backgrounds", {
+        "9": theme.board.custom.gridBackgroundImageUrls["9x9"] ?? "",
+        "13": theme.board.custom.gridBackgroundImageUrls["13x13"] ?? "",
+        "19": theme.board.custom.gridBackgroundImageUrls["19x19"] ?? "",
+    });
+    preferences.set("goban-theme-black", theme.stones.black.theme);
+    preferences.set("goban-theme-custom-black-stone-color", theme.stones.black.custom.color);
+    preferences.set(
+        "goban-theme-custom-black-text-color",
+        theme.stones.black.custom.markerColor ?? "",
+    );
+    preferences.set("goban-theme-custom-black-urls", [...theme.stones.black.custom.imageUrls]);
+    preferences.set("goban-theme-white", theme.stones.white.theme);
+    preferences.set("goban-theme-custom-white-stone-color", theme.stones.white.custom.color);
+    preferences.set(
+        "goban-theme-custom-white-text-color",
+        theme.stones.white.custom.markerColor ?? "",
+    );
+    preferences.set("goban-theme-custom-white-urls", [...theme.stones.white.custom.imageUrls]);
+    preferences.set("goban-theme-stone-scale", theme.stones.scale);
+    preferences.set("goban-theme-stone-shadows", theme.shadows.style);
+    preferences.set("goban-theme-custom-black-shadow-color", theme.shadows.black.color);
+    preferences.set(
+        "goban-theme-custom-black-shadow-gradient",
+        theme.shadows.black.gradientTransform,
+    );
+    preferences.set("goban-theme-custom-white-shadow-color", theme.shadows.white.color);
+    preferences.set(
+        "goban-theme-custom-white-shadow-gradient",
+        theme.shadows.white.gradientTransform,
+    );
+    preferences.set("fuzzy-stone-placement", theme.fuzzyPlacement);
+}
+
+export function importGobanTheme(json: string): GobanThemeConfigV1 {
+    const theme = parseGobanTheme(json);
+    applyGobanTheme(theme);
+    return theme;
+}
+
+export function resetShareableGobanTheme(): void {
+    const defaults = createGobanThemePreferenceDefaults();
+    for (const key of Object.keys(defaults) as Array<keyof typeof defaults>) {
+        preferences.set(key, defaults[key]);
+    }
+}

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -16,22 +16,13 @@
  */
 
 import * as data from "@/lib/data";
-import {
-    GobanSelectedThemes,
-    Goban,
-    LabelPosition,
-    JGOFTimeControlSpeed,
-    Size,
-    ShadowTheme,
-    CustomBoardGridBackgrounds,
-    emptyCustomBoardGridBackgrounds,
-    blendWithInverseColor,
-} from "goban";
+import { GobanSelectedThemes, Goban, LabelPosition, JGOFTimeControlSpeed, Size } from "goban";
 import * as React from "react";
 import { current_language } from "@/lib/translate";
 import { DataSchema } from "./data_schema";
 import { FollowedChannel } from "@/views/GoTV";
 import { getWindowWidth } from "./device";
+import { createGobanThemePreferenceDefaults } from "./goban_theme_defaults";
 
 export const defaults = {
     "ai-review-enabled": true,
@@ -89,44 +80,16 @@ export const defaults = {
     "dock-delay": 0, // seconds.
     "double-click-submit-correspondence": false,
     "double-click-submit-live": false,
-    "fuzzy-stone-placement": false,
     "last-move-opacity": 1.0,
     "variation-stone-opacity": 0.6,
     "variation-move-count": 10,
     "visual-undo-request-indicator": true,
     "stone-font-scale": 1.0,
-    "goban-theme-black": null as null | string,
-    "goban-theme-board": null as null | string,
-    "goban-theme-white": null as null | string,
+    ...createGobanThemePreferenceDefaults(),
     //"goban-theme-black_stone_url": null as null | string,
     //"goban-theme-white_stone_url": null as null | string,
     "goban-theme-removal-graphic": "square" as "square" | "x",
     "goban-theme-removal-scale": 0.9,
-    "goban-theme-stone-scale": 1.0,
-    "goban-theme-stone-shadows": "default" as ShadowTheme,
-    "goban-theme-custom-black-shadow-color": "#000000",
-    "goban-theme-custom-black-shadow-gradient": "rotate(45) scale(1.10 1.0) translate(0.05 -0.50)",
-    "goban-theme-custom-white-shadow-color": "#000000",
-    "goban-theme-custom-white-shadow-gradient": "rotate(45) scale(1.10 1.0) translate(0.05 -0.50)",
-    "goban-theme-custom-board-background": "#DCB35C",
-    "goban-theme-custom-board-url": "",
-    /*
-     * V1 baked-grid board assets are compactly stored as one URL per board size. The goban
-     * renderer maps these into a structured asset descriptor so future variants can add
-     * small margins, baked coordinates, coordinate origins, or numbering formats without
-     * changing the meaning of these saved URLs.
-     */
-    "goban-theme-custom-board-grid-backgrounds": {
-        ...emptyCustomBoardGridBackgrounds,
-    } as CustomBoardGridBackgrounds,
-    "goban-theme-custom-board-line": "#000000",
-    "goban-theme-custom-board-label": blendWithInverseColor("#000000", 0.75),
-    "goban-theme-custom-black-stone-color": "#000000",
-    "goban-theme-custom-black-text-color": "",
-    "goban-theme-custom-black-urls": [] as string[],
-    "goban-theme-custom-white-stone-color": "#ffffff",
-    "goban-theme-custom-white-text-color": "",
-    "goban-theme-custom-white-urls": [] as string[],
     "hide-ranks": false,
     "label-positioning": "all" as LabelPosition,
     "label-positioning-puzzles": "all" as LabelPosition,

--- a/src/views/Settings/GobanThemeImportExport.css
+++ b/src/views/Settings/GobanThemeImportExport.css
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.GobanThemeImportExport {
+    width: 365px;
+    max-width: 100%;
+
+    .theme-import-export-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .theme-import-export-content {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-top: 0.75rem;
+
+        textarea {
+            box-sizing: border-box;
+            width: 100%;
+            min-height: 16rem;
+            max-height: 24rem;
+            resize: vertical;
+            overflow: auto;
+            font-family: monospace;
+            white-space: pre;
+        }
+    }
+
+    .theme-import-export-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.75rem;
+    }
+
+    .theme-import-export-status {
+        &.error {
+            color: var(--reject);
+        }
+    }
+}

--- a/src/views/Settings/GobanThemeImportExport.css
+++ b/src/views/Settings/GobanThemeImportExport.css
@@ -18,18 +18,14 @@
 .GobanThemeImportExport {
     width: 365px;
     max-width: 100%;
-
-    .theme-import-export-toggle {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-    }
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 
     .theme-import-export-content {
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
-        margin-top: 0.75rem;
 
         textarea {
             box-sizing: border-box;
@@ -43,6 +39,16 @@
         }
     }
 
+    .manual-copy-json {
+        box-sizing: border-box;
+        width: 100%;
+        min-height: 8rem;
+        resize: vertical;
+        overflow: auto;
+        font-family: monospace;
+        white-space: pre;
+    }
+
     .theme-import-export-actions {
         display: flex;
         justify-content: flex-end;
@@ -50,7 +56,7 @@
     }
 
     .theme-import-export-status {
-        &.error {
+        &.is-error {
             color: var(--reject);
         }
     }

--- a/src/views/Settings/GobanThemeImportExport.test.tsx
+++ b/src/views/Settings/GobanThemeImportExport.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C)  Online-Go.com
+ */
+
+import * as React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { importGobanTheme, serializeGobanTheme } from "@/lib/goban_theme_json";
+import { GobanThemeImportExport } from "./GobanThemeImportExport";
+
+jest.mock("@/lib/translate", () => ({
+    pgettext: (_context: string, message: string) => message,
+}));
+
+jest.mock("@/lib/goban_theme_json", () => ({
+    importGobanTheme: jest.fn(),
+    serializeGobanTheme: jest.fn(() => '{\n  "version": 1\n}'),
+}));
+
+const mockedImport = jest.mocked(importGobanTheme);
+const mockedSerialize = jest.mocked(serializeGobanTheme);
+
+describe("GobanThemeImportExport", () => {
+    beforeEach(() => {
+        mockedImport.mockReset();
+        mockedSerialize.mockReset();
+        mockedSerialize.mockReturnValue('{\n  "version": 1\n}');
+    });
+
+    test("reveals a fixed JSON editor populated from current settings", () => {
+        render(<GobanThemeImportExport />);
+
+        expect(screen.queryByRole("textbox")).toBeNull();
+        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
+
+        expect(screen.getByRole("textbox")).toHaveValue('{\n  "version": 1\n}');
+        expect(mockedSerialize).toHaveBeenCalledTimes(1);
+    });
+
+    test("copies the current textarea", async () => {
+        const writeText = jest.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            value: { writeText },
+        });
+        render(<GobanThemeImportExport />);
+        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
+        fireEvent.change(screen.getByRole("textbox"), { target: { value: "shared JSON" } });
+        fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+        await waitFor(() => expect(writeText).toHaveBeenCalledWith("shared JSON"));
+        expect(await screen.findByRole("status")).toHaveTextContent("Theme JSON copied.");
+    });
+
+    test("imports pasted JSON and refreshes the canonical text", () => {
+        mockedSerialize
+            .mockReturnValueOnce('{\n  "version": 1\n}')
+            .mockReturnValueOnce('{\n  "version": 1,\n  "normalized": true\n}');
+        render(<GobanThemeImportExport />);
+        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
+        fireEvent.change(screen.getByRole("textbox"), { target: { value: "pasted JSON" } });
+        fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+        expect(mockedImport).toHaveBeenCalledWith("pasted JSON");
+        expect(screen.getByRole("textbox")).toHaveValue(
+            '{\n  "version": 1,\n  "normalized": true\n}',
+        );
+        expect(screen.getByRole("status")).toHaveTextContent("Theme imported.");
+    });
+
+    test("shows validation errors without replacing the pasted JSON", () => {
+        mockedImport.mockImplementation(() => {
+            throw new Error("$.board.theme: is not an available theme");
+        });
+        render(<GobanThemeImportExport />);
+        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
+        fireEvent.change(screen.getByRole("textbox"), { target: { value: "invalid JSON" } });
+        fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+        expect(screen.getByRole("alert")).toHaveTextContent(
+            "$.board.theme: is not an available theme",
+        );
+        expect(screen.getByRole("textbox")).toHaveValue("invalid JSON");
+    });
+});

--- a/src/views/Settings/GobanThemeImportExport.test.tsx
+++ b/src/views/Settings/GobanThemeImportExport.test.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { importGobanTheme, serializeGobanTheme } from "@/lib/goban_theme_json";
+import { toast } from "@/lib/toast";
 import { GobanThemeImportExport } from "./GobanThemeImportExport";
 
 jest.mock("@/lib/translate", () => ({
@@ -16,55 +17,58 @@ jest.mock("@/lib/goban_theme_json", () => ({
     serializeGobanTheme: jest.fn(() => '{\n  "version": 1\n}'),
 }));
 
+jest.mock("@/lib/toast", () => ({
+    toast: jest.fn(),
+}));
+
 const mockedImport = jest.mocked(importGobanTheme);
 const mockedSerialize = jest.mocked(serializeGobanTheme);
+const mockedToast = jest.mocked(toast);
 
 describe("GobanThemeImportExport", () => {
     beforeEach(() => {
         mockedImport.mockReset();
         mockedSerialize.mockReset();
         mockedSerialize.mockReturnValue('{\n  "version": 1\n}');
+        mockedToast.mockReset();
     });
 
-    test("reveals a fixed JSON editor populated from current settings", () => {
+    test("renders separate copy and import controls", () => {
         render(<GobanThemeImportExport />);
 
         expect(screen.queryByRole("textbox")).toBeNull();
-        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
-
-        expect(screen.getByRole("textbox")).toHaveValue('{\n  "version": 1\n}');
-        expect(mockedSerialize).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole("button", { name: "Copy theme" })).toBeVisible();
+        expect(screen.getByRole("button", { name: "Import theme" })).toBeVisible();
     });
 
-    test("copies the current textarea", async () => {
+    test("serializes and copies the current theme when clicked", async () => {
         const writeText = jest.fn().mockResolvedValue(undefined);
         Object.defineProperty(navigator, "clipboard", {
             configurable: true,
             value: { writeText },
         });
         render(<GobanThemeImportExport />);
-        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
-        fireEvent.change(screen.getByRole("textbox"), { target: { value: "shared JSON" } });
-        fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+        fireEvent.click(screen.getByRole("button", { name: "Copy theme" }));
 
-        await waitFor(() => expect(writeText).toHaveBeenCalledWith("shared JSON"));
-        expect(await screen.findByRole("status")).toHaveTextContent("Theme JSON copied.");
+        await waitFor(() => expect(writeText).toHaveBeenCalledWith('{\n  "version": 1\n}'));
+        expect(mockedSerialize).toHaveBeenCalledTimes(1);
+        expect(mockedToast).toHaveBeenCalledWith(<div>Theme JSON copied.</div>, 3000);
+        expect(screen.queryByRole("alert")).toBeNull();
     });
 
-    test("imports pasted JSON and refreshes the canonical text", () => {
-        mockedSerialize
-            .mockReturnValueOnce('{\n  "version": 1\n}')
-            .mockReturnValueOnce('{\n  "version": 1,\n  "normalized": true\n}');
+    test("opens an empty import editor and applies pasted JSON", () => {
         render(<GobanThemeImportExport />);
-        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
+        fireEvent.click(screen.getByRole("button", { name: "Import theme" }));
+
+        expect(screen.getByRole("textbox", { name: "Theme JSON to import" })).toHaveValue("");
         fireEvent.change(screen.getByRole("textbox"), { target: { value: "pasted JSON" } });
-        fireEvent.click(screen.getByRole("button", { name: "Import" }));
+        fireEvent.click(screen.getByRole("button", { name: "Apply theme" }));
 
         expect(mockedImport).toHaveBeenCalledWith("pasted JSON");
-        expect(screen.getByRole("textbox")).toHaveValue(
-            '{\n  "version": 1,\n  "normalized": true\n}',
-        );
-        expect(screen.getByRole("status")).toHaveTextContent("Theme imported.");
+        expect(screen.queryByRole("textbox")).toBeNull();
+        expect(mockedSerialize).not.toHaveBeenCalled();
+        expect(mockedToast).toHaveBeenCalledWith(<div>Theme imported.</div>, 3000);
+        expect(screen.queryByRole("alert")).toBeNull();
     });
 
     test("shows validation errors without replacing the pasted JSON", () => {
@@ -72,13 +76,29 @@ describe("GobanThemeImportExport", () => {
             throw new Error("$.board.theme: is not an available theme");
         });
         render(<GobanThemeImportExport />);
-        fireEvent.click(screen.getByRole("button", { name: "Import / export" }));
+        fireEvent.click(screen.getByRole("button", { name: "Import theme" }));
         fireEvent.change(screen.getByRole("textbox"), { target: { value: "invalid JSON" } });
-        fireEvent.click(screen.getByRole("button", { name: "Import" }));
+        fireEvent.click(screen.getByRole("button", { name: "Apply theme" }));
 
         expect(screen.getByRole("alert")).toHaveTextContent(
             "$.board.theme: is not an available theme",
         );
         expect(screen.getByRole("textbox")).toHaveValue("invalid JSON");
+    });
+
+    test("shows current theme JSON for manual copying when clipboard access fails", async () => {
+        Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            value: undefined,
+        });
+        render(<GobanThemeImportExport />);
+        fireEvent.click(screen.getByRole("button", { name: "Copy theme" }));
+
+        expect(await screen.findByRole("textbox", { name: "Theme JSON to copy" })).toHaveValue(
+            '{\n  "version": 1\n}',
+        );
+        expect(screen.getByRole("alert")).toHaveTextContent(
+            "The JSON has been selected for manual copying.",
+        );
     });
 });

--- a/src/views/Settings/GobanThemeImportExport.tsx
+++ b/src/views/Settings/GobanThemeImportExport.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { pgettext } from "@/lib/translate";
+import { importGobanTheme, serializeGobanTheme } from "@/lib/goban_theme_json";
+import "./GobanThemeImportExport.css";
+
+type Status = { kind: "success" | "error"; message: string } | null;
+
+export function GobanThemeImportExport(): React.ReactElement {
+    const [open, setOpen] = React.useState(false);
+    const [json, setJson] = React.useState("");
+    const [status, setStatus] = React.useState<Status>(null);
+    const textarea = React.useRef<HTMLTextAreaElement>(null);
+
+    function toggleOpen(): void {
+        setOpen((was_open) => {
+            if (!was_open) {
+                setJson(serializeGobanTheme());
+                setStatus(null);
+            }
+            return !was_open;
+        });
+    }
+
+    async function copyJson(): Promise<void> {
+        try {
+            if (!navigator.clipboard?.writeText) {
+                throw new Error("Clipboard API unavailable");
+            }
+            await navigator.clipboard.writeText(json);
+            setStatus({
+                kind: "success",
+                message: pgettext("Goban theme JSON clipboard success", "Theme JSON copied."),
+            });
+        } catch {
+            textarea.current?.focus();
+            textarea.current?.select();
+            setStatus({
+                kind: "error",
+                message: pgettext(
+                    "Goban theme JSON clipboard fallback",
+                    "Copy was blocked by the browser. The JSON has been selected for manual copying.",
+                ),
+            });
+        }
+    }
+
+    function importJson(): void {
+        try {
+            importGobanTheme(json);
+            setJson(serializeGobanTheme());
+            setStatus({
+                kind: "success",
+                message: pgettext("Goban theme JSON import success", "Theme imported."),
+            });
+        } catch (error) {
+            setStatus({
+                kind: "error",
+                message:
+                    error instanceof Error
+                        ? error.message
+                        : pgettext(
+                              "Goban theme JSON unknown import error",
+                              "The theme JSON could not be imported.",
+                          ),
+            });
+        }
+    }
+
+    return (
+        <div className="GobanThemeImportExport">
+            <button
+                type="button"
+                className="theme-import-export-toggle"
+                aria-expanded={open}
+                onClick={toggleOpen}
+            >
+                <i className={`fa fa-caret-${open ? "down" : "right"}`} />
+                <span>
+                    {pgettext("Toggle goban theme JSON import/export controls", "Import / export")}
+                </span>
+            </button>
+
+            {open && (
+                <div className="theme-import-export-content">
+                    <textarea
+                        ref={textarea}
+                        value={json}
+                        aria-label={pgettext("Goban theme JSON editor", "Goban theme JSON")}
+                        spellCheck={false}
+                        onChange={(event) => {
+                            setJson(event.target.value);
+                            setStatus(null);
+                        }}
+                    />
+                    <div className="theme-import-export-actions">
+                        <button type="button" onClick={copyJson}>
+                            {pgettext("Copy goban theme JSON", "Copy")}
+                        </button>
+                        <button type="button" className="primary" onClick={importJson}>
+                            {pgettext("Import goban theme JSON", "Import")}
+                        </button>
+                    </div>
+                    {status && (
+                        <small
+                            className={`theme-import-export-status ${status.kind}`}
+                            role={status.kind === "error" ? "alert" : "status"}
+                        >
+                            {status.message}
+                        </small>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/views/Settings/GobanThemeImportExport.tsx
+++ b/src/views/Settings/GobanThemeImportExport.tsx
@@ -18,114 +18,139 @@
 import * as React from "react";
 import { pgettext } from "@/lib/translate";
 import { importGobanTheme, serializeGobanTheme } from "@/lib/goban_theme_json";
+import { toast } from "@/lib/toast";
 import "./GobanThemeImportExport.css";
 
-type Status = { kind: "success" | "error"; message: string } | null;
+const SUCCESS_TOAST_DURATION_MS = 3000;
 
 export function GobanThemeImportExport(): React.ReactElement {
-    const [open, setOpen] = React.useState(false);
-    const [json, setJson] = React.useState("");
-    const [status, setStatus] = React.useState<Status>(null);
-    const textarea = React.useRef<HTMLTextAreaElement>(null);
+    const [import_open, setImportOpen] = React.useState(false);
+    const [import_json, setImportJson] = React.useState("");
+    const [manual_copy_json, setManualCopyJson] = React.useState<string | null>(null);
+    const [error_message, setErrorMessage] = React.useState<string | null>(null);
+    const manual_copy_textarea = React.useRef<HTMLTextAreaElement>(null);
 
-    function toggleOpen(): void {
-        setOpen((was_open) => {
-            if (!was_open) {
-                setJson(serializeGobanTheme());
-                setStatus(null);
-            }
-            return !was_open;
-        });
-    }
+    React.useEffect(() => {
+        if (manual_copy_json !== null) {
+            manual_copy_textarea.current?.focus();
+            manual_copy_textarea.current?.select();
+        }
+    }, [manual_copy_json]);
 
-    async function copyJson(): Promise<void> {
+    async function copyTheme(): Promise<void> {
+        const json = serializeGobanTheme();
         try {
             if (!navigator.clipboard?.writeText) {
                 throw new Error("Clipboard API unavailable");
             }
             await navigator.clipboard.writeText(json);
-            setStatus({
-                kind: "success",
-                message: pgettext("Goban theme JSON clipboard success", "Theme JSON copied."),
-            });
+            setManualCopyJson(null);
+            setErrorMessage(null);
+            toast(
+                <div>{pgettext("Goban theme JSON clipboard success", "Theme JSON copied.")}</div>,
+                SUCCESS_TOAST_DURATION_MS,
+            );
         } catch {
-            textarea.current?.focus();
-            textarea.current?.select();
-            setStatus({
-                kind: "error",
-                message: pgettext(
+            setManualCopyJson(json);
+            setErrorMessage(
+                pgettext(
                     "Goban theme JSON clipboard fallback",
                     "Copy was blocked by the browser. The JSON has been selected for manual copying.",
                 ),
-            });
+            );
         }
     }
 
-    function importJson(): void {
+    function openImport(): void {
+        setImportOpen(true);
+        setImportJson("");
+        setManualCopyJson(null);
+        setErrorMessage(null);
+    }
+
+    function cancelImport(): void {
+        setImportOpen(false);
+        setImportJson("");
+        setErrorMessage(null);
+    }
+
+    function importTheme(): void {
         try {
-            importGobanTheme(json);
-            setJson(serializeGobanTheme());
-            setStatus({
-                kind: "success",
-                message: pgettext("Goban theme JSON import success", "Theme imported."),
-            });
+            importGobanTheme(import_json);
+            setImportOpen(false);
+            setImportJson("");
+            setErrorMessage(null);
+            toast(
+                <div>{pgettext("Goban theme JSON import success", "Theme imported.")}</div>,
+                SUCCESS_TOAST_DURATION_MS,
+            );
         } catch (error) {
-            setStatus({
-                kind: "error",
-                message:
-                    error instanceof Error
-                        ? error.message
-                        : pgettext(
-                              "Goban theme JSON unknown import error",
-                              "The theme JSON could not be imported.",
-                          ),
-            });
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : pgettext(
+                          "Goban theme JSON unknown import error",
+                          "The theme JSON could not be imported.",
+                      ),
+            );
         }
     }
 
     return (
         <div className="GobanThemeImportExport">
-            <button
-                type="button"
-                className="theme-import-export-toggle"
-                aria-expanded={open}
-                onClick={toggleOpen}
-            >
-                <i className={`fa fa-caret-${open ? "down" : "right"}`} />
-                <span>
-                    {pgettext("Toggle goban theme JSON import/export controls", "Import / export")}
-                </span>
-            </button>
+            <div className="theme-import-export-actions">
+                <button type="button" onClick={copyTheme}>
+                    {pgettext("Copy current goban theme JSON", "Copy theme")}
+                </button>
+                <button type="button" aria-expanded={import_open} onClick={openImport}>
+                    {pgettext("Open goban theme JSON import controls", "Import theme")}
+                </button>
+            </div>
 
-            {open && (
+            {manual_copy_json !== null && (
+                <textarea
+                    ref={manual_copy_textarea}
+                    className="manual-copy-json"
+                    value={manual_copy_json}
+                    aria-label={pgettext(
+                        "Goban theme JSON selected for manual copying",
+                        "Theme JSON to copy",
+                    )}
+                    readOnly
+                    spellCheck={false}
+                />
+            )}
+
+            {import_open && (
                 <div className="theme-import-export-content">
                     <textarea
-                        ref={textarea}
-                        value={json}
-                        aria-label={pgettext("Goban theme JSON editor", "Goban theme JSON")}
+                        value={import_json}
+                        aria-label={pgettext(
+                            "Goban theme JSON import editor",
+                            "Theme JSON to import",
+                        )}
+                        autoFocus
                         spellCheck={false}
                         onChange={(event) => {
-                            setJson(event.target.value);
-                            setStatus(null);
+                            setImportJson(event.target.value);
+                            setErrorMessage(null);
                         }}
                     />
                     <div className="theme-import-export-actions">
-                        <button type="button" onClick={copyJson}>
-                            {pgettext("Copy goban theme JSON", "Copy")}
+                        <button type="button" onClick={cancelImport}>
+                            {pgettext("Cancel goban theme JSON import", "Cancel")}
                         </button>
-                        <button type="button" className="primary" onClick={importJson}>
-                            {pgettext("Import goban theme JSON", "Import")}
+                        <button type="button" className="primary" onClick={importTheme}>
+                            {pgettext("Apply imported goban theme JSON", "Apply theme")}
                         </button>
                     </div>
-                    {status && (
-                        <small
-                            className={`theme-import-export-status ${status.kind}`}
-                            role={status.kind === "error" ? "alert" : "status"}
-                        >
-                            {status.message}
-                        </small>
-                    )}
                 </div>
+            )}
+
+            {error_message && (
+                <small className="theme-import-export-status is-error" role="alert">
+                    {error_message}
+                </small>
             )}
         </div>
     );

--- a/src/views/Settings/ThemePreferences.css
+++ b/src/views/Settings/ThemePreferences.css
@@ -15,6 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 .ThemePreferences {
+    flex: 1;
+    min-width: 0;
+
+    .PreferenceLine.goban-theme-sharing {
+        display: flex;
+        width: 100%;
+        align-items: flex-start;
+
+        .PreferenceLineTitle {
+            padding-top: 0.5rem;
+        }
+
+        .PreferenceLineBody {
+            flex: 1 1 24rem;
+            min-width: 0;
+        }
+    }
+
     .select-custom {
         font-size: larger;
         font-weight: bold;

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -242,7 +242,7 @@ export function ThemePreferences(): React.ReactElement | null {
 
             <PreferenceLine
                 className="goban-theme-sharing"
-                title={pgettext("Goban theme sharing settings", "Share theme")}
+                title={pgettext("Goban theme import and sharing settings", "Share or import theme")}
             >
                 <GobanThemeImportExport />
             </PreferenceLine>

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -35,6 +35,7 @@ import { useData } from "@/lib/hooks";
 import { MiniGoban } from "@/components/MiniGoban";
 import { GobanEngineConfig, setGobanRenderer } from "goban";
 import { Toggle } from "@/components/Toggle";
+import { GobanThemeImportExport } from "./GobanThemeImportExport";
 import "./ThemePreferences.css";
 
 const sample_board_data: GobanEngineConfig = {
@@ -237,6 +238,13 @@ export function ThemePreferences(): React.ReactElement | null {
             <PreferenceLine className="title-on-top body-as-column" title={_("White stone theme")}>
                 <GobanWhiteThemePicker />
                 <GobanCustomWhitePicker />
+            </PreferenceLine>
+
+            <PreferenceLine
+                className="goban-theme-sharing"
+                title={pgettext("Goban theme sharing settings", "Share theme")}
+            >
+                <GobanThemeImportExport />
             </PreferenceLine>
 
             <PreferenceLine title={_("Board label positioning")}>


### PR DESCRIPTION
This is the last part of the [More expressive theme system #3608](https://github.com/online-go/online-go.com/issues/3608).

## Summary

Adds controls to copy and import goban themes as JSON that is decoupled from the internal preferences representation. It supports everything that affects board look - except for the personal display and accessibility preferences.

The imports are fully parsed, migrated, and validated before replacing the theme settings. Clipboard fallback, translated UI, documentation, and test coverage are included.

## Motivation

The themes I developed need tweaking about ten settings to apply. I'd like to make this easy to do, but in a more portable manner than adding those themes as OGS defaults. I would expect players to share their own themes as JSON on the OGS forum.

As the settings evolve, the older snippets should be handled in a consistent manner. Most of the complexity in this PR comes from that - it includes strict runtime validation, stable defaults, versioned migrations, atomic application.

## Refactoring
Centralizes goban theme defaults in a module.  Reuses those defaults across preferences, imports, and theme-editor reset controls. It affects a lot of the existing code, but in a mechanical manner. I decided that this is better than repeating defaults in yet two more places. This improves on the existing duplication.

## Testing
1. Copy your existing settings as a backup by using Copy Theme
2. Apply theme JSON from https://github.com/lykahb/goban-decals/tree/master/themes/sand-and-pebbles.

<img width="917" height="310" alt="image" src="https://github.com/user-attachments/assets/40cfd61e-3e5d-434f-98c7-946231ded42e" />

Implemented with Codex, with close steering for the key technical decisions.