### PR TITLE
UI bug: fix friend and notifications overlap

### DIFF
--- a/src/components/FriendList/FriendIndicator.tsx
+++ b/src/components/FriendList/FriendIndicator.tsx
@@ -36,7 +36,13 @@ export function FriendIndicator(): React.ReactElement | null {
     const friend_list = React.useRef<any[]>([]);
 
     React.useEffect(() => {
-        setSetShowFriendList((show) => setActiveMenu(show ? "friends" : null));
+        setSetShowFriendList((show) => {
+            if (show) {
+                setActiveMenu("friends");
+            } else {
+                setActiveMenu((currentMenu) => (currentMenu === "friends" ? null : currentMenu));
+            }
+        });
         return () => setSetShowFriendList(() => {});
     }, [setActiveMenu]);
 

--- a/src/components/FriendList/FriendIndicator.tsx
+++ b/src/components/FriendList/FriendIndicator.tsx
@@ -21,6 +21,7 @@ import * as data from "@/lib/data";
 import { FriendList } from "./FriendList";
 import { KBShortcut } from "@/components/KBShortcut";
 import cached from "@/lib/cached";
+import { MenuContext } from "@/components/NavBar/Menu";
 import { setSetShowFriendList } from "./close_friend_list";
 import "./FriendIndicator.css";
 
@@ -28,12 +29,16 @@ const online_subscriptions = {};
 
 export function FriendIndicator(): React.ReactElement | null {
     const user = data.get("user");
-    const [show_friend_list, setShowFriendList] = React.useState(false);
+    const { activeMenu, setActiveMenu } = React.useContext(MenuContext);
+    const show_friend_list = activeMenu === "friends";
     const [online_ct, setOnlineCt] = React.useState(0);
     const [, refresh] = React.useState(0);
     const friend_list = React.useRef<any[]>([]);
 
-    setSetShowFriendList(setShowFriendList);
+    React.useEffect(() => {
+        setSetShowFriendList((show) => setActiveMenu(show ? "friends" : null));
+        return () => setSetShowFriendList(() => {});
+    }, [setActiveMenu]);
 
     React.useEffect(() => {
         if (user.id) {
@@ -67,7 +72,7 @@ export function FriendIndicator(): React.ReactElement | null {
     }, [user.id]);
 
     const toggleFriendList = () => {
-        setShowFriendList(!show_friend_list);
+        setActiveMenu(show_friend_list ? null : "friends");
     };
 
     if (friend_list.current.length === 0) {

--- a/src/components/NavBar/Menu.tsx
+++ b/src/components/NavBar/Menu.tsx
@@ -150,8 +150,8 @@ export function Menu<T extends React.ElementType = "li">({
 // menu context to track currently open menu
 export const MenuContext = React.createContext<{
     activeMenu: string | null;
-    setActiveMenu: (menu: string | null) => void;
+    setActiveMenu: React.Dispatch<React.SetStateAction<string | null>>;
 }>({
     activeMenu: null,
-    setActiveMenu: (_menu: string | null) => {},
+    setActiveMenu: (_menu: React.SetStateAction<string | null>) => {},
 });

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -72,8 +72,7 @@ export function NavBar(): React.ReactElement {
     const [search, setSearch] = React.useState<string>("");
     const [search_focus, setSearchFocus] = React.useState<boolean>(false);
     const [omniMouseOver, setOmniMouseOver] = React.useState<boolean>(false);
-    const [right_nav_active, setRightNavActive] = React.useState(false);
-    const [notifications_active, setNotificationsActive] = React.useState(false);
+    const [activeMenu, setActiveMenu] = useState<null | string>(null);
     const [hamburger_expanded, setHamburgerExpanded] = React.useState(false);
     const search_input = React.useRef<HTMLInputElement>(null);
     const [force_nav_close, setForceNavClose] = React.useState(false);
@@ -103,21 +102,23 @@ export function NavBar(): React.ReactElement {
 
     const { ref: settingsNavLink } = registerTargetItem("settings-nav-link");
 
+    const notifications_active = activeMenu === "notifications";
+    const right_nav_active = activeMenu === "right-nav";
+
     const closeNavbar = () => {
-        setRightNavActive(false);
-        setNotificationsActive(false);
+        setActiveMenu(null);
         setSearch("");
     };
 
     const toggleNotifications = () => {
-        if (notifications_active === false) {
+        if (!notifications_active) {
             notification_manager.event_emitter.emit("notification-count", 0);
         }
-        setNotificationsActive(!notifications_active);
+        setActiveMenu(notifications_active ? null : "notifications");
     };
 
     const toggleRightNav = () => {
-        setRightNavActive(!right_nav_active);
+        setActiveMenu(right_nav_active ? null : "right-nav");
         rightNavToggled();
     };
 
@@ -125,7 +126,7 @@ export function NavBar(): React.ReactElement {
         if (hamburger_expanded) {
             setSearch("");
         }
-        setRightNavActive(false);
+        setActiveMenu(null);
         setHamburgerExpanded(!hamburger_expanded);
     };
 
@@ -166,8 +167,6 @@ export function NavBar(): React.ReactElement {
     const show_appeal_box = !window.location.pathname.includes("/appeal");
 
     const searchInputId = useId();
-
-    const [activeMenu, setActiveMenu] = useState<null | string>(null);
 
     return (
         <MenuContext.Provider value={{ setActiveMenu, activeMenu }}>


### PR DESCRIPTION
The bug happened because each dropdown had separate state:

- Notifications used `NavBar` state.
- Friends used its own local state.
- Both could be open at the same time, so CSS stacking made one appear over the other.

The fix uses the existing `MenuContext` as one shared menu state:

```ts
activeMenu = "notifications" | "friends" | "right-nav" | "settings" | null
```

Clicking notifications sets `activeMenu` to `"notifications"`. Clicking friends changes it to `"friends"`, which causes the notification component to unmount automatically. This removes the overlapping dropdown instead of trying to correct it with z-index values.

<img width="530" height="422" alt="image" src="https://github.com/user-attachments/assets/3ccdf43d-0b3b-48e4-a558-f10b347e3002" />

<img width="535" height="727" alt="image" src="https://github.com/user-attachments/assets/ac54a2b3-b8da-433b-b73c-ca79d2c5a0d1" />
