### PR TITLE
Fix feeding_white assignment for white_src

### DIFF
--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3267,11 +3267,8 @@ function createEliminationNodes(rounds: Round[]) {
             }
             if (obj.white_src) {
                 obj.white_src.parent = obj;
-                // Is this a bug?  TypeScript complains because black_src
-                // can be null.  Perhaps this should be white_src.feeding_white?
-                //  -bpj
-                (obj.black_src as ObjectType).feeding_white = true;
-            }
+                obj.white_src.feeding_white = true;
+            }    
             all_objects.push(obj);
 
             cur_bucket[match.black] = obj;

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -3268,7 +3268,7 @@ function createEliminationNodes(rounds: Round[]) {
             if (obj.white_src) {
                 obj.white_src.parent = obj;
                 obj.white_src.feeding_white = true;
-            }    
+            }
             all_objects.push(obj);
 
             cur_bucket[match.black] = obj;


### PR DESCRIPTION
HI my ogs nickname is CHAERO0707 Jiseok
Modified file: src/views/Tournament/Tournament.tsx

Error: When creating the tournament bracket, the `feeding_white` property should have been set on the white stone source (`white_src`), but it was mistakenly set on the black stone source (`black_src`). There was even a comment in the code asking, "Is this a bug? Perhaps this should be white_src.feeding_white?"

Changes:


Tournament.tsx
Lines 3268-3271
if (obj.white_src) {
    obj.white_src.parent = obj;
    obj.white_src.feeding_white = true;
}
Before change:

After setting `obj.white_src.parent = obj`
`(obj.black_src as ObjectType).feeding_white = true` — Flag set on the wrong object
Caused a TypeScript warning because `black_src` could be null
After change:

`obj.white_src.feeding_white = true` — Correctly set on the white stone source node
Removed unnecessary type cast and the comment regarding the suspected bug
This change aligns the implementation with the pattern used for the black stone side (`black_src.feeding_black = true`).