### PR TITLE
Show game name in preferred settings dropdown (#3592)

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.test.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.test.tsx
@@ -17,11 +17,14 @@
 
 import * as React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ChallengeModalBody } from "./ChallengeModal";
 import { post } from "@/lib/requests";
 import { ChallengeModalProperties } from "@/components/ChallengeModal/ChallengeModal.types";
 import { sanitizeChallengeDetails } from "./ChallengeModal.utils";
 import { bots_list, Bot } from "@/lib/bots";
+
+let mockPreferredSettings: unknown[] = [];
 
 // Mock data module
 jest.mock("@/lib/data", () => ({
@@ -63,7 +66,7 @@ jest.mock("@/lib/data", () => ({
             return false;
         }
         if (key === "preferred-game-settings") {
-            return [];
+            return mockPreferredSettings;
         }
 
         return default_value;
@@ -78,7 +81,7 @@ jest.mock("@/lib/data", () => ({
 jest.mock("@/lib/requests", () => ({
     post: jest.fn(),
     del: jest.fn(),
-    get: jest.fn(),
+    get: jest.fn(() => Promise.resolve({})),
 }));
 
 jest.mock("@/lib/bots", () => ({
@@ -97,6 +100,11 @@ jest.mock("@/lib/translate", () => ({
         if (Array.isArray(params)) {
             for (const p of params) {
                 res = res.replace("%s", p);
+            }
+        }
+        if (typeof params === "object" && params !== null) {
+            for (const [key, value] of Object.entries(params)) {
+                res = res.replace(`{{${key}}}`, value);
             }
         }
         return res;
@@ -171,12 +179,127 @@ const mockModal = {
 describe("ChallengeModalBody", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockPreferredSettings = [];
     });
 
     it("renders game name input", () => {
         render(<ChallengeModalBody {...defaultProps} modal={mockModal} />);
         const gameNameInput = screen.getByPlaceholderText("Game Name");
         expect(gameNameInput).toBeInTheDocument();
+    });
+
+    it("shows the game name at the start of preferred settings options", async () => {
+        const user = userEvent.setup();
+        mockPreferredSettings = [
+            {
+                initialized: false,
+                min_ranking: -1000,
+                max_ranking: 1000,
+                challenger_color: "automatic",
+                rengo_auto_start: 0,
+                game: {
+                    name: "Bot Practice 1",
+                    rules: "japanese",
+                    ranked: false,
+                    width: 19,
+                    height: 19,
+                    handicap: 0,
+                    komi_auto: "automatic",
+                    disable_analysis: false,
+                    initial_state: null,
+                    private: false,
+                    rengo: false,
+                    rengo_casual_mode: true,
+                },
+            },
+        ];
+
+        render(<ChallengeModalBody {...defaultProps} modal={mockModal} />);
+
+        await user.click(screen.getByText("Preferred settings (1)"));
+
+        const options = Array.from(document.querySelectorAll(".ogs-react-select__option"));
+        expect(options[0].textContent).toBe(
+            "Bot Practice 1 | Unranked, 19x19, Japanese rules, 0 handicap",
+        );
+    });
+
+    it("sorts named preferred settings before unnamed ones", async () => {
+        const user = userEvent.setup();
+        mockPreferredSettings = [
+            {
+                initialized: false,
+                min_ranking: -1000,
+                max_ranking: 1000,
+                challenger_color: "automatic",
+                rengo_auto_start: 0,
+                game: {
+                    name: "",
+                    rules: "japanese",
+                    ranked: false,
+                    width: 19,
+                    height: 19,
+                    handicap: 0,
+                    komi_auto: "automatic",
+                    disable_analysis: false,
+                    initial_state: null,
+                    private: false,
+                    rengo: false,
+                    rengo_casual_mode: true,
+                },
+            },
+            {
+                initialized: false,
+                min_ranking: -1000,
+                max_ranking: 1000,
+                challenger_color: "automatic",
+                rengo_auto_start: 0,
+                game: {
+                    name: "Zebra",
+                    rules: "japanese",
+                    ranked: false,
+                    width: 19,
+                    height: 19,
+                    handicap: 0,
+                    komi_auto: "automatic",
+                    disable_analysis: false,
+                    initial_state: null,
+                    private: false,
+                    rengo: false,
+                    rengo_casual_mode: true,
+                },
+            },
+            {
+                initialized: false,
+                min_ranking: -1000,
+                max_ranking: 1000,
+                challenger_color: "automatic",
+                rengo_auto_start: 0,
+                game: {
+                    name: "Alpha",
+                    rules: "japanese",
+                    ranked: false,
+                    width: 19,
+                    height: 19,
+                    handicap: 0,
+                    komi_auto: "automatic",
+                    disable_analysis: false,
+                    initial_state: null,
+                    private: false,
+                    rengo: false,
+                    rengo_casual_mode: true,
+                },
+            },
+        ];
+
+        render(<ChallengeModalBody {...defaultProps} modal={mockModal} />);
+
+        await user.click(screen.getByText("Preferred settings (3)"));
+
+        const options = Array.from(document.querySelectorAll(".ogs-react-select__option"));
+        expect(options[0].textContent).toContain("Alpha |");
+        expect(options[1].textContent).toContain("Zebra |");
+        expect(options[2].textContent).toBe("Unranked, 19x19, Japanese rules, 0 handicap");
     });
 
     it("renders private checkbox", () => {

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -51,7 +51,8 @@ import { SPEED_OPTIONS } from "@/views/Play/SPEED_OPTIONS";
 import Select from "react-select";
 import {
     rejectionDetailsToMessage,
-    challenge_text_description,
+    preferred_setting_label,
+    sort_preferred_settings,
     sanitizeChallengeDetails,
     getPreferredSettings,
     getDefaultKomi,
@@ -1540,12 +1541,12 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
     };
 
     preferredGameSettings = () => {
-        const options: PreferredSettingOption[] = this.state.preferred_settings.map(
-            (setting: ChallengeDetails, index: number) => ({
+        const options: PreferredSettingOption[] = sort_preferred_settings(
+            this.state.preferred_settings.map((setting: ChallengeDetails, index: number) => ({
                 value: index,
-                label: challenge_text_description(setting),
+                label: preferred_setting_label(setting),
                 setting: setting,
-            }),
+            })),
         );
 
         const handicap = this.state.challenge.game.handicap;

--- a/src/components/ChallengeModal/ChallengeModal.utils.test.ts
+++ b/src/components/ChallengeModal/ChallengeModal.utils.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { preferred_setting_label, sort_preferred_settings } from "./ChallengeModal.utils";
+import { ChallengeDetails } from "@/components/ChallengeModal/ChallengeModal.types";
+
+jest.mock("@/lib/translate", () => ({
+    _: (s: string) => s,
+    pgettext: (_c: string, s: string) => s,
+    npgettext: (_c: string, s: string, p: string, n: number) => (n === 1 ? s : p),
+    llm_pgettext: (_c: string, s: string) => s,
+    interpolate: (str: string, params: Array<any> | { [key: string]: any }) => {
+        if (Array.isArray(params)) {
+            let idx = 0;
+            return str.replace(/%[sd]/g, () => params[idx++]);
+        }
+        if (typeof params === "object" && params !== null) {
+            return str.replace(/{{([^}]+)}}/g, (_m: string, key: string) => params[key] ?? "");
+        }
+        return str.replace(/%[sd]/g, () => params);
+    },
+}));
+
+jest.mock("@/lib/misc", () => ({
+    rulesText: (rules: string) => rules,
+}));
+
+jest.mock("@/components/TimeControl", () => ({
+    shortShortTimeControl: () => "10 min",
+    timeControlSystemText: (system: string) => system,
+}));
+
+jest.mock("@/lib/rank_utils", () => ({
+    rankSelectorIndexToText: (r: number) => `rank ${r}`,
+}));
+
+jest.mock("@/lib/data", () => ({
+    get: jest.fn(() => undefined),
+}));
+
+function makeSetting(
+    name: string,
+    overrides: { game?: Partial<ChallengeDetails["game"]> } = {},
+): ChallengeDetails {
+    return {
+        initialized: false,
+        min_ranking: -1000,
+        max_ranking: 1000,
+        challenger_color: "automatic",
+        rengo_auto_start: 0,
+        game: {
+            name,
+            rules: "japanese",
+            ranked: false,
+            width: 19,
+            height: 19,
+            handicap: 0,
+            komi_auto: "automatic",
+            disable_analysis: false,
+            initial_state: null,
+            private: false,
+            rengo: false,
+            rengo_casual_mode: true,
+            ...(overrides.game ?? {}),
+        },
+    };
+}
+
+describe("preferred_setting_label", () => {
+    it("prefixes the description with the game name", () => {
+        expect(preferred_setting_label(makeSetting("Bot Practice 1"))).toBe(
+            "Bot Practice 1 | Unranked, 19x19, japanese rules, 0 handicap",
+        );
+    });
+
+    it("does not add a prefix when the game has no name", () => {
+        const label = preferred_setting_label(makeSetting(""));
+        expect(label).toBe("Unranked, 19x19, japanese rules, 0 handicap");
+        expect(label).not.toContain("|");
+    });
+
+    it("treats a whitespace-only name as unnamed", () => {
+        const label = preferred_setting_label(makeSetting("   "));
+        expect(label).not.toContain("|");
+    });
+});
+
+describe("sort_preferred_settings", () => {
+    function optionsOf(settings: ChallengeDetails[]) {
+        return settings.map((setting, index) => ({
+            value: index,
+            label: preferred_setting_label(setting),
+            setting,
+        }));
+    }
+
+    it("sorts named games alphabetically before unnamed games", () => {
+        const settings = [
+            makeSetting("Zulu"),
+            makeSetting(""),
+            makeSetting("bravo"),
+            makeSetting("Alpha"),
+        ];
+        const sorted = sort_preferred_settings(optionsOf(settings));
+
+        expect(sorted.map((o) => o.setting.game.name)).toEqual(["Alpha", "bravo", "Zulu", ""]);
+        expect(sorted.map((o) => o.value)).toEqual([3, 2, 0, 1]);
+    });
+
+    it("sorts unnamed games alphabetically by description after named games", () => {
+        const settings = [
+            makeSetting("", { game: { width: 19, height: 19 } }),
+            makeSetting("Named"),
+            makeSetting("", { game: { width: 9, height: 9 } }),
+        ];
+        const sorted = sort_preferred_settings(optionsOf(settings));
+
+        expect(sorted.map((o) => o.setting.game.name)).toEqual(["Named", "", ""]);
+        expect(sorted[1].label).toBe("Unranked, 19x19, japanese rules, 0 handicap");
+        expect(sorted[2].label).toBe("Unranked, 9x9, japanese rules, 0 handicap");
+    });
+});

--- a/src/components/ChallengeModal/ChallengeModal.utils.ts
+++ b/src/components/ChallengeModal/ChallengeModal.utils.ts
@@ -27,6 +27,31 @@ import {
 import { rankSelectorIndexToText } from "@/lib/rank_utils";
 import { RuleSet } from "@/lib/types";
 
+export function preferred_setting_label(setting: ChallengeDetails): string {
+    const description = challenge_text_description(setting);
+    const name = setting.game.name?.trim();
+    return name ? `${name} | ${description}` : description;
+}
+
+export function sort_preferred_settings<T extends { setting: ChallengeDetails; label: string }>(
+    options: T[],
+): T[] {
+    return options.sort((a, b) => {
+        const a_name = a.setting.game.name?.trim().toLocaleLowerCase() ?? "";
+        const b_name = b.setting.game.name?.trim().toLocaleLowerCase() ?? "";
+        const a_named = a_name.length > 0;
+        const b_named = b_name.length > 0;
+
+        if (a_named !== b_named) {
+            return a_named ? -1 : 1;
+        }
+
+        const a_key = a_named ? a_name : a.label.toLocaleLowerCase();
+        const b_key = b_named ? b_name : b.label.toLocaleLowerCase();
+        return a_key.localeCompare(b_key);
+    });
+}
+
 export function challenge_text_description(challenge: ChallengeDetails) {
     const c = challenge;
     const g = "game" in challenge ? challenge.game : challenge;


### PR DESCRIPTION
The preferred settings dropdown in the challenge modal now shows the game name first when one is set (e.g. "My Game | Unranked, 19x19..."). Unnamed settings are unchanged. Named settings sort alphabetically before unnamed ones. Solves #3592.

Why: Saved settings are hard to distinguish when they all read "Unranked, 19x19, Japanese rules..." as shown by screenshot of #3592.

Also added unit and component tests (428 total pass). Type-check, lint prettier and build all clean