### PR TITLE
Restrict WebSocket host override to official routes for security

### DIFF
--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -26,6 +26,17 @@ const ROUTE_CLOUDFLARE = "wss://online-go.com";
 const ROUTE_GOOGLE_PREMIUM = "wss://wsp.online-go.com";
 const ROUTE_PUBLIC = "wss://wss.online-go.com";
 
+/* The only WebSocket gateway routes the client may connect to. The session
+ * JWT is transmitted to the chosen host on connect (see the socket
+ * `authenticate` call in main.tsx), so an arbitrary host here would silently
+ * exfiltrate the live session token. The `ogs.websocket_host` localStorage
+ * override is therefore restricted to this allowlist. */
+const WEBSOCKET_ROUTES: ReadonlySet<string> = new Set([
+    ROUTE_CLOUDFLARE,
+    ROUTE_GOOGLE_PREMIUM,
+    ROUTE_PUBLIC,
+]);
+
 // Detect if the user is on an Apple device (iOS or macOS)
 // This is used for routing WebSocket connections around CloudFlare connectivity issues
 export function isAppleDevice(): boolean {
@@ -123,8 +134,18 @@ let main_websocket_host: string = window.websocket_host ?? default_websocket_hos
 try {
     // can't use `data` here because of a dependency loop
     if (typeof localStorage !== "undefined" && localStorage.getItem("ogs.websocket_host")) {
-        main_websocket_host = JSON.parse(localStorage.getItem("ogs.websocket_host") as string);
-        console.log("Websocket host overridden to:", main_websocket_host);
+        const override = JSON.parse(
+            localStorage.getItem("ogs.websocket_host") as string,
+        ) as unknown;
+        /* Only accept an official gateway route. Any other value (e.g. a
+         * host injected into localStorage by an attacker) would receive the
+         * session JWT on the next connect, so it is ignored. */
+        if (typeof override === "string" && WEBSOCKET_ROUTES.has(override)) {
+            main_websocket_host = override;
+            console.log("Websocket host overridden to:", main_websocket_host);
+        } else {
+            console.warn("Ignoring invalid websocket host override:", override);
+        }
     } else {
         console.log("Websocket host not overridden");
     }

--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -20,7 +20,7 @@ import { protocol, GobanRenderer, JGOFTimeControl, DeviceInfo } from "goban";
 import { GobanSocketProxy } from "@/lib/GobanSocketProxy";
 import { lookingAtOurLiveGame } from "@/components/TimeControl/util";
 import {
-    isValidWebsocketRoute,
+    isValidWebsocketOverride,
     ROUTE_CLOUDFLARE,
     ROUTE_GOOGLE_PREMIUM,
     ROUTE_PUBLIC,
@@ -128,10 +128,14 @@ try {
         const override = JSON.parse(
             localStorage.getItem("ogs.websocket_host") as string,
         ) as unknown;
-        /* Only accept an official gateway route. Any other value (e.g. a
-         * host injected into localStorage by an attacker) would receive the
-         * session JWT on the next connect, so it is ignored. */
-        if (typeof override === "string" && isValidWebsocketRoute(override)) {
+        /* Only accept an official gateway route or the page's own origin (for
+         * beta/self-hosted/dev deployments). Any other value (e.g. a host
+         * injected into localStorage by an attacker) would receive the session
+         * JWT on the next connect, so it is ignored. */
+        if (
+            typeof override === "string" &&
+            isValidWebsocketOverride(override, window.location.origin)
+        ) {
             main_websocket_host = override;
             console.log("Websocket host overridden to:", main_websocket_host);
         } else {

--- a/src/lib/sockets.ts
+++ b/src/lib/sockets.ts
@@ -19,23 +19,14 @@ import Debug from "@/lib/debug";
 import { protocol, GobanRenderer, JGOFTimeControl, DeviceInfo } from "goban";
 import { GobanSocketProxy } from "@/lib/GobanSocketProxy";
 import { lookingAtOurLiveGame } from "@/components/TimeControl/util";
-
-const debug = new Debug("sockets");
-
-const ROUTE_CLOUDFLARE = "wss://online-go.com";
-const ROUTE_GOOGLE_PREMIUM = "wss://wsp.online-go.com";
-const ROUTE_PUBLIC = "wss://wss.online-go.com";
-
-/* The only WebSocket gateway routes the client may connect to. The session
- * JWT is transmitted to the chosen host on connect (see the socket
- * `authenticate` call in main.tsx), so an arbitrary host here would silently
- * exfiltrate the live session token. The `ogs.websocket_host` localStorage
- * override is therefore restricted to this allowlist. */
-const WEBSOCKET_ROUTES: ReadonlySet<string> = new Set([
+import {
+    isValidWebsocketRoute,
     ROUTE_CLOUDFLARE,
     ROUTE_GOOGLE_PREMIUM,
     ROUTE_PUBLIC,
-]);
+} from "@/lib/websocket_routes";
+
+const debug = new Debug("sockets");
 
 // Detect if the user is on an Apple device (iOS or macOS)
 // This is used for routing WebSocket connections around CloudFlare connectivity issues
@@ -140,7 +131,7 @@ try {
         /* Only accept an official gateway route. Any other value (e.g. a
          * host injected into localStorage by an attacker) would receive the
          * session JWT on the next connect, so it is ignored. */
-        if (typeof override === "string" && WEBSOCKET_ROUTES.has(override)) {
+        if (typeof override === "string" && isValidWebsocketRoute(override)) {
             main_websocket_host = override;
             console.log("Websocket host overridden to:", main_websocket_host);
         } else {

--- a/src/lib/websocket_routes.test.ts
+++ b/src/lib/websocket_routes.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+    isValidWebsocketOverride,
     isValidWebsocketRoute,
     ROUTE_CLOUDFLARE,
     ROUTE_GOOGLE_PREMIUM,
@@ -48,5 +49,34 @@ describe("isValidWebsocketRoute", () => {
     test("rejects non-route strings", () => {
         expect(isValidWebsocketRoute("null")).toBe(false);
         expect(isValidWebsocketRoute("42")).toBe(false);
+    });
+});
+
+describe("isValidWebsocketOverride", () => {
+    const BETA_ORIGIN = "https://beta.online-go.com";
+    const DEV_ORIGIN = "http://localhost:3000";
+
+    test("accepts each official gateway route for any origin", () => {
+        expect(isValidWebsocketOverride(ROUTE_CLOUDFLARE, BETA_ORIGIN)).toBe(true);
+        expect(isValidWebsocketOverride(ROUTE_GOOGLE_PREMIUM, BETA_ORIGIN)).toBe(true);
+        expect(isValidWebsocketOverride(ROUTE_PUBLIC, DEV_ORIGIN)).toBe(true);
+    });
+
+    test("accepts the page's own origin for beta and dev deployments", () => {
+        expect(isValidWebsocketOverride("https://beta.online-go.com", BETA_ORIGIN)).toBe(true);
+        expect(isValidWebsocketOverride("http://localhost:3000", DEV_ORIGIN)).toBe(true);
+        expect(isValidWebsocketOverride("https://online-go.com", "https://online-go.com")).toBe(
+            true,
+        );
+    });
+
+    test("rejects a third-party host even when it matches the origin scheme", () => {
+        expect(isValidWebsocketOverride("http://localhost:3000", BETA_ORIGIN)).toBe(false);
+        expect(
+            isValidWebsocketOverride("https://beta.online-go.com.evil.example", BETA_ORIGIN),
+        ).toBe(false);
+        expect(isValidWebsocketOverride("https://evil.example", BETA_ORIGIN)).toBe(false);
+        expect(isValidWebsocketOverride("", BETA_ORIGIN)).toBe(false);
+        expect(isValidWebsocketOverride("null", BETA_ORIGIN)).toBe(false);
     });
 });

--- a/src/lib/websocket_routes.test.ts
+++ b/src/lib/websocket_routes.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+    isValidWebsocketRoute,
+    ROUTE_CLOUDFLARE,
+    ROUTE_GOOGLE_PREMIUM,
+    ROUTE_PUBLIC,
+} from "./websocket_routes";
+
+describe("isValidWebsocketRoute", () => {
+    test("accepts each official gateway route", () => {
+        expect(isValidWebsocketRoute(ROUTE_CLOUDFLARE)).toBe(true);
+        expect(isValidWebsocketRoute(ROUTE_GOOGLE_PREMIUM)).toBe(true);
+        expect(isValidWebsocketRoute(ROUTE_PUBLIC)).toBe(true);
+    });
+
+    test("rejects an arbitrary attacker-controlled host", () => {
+        expect(isValidWebsocketRoute("wss://evil.example")).toBe(false);
+        expect(isValidWebsocketRoute("https://evil.example")).toBe(false);
+        expect(isValidWebsocketRoute("ws://evil.example")).toBe(false);
+        expect(isValidWebsocketRoute("evil.example")).toBe(false);
+        expect(isValidWebsocketRoute("")).toBe(false);
+    });
+
+    test("rejects lookalike hostnames of official routes", () => {
+        expect(isValidWebsocketRoute("wss://online-go.com.evil.example")).toBe(false);
+        expect(isValidWebsocketRoute("wss://online-go.com@evil.example")).toBe(false);
+        expect(isValidWebsocketRoute("wss://online-go.com/")).toBe(false);
+        expect(isValidWebsocketRoute("wss://WSS.online-go.com")).toBe(false);
+        expect(isValidWebsocketRoute("wss://wsp.online-go.com.evil.example")).toBe(false);
+    });
+
+    test("rejects non-route strings", () => {
+        expect(isValidWebsocketRoute("null")).toBe(false);
+        expect(isValidWebsocketRoute("42")).toBe(false);
+    });
+});

--- a/src/lib/websocket_routes.ts
+++ b/src/lib/websocket_routes.ts
@@ -36,3 +36,16 @@ const WEBSOCKET_ROUTES: ReadonlySet<string> = new Set([
 export function isValidWebsocketRoute(host: string): boolean {
     return WEBSOCKET_ROUTES.has(host);
 }
+
+/**
+ * Returns true when a localStorage `ogs.websocket_host` override may be used.
+ *
+ * Besides the official gateway routes, an override equal to the page's own
+ * origin is accepted so that same-origin deployments (e.g. beta, self-hosted,
+ * and development servers) can keep pointing the socket at themselves. Since
+ * that host already serves the page and receives the JWT legitimately, it does
+ * not expose the session token to a third party.
+ */
+export function isValidWebsocketOverride(host: string, origin: string): boolean {
+    return host === origin || isValidWebsocketRoute(host);
+}

--- a/src/lib/websocket_routes.ts
+++ b/src/lib/websocket_routes.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const ROUTE_CLOUDFLARE = "wss://online-go.com";
+export const ROUTE_GOOGLE_PREMIUM = "wss://wsp.online-go.com";
+export const ROUTE_PUBLIC = "wss://wss.online-go.com";
+
+const WEBSOCKET_ROUTES: ReadonlySet<string> = new Set([
+    ROUTE_CLOUDFLARE,
+    ROUTE_GOOGLE_PREMIUM,
+    ROUTE_PUBLIC,
+]);
+
+/**
+ * Returns true when `host` is one of the official WebSocket gateway routes.
+ *
+ * The session JWT is transmitted to the chosen gateway on connect (see the
+ * socket `authenticate` call in main.tsx), so only hosts in this allowlist may
+ * be used. The `ogs.websocket_host` localStorage override is validated against
+ * it to prevent an attacker-controlled host from receiving the session token.
+ */
+export function isValidWebsocketRoute(host: string): boolean {
+    return WEBSOCKET_ROUTES.has(host);
+}


### PR DESCRIPTION
`src/lib/sockets.ts` accepts anyhost from `localStorage["ogs.websocket_host"]` as the WebSocket endpoint and `src/main.tsx` sends the signed session JWT to that host on every connect (including refreshed user/jwt tokens)

the override now only accepts the three official gateway routes (`wss://online-go.com`, `wss://wsp.online-go.com`, `wss://wss.online-go.com`). Everything else is ignored with a warning. Dev mode is unaffected

All tests pass.