### PR TITLE
Fix SGF Library header title and mobile overflow (#3545)

### DIFF
--- a/src/views/LibraryPlayer/LibraryPlayer.css
+++ b/src/views/LibraryPlayer/LibraryPlayer.css
@@ -20,11 +20,15 @@
         justify-content: space-between;
         align-items: center;
         gap: 1rem;
+        flex-wrap: wrap;
     }
 
     .breadcrumbs {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
+        min-width: 0;
+        flex: 1 1 auto;
         padding: 1rem;
         font-size: var(--font-size-big);
 
@@ -213,14 +217,20 @@
         display: flex;
         align-items: center;
         gap: 1rem;
+        flex-wrap: wrap;
+        min-width: 0;
 
         button {
             height: auto;
             min-height: 2em;
+            flex-shrink: 0;
         }
 
         input[type='text'] {
-            min-width: 200px;
+            min-width: 0;
+            width: 12rem;
+            max-width: 100%;
+            flex: 1 1 8rem;
             margin: 0;
         }
 
@@ -265,4 +275,27 @@
         }
     }
 
+}
+
+/* Keep header controls usable on narrow phones (e.g. iPhone 14 Pro) */
+@media (max-width: 767px) {
+    .LibraryPlayer {
+        .space-between {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .breadcrumbs {
+            padding: 0.5rem 0;
+        }
+
+        .new-collection {
+            width: 100%;
+
+            input[type='text'] {
+                width: 100%;
+                flex: 1 1 auto;
+            }
+        }
+    }
 }

--- a/src/views/LibraryPlayer/LibraryPlayer.tsx
+++ b/src/views/LibraryPlayer/LibraryPlayer.tsx
@@ -673,7 +673,9 @@ class _LibraryPlayer extends React.PureComponent<LibraryPlayerProperties, Librar
                                 onClick={this.setCollection.bind(this, collection.id)}
                                 key={idx}
                             >
-                                <span className="breadcrumb-name">{collection.name}</span>
+                                <span className="breadcrumb-name">
+                                    {collection.name || _("SGF Library")}
+                                </span>
                                 <span className="breadcrumb-slash">/</span>
                             </span>
                         ))}


### PR DESCRIPTION
Show "SGF Library" for the root breadcrumb (previously empty name rendered as "/" only). Allow the header row and create-collection controls to wrap on narrow screens so the button stays reachable without horizontal scroll.