### PR TITLE
Restore "Key moves" label in AI Review

### DIFF
--- a/src/components/AIReview/AIReview.css
+++ b/src/components/AIReview/AIReview.css
@@ -201,7 +201,8 @@
 
     .worst-move-list-container {
         user-select: none;
-        display: inline-flex;
+        display: flex;
+        flex-direction: column;
         width: 100%;
         text-align: center;
 

--- a/src/components/AIReview/WorstMovesList.tsx
+++ b/src/components/AIReview/WorstMovesList.tsx
@@ -48,6 +48,12 @@ export function WorstMovesList({
 
     return (
         <div className="worst-move-list-container">
+            <div className="key-moves">
+                {pgettext(
+                    "Label above the list of the most significant mistakes in an AI review",
+                    "Key moves",
+                )}
+            </div>
             <div className="move-list">
                 {moves.slice(0, maxMovesShown).map((de, idx) => {
                     const pretty_coords = goban.engine!.prettyCoordinates(de.move.x, de.move.y);


### PR DESCRIPTION
Restores the "Key moves" label above the worst-moves buttons in the AI Review panel.

The CSS for `.key-moves` was still present; only the markup had been removed. New users found the unlabeled buttons confusing (#3601).

Also sets the worst-move list container to column flex so the label sits above the moves.