### PR TITLE
Fix open redirect via ?return= and harden remaining tab-nabbing links

### DIFF
--- a/src/components/ACLModal/ACLModal.tsx
+++ b/src/components/ACLModal/ACLModal.tsx
@@ -152,6 +152,7 @@ export class ACLModal extends Modal<Events, ACLModalProperties, any> {
                                         target="_blank"
                                         href={`/group/${obj.group_id}`}
                                         className="group"
+                                        rel="noopener noreferrer"
                                     >
                                         {obj.group_name}
                                     </a>

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -1031,6 +1031,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
                                         href="https://github.com/online-go/online-go.com/wiki/Rengo"
                                         className="help"
                                         target="_blank"
+                                        rel="noopener noreferrer"
                                     >
                                         <i className="fa fa-question-circle-o"></i>
                                     </a>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -625,6 +625,7 @@ const MenuLink = forwardRef<HTMLElement, MenuLinkProps>(
             Element = "a";
             elementProps.href = to;
             elementProps.target = target;
+            elementProps.rel = "noopener noreferrer";
         } else {
             // Internal link
             Element = Link;

--- a/src/components/NavBar/OmniSearch.tsx
+++ b/src/components/NavBar/OmniSearch.tsx
@@ -99,7 +99,7 @@ export function OmniSearch(props: OmniSearchProperties): React.ReactElement | nu
                             {e?.[1]?.[0] === "/" ? (
                                 <Link to={e[1]}>{e[0]}</Link>
                             ) : (
-                                <a href={e[1]} target="_blank">
+                                <a href={e[1]} target="_blank" rel="noopener noreferrer">
                                     {e[0]}
                                 </a>
                             )}

--- a/src/views/AnnouncementCenter/AnnouncementCenter.tsx
+++ b/src/views/AnnouncementCenter/AnnouncementCenter.tsx
@@ -1042,7 +1042,11 @@ export function AnnouncementCenter(): React.ReactElement {
                                             {a.entries.map(
                                                 (entry: AnnouncementEntry, idx: number) => (
                                                     <div key={idx}>
-                                                        <a href={entry.link} target="_blank">
+                                                        <a
+                                                            href={entry.link}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                        >
                                                             {entry.en || entry.link}
                                                         </a>
                                                     </div>

--- a/src/views/Developer/Developer.tsx
+++ b/src/views/Developer/Developer.tsx
@@ -47,7 +47,7 @@ export class Developer extends React.PureComponent {
                 <h1>API Documentation</h1>
                 <h2>(out-dated)</h2>
                 <h2>
-                    <a href="https://docs.online-go.com" target="_blank">
+                    <a href="https://docs.online-go.com" target="_blank" rel="noopener noreferrer">
                         https://docs.online-go.com
                     </a>
                 </h2>

--- a/src/views/Game/GameDock.tsx
+++ b/src/views/Game/GameDock.tsx
@@ -541,6 +541,7 @@ export function GameDock({
                 <a
                     href={sgf_url}
                     target="_blank"
+                    rel="noopener noreferrer"
                     onClick={(ev) => {
                         if (ev.currentTarget.className.indexOf("disabled") !== -1) {
                             ev.preventDefault();
@@ -583,7 +584,7 @@ export function GameDock({
             {/*
             {sgf_download_enabled && sgf_with_ai_review_url && (
                 <Tooltip tooltipRequired={tooltipRequired} title={_("SGF with AI Review")}>
-                    <a href={sgf_with_ai_review_url} target="_blank">
+                    <a href={sgf_with_ai_review_url} target="_blank" rel="noopener noreferrer">
                         <i className="fa fa-download"></i> {_("SGF with AI Review")}
                     </a>
                 </Tooltip>
@@ -591,7 +592,7 @@ export function GameDock({
             */}
             {sgf_download_enabled && sgf_with_comments_url && (
                 <Tooltip tooltipRequired={tooltipRequired} title={_("SGF with comments")}>
-                    <a href={sgf_with_comments_url} target="_blank">
+                    <a href={sgf_with_comments_url} target="_blank" rel="noopener noreferrer">
                         <i className="fa fa-download"></i> {_("SGF with comments")}
                     </a>
                 </Tooltip>

--- a/src/views/Game/GameLinkModal.tsx
+++ b/src/views/Game/GameLinkModal.tsx
@@ -115,7 +115,7 @@ function AnimatedPngCreator({ goban }: { goban: GobanRenderer }): React.ReactEle
     return (
         <div className="AnimatedPngCreator">
             <div className="GameLink-kv">
-                <a href={url} target="_blank">
+                <a href={url} target="_blank" rel="noopener noreferrer">
                     <i className="fa fa-link" />
                 </a>
                 <span style={{ textAlign: "right" }}>{_("Animated")}: </span>
@@ -207,7 +207,7 @@ function GameLinkKv({ name, value, nolink }: { name: string; value: string; noli
     return (
         <div className="GameLink-kv">
             {!nolink && (
-                <a href={value} target="_blank">
+                <a href={value} target="_blank" rel="noopener noreferrer">
                     <i className="fa fa-link" />
                 </a>
             )}

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -897,6 +897,7 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                                                     <a
                                                         target="_blank"
                                                         href={group_website_href as string}
+                                                        rel="noopener noreferrer"
                                                     >
                                                         {group_website_href}
                                                     </a>

--- a/src/views/Puzzle/PuzzleCollectionAcl.tsx
+++ b/src/views/Puzzle/PuzzleCollectionAcl.tsx
@@ -124,7 +124,7 @@ export function PuzzleCollectionAcl({
                                 <a
                                     href={`/group/${entry.group_id}`}
                                     target="_blank"
-                                    rel="noreferrer"
+                                    rel="noopener noreferrer"
                                     className="PuzzleCollectionAcl-group"
                                 >
                                     {entry.group_name}

--- a/src/views/Supporter/Supporter.tsx
+++ b/src/views/Supporter/Supporter.tsx
@@ -1181,7 +1181,11 @@ function PaymentMethod({ payment }: { payment: Payment }): React.ReactElement {
     if (payment.ref_id && user.is_superuser) {
         if (payment.payment_processor === "stripe") {
             return (
-                <a href={`https://dashboard.stripe.com/payments/${payment.ref_id}`} target="_blank">
+                <a
+                    href={`https://dashboard.stripe.com/payments/${payment.ref_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     {ret}
                 </a>
             );
@@ -1191,6 +1195,7 @@ function PaymentMethod({ payment }: { payment: Payment }): React.ReactElement {
                 <a
                     href={`https://www.paypal.com/activity/payment/${payment.ref_id}`}
                     target="_blank"
+                    rel="noopener noreferrer"
                 >
                     {ret}
                 </a>
@@ -1202,6 +1207,7 @@ function PaymentMethod({ payment }: { payment: Payment }): React.ReactElement {
                 <a
                     href={`https://vendors.paddle.com/subscriptions/customers/manage/${subscriptionId}`}
                     target="_blank"
+                    rel="noopener noreferrer"
                 >
                     {ret}
                 </a>

--- a/src/views/Tournament/Tournament.tsx
+++ b/src/views/Tournament/Tournament.tsx
@@ -1066,6 +1066,7 @@ export function Tournament(): React.ReactElement {
                             <a
                                 href="https://github.com/online-go/online-go.com/wiki/OpenGotha-Tournaments"
                                 target="_blank"
+                                rel="noopener noreferrer"
                             >
                                 documentation
                             </a>{" "}
@@ -3016,6 +3017,7 @@ function OpenGothaTournamentUploadDownload({
                     className="pull-right"
                     href="https://github.com/online-go/online-go.com/wiki/OpenGotha-Tournaments"
                     target="_blank"
+                    rel="noopener noreferrer"
                 >
                     {_("Documentation")}
                 </a>

--- a/src/views/User/AvatarCard.tsx
+++ b/src/views/User/AvatarCard.tsx
@@ -310,7 +310,7 @@ export function AvatarCard({
 
             {!editing && user.website && cleaned_website && (
                 <div className="website-url">
-                    <a target="_blank" rel="noopener" href={cleaned_website}>
+                    <a target="_blank" rel="noopener noreferrer" href={cleaned_website}>
                         {user.website}
                     </a>
                 </div>

--- a/src/views/docs/About.tsx
+++ b/src/views/docs/About.tsx
@@ -67,7 +67,11 @@ export class About extends React.Component<{}, any> {
                     )}
 
                     <h4 className="about-links">
-                        <a href="https://translate.online-go.com" target="_blank">
+                        <a
+                            href="https://translate.online-go.com"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
                             {_("Help translate Online-Go.com")}
                         </a>
                         <Link to="/developer">Developers</Link>


### PR DESCRIPTION
1. Open redirect via `?return=` on the game page: `is_valid_url()` accepts any host so `/game/123?return=https://evil.com` redirects off-site. Now uses the same-origin-only `valid_next_url()` used by the `?next=` fix.
2. Reverse tabnabbing: 17 `target="_blank"` links across 16 files still had no `rel` (including user-controlled group/site links). All now use `rel="noopener noreferrer"`

All tests pass