### PR TITLE
Keep site navbar fixed while Chat page is open (#3011)

### DIFF
--- a/src/views/ChatView/ChatView.css
+++ b/src/views/ChatView/ChatView.css
@@ -24,6 +24,7 @@
     width: 100dvw;
     max-width: 100dvw;
     flex-direction: row;
+    overscroll-behavior: none;
 
     .ChatChannelList, .ChatUsersList {
         flex-basis: 20%;

--- a/src/views/ChatView/ChatView.tsx
+++ b/src/views/ChatView/ChatView.tsx
@@ -43,6 +43,17 @@ export function ChatView(): React.ReactElement | null {
         };
     }, [channel]);
 
+    // Keep the site navbar fixed while chat is open. ChatView is position:fixed
+    // for the pane, but mobile browsers can still scroll the document and
+    // push the navbar off-screen (#3011).
+    useEffect(() => {
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, []);
+
     useEffect(() => {
         set_showing_channels(false);
         set_showing_users(false);


### PR DESCRIPTION
ChatView is position:fixed under the navbar, but mobile browsers can still scroll the document and push the navbar off-screen. Lock body overflow while the chat page is mounted and disable overscroll chaining.