### PR TITLE
Thin the x-axis ticks on the CM voting graphs as the period grows

### DIFF
--- a/src/components/CMVotingGroupGraph/CMVotingGraphs.tsx
+++ b/src/components/CMVotingGroupGraph/CMVotingGraphs.tsx
@@ -20,6 +20,8 @@ import { subDays, startOfWeek as startOfWeekDateFns } from "date-fns";
 import { dropCurrentPeriod } from "@/lib/misc";
 import * as data from "@/lib/data";
 
+import { weeklyTickInterval } from "./weekly_ticks";
+
 import { ResponsiveLine } from "@nivo/line";
 import React from "react";
 
@@ -176,6 +178,8 @@ export const CMVoteCountGraph = ({
     // Use the first data point's date as the x-axis minimum, with fallback to period start
     const xScaleMin = filteredDataByWeek[0]?.date ?? periodStartDate.toISOString().slice(0, 10);
 
+    const tick_interval = weeklyTickInterval(period);
+
     if (!totals_data[0].data.length) {
         return <div className="aggregate-vote-activity-graph">No activity yet</div>;
     }
@@ -192,7 +196,7 @@ export const CMVoteCountGraph = ({
                     enableSlices="x"
                     axisBottom={{
                         format: "%d %b %g",
-                        tickValues: "every week",
+                        tickValues: tick_interval,
                     }}
                     xFormat="time:%Y-%m-%d"
                     xScale={{
@@ -233,7 +237,7 @@ export const CMVoteCountGraph = ({
                     enableSlices="x"
                     axisBottom={{
                         format: "%d %b %g",
-                        tickValues: "every week",
+                        tickValues: tick_interval,
                     }}
                     xFormat="time:%Y-%m-%d"
                     xScale={{
@@ -393,6 +397,8 @@ export const CMVotingGroupGraph = ({
     // Use the first data point's date as the x-axis minimum, with fallback to period start
     const xScaleMin = filteredDataByWeek[0]?.date ?? periodStartDate.toISOString().slice(0, 10);
 
+    const tick_interval = weeklyTickInterval(period);
+
     if (!totals_data[0].data.length) {
         return <div className="aggregate-vote-activity-graph">No activity yet</div>;
     }
@@ -409,7 +415,7 @@ export const CMVotingGroupGraph = ({
                     enableSlices="x"
                     axisBottom={{
                         format: "%d %b %g",
-                        tickValues: "every week",
+                        tickValues: tick_interval,
                     }}
                     xFormat="time:%Y-%m-%d"
                     xScale={{
@@ -450,7 +456,7 @@ export const CMVotingGroupGraph = ({
                     enableSlices="x"
                     axisBottom={{
                         format: "%d %b %g",
-                        tickValues: "every week",
+                        tickValues: tick_interval,
                     }}
                     xFormat="time:%Y-%m-%d"
                     xScale={{

--- a/src/components/CMVotingGroupGraph/weekly_ticks.test.ts
+++ b/src/components/CMVotingGroupGraph/weekly_ticks.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { MAX_WEEKLY_TICKS, weeklyTickInterval } from "./weekly_ticks";
+
+// How many labels the axis ends up with for a period, given the interval chosen
+function tickCount(period: number): number {
+    const interval = weeklyTickInterval(period);
+    const every = interval === "every week" ? 1 : Number(/^every (\d+) weeks$/.exec(interval)![1]);
+    return Math.ceil(period / 7 / every);
+}
+
+describe("weeklyTickInterval", () => {
+    test("labels every week over a two month period", () => {
+        expect(weeklyTickInterval(60)).toBe("every week");
+    });
+
+    test("labels every second week over a four month period", () => {
+        expect(weeklyTickInterval(120)).toBe("every 2 weeks");
+    });
+
+    test("keeps the axis within its label budget however long the period", () => {
+        for (const period of [7, 30, 60, 90, 120, 365, 730]) {
+            expect(tickCount(period)).toBeLessThanOrEqual(MAX_WEEKLY_TICKS);
+        }
+    });
+
+    test("never asks for less than every week", () => {
+        expect(weeklyTickInterval(1)).toBe("every week");
+    });
+});

--- a/src/components/CMVotingGroupGraph/weekly_ticks.ts
+++ b/src/components/CMVotingGroupGraph/weekly_ticks.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// The most dated labels that fit across these graphs without colliding.  They are
+// as narrow as a graph in a table cell, so this is a tighter budget than a full
+// width chart would allow.
+export const MAX_WEEKLY_TICKS = 10;
+
+/**
+ * The `tickValues` interval for a weekly x-axis covering `period` days.
+ *
+ * The graphs plot one point per week, so ticks land on week boundaries.  Labelling
+ * every week stops fitting once the period runs past a couple of months, so longer
+ * periods label every second week, every third, and so on.
+ */
+export function weeklyTickInterval(period: number): string {
+    const weeks = Math.ceil(period / 7);
+    const every = Math.max(1, Math.ceil(weeks / MAX_WEEKLY_TICKS));
+
+    return every === 1 ? "every week" : `every ${every} weeks`;
+}


### PR DESCRIPTION
A label on every week fits a two month period, but the individual outcomes graphs cover four months in the width of a table cell, where the dates collide.  The interval now scales with the period, so the axis carries about the same number of labels whatever it spans.

