### PR TITLE
Fix email preference toggles overflowing on mobile

### DIFF
--- a/src/views/Settings/Settings.css
+++ b/src/views/Settings/Settings.css
@@ -309,12 +309,23 @@
     .EmailNotificationToggle {
         margin-top: 1rem;
         margin-left: 1rem;
+        max-width: calc(100% - 1rem);
 
         label {
+            flex: 1;
+            min-width: 0;
+
             .preference-toggle-name {
-                width: 20rem;
-                flex-basis: 20rem;
+                width: auto;
+                max-width: 20rem;
+                flex: 1 1 auto;
+                flex-basis: auto;
+                min-width: 0;
             }
+        }
+
+        .Toggle {
+            flex-shrink: 0;
         }
     }
 
@@ -468,6 +479,15 @@
 
     #SettingsContainer {
         align-items: stretch;
+    }
+
+    .Settings .EmailNotificationToggle {
+        margin-left: 0;
+        max-width: 100%;
+
+        label .preference-toggle-name {
+            max-width: none;
+        }
     }
 }
 


### PR DESCRIPTION
The email notification preference name used a fixed 20rem width, which pushed the toggle off-screen on narrow phones (e.g. iPhone 14 Pro).

Allow the label to shrink and keep the toggle visible without horizontal scroll.

Addresses #3547.