### PR TITLE
Fix open redirect, JavaScript execution and tab-nabbing vulnerabilities

### DIFF
--- a/src/components/Chat/chat_markup.test.tsx
+++ b/src/components/Chat/chat_markup.test.tsx
@@ -32,13 +32,25 @@ test("No markup", () => {
 test("GitHub", () => {
     expect_singular_markup(
         "https://github.com/online-go/online-go.com/pull/1",
-        <a key={0} target="_blank" href={"https://github.com/online-go/online-go.com/pull/1"}>
+        <a
+            key={0}
+            target="_blank"
+            /* cspell:disable-next-line */
+            rel="noopener noreferrer"
+            href={"https://github.com/online-go/online-go.com/pull/1"}
+        >
             {"GH-1"}
         </a>,
     );
     expect_singular_markup(
         "https://github.com/online-go/online-go.com/issues/4",
-        <a key={0} target="_blank" href={"https://github.com/online-go/online-go.com/issues/4"}>
+        <a
+            key={0}
+            target="_blank"
+            /* cspell:disable-next-line */
+            rel="noopener noreferrer"
+            href={"https://github.com/online-go/online-go.com/issues/4"}
+        >
             {"GH-4"}
         </a>,
     );
@@ -47,7 +59,13 @@ test("GitHub", () => {
 test("E-mail", () => {
     expect_singular_markup(
         "john.doe@emailhost.com",
-        <a key={0} target="_blank" href={"mailto:john.doe@emailhost.com"}>
+        <a
+            key={0}
+            target="_blank"
+            /* cspell:disable-next-line */
+            rel="noopener noreferrer"
+            href={"mailto:john.doe@emailhost.com"}
+        >
             {"john.doe@emailhost.com"}
         </a>,
     );
@@ -60,6 +78,8 @@ test("Google Maps link not parsed as e-mail", () => {
         <a
             key={0}
             target="_blank"
+            /* cspell:disable-next-line */
+            rel="noopener noreferrer"
             href={"https://www.google.com/maps/@50.7006874,-3.0915427,13.75z"}
         >
             {"https://www.google.com/maps/@50.7006874,-3.0915427,13.75z"}

--- a/src/components/Chat/chat_markup.tsx
+++ b/src/components/Chat/chat_markup.tsx
@@ -37,6 +37,8 @@ const global_replacements: TextReplacement[] = [
             <a
                 key={idx}
                 target="_blank"
+                /* cspell:disable-next-line */
+                rel="noopener noreferrer"
                 href={`https://github.com/online-go/online-go.com/pull/${m[2]}`}
             >
                 {"GH-" + m[2]}
@@ -51,6 +53,8 @@ const global_replacements: TextReplacement[] = [
             <a
                 key={idx}
                 target="_blank"
+                /* cspell:disable-next-line */
+                rel="noopener noreferrer"
                 href={`https://github.com/online-go/online-go.com/issues/${m[2]}`}
             >
                 {"GH-" + m[2]}
@@ -64,6 +68,8 @@ const global_replacements: TextReplacement[] = [
             <a
                 key={idx}
                 target="_blank"
+                /* cspell:disable-next-line */
+                rel="noopener noreferrer"
                 href={`https://github.com/online-go/online-go.com/issues/${m[2]}`}
             >
                 {m[1] + "-" + m[2]}
@@ -97,7 +103,13 @@ const global_replacements: TextReplacement[] = [
         pattern:
             /\b(https?:\/\/forums\.online-go\.com\/t\/([a-zA-Z0-9-]+)\/[0-9]+(?:\/[0-9]+)?(?:\?[^\/<> ]+)?(?:\/|\b))/i,
         replacement: (m, idx) => (
-            <a key={idx} target="_blank" href={m[1]}>
+            <a
+                key={idx}
+                target="_blank"
+                /* cspell:disable-next-line */
+                rel="noopener noreferrer"
+                href={m[1]}
+            >
                 {m[2].replace(/(\-)/i, " ")}
             </a>
         ),
@@ -354,7 +366,13 @@ const global_replacements: TextReplacement[] = [
         split: /\b(https?:\/\/senseis\.xmp\.net\/\?(?:[^\/<> ]+)*(?:\/|\b))/i,
         pattern: /\b(https?:\/\/senseis\.xmp\.net\/\?([^\/<> ]+)(?:\/|\b))/i,
         replacement: (m, idx) => (
-            <a key={idx} target="_blank" href={m[1]}>
+            <a
+                key={idx}
+                target="_blank"
+                /* cspell:disable-next-line */
+                rel="noopener noreferrer"
+                href={m[1]}
+            >
                 {"senseis: " + m[2]}
             </a>
         ),
@@ -364,7 +382,13 @@ const global_replacements: TextReplacement[] = [
         split: /\b([A-Za-z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}(?:\/|\b))/i,
         pattern: /\b([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}(?:\/|\b))/i,
         replacement: (m, idx) => (
-            <a key={idx} target="_blank" href={"mailto:" + m[1]}>
+            <a
+                key={idx}
+                target="_blank"
+                /* cspell:disable-next-line */
+                rel="noopener noreferrer"
+                href={"mailto:" + m[1]}
+            >
                 {m[1]}
             </a>
         ),
@@ -375,7 +399,13 @@ const global_replacements: TextReplacement[] = [
         split: /(https?:\/\/[^<> ]+)/i,
         pattern: /(https?:\/\/[^<> ]+)/i,
         replacement: (m, idx) => (
-            <a key={idx} target="_blank" href={m[1]}>
+            <a
+                key={idx}
+                target="_blank"
+                /* cspell:disable-next-line */
+                rel="noopener noreferrer"
+                href={m[1]}
+            >
                 {m[1]}
             </a>
         ),

--- a/src/components/IncidentReportTracker/IncidentReportCard.tsx
+++ b/src/components/IncidentReportTracker/IncidentReportCard.tsx
@@ -172,7 +172,12 @@ export function IncidentReportCard({ report }: IncidentReportCardProps): React.R
 
             <div className="spread">
                 {report.url && (
-                    <a href={report.url} target="_blank">
+                    <a
+                        href={report.url}
+                        target="_blank"
+                        /* cspell:disable-next-line */
+                        rel="noopener noreferrer"
+                    >
                         {report.url}
                     </a>
                 )}

--- a/src/lib/url_validation.test.ts
+++ b/src/lib/url_validation.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { is_valid_url, valid_next_url } from "./url_validation";
+
+describe("valid_next_url", () => {
+    test("accepts a bare root path", () => {
+        expect(valid_next_url("/")).toBe("/");
+    });
+
+    test("accepts an internal relative path", () => {
+        expect(valid_next_url("/game/12345")).toBe("/game/12345");
+    });
+
+    test("accepts an internal path with query and hash", () => {
+        expect(valid_next_url("/group/42?tab=players#schedule")).toBe(
+            "/group/42?tab=players#schedule",
+        );
+    });
+
+    test("accepts a same-origin absolute url, normalized to a path", () => {
+        expect(valid_next_url(window.location.origin + "/welcome")).toBe("/welcome");
+    });
+
+    test("rejects a javascript url", () => {
+        expect(valid_next_url("javascript:alert(1)")).toBeNull();
+    });
+
+    test("rejects a javascript url with leading whitespace", () => {
+        expect(valid_next_url("  javascript:alert(1)")).toBeNull();
+    });
+
+    test("rejects a data url", () => {
+        expect(valid_next_url("data:text/html,<script>alert(1)</script>")).toBeNull();
+    });
+
+    test("rejects an off-site url", () => {
+        expect(valid_next_url("https://evil.example/phish")).toBeNull();
+    });
+
+    test("rejects a protocol-relative url", () => {
+        expect(valid_next_url("//evil.example/phish")).toBeNull();
+    });
+
+    test("rejects a protocol-relative url using backslashes", () => {
+        expect(valid_next_url("/\\evil.example/phish")).toBeNull();
+    });
+
+    test("rejects an embedded-tab protocol-relative url (control chars are stripped by the browser)", () => {
+        expect(valid_next_url("/\t/evil.example/phish")).toBeNull();
+        expect(valid_next_url("/\n/evil.example/phish")).toBeNull();
+        expect(valid_next_url("/\r/evil.example/phish")).toBeNull();
+    });
+
+    test("strips harmless internal control characters on a safe path", () => {
+        expect(valid_next_url("/game/\t12345")).toBe("/game/12345");
+    });
+
+    test("rejects null, empty and whitespace-only input", () => {
+        expect(valid_next_url(null)).toBeNull();
+        expect(valid_next_url("")).toBeNull();
+        expect(valid_next_url("   ")).toBeNull();
+    });
+});
+
+describe("is_valid_url", () => {
+    test("accepts http and https urls", () => {
+        expect(is_valid_url("https://example.com")).toBe(true);
+        expect(is_valid_url("http://example.com")).toBe(true);
+    });
+
+    test("rejects javascript and data urls", () => {
+        expect(is_valid_url("javascript:alert(1)")).toBe(false);
+        expect(is_valid_url("data:text/html,<script>alert(1)</script>")).toBe(false);
+    });
+
+    test("rejects empty and non-string input", () => {
+        expect(is_valid_url("")).toBe(false);
+        expect(is_valid_url(undefined as unknown as string)).toBe(false);
+    });
+});

--- a/src/lib/url_validation.ts
+++ b/src/lib/url_validation.ts
@@ -21,3 +21,46 @@ export function is_valid_url(url: string): boolean {
     }
     return /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)\/?$/.test(url.toLowerCase());
 }
+
+/**
+ * Validates a `?next=` redirect target coming from the URL query string before
+ * it is handed to `window.location` after sign-in or registration.
+ *
+ * Only same-origin targets are accepted. Anything else - off-site URLs,
+ * `javascript:`, `data:`, and other non-http schemes - is rejected, since
+ * assigning it to `location.href` would either redirect the user off the site
+ * after authenticating, or, in the case of a `javascript:` URL, execute
+ * attacker-controlled code in the OGS origin with the freshly-established
+ * session.
+ *
+ * The value is always run through the URL parser rather than inspected with
+ * string prefix checks. Prefix checks are unsafe here: browsers strip embedded
+ * ASCII tab/newline characters while parsing a URL, so a value like `/%09/evil.com`
+ * passes a `startsWith("/")` check but normalizes to `//evil.com` (an off-site
+ * redirect) once assigned to `location.href`. The URL parser performs the same
+ * normalization as the browser, so the origin comparison below sees exactly what
+ * the browser would navigate to.
+ *
+ * Returns the trimmed safe target, or null if it is not safe to navigate to.
+ */
+export function valid_next_url(next: string | null): string | null {
+    if (!next || typeof next !== "string") {
+        return null;
+    }
+
+    const url = next.trim();
+    if (url === "") {
+        return null;
+    }
+
+    try {
+        const parsed = new URL(url, window.location.origin);
+        if (parsed.origin === window.location.origin) {
+            return parsed.pathname + parsed.search + parsed.hash;
+        }
+    } catch {
+        /* malformed URL, fall through to null */
+    }
+
+    return null;
+}

--- a/src/views/Register/Register.tsx
+++ b/src/views/Register/Register.tsx
@@ -23,6 +23,7 @@ import { _, pgettext } from "@/lib/translate";
 import { Card } from "@/components/material";
 import { errorAlerter } from "@/lib/misc";
 import { post } from "@/lib/requests";
+import { valid_next_url } from "@/lib/url_validation";
 import { get_ebi } from "@/views/SignIn";
 import { useUser } from "@/lib/hooks";
 import cached from "@/lib/cached";
@@ -43,7 +44,7 @@ export function Register(): React.ReactElement {
     const [submitLoading, setSubmitLoading] = React.useState(false);
 
     // Get the next URL from query params (for OAuth flow)
-    const nextParam = searchParams.get("next");
+    const nextParam = valid_next_url(searchParams.get("next"));
     const socialNextUrl = nextParam || "/wait-for-user#" + window.location.hash.substring(1);
 
     if (!user.anonymous) {

--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -23,6 +23,7 @@ import { _ } from "@/lib/translate";
 import { Card } from "@/components/material";
 import { errorAlerter, uuid } from "@/lib/misc";
 import { post } from "@/lib/requests";
+import { valid_next_url } from "@/lib/url_validation";
 import cached from "@/lib/cached";
 import { Md5 } from "ts-md5";
 import { useUser } from "@/lib/hooks";
@@ -98,7 +99,7 @@ export function SignIn(): React.ReactElement {
     }
 
     // Get the next URL from query params (for OAuth flow) or hash (for regular flow)
-    const nextParam = searchParams.get("next");
+    const nextParam = valid_next_url(searchParams.get("next"));
     const socialNextUrl = nextParam || "/wait-for-user#" + window.location.hash.substring(1);
 
     const onSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
@@ -141,8 +142,9 @@ export function SignIn(): React.ReactElement {
 
                     // Note: this causes a page reload, and the new user is set up from scratch in the process
                     // Check for ?next= query parameter first (used by OAuth authorization flow)
-                    const searchParams = new URLSearchParams(window.location.search);
-                    const nextParam = searchParams.get("next");
+                    const nextParam = valid_next_url(
+                        new URLSearchParams(window.location.search).get("next"),
+                    );
 
                     if (nextParam) {
                         // Redirect to the ?next= URL (for OAuth authorization flow)


### PR DESCRIPTION
A few things stacked together here.

The `?next=` param on `/sign-in` and `/register` was getting handed straight to `window.location.href` after login. No checks at all. Meaning someone could craft a `?next=javascript:....` link and once the victim logs in, it runs arbitrary code into OGS origin, with their brand new session attached. Thats basically full account takeover from one click.

Same param also let off-site URLs through, so people could get redirected clean off the site right after authenticating too.

Fix is `valid_next_url()`: it only lets same-origin relative paths or same-origin absolute URLs through, and it'll reject anything `javascript:`, `data:`, off-site, or protocol-relative. Wrote unit tests for both what it should accept and reject, including the sneaky ones with encoding and whitespace tricks people use to slip past filters

Another related issue: external links built from user input, in `chat_markup.tsx` and also `IncidentReportCard.tsx`, were using `target=_blank` **without** `rel=noopener`. That means the tab you just opened could reach back and control the original OGS tab through `window.opener`, classic reverse tab-nabbing, good for phishing. Added `rel="noopener noreferrer"` on those and updated the chat markup tests so they match now.

All tests pass