### PR TITLE
Fix stored XSS in private chat message rendering

### DIFF
--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -628,7 +628,12 @@ class PrivateChat {
         }
 
         const message = document.createElement("span");
-        message.innerHTML = chat_markup(profanity_filter(txt)) || "";
+        const message_nodes = chat_markup(profanity_filter(txt));
+        if (message_nodes) {
+            for (const node of message_nodes) {
+                message.appendChild(node);
+            }
+        }
         line.appendChild(message);
 
         this.lines.push(line);
@@ -961,37 +966,113 @@ export function getPrivateChat(user_id: number, username?: string) {
     return pc;
 }
 
-function chat_markup(body: string): string | undefined {
-    if (typeof body === "string") {
-        const div = document.createElement("div");
-        div.textContent = body;
-        let ret = div.innerHTML;
-        // Some link urls can have an @-sign in. Be careful not to cause the link_matcher
-        // and email_matcher to overlap! See for example
-        // https://www.google.co.uk/maps/place/Platform+9%C2%BE/@51.5321578,-0.1261661
-        const link_matcher = /(((ftp|http)(s)?:\/\/)([^<> ]+))/gi;
-        ret = ret.replace(
-            link_matcher,
-            (match) =>
-                "<a target='_blank' href='" +
-                match.replace("@", "%40") +
-                "'>" +
-                match.replace("@", "&commat;") +
-                "</a>",
-        );
-        const email_matcher = /([^<> ]+[@][^<> ]+[.][^<> ]+)/gi;
-        ret = ret.replace(email_matcher, "<a target='_blank' href='mailto:$1'>$1</a>");
-        const review_matcher = /(^##([0-9]{3,})|([ ])##([0-9]{3,}))/gi;
-        ret = ret.replace(review_matcher, "<a target='_blank' href='/review/$2$4'>$3##$2$4</a>");
-        const game_matcher = /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi;
-        ret = ret.replace(game_matcher, "<a target='_blank' href='/game/$2$4'>$3#$2$4</a>");
-        const player_matcher = /(player ([0-9]+))/gi;
-        ret = ret.replace(player_matcher, "<a target='_blank' href='/user/view/$2'>$1</a>");
-        const group_matcher = /(#group-([0-9]+))/gi;
-        ret = ret.replace(group_matcher, "<a target='_blank' href='/group/$2'>$1</a>");
-        return ret;
-    } else {
+function chat_markup(body: string): Node[] | undefined {
+    if (typeof body !== "string") {
         console.log("Attempted to markup non-text object: ", body);
+        return;
     }
-    return;
+
+    const rules: Array<{ pattern: RegExp; render: (m: RegExpExecArray) => HTMLAnchorElement }> = [
+        {
+            pattern: /((?:ftp|http)s?:\/\/[^<> ]+)/gi,
+            render: (m) => {
+                const a = document.createElement("a");
+                a.target = "_blank";
+                a.href = m[1].replace("@", "%40");
+                a.textContent = m[1];
+                return a;
+            },
+        },
+        {
+            pattern: /[^<> ]+[@][^<> ]+[.][^<> ]+/gi,
+            render: (m) => {
+                const a = document.createElement("a");
+                a.target = "_blank";
+                a.href = "mailto:" + m[0];
+                a.textContent = m[0];
+                return a;
+            },
+        },
+        {
+            pattern: /(^##([0-9]{3,})|([ ])##([0-9]{3,}))/gi,
+            render: (m) => {
+                const a = document.createElement("a");
+                a.target = "_blank";
+                a.href = `/review/${m[2] || m[4] || ""}`;
+                a.textContent = `${m[3] || ""}##${m[2] || m[4] || ""}`;
+                return a;
+            },
+        },
+        {
+            pattern: /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi,
+            render: (m) => {
+                const a = document.createElement("a");
+                a.target = "_blank";
+                a.href = `/game/${m[2] || m[4] || ""}`;
+                a.textContent = `${m[3] || ""}#${m[2] || m[4] || ""}`;
+                return a;
+            },
+        },
+        {
+            pattern: /(player ([0-9]+))/gi,
+            render: (m) => {
+                const a = document.createElement("a");
+                a.target = "_blank";
+                a.href = `/user/view/${m[2]}`;
+                a.textContent = m[1];
+                return a;
+            },
+        },
+        {
+            pattern: /(#group-([0-9]+))/gi,
+            render: (m) => {
+                const a = document.createElement("a");
+                a.target = "_blank";
+                a.href = `/group/${m[2]}`;
+                a.textContent = m[1];
+                return a;
+            },
+        },
+    ];
+
+    const nodes: Node[] = [];
+    let pos = 0;
+
+    while (pos < body.length) {
+        let matched: {
+            m: RegExpExecArray;
+            render: (m: RegExpExecArray) => HTMLAnchorElement;
+        } | null = null;
+
+        for (const rule of rules) {
+            rule.pattern.lastIndex = pos;
+            const m = rule.pattern.exec(body);
+            if (m && m.index === pos) {
+                matched = { m, render: rule.render };
+                break;
+            }
+        }
+
+        if (matched && matched.m[0].length > 0) {
+            nodes.push(matched.render(matched.m));
+            pos = matched.m.index + matched.m[0].length;
+            continue;
+        }
+
+        let next = body.length;
+        for (const rule of rules) {
+            rule.pattern.lastIndex = pos + 1;
+            const m = rule.pattern.exec(body);
+            if (m && m.index < next) {
+                next = m.index;
+            }
+        }
+        if (next <= pos) {
+            next = pos + 1;
+        }
+        nodes.push(document.createTextNode(body.substring(pos, next)));
+        pos = next;
+    }
+
+    return nodes;
 }

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -30,6 +30,7 @@ import * as player_cache from "@/lib/player_cache";
 import online_status from "@/lib/online_status";
 import { openReport } from "@/components/Report";
 import { alert } from "@/lib/swal_config";
+import { chat_markup } from "./chat_markup";
 import { nicknameTabComplete } from "./tab_complete";
 import "./PrivateChat.css";
 
@@ -964,115 +965,4 @@ export function getPrivateChat(user_id: number, username?: string) {
         pc = instances[user_id] = new PrivateChat(user_id, username ?? "<unknown>");
     }
     return pc;
-}
-
-function chat_markup(body: string): Node[] | undefined {
-    if (typeof body !== "string") {
-        console.log("Attempted to markup non-text object: ", body);
-        return;
-    }
-
-    const rules: Array<{ pattern: RegExp; render: (m: RegExpExecArray) => HTMLAnchorElement }> = [
-        {
-            pattern: /((?:ftp|http)s?:\/\/[^<> ]+)/gi,
-            render: (m) => {
-                const a = document.createElement("a");
-                a.target = "_blank";
-                a.href = m[1].replace("@", "%40");
-                a.textContent = m[1];
-                return a;
-            },
-        },
-        {
-            pattern: /[^<> ]+[@][^<> ]+[.][^<> ]+/gi,
-            render: (m) => {
-                const a = document.createElement("a");
-                a.target = "_blank";
-                a.href = "mailto:" + m[0];
-                a.textContent = m[0];
-                return a;
-            },
-        },
-        {
-            pattern: /(^##([0-9]{3,})|([ ])##([0-9]{3,}))/gi,
-            render: (m) => {
-                const a = document.createElement("a");
-                a.target = "_blank";
-                a.href = `/review/${m[2] || m[4] || ""}`;
-                a.textContent = `${m[3] || ""}##${m[2] || m[4] || ""}`;
-                return a;
-            },
-        },
-        {
-            pattern: /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi,
-            render: (m) => {
-                const a = document.createElement("a");
-                a.target = "_blank";
-                a.href = `/game/${m[2] || m[4] || ""}`;
-                a.textContent = `${m[3] || ""}#${m[2] || m[4] || ""}`;
-                return a;
-            },
-        },
-        {
-            pattern: /(player ([0-9]+))/gi,
-            render: (m) => {
-                const a = document.createElement("a");
-                a.target = "_blank";
-                a.href = `/user/view/${m[2]}`;
-                a.textContent = m[1];
-                return a;
-            },
-        },
-        {
-            pattern: /(#group-([0-9]+))/gi,
-            render: (m) => {
-                const a = document.createElement("a");
-                a.target = "_blank";
-                a.href = `/group/${m[2]}`;
-                a.textContent = m[1];
-                return a;
-            },
-        },
-    ];
-
-    const nodes: Node[] = [];
-    let pos = 0;
-
-    while (pos < body.length) {
-        let matched: {
-            m: RegExpExecArray;
-            render: (m: RegExpExecArray) => HTMLAnchorElement;
-        } | null = null;
-
-        for (const rule of rules) {
-            rule.pattern.lastIndex = pos;
-            const m = rule.pattern.exec(body);
-            if (m && m.index === pos) {
-                matched = { m, render: rule.render };
-                break;
-            }
-        }
-
-        if (matched && matched.m[0].length > 0) {
-            nodes.push(matched.render(matched.m));
-            pos = matched.m.index + matched.m[0].length;
-            continue;
-        }
-
-        let next = body.length;
-        for (const rule of rules) {
-            rule.pattern.lastIndex = pos + 1;
-            const m = rule.pattern.exec(body);
-            if (m && m.index < next) {
-                next = m.index;
-            }
-        }
-        if (next <= pos) {
-            next = pos + 1;
-        }
-        nodes.push(document.createTextNode(body.substring(pos, next)));
-        pos = next;
-    }
-
-    return nodes;
 }

--- a/src/components/PrivateChat/chat_markup.test.ts
+++ b/src/components/PrivateChat/chat_markup.test.ts
@@ -64,6 +64,13 @@ test("adjacent urls are linked separately", () => {
     expect(links[1].getAttribute("href")).toBe("http://b.com");
 });
 
+test("many repeated tokens are all linked", () => {
+    const message = "http://a.com ".repeat(500).trimEnd();
+    const nodes = chat_markup(message);
+    expect(linkNodes(nodes)).toHaveLength(500);
+    expect(textOf(nodes)).toBe(message);
+});
+
 test("url containing an at sign is not parsed as an e-mail address", () => {
     const nodes = chat_markup("https://www.google.com/maps/@50.7,-3.1,13.75z");
     const links = linkNodes(nodes);

--- a/src/components/PrivateChat/chat_markup.test.ts
+++ b/src/components/PrivateChat/chat_markup.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { chat_markup } from "./chat_markup";
+
+function linkNodes(nodes: Node[] | undefined): HTMLAnchorElement[] {
+    if (!nodes) {
+        return [];
+    }
+    return nodes.filter((node): node is HTMLAnchorElement => node.nodeName === "A");
+}
+
+function textOf(nodes: Node[] | undefined): string {
+    if (!nodes) {
+        return "";
+    }
+    return nodes.map((node) => node.textContent ?? "").join("");
+}
+
+test("plain text is returned as a single text node", () => {
+    const nodes = chat_markup("This is a normal message.");
+    expect(textOf(nodes)).toBe("This is a normal message.");
+    expect(linkNodes(nodes)).toHaveLength(0);
+});
+
+test("empty string produces no nodes", () => {
+    expect(chat_markup("")).toEqual([]);
+});
+
+test("non-string input returns undefined", () => {
+    expect(chat_markup(42 as unknown as string)).toBeUndefined();
+});
+
+test("urls are linked with safe attributes", () => {
+    const nodes = chat_markup("see http://example.com now");
+    const links = linkNodes(nodes);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("http://example.com");
+    expect(links[0].getAttribute("target")).toBe("_blank");
+    /* cspell:disable-next-line */
+    expect(links[0].getAttribute("rel")).toBe("noopener noreferrer");
+    expect(textOf(nodes)).toBe("see http://example.com now");
+});
+
+test("adjacent urls are linked separately", () => {
+    const nodes = chat_markup("http://a.com http://b.com");
+    const links = linkNodes(nodes);
+    expect(links).toHaveLength(2);
+    expect(links[0].getAttribute("href")).toBe("http://a.com");
+    expect(links[1].getAttribute("href")).toBe("http://b.com");
+});
+
+test("url containing an at sign is not parsed as an e-mail address", () => {
+    const nodes = chat_markup("https://www.google.com/maps/@50.7,-3.1,13.75z");
+    const links = linkNodes(nodes);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("https://www.google.com/maps/%4050.7,-3.1,13.75z");
+    expect(textOf(nodes)).toBe("https://www.google.com/maps/@50.7,-3.1,13.75z");
+});
+
+test("e-mail addresses are turned into mailto links", () => {
+    const nodes = chat_markup("mail john.doe@example.com today");
+    const links = linkNodes(nodes);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("mailto:john.doe@example.com");
+    expect(textOf(nodes)).toBe("mail john.doe@example.com today");
+});
+
+test("review references are linked", () => {
+    const at_start = chat_markup("##123");
+    expect(linkNodes(at_start)[0].getAttribute("href")).toBe("/review/123");
+    expect(textOf(at_start)).toBe("##123");
+
+    const mid_message = chat_markup("see ##456 now");
+    expect(linkNodes(mid_message)[0].getAttribute("href")).toBe("/review/456");
+    expect(textOf(mid_message)).toBe("see ##456 now");
+});
+
+test("game references are linked", () => {
+    const at_start = chat_markup("#123");
+    expect(linkNodes(at_start)[0].getAttribute("href")).toBe("/game/123");
+    expect(textOf(at_start)).toBe("#123");
+
+    const mid_message = chat_markup("play #456 now");
+    expect(linkNodes(mid_message)[0].getAttribute("href")).toBe("/game/456");
+    expect(textOf(mid_message)).toBe("play #456 now");
+});
+
+test("player references are linked", () => {
+    const nodes = chat_markup("hello player 123");
+    expect(linkNodes(nodes)[0].getAttribute("href")).toBe("/user/view/123");
+    expect(textOf(nodes)).toBe("hello player 123");
+});
+
+test("group references are linked", () => {
+    const nodes = chat_markup("join #group-77");
+    expect(linkNodes(nodes)[0].getAttribute("href")).toBe("/group/77");
+    expect(textOf(nodes)).toBe("join #group-77");
+});
+
+test("quotes inside urls cannot inject attributes", () => {
+    const nodes = chat_markup("http://x/'onmouseover='alert(1)");
+    const links = linkNodes(nodes);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("http://x/'onmouseover='alert(1)");
+    expect(links[0].hasAttribute("onmouseover")).toBe(false);
+    expect(links[0].hasAttribute("onclick")).toBe(false);
+});
+
+test("html tags are rendered as text, not as elements", () => {
+    const nodes = chat_markup("<script>alert(1)</script><img src=x onerror=alert(1)>");
+    for (const node of nodes ?? []) {
+        expect(node.nodeType).toBe(Node.TEXT_NODE);
+    }
+    expect(textOf(nodes)).toBe("<script>alert(1)</script><img src=x onerror=alert(1)>");
+});
+
+test("mixed content keeps ordering and text", () => {
+    const nodes = chat_markup("##123 #456 player 789 http://a.com text");
+    const links = linkNodes(nodes);
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+        "/review/123",
+        "/game/456",
+        "/user/view/789",
+        "http://a.com",
+    ]);
+    expect(textOf(nodes)).toBe("##123 #456 player 789 http://a.com text");
+});

--- a/src/components/PrivateChat/chat_markup.ts
+++ b/src/components/PrivateChat/chat_markup.ts
@@ -66,42 +66,40 @@ export function chat_markup(body: string): Node[] | undefined {
     }
 
     const nodes: Node[] = [];
-    let pos = 0;
+    const combined = new RegExp(rules.map((rule) => `(${rule.pattern.source})`).join("|"), "gi");
 
-    while (pos < body.length) {
-        let matched: {
-            m: RegExpExecArray;
-            render: (m: RegExpExecArray) => HTMLAnchorElement;
-        } | null = null;
-
-        for (const rule of rules) {
-            rule.pattern.lastIndex = pos;
-            const m = rule.pattern.exec(body);
-            if (m && m.index === pos) {
-                matched = { m, render: rule.render };
-                break;
-            }
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = combined.exec(body)) !== null) {
+        if (m.index > last) {
+            nodes.push(document.createTextNode(body.substring(last, m.index)));
         }
 
-        if (matched && matched.m[0].length > 0) {
-            nodes.push(matched.render(matched.m));
-            pos = matched.m.index + matched.m[0].length;
+        if (m[0].length === 0) {
+            last = Math.min(last + 1, body.length);
+            combined.lastIndex = Math.max(combined.lastIndex, m.index + 1);
             continue;
         }
 
-        let next = body.length;
+        let rendered = false;
         for (const rule of rules) {
-            rule.pattern.lastIndex = pos + 1;
-            const m = rule.pattern.exec(body);
-            if (m && m.index < next) {
-                next = m.index;
+            rule.pattern.lastIndex = 0;
+            const match = rule.pattern.exec(m[0]);
+            if (match && match.index === 0 && match[0].length === m[0].length) {
+                nodes.push(rule.render(match));
+                rendered = true;
+                break;
             }
         }
-        if (next <= pos) {
-            next = pos + 1;
+        if (!rendered) {
+            nodes.push(document.createTextNode(m[0]));
         }
-        nodes.push(document.createTextNode(body.substring(pos, next)));
-        pos = next;
+
+        last = m.index + m[0].length;
+    }
+
+    if (last < body.length) {
+        nodes.push(document.createTextNode(body.substring(last)));
     }
 
     return nodes;

--- a/src/components/PrivateChat/chat_markup.ts
+++ b/src/components/PrivateChat/chat_markup.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+interface ChatMarkupRule {
+    pattern: RegExp;
+    render: (m: RegExpExecArray) => HTMLAnchorElement;
+}
+
+function createLink(href: string, text: string): HTMLAnchorElement {
+    const a = document.createElement("a");
+    a.target = "_blank";
+    /* cspell:disable-next-line */
+    a.rel = "noopener noreferrer";
+    a.href = href;
+    a.textContent = text;
+    return a;
+}
+
+const rules: ChatMarkupRule[] = [
+    {
+        pattern: /((?:ftp|http)s?:\/\/[^<> ]+)/gi,
+        render: (m) => createLink(m[1].replace("@", "%40"), m[1]),
+    },
+    {
+        pattern: /[^<> ]+[@][^<> ]+[.][^<> ]+/gi,
+        render: (m) => createLink("mailto:" + m[0], m[0]),
+    },
+    {
+        pattern: /(^##([0-9]{3,})|([ ])##([0-9]{3,}))/gi,
+        render: (m) =>
+            createLink(`/review/${m[2] || m[4] || ""}`, `${m[3] || ""}##${m[2] || m[4] || ""}`),
+    },
+    {
+        pattern: /(^#([0-9]{3,})|([ ])#([0-9]{3,}))/gi,
+        render: (m) =>
+            createLink(`/game/${m[2] || m[4] || ""}`, `${m[3] || ""}#${m[2] || m[4] || ""}`),
+    },
+    {
+        pattern: /(player ([0-9]+))/gi,
+        render: (m) => createLink(`/user/view/${m[2]}`, m[1]),
+    },
+    {
+        pattern: /(#group-([0-9]+))/gi,
+        render: (m) => createLink(`/group/${m[2]}`, m[1]),
+    },
+];
+
+export function chat_markup(body: string): Node[] | undefined {
+    if (typeof body !== "string") {
+        console.log("Attempted to markup non-text object: ", body);
+        return;
+    }
+
+    const nodes: Node[] = [];
+    let pos = 0;
+
+    while (pos < body.length) {
+        let matched: {
+            m: RegExpExecArray;
+            render: (m: RegExpExecArray) => HTMLAnchorElement;
+        } | null = null;
+
+        for (const rule of rules) {
+            rule.pattern.lastIndex = pos;
+            const m = rule.pattern.exec(body);
+            if (m && m.index === pos) {
+                matched = { m, render: rule.render };
+                break;
+            }
+        }
+
+        if (matched && matched.m[0].length > 0) {
+            nodes.push(matched.render(matched.m));
+            pos = matched.m.index + matched.m[0].length;
+            continue;
+        }
+
+        let next = body.length;
+        for (const rule of rules) {
+            rule.pattern.lastIndex = pos + 1;
+            const m = rule.pattern.exec(body);
+            if (m && m.index < next) {
+                next = m.index;
+            }
+        }
+        if (next <= pos) {
+            next = pos + 1;
+        }
+        nodes.push(document.createTextNode(body.substring(pos, next)));
+        pos = next;
+    }
+
+    return nodes;
+}


### PR DESCRIPTION
Got surprised this time lol, found stored XSS in private messages.

Incoming text was getting shoved into `innerHTML` and the escaping only handled <, >, and &, quotes were left alone. So a link like `http://x/'onmouseover='alert(1)` broke out of the href attribute and the browser parsed the injected handler as real HTML

Since messages persist, all it takes is the recipient hovering or clicking, and it survives reloads. There was an earlier sanitization pass but it only normalized whitespace and never actually touched incoming messages, so this was never caught.

Reachable cross-user: attacker to victim via the private-message socket event. Stores in chat/pm/load re-renders history on reload through the same path.

Fixed it by rendering messages as DOM nodes instead of HTML strings. Text is now text nodes, links are built as real <a> elements through the DOM API. No innerHTML anywhere in the path, so no attribute breakout, no javascript payloads

Also swept the rest of chat and notifications for the same pattern, this was the only sink. Found another bug but completely unrelated to this one. Felt like detaching it from this pr though.

Tests passing