### PR TITLE
Increase z-index and spacing for resign/cancel button

### DIFF
--- a/src/views/Game/PlayControls.css
+++ b/src/views/Game/PlayControls.css
@@ -182,7 +182,7 @@
 
     .cancel-button {
         position: relative;
-        z-index: 2;
+        z-index: calc(var(--z-dock) + 1);
         margin-left: 0.5rem;
     }
 

--- a/src/views/Game/PlayControls.css
+++ b/src/views/Game/PlayControls.css
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 .PlayControls {
     flex-grow: 0;
     flex-shrink: 0;
@@ -165,11 +181,9 @@
     }
 
     .cancel-button {
-        /*
-        position: absolute;
-        right: 0.5em;
-        bottom: 0.5em;
-        */
+        position: relative;
+        z-index: 2;
+        margin-left: 0.5rem;
     }
 
     .undo-button {


### PR DESCRIPTION
…ap with game info panel (#3564)

The resign button can be covered by the expanding Dock or info panel when the mouse approaches it. Give the button a higher stacking context and a small margin so it remains reachable.