### PR TITLE
Prevent variation link hover from reflowing chat text (#3642)

### DIFF
--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -96,6 +96,7 @@
         display: flex;
         align-items: flex-end;
         justify-content: center;
+        font-style: italic;
         height: 100%;
     }
 
@@ -161,17 +162,16 @@
     }
 
     .chat-input-player-list-toggle {
-        flex: 0;
-        height: 30px;
-        width: 30px;
-        font-size: 1.2rem;
-        border-radius: 0;
-        padding: 0;
+        border-top-right-radius: 0;
+        box-shadow: none;
+        white-space: nowrap;
     }
 
     .chat-input-container {
+        flex-shrink: 0;
+        flex-grow: 0;
+        /* flex-basis: auto; */
         display: flex;
-        max-height: 30%;
         /* max-width: 100%; */
         /* width: 100%; */
         /* overflow: hidden; */

--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -96,7 +96,6 @@
         display: flex;
         align-items: flex-end;
         justify-content: center;
-        font-style: italic;
         height: 100%;
     }
 
@@ -130,13 +129,17 @@
         margin-right: 0.2em;
         padding-left: 0.2em;
         padding-right: 0.2em;
+        /* Keep underline metrics stable so hover does not reflow chat text (#3642) */
+        text-decoration: underline;
+        text-decoration-color: transparent;
+        text-underline-offset: 0.15em;
     }
 
     .variation:hover, .position:hover {
         /* border: 1px solid #ccc; */
         /* background-color: #E7F3FC; */
         color: var(--variation-hover);
-        text-decoration: underline;
+        text-decoration-color: currentColor;
     }
 
     .variation {
@@ -158,16 +161,17 @@
     }
 
     .chat-input-player-list-toggle {
-        border-top-right-radius: 0;
-        box-shadow: none;
-        white-space: nowrap;
+        flex: 0;
+        height: 30px;
+        width: 30px;
+        font-size: 1.2rem;
+        border-radius: 0;
+        padding: 0;
     }
 
     .chat-input-container {
-        flex-shrink: 0;
-        flex-grow: 0;
-        /* flex-basis: auto; */
         display: flex;
+        max-height: 30%;
         /* max-width: 100%; */
         /* width: 100%; */
         /* overflow: hidden; */


### PR DESCRIPTION
Underline was applied only on hover, which shifted chat line layout and made review variation/position links flicker under the cursor.

Reserve underline space always and only change decoration color on hover.