### PR TITLE
Fix rematch against bots showing ranked checkbox (#3603)

### DIFF
--- a/src/components/ChallengeModal/ChallengeModal.api.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.api.tsx
@@ -77,6 +77,8 @@ export function challengeRematch(
     //config.syncBoardSize();
     //config.syncTimeControl();
 
+    const is_bot_game = conf.is_bot_game ? true : false;
+
     const config: ChallengeModalConfig = {
         conf: {
             selected_board_size: isStandardBoardSize(board_size) ? board_size : "custom",
@@ -104,5 +106,5 @@ export function challengeRematch(
         time_control: dup(conf.time_control),
     };
 
-    challenge(opponent.id, null, false, config);
+    challenge(opponent.id, null, is_bot_game, config);
 }

--- a/src/components/ChallengeModal/ChallengeModal.api.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.api.tsx
@@ -77,8 +77,6 @@ export function challengeRematch(
     //config.syncBoardSize();
     //config.syncTimeControl();
 
-    const is_bot_game = conf.is_bot_game ? true : false;
-
     const config: ChallengeModalConfig = {
         conf: {
             selected_board_size: isStandardBoardSize(board_size) ? board_size : "custom",
@@ -99,12 +97,13 @@ export function challengeRematch(
                 disable_analysis: conf.disable_analysis,
                 pause_on_weekends: original_game_meta.pause_on_weekends ?? false,
                 initial_state: null,
-                private: (conf as any)["private"], // this is either missing from the type def or invalid
+                private: (conf as any)["private"], // this is either missing from the type def or invalid,
+                is_bot_game: conf.is_bot_game,
             },
             invite_only: false, // maybe one day we will support challenge-links on the rematch dialog!
         },
         time_control: dup(conf.time_control),
     };
 
-    challenge(opponent.id, null, is_bot_game, config);
+    challenge(opponent.id, null, false, config);
 }

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -507,6 +507,10 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             challenge.game.komi = undefined;
         }
 
+        if (this.props.mode === "computer") {
+            challenge.game.is_bot_game = true;
+        }
+
         return challenge;
     }
 

--- a/src/components/ChallengeModal/ChallengeModal.tsx
+++ b/src/components/ChallengeModal/ChallengeModal.tsx
@@ -265,9 +265,11 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
         }
 
         state.challenge.game = coerceKomiForAutoHandicap(state.challenge.game);
-        if (this.props.mode === "computer") {
+
+        if (this.props.mode === "computer" || state.challenge.game.is_bot_game) {
             state.challenge.game = applyBotRanked(state.challenge.game);
             state.challenge.game.disable_analysis = false;
+            state.challenge.game.is_bot_game = true;
         }
 
         if (this.props.autoCreate) {
@@ -505,10 +507,6 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
         }
         if (challenge.game.komi_auto === "automatic") {
             challenge.game.komi = undefined;
-        }
-
-        if (this.props.mode === "computer") {
-            challenge.game.is_bot_game = true;
         }
 
         return challenge;
@@ -1222,6 +1220,7 @@ export class ChallengeModalBody extends React.Component<ChallengeModalInput, Cha
             >
                 {!this.state.forking_game &&
                     this.props.mode !== "computer" &&
+                    !this.state.challenge.game.is_bot_game &&
                     this.rankedSettings()}
                 {!this.state.forking_game && this.boardSizeSettings()}
             </div>

--- a/src/components/ChallengeModal/ChallengeModal.types.ts
+++ b/src/components/ChallengeModal/ChallengeModal.types.ts
@@ -105,6 +105,7 @@ export interface ChallengeModalConfig {
             height?: number;
             komi?: number;
             pause_on_weekends?: boolean;
+            is_bot_game?: boolean;
         };
     };
     conf: {
@@ -155,6 +156,7 @@ export type GameInput = {
     time_control?: TimeControlTypes.TimeControlSystem;
     time_control_parameters?: TimeControl;
     speed?: JGOFTimeControlSpeed;
+    is_bot_game?: boolean;
 };
 
 export type ChallengeInput = {

--- a/src/models/challenges.d.ts
+++ b/src/models/challenges.d.ts
@@ -107,6 +107,7 @@ declare namespace rest_api {
             pause_on_weekends?: boolean;
             time_control?: import("../components/TimeControl").TimeControlTypes.TimeControlSystem;
             time_control_parameters?: import("../components/TimeControl").TimeControl;
+            is_bot_game?: boolean;
         };
     }
 


### PR DESCRIPTION
As referenced in #3603 the rematch page incorrectly shows the ranked checkbox for bot matches (which are only unranked now). I believe this PR should fix the issue by passing a new parameter is_bot_game to the goban engine, allowing the rematch logic to render the ranked checkbox properly.

I could be wrong about how the goban engine gets its values however, in this PR I did it by modifying the challenge sent out from the ChallengeModal. Please correct me if the goban engine gets its values differently from how I set them here.

I am also looking into writing a test case for this fix, but I figured getting input on if I passed the data properly should come first. Thank you!