### PR TITLE
Persist PaginatedTable page number across refreshes

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -85,10 +85,14 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
     ref: React.ForwardedRef<PaginatedTableRef>,
 ): React.ReactElement {
     const table_name = props.name || "default";
+    const initial_page = data.get(
+        `paginated-table.${table_name}.page`,
+        props.startingPage || 1,
+    ) as number;
     const [rows, setRows]: [any[], (x: any[]) => void] = React.useState<GroomedEntryT[]>([]);
-    const [page, _setPage]: [number, (x: number) => void] = React.useState(props.startingPage || 1);
+    const [page, _setPage]: [number, (x: number) => void] = React.useState(initial_page);
     const [page_input_text, _setPageInputText]: [string, (s: string) => void] = React.useState(
-        (props.startingPage || 1).toString(),
+        initial_page.toString(),
     );
     const [num_pages, setNumPages]: [number, (x: number) => void] = React.useState(1);
     const [page_size, _setPageSize]: [number, (x: number) => void] = React.useState(
@@ -176,6 +180,7 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
                 setNumPages(Math.ceil(res.count / page_size) || 1);
                 if (page > Math.ceil(res.count / page_size)) {
                     const new_page = Math.max(1, Math.ceil(res.count / page_size));
+                    data.set(`paginated-table.${table_name}.page`, new_page);
                     _setPage(new_page);
                     setPageInputText(new_page.toString());
                 }
@@ -232,6 +237,7 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
 
     function setPage(page: number): void {
         const new_page = Math.max(1, Math.min(page, num_pages));
+        data.set(`paginated-table.${table_name}.page`, new_page);
         _setPage(new_page);
         setPageInputText(new_page.toString());
     }
@@ -258,6 +264,7 @@ function PaginatedTableImpl<RawEntryT = any, GroomedEntryT = RawEntryT>(
         _setPageSize(new_page_size);
 
         const new_page = Math.floor(Math.max(0, ((page - 1) * old_page_size) / new_page_size) + 1);
+        data.set(`paginated-table.${table_name}.page`, new_page);
         _setPage(new_page);
         setPageInputText(new_page.toString());
     }

--- a/src/lib/data_schema.ts
+++ b/src/lib/data_schema.ts
@@ -337,6 +337,7 @@ export interface DataSchema
     [moderator_join_game_publicly_key: `moderator.join-game-publicly.${string}`]: boolean;
     [puzzle_last_visited_key: `puzzle.collection.${number}.last-visited`]: number;
     [paginated_table_page_size_key: `paginated-table.${string}.page_size`]: number;
+    [paginated_table_page_key: `paginated-table.${string}.page`]: number;
     [dismissed_key: `dismissed.${string}`]: boolean;
     [experiments_key: `experiments.${string}`]: string;
 


### PR DESCRIPTION
## Summary

Fixes / partially addresses #313 ("When refreshing the game list, it forgets the current page number").

### What changed

`PaginatedTable` already persisted `page_size` via `data.get` / `data.set`. This change does the same for the current **page** number:

- On mount, the table restores the last page the user was on for that table name.
- When the user changes page (arrows, typing, page size change), the new page is stored.
- When filters change, the page still resets to 1 (existing behaviour preserved).
- If the restored page is past the end of the result set, it is clamped to the last valid page.

### Why this approach

The discussion on #313 prefers encoding state in the URL for full browser history support. That is a larger change. This patch is a smaller, low-risk improvement that solves the common "I refreshed and lost my place" case using the same storage mechanism the component already uses for page size.

### Testing

- [ ] Manual: open a paginated list (e.g. user game history), go to page 3+, refresh → should stay on same page.
- [ ] Manual: change filters → should reset to page 1.
- [ ] Desktop + mobile.

### Notes

AI-assisted contribution (Grok). I have reviewed the change. Happy to adjust based on maintainer feedback.