### PR TITLE
fix(PlayerCards): add missing Disconnection and Abandonment outcome checks in show_points

### DIFF
--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -275,7 +275,9 @@ export function PlayerCard({
         (engine.phase === "finished" || engine.phase === "stone removal") &&
         goban.mode !== "analyze" &&
         engine.outcome !== "Timeout" &&
+        engine.outcome !== "Disconnection" &&
         engine.outcome !== "Resignation" &&
+        engine.outcome !== "Abandonment" &&
         engine.outcome !== "Cancellation" &&
         !engine.outcome.startsWith("Server Decision");
 


### PR DESCRIPTION
Hi my ogs nickname is CHAERO0707 Jiseok
Bug Description
What was wrong
show_points in PlayerCard was missing outcome exclusions for "Disconnection" and "Abandonment" that were already present in the useScore hook.

This inconsistency caused the score (total points) UI to be incorrectly shown on player cards when a game ended by disconnection or abandonment — even though useScore correctly computed captures-based scores for those cases.

Root Cause
Two places in PlayerCards.tsx control what gets rendered:

useScore (line 167–179) — decides whether to call computeScore(false) (territory) or computeScore(true) (prisoners/captures). It correctly excludes Disconnection and Abandonment.

show_points (line 274–282) — decides whether to render the {{total}} points UI. It was missing the same two exclusions, so it fell through and displayed a points score that was semantically wrong for those game-end conditions.

Fix
Added the two missing outcome guards to show_points to make it consistent with useScore:

 const show_points =
     (engine.phase === "finished" || engine.phase === "stone removal") &&
     goban.mode !== "analyze" &&
     engine.outcome !== "Timeout" &&
+    engine.outcome !== "Disconnection" &&
     engine.outcome !== "Resignation" &&
+    engine.outcome !== "Abandonment" &&
     engine.outcome !== "Cancellation" &&
     !engine.outcome.startsWith("Server Decision");
Impact
Games that ended by disconnection or abandonment now correctly show captures instead of a misleading points total on the player card score area.
