### PR TITLE
Preserve raw game name when saving preferred settings

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.test.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.test.tsx
@@ -20,7 +20,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ChallengeModalBody } from "./ChallengeModal";
 import { post } from "@/lib/requests";
-import { ChallengeModalProperties } from "@/components/ChallengeModal/ChallengeModal.types";
+import {
+    ChallengeDetails,
+    ChallengeModalProperties,
+} from "@/components/ChallengeModal/ChallengeModal.types";
 import { sanitizeChallengeDetails } from "./ChallengeModal.utils";
 import { bots_list, Bot } from "@/lib/bots";
 
@@ -28,6 +31,12 @@ let mockPreferredSettings: unknown[] = [];
 
 // Mock data module
 jest.mock("@/lib/data", () => ({
+    Replication: {
+        NONE: 0x0,
+        LOCAL_OVERWRITES_REMOTE: 0x1,
+        REMOTE_OVERWRITES_LOCAL: 0x2,
+        REMOTE_ONLY: 0x4,
+    },
     get: (key: string, default_value: unknown) => {
         if (key === "user") {
             return { id: 123, ranking: 10 };
@@ -300,6 +309,37 @@ describe("ChallengeModalBody", () => {
         expect(options[0].textContent).toContain("Alpha |");
         expect(options[1].textContent).toContain("Zebra |");
         expect(options[2].textContent).toBe("Unranked, 19x19, Japanese rules, 0 handicap");
+    });
+
+    it("saves the typed game name in preferred settings", async () => {
+        const user = userEvent.setup();
+        render(<ChallengeModalBody {...defaultProps} modal={mockModal} />);
+
+        const gameNameInput = screen.getByPlaceholderText("Game Name");
+        await user.clear(gameNameInput);
+        await user.type(gameNameInput, "My Custom Game");
+        await user.click(screen.getByText("Add current setting"));
+
+        const { set } = jest.requireMock("@/lib/data");
+        const savedSettings = set.mock.calls.find(
+            ([key]: string[]) => key === "preferred-game-settings",
+        )?.[1] as ChallengeDetails[];
+        expect(savedSettings[0].game.name).toBe("My Custom Game");
+    });
+
+    it("saves unnamed games without the default game name", async () => {
+        const user = userEvent.setup();
+        render(<ChallengeModalBody {...defaultProps} modal={mockModal} />);
+
+        const gameNameInput = screen.getByPlaceholderText("Game Name");
+        await user.clear(gameNameInput);
+        await user.click(screen.getByText("Add current setting"));
+
+        const { set } = jest.requireMock("@/lib/data");
+        const savedSettings = set.mock.calls.find(
+            ([key]: string[]) => key === "preferred-game-settings",
+        )?.[1] as ChallengeDetails[];
+        expect(savedSettings[0].game.name).toBe("");
     });
 
     it("renders private checkbox", () => {

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -389,6 +389,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
     addToPreferredSettings = () => {
         const preferred_settings = getPreferredSettings();
         const challenge = dup(this.getChallenge());
+        challenge.game.name = (this.gameState().name ?? "").trim();
         preferred_settings.push(challenge);
         data.set(
             "preferred-game-settings",


### PR DESCRIPTION
As I was looking back through my previous pr commit (#3647) I noticed the unnamed-game handling wasn't actually reachable. 

`getChallenge()` stamps a localized "Friendly Match" name on every game before saving so settings never had an empty name. Default-named games ended up sorting among the named ones instead of after them, which is what the original issue asked for.

This change keeps the raw typed name when saving so unnamed games stay
unnamed and sort last, also added tests for the save path plus the `Replication` mock they need.

You're welcome!