### PR TITLE
Ladder: show why a vacationing opponent's game doesn't count

### DIFF
--- a/e2e-tests/ladders/ladder-vacation-challenge-limit.ts
+++ b/e2e-tests/ladders/ladder-vacation-challenge-limit.ts
@@ -24,12 +24,11 @@
  * 1. P1 creates a public group; P1-P6 join it and its 9x9 ladder in order,
  *    so P6 sits at the bottom and can challenge everyone above.
  * 2. P6 challenges P1, P2 and P3 - at the cap. P4 reports 0x005.
- * 3. P5, never challenged, goes on vacation. P5's row is dimmed with the
- *    umbrella and reports 0x009.
+ * 3. P5, never challenged, goes on vacation and reports 0x009.
  * 4. P1 goes on vacation. P6's count drops to two and P4 becomes challengeable.
  * 5. P6 challenges P4 - four open games, three counting.
- * 6. P5 ends vacation (row clears), then P1 ends vacation: P6 is at four
- *    counting, and P5 reports 0x005 again.
+ * 6. P5 ends vacation (0x009 gives way to the cap), then P1 ends vacation:
+ *    P6 is at four counting, and P5 reports 0x005 again.
  * 7. Teardown (in a finally, so it runs even when an assertion fails): P1
  *    deletes the group, taking its three ladders with it, and the test
  *    confirms they are gone.
@@ -259,13 +258,9 @@ export const ladderVacationChallengeLimitTest = async (
         log("P5 is on vacation");
 
         await p6Page.goto(ladderUrl);
-        const p5Row = p6Page.locator(".LadderRow").filter({ hasText: "E2E_LADDER_P5" });
-        await expect(p5Row).toHaveClass(/on-vacation/, { timeout: 15000 });
-        await expect(p5Row.locator(".on-vacation-icon")).toBeVisible();
-
         await openRowPopover(p6Page, "E2E_LADDER_P5");
         await expect(p6Page.getByText("Player is on vacation")).toBeVisible({ timeout: 15000 });
-        log("P5 shows the vacation indicator and reports 0x009");
+        log("P5 reports 0x009 - a player on vacation cannot be challenged");
 
         // 6. P1 goes on vacation: P6's discounted count drops to two, freeing a slot.
         await setVacation(p1Page, true);
@@ -281,13 +276,16 @@ export const ladderVacationChallengeLimitTest = async (
         await challengePlayer(p6Page, ladderUrl, "E2E_LADDER_P4");
         log("P6 challenged P4");
 
-        // 8. P5 comes back: the indicator clears.
+        // 8. P5 comes back: the vacation reason gives way to the cap reason. P6
+        //    holds four open games and P1 is still away, so three of them count.
         await setVacation(p5Page, false);
         await p6Page.goto(ladderUrl);
-        const p5RowBack = p6Page.locator(".LadderRow").filter({ hasText: "E2E_LADDER_P5" });
-        await expect(p5RowBack).not.toHaveClass(/on-vacation/, { timeout: 15000 });
-        await expect(p5RowBack.locator(".on-vacation-icon")).toHaveCount(0);
-        log("P5's vacation indicator cleared");
+        await openRowPopover(p6Page, "E2E_LADDER_P5");
+        await expect(p6Page.getByText("Already playing 3 games you've initiated")).toBeVisible({
+            timeout: 15000,
+        });
+        await expect(p6Page.getByText("Player is on vacation")).toHaveCount(0);
+        log("P5 is back: reports the cap with three counting, no longer 0x009");
 
         // 9. P1 comes back: P6 is at four counting games, over the cap. P5 is the
         //    only player P6 has not challenged, and is no longer on vacation, so P5

--- a/e2e-tests/ladders/ladder-vacation-challenge-limit.ts
+++ b/e2e-tests/ladders/ladder-vacation-challenge-limit.ts
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * A ladder player may have at most three open games they initiated. A game
+ * whose opponent is on vacation is paused, so it should not occupy one of
+ * those slots - and a player already on vacation cannot be challenged at all.
+ *
+ * Flow:
+ * 1. P1 creates a public group; P1-P6 join it and its 9x9 ladder in order,
+ *    so P6 sits at the bottom and can challenge everyone above.
+ * 2. P6 challenges P1, P2 and P3 - at the cap. P4 reports 0x005.
+ * 3. P5, never challenged, goes on vacation. P5's row is dimmed with the
+ *    umbrella and reports 0x009.
+ * 4. P1 goes on vacation. P6's count drops to two and P4 becomes challengeable.
+ * 5. P6 challenges P4 - four open games, three counting.
+ * 6. P5 ends vacation (row clears), then P1 ends vacation: P6 is at four
+ *    counting, and P5 reports 0x005 again.
+ * 7. Teardown (in a finally, so it runs even when an assertion fails): P1
+ *    deletes the group, taking its three ladders with it, and the test
+ *    confirms they are gone.
+ */
+
+import type { CreateContextOptions } from "@helpers";
+
+import { BrowserContext, Page, TestInfo } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+import { setupSeededUser } from "@helpers/user-utils";
+import { expectOGSClickableByName } from "@helpers/matchers";
+import { log } from "@helpers/logger";
+
+const LADDER_PLAYERS = [
+    "E2E_LADDER_P1",
+    "E2E_LADDER_P2",
+    "E2E_LADDER_P3",
+    "E2E_LADDER_P4",
+    "E2E_LADDER_P5",
+    "E2E_LADDER_P6",
+];
+
+/** Open a ladder row's popover by the player's username. */
+const openRowPopover = async (page: Page, username: string) => {
+    const row = page.locator(".LadderRow").filter({ hasText: username });
+    await expect(row).toBeVisible({ timeout: 15000 });
+    await row.click();
+};
+
+/** Challenge a player from the ladder page, confirming the dialog. */
+const challengePlayer = async (page: Page, ladderUrl: string, username: string) => {
+    await page.goto(ladderUrl);
+    await openRowPopover(page, username);
+
+    const challengeButton = await expectOGSClickableByName(page, /^Challenge$/);
+    await challengeButton.click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog.getByText(/Are you ready to start your game with/)).toBeVisible();
+    const yesButton = await expectOGSClickableByName(page, /^Yes!$/);
+    await yesButton.click();
+
+    await expect(dialog).not.toBeVisible({ timeout: 30000 });
+};
+
+/**
+ * Delete the test's group as its founder, removing its ladders with it.
+ * Verify the selectors against src/views/Group/Group.tsx before relying on them.
+ */
+const deleteGroup = async (page: Page, groupUrl: string) => {
+    await page.goto(groupUrl);
+
+    // The pencil toggles edit mode; "Delete Group" only renders while editing.
+    const editToggle = page.locator("i.fa-pencil").first();
+    await expect(editToggle).toBeVisible({ timeout: 15000 });
+    await editToggle.click();
+
+    const deleteButton = await expectOGSClickableByName(page, /Delete Group/);
+    await deleteButton.click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog.getByText(/Are you SURE you want to delete this group/)).toBeVisible();
+    const okButton = dialog.getByRole("button", { name: "OK" });
+    await expect(okButton).toBeVisible();
+    await okButton.click();
+
+    // deleteGroup() redirects to /groups/ on success.
+    await page.waitForURL(/\/groups\/?$/, { timeout: 30000 });
+};
+
+/** Toggle the signed-in user's vacation from the settings page. */
+const setVacation = async (page: Page, on: boolean) => {
+    await page.goto("/user/settings");
+    // Scoped to the desktop selector list: the mobile dropdown (#SettingsGroupDropdown)
+    // also renders the text "Vacation" as its current value once vacation has been
+    // selected before, which this test does repeatedly on the same seeded pages -
+    // an unscoped getByText("Vacation") becomes a strict-mode violation on revisits.
+    const vacationTab = page.locator("#SettingsGroupSelector").getByText("Vacation", {
+        exact: true,
+    });
+    await expect(vacationTab).toBeVisible({ timeout: 10000 });
+    await vacationTab.click();
+
+    const label = on ? /Go on vacation/ : /End vacation/;
+    const button = await expectOGSClickableByName(page, label);
+    await button.click();
+
+    // Confirm the toggle took before moving on.
+    const confirmation = on ? /End vacation/ : /Go on vacation/;
+    await expect(page.getByRole("button", { name: confirmation })).toBeVisible({
+        timeout: 15000,
+    });
+};
+
+/**
+ * Make sure the signed-in user is not on vacation, whatever state they are in.
+ * Safe to call when they are already off vacation. Used in teardown:
+ * P1 and P5 are shared seeded accounts, so if an earlier assertion in this test
+ * fails before the flow gets around to ending their vacation, a plain setVacation
+ * call would itself fail (there is no "End vacation" button to click when the
+ * account is already off vacation) and leave the account on vacation for every
+ * run afterwards - as happened once during development of this test.
+ */
+const ensureVacationOff = async (page: Page) => {
+    await page.goto("/user/settings");
+    const vacationTab = page.locator("#SettingsGroupSelector").getByText("Vacation", {
+        exact: true,
+    });
+    await expect(vacationTab).toBeVisible({ timeout: 10000 });
+    await vacationTab.click();
+
+    const endVacationButton = page.getByRole("button", { name: /End vacation/ });
+    if (await endVacationButton.isVisible().catch(() => false)) {
+        await endVacationButton.click();
+        await expect(page.getByRole("button", { name: /Go on vacation/ })).toBeVisible({
+            timeout: 15000,
+        });
+    }
+};
+
+export const ladderVacationChallengeLimitTest = async (
+    {
+        createContext,
+    }: { createContext: (options?: CreateContextOptions) => Promise<BrowserContext> },
+    testInfo: TestInfo,
+) => {
+    // @Slow: this test signs in six seeded players, creates a group, joins six
+    // players to a ladder and starts four correspondence games to build up the
+    // open-challenge state the assertions check. The time is cumulative setup,
+    // not an explicit wait - see e2e-tests/CLAUDE.md for the rule.
+    const TIMEOUT_MS = 600 * 1000;
+    testInfo.setTimeout(TIMEOUT_MS);
+
+    log("=== Ladder Vacation Challenge Limit Test ===");
+
+    // 1. Sign in all six seeded players.
+    const pages: Page[] = [];
+    for (const username of LADDER_PLAYERS) {
+        const { userPage } = await setupSeededUser(createContext, username);
+        pages.push(userPage);
+    }
+    // Indices 0, 4 and 5 are P1, P5 and P6 - the only pages the flow drives
+    // directly after everyone has joined.
+    const [p1Page, , , , p5Page, p6Page] = pages;
+
+    // 2. P1 creates a public group. A fresh group means a fresh ladder, which is
+    //    what keeps these reused seeded accounts free of prior-run state.
+    log("P1 creating a group...");
+    await p1Page.goto("/group/create");
+
+    const groupName = `E2E Ladder Vac ${Date.now()}`;
+    const groupNameInput = p1Page.locator("#group-create-name");
+    await expect(groupNameInput).toBeVisible();
+    await groupNameInput.fill(groupName);
+    await expect(groupNameInput).toHaveValue(groupName);
+
+    // Public by default (GroupCreate.tsx) - assert rather than toggle.
+    await expect(p1Page.locator("#group-create-public")).toBeChecked();
+
+    const createGroupButton = await expectOGSClickableByName(p1Page, /Create your group!/);
+    await createGroupButton.click();
+    await p1Page.waitForURL(/\/group\/\d+/, { timeout: 30000 });
+
+    const groupUrl = p1Page.url();
+    log(`Group created at: ${groupUrl}`);
+
+    // Find the 9x9 ladder URL from the group page.
+    const ladderLink = p1Page.getByRole("link", { name: "9x9 Ladder" });
+    await expect(ladderLink).toBeVisible();
+    const ladderHref = await ladderLink.getAttribute("href");
+    const ladderUrl = ladderHref as string;
+    log(`9x9 ladder at: ${ladderUrl}`);
+
+    try {
+        // 3. Each player joins the group, then the ladder, in order. Join order sets
+        //    ladder rank, so P6 ends up at the bottom.
+        for (let i = 0; i < pages.length; i++) {
+            const page = pages[i];
+            const username = LADDER_PLAYERS[i];
+
+            if (i > 0) {
+                // P1 created the group and is already a member.
+                await page.goto(groupUrl);
+                const joinGroup = await expectOGSClickableByName(page, /Join Group/);
+                await joinGroup.click();
+            }
+
+            await page.goto(ladderUrl);
+            const joinLadder = await expectOGSClickableByName(page, /Join Ladder/);
+            await joinLadder.click();
+            await expect(page.getByRole("button", { name: /Drop out from ladder/ })).toBeVisible({
+                timeout: 15000,
+            });
+            log(`${username} joined the ladder at rank ${i + 1}`);
+        }
+
+        // 4. P6 challenges P1, P2 and P3 - three open games, at the cap.
+        //    challengePlayer navigates first, so each challenge starts from a fresh
+        //    page: creating one invalidates the ladder list behind the popover.
+        for (const username of ["E2E_LADDER_P1", "E2E_LADDER_P2", "E2E_LADDER_P3"]) {
+            await challengePlayer(p6Page, ladderUrl, username);
+            log(`P6 challenged ${username}`);
+        }
+
+        // P4 is now blocked by the cap.
+        await p6Page.goto(ladderUrl);
+        await openRowPopover(p6Page, "E2E_LADDER_P4");
+        await expect(p6Page.getByText("Already playing 3 games you've initiated")).toBeVisible({
+            timeout: 15000,
+        });
+        log("P6 is at the cap: P4 reports 0x005");
+
+        // 5. P5 goes on vacation, having never been challenged.
+        await setVacation(p5Page, true);
+        log("P5 is on vacation");
+
+        await p6Page.goto(ladderUrl);
+        const p5Row = p6Page.locator(".LadderRow").filter({ hasText: "E2E_LADDER_P5" });
+        await expect(p5Row).toHaveClass(/on-vacation/, { timeout: 15000 });
+        await expect(p5Row.locator(".on-vacation-icon")).toBeVisible();
+
+        await openRowPopover(p6Page, "E2E_LADDER_P5");
+        await expect(p6Page.getByText("Player is on vacation")).toBeVisible({ timeout: 15000 });
+        log("P5 shows the vacation indicator and reports 0x009");
+
+        // 6. P1 goes on vacation: P6's discounted count drops to two, freeing a slot.
+        await setVacation(p1Page, true);
+        log("P1 is on vacation");
+
+        await p6Page.goto(ladderUrl);
+        await openRowPopover(p6Page, "E2E_LADDER_P4");
+        const challengeP4 = await expectOGSClickableByName(p6Page, /^Challenge$/);
+        await expect(challengeP4).toBeVisible();
+        log("P4 is challengeable again - the vacation discount applied");
+
+        // 7. P6 challenges P4 - four open games, three counting.
+        await challengePlayer(p6Page, ladderUrl, "E2E_LADDER_P4");
+        log("P6 challenged P4");
+
+        // 8. P5 comes back: the indicator clears.
+        await setVacation(p5Page, false);
+        await p6Page.goto(ladderUrl);
+        const p5RowBack = p6Page.locator(".LadderRow").filter({ hasText: "E2E_LADDER_P5" });
+        await expect(p5RowBack).not.toHaveClass(/on-vacation/, { timeout: 15000 });
+        await expect(p5RowBack.locator(".on-vacation-icon")).toHaveCount(0);
+        log("P5's vacation indicator cleared");
+
+        // 9. P1 comes back: P6 is at four counting games, over the cap. P5 is the
+        //    only player P6 has not challenged, and is no longer on vacation, so P5
+        //    is the row that must now report the cap.
+        await setVacation(p1Page, false);
+        await p6Page.goto(ladderUrl);
+        await openRowPopover(p6Page, "E2E_LADDER_P5");
+        await expect(p6Page.getByText("Already playing 4 games you've initiated")).toBeVisible({
+            timeout: 15000,
+        });
+        log("P6 is over the cap with everyone back - no games were cancelled");
+
+        log("=== Ladder Vacation Challenge Limit Test Complete ===");
+    } finally {
+        // 10. P1 and P5 are shared seeded accounts reused by every run of this test.
+        //     If an assertion above failed before steps 8/9 turned their vacation
+        //     back off, leaving either on vacation would break every subsequent run
+        //     (a player already on vacation cannot be challenged at all - the very
+        //     rule this test is checking). Restore both unconditionally.
+        log("Ensuring P1 and P5 are not left on vacation...");
+        await ensureVacationOff(p1Page);
+        await ensureVacationOff(p5Page);
+
+        // 11. Drop the group. Its three ladders go with it (LadderTournament.group
+        //     is on_delete=CASCADE), which stops every run leaving ladders behind.
+        log(`Deleting group ${groupUrl}...`);
+        await deleteGroup(p1Page, groupUrl);
+
+        // /group/:id and /ladder/:id match unconditionally in routes.tsx - only
+        // genuinely unmatched paths hit PageNotFound - so navigating to a deleted
+        // group or ladder still gets a 200-status page load; React Router renders
+        // the view, which then fails to load its data. The real proof the group
+        // and ladder are gone is the API call each view makes to resolve itself:
+        // assert that call's response status directly, not the outer navigation.
+        const groupId = groupUrl.match(/\/group\/(\d+)/)?.[1];
+        const ladderId = ladderUrl.match(/\/ladder\/(\d+)/)?.[1];
+        if (!groupId || !ladderId) {
+            throw new Error(`Could not parse ids from groupUrl=${groupUrl} ladderUrl=${ladderUrl}`);
+        }
+
+        const [groupApiResponse] = await Promise.all([
+            p1Page.waitForResponse((res) => res.url().endsWith(`/api/v1/groups/${groupId}`)),
+            p1Page.goto(groupUrl),
+        ]);
+        expect(groupApiResponse.status()).toBe(404);
+
+        const [ladderApiResponse] = await Promise.all([
+            p1Page.waitForResponse((res) => res.url().endsWith(`/api/v1/ladders/${ladderId}`)),
+            p1Page.goto(ladderUrl),
+        ]);
+        expect(ladderApiResponse.status()).toBe(404);
+        log("Group and its ladders confirmed deleted (API returns 404 for both)");
+    }
+};

--- a/e2e-tests/ladders/ladder-vacation-challenge-limit.ts
+++ b/e2e-tests/ladders/ladder-vacation-challenge-limit.ts
@@ -179,32 +179,43 @@ export const ladderVacationChallengeLimitTest = async (
     // 2. P1 creates a public group. A fresh group means a fresh ladder, which is
     //    what keeps these reused seeded accounts free of prior-run state.
     log("P1 creating a group...");
-    await p1Page.goto("/group/create");
 
-    const groupName = `E2E Ladder Vac ${Date.now()}`;
-    const groupNameInput = p1Page.locator("#group-create-name");
-    await expect(groupNameInput).toBeVisible();
-    await groupNameInput.fill(groupName);
-    await expect(groupNameInput).toHaveValue(groupName);
-
-    // Public by default (GroupCreate.tsx) - assert rather than toggle.
-    await expect(p1Page.locator("#group-create-public")).toBeChecked();
-
-    const createGroupButton = await expectOGSClickableByName(p1Page, /Create your group!/);
-    await createGroupButton.click();
-    await p1Page.waitForURL(/\/group\/\d+/, { timeout: 30000 });
-
-    const groupUrl = p1Page.url();
-    log(`Group created at: ${groupUrl}`);
-
-    // Find the 9x9 ladder URL from the group page.
-    const ladderLink = p1Page.getByRole("link", { name: "9x9 Ladder" });
-    await expect(ladderLink).toBeVisible();
-    const ladderHref = await ladderLink.getAttribute("href");
-    const ladderUrl = ladderHref as string;
-    log(`9x9 ladder at: ${ladderUrl}`);
+    // Declared outside the try so the finally below can still reach them to tear
+    // the group down, even if a step inside the try throws before both are
+    // assigned - see the undefined check in the finally.
+    let groupUrl: string | undefined;
+    let ladderUrl: string | undefined;
 
     try {
+        // The try opens right after this navigation: from here on a group may
+        // exist in the database, so everything that follows - including reading
+        // back the group's URL and looking up its ladder link - runs inside the
+        // block whose finally deletes it.
+        await p1Page.goto("/group/create");
+
+        const groupName = `E2E Ladder Vac ${Date.now()}`;
+        const groupNameInput = p1Page.locator("#group-create-name");
+        await expect(groupNameInput).toBeVisible();
+        await groupNameInput.fill(groupName);
+        await expect(groupNameInput).toHaveValue(groupName);
+
+        // Public by default (GroupCreate.tsx) - assert rather than toggle.
+        await expect(p1Page.locator("#group-create-public")).toBeChecked();
+
+        const createGroupButton = await expectOGSClickableByName(p1Page, /Create your group!/);
+        await createGroupButton.click();
+        await p1Page.waitForURL(/\/group\/\d+/, { timeout: 30000 });
+
+        groupUrl = p1Page.url();
+        log(`Group created at: ${groupUrl}`);
+
+        // Find the 9x9 ladder URL from the group page.
+        const ladderLink = p1Page.getByRole("link", { name: "9x9 Ladder" });
+        await expect(ladderLink).toBeVisible();
+        const ladderHref = await ladderLink.getAttribute("href");
+        ladderUrl = ladderHref as string;
+        log(`9x9 ladder at: ${ladderUrl}`);
+
         // 3. Each player joins the group, then the ladder, in order. Join order sets
         //    ladder rank, so P6 ends up at the bottom.
         for (let i = 0; i < pages.length; i++) {
@@ -295,39 +306,63 @@ export const ladderVacationChallengeLimitTest = async (
         //     If an assertion above failed before steps 8/9 turned their vacation
         //     back off, leaving either on vacation would break every subsequent run
         //     (a player already on vacation cannot be challenged at all - the very
-        //     rule this test is checking). Restore both unconditionally.
+        //     rule this test is checking). Restore both unconditionally. Each call
+        //     is isolated in its own try/catch: a navigation or locator timeout in
+        //     one - the same risk every other step in this test carries - is
+        //     logged rather than thrown, so it can never suppress the other restore
+        //     or block the group deletion below, the one guarantee here that is
+        //     non-negotiable.
         log("Ensuring P1 and P5 are not left on vacation...");
-        await ensureVacationOff(p1Page);
-        await ensureVacationOff(p5Page);
+        try {
+            await ensureVacationOff(p1Page);
+        } catch (error) {
+            log(`Failed to ensure P1 is off vacation: ${String(error)}`);
+        }
+
+        try {
+            await ensureVacationOff(p5Page);
+        } catch (error) {
+            log(`Failed to ensure P5 is off vacation: ${String(error)}`);
+        }
 
         // 11. Drop the group. Its three ladders go with it (LadderTournament.group
         //     is on_delete=CASCADE), which stops every run leaving ladders behind.
-        log(`Deleting group ${groupUrl}...`);
-        await deleteGroup(p1Page, groupUrl);
+        //     Skipped only when group creation itself never got far enough to
+        //     yield a URL, in which case there is nothing in the database to
+        //     remove.
+        if (groupUrl === undefined) {
+            log("Group was never created - nothing to delete.");
+        } else {
+            log(`Deleting group ${groupUrl}...`);
+            await deleteGroup(p1Page, groupUrl);
 
-        // /group/:id and /ladder/:id match unconditionally in routes.tsx - only
-        // genuinely unmatched paths hit PageNotFound - so navigating to a deleted
-        // group or ladder still gets a 200-status page load; React Router renders
-        // the view, which then fails to load its data. The real proof the group
-        // and ladder are gone is the API call each view makes to resolve itself:
-        // assert that call's response status directly, not the outer navigation.
-        const groupId = groupUrl.match(/\/group\/(\d+)/)?.[1];
-        const ladderId = ladderUrl.match(/\/ladder\/(\d+)/)?.[1];
-        if (!groupId || !ladderId) {
-            throw new Error(`Could not parse ids from groupUrl=${groupUrl} ladderUrl=${ladderUrl}`);
+            // /group/:id and /ladder/:id match unconditionally in routes.tsx - only
+            // genuinely unmatched paths hit PageNotFound - so navigating to a
+            // deleted group or ladder still gets a 200-status page load; React
+            // Router renders the view, which then fails to load its data. The real
+            // proof the group and ladder are gone is the API call each view makes
+            // to resolve itself: assert that call's response status directly, not
+            // the outer navigation.
+            const groupId = groupUrl.match(/\/group\/(\d+)/)?.[1];
+            const ladderId = ladderUrl?.match(/\/ladder\/(\d+)/)?.[1];
+            if (!groupId || !ladderUrl || !ladderId) {
+                throw new Error(
+                    `Could not parse ids from groupUrl=${groupUrl} ladderUrl=${ladderUrl}`,
+                );
+            }
+
+            const [groupApiResponse] = await Promise.all([
+                p1Page.waitForResponse((res) => res.url().endsWith(`/api/v1/groups/${groupId}`)),
+                p1Page.goto(groupUrl),
+            ]);
+            expect(groupApiResponse.status()).toBe(404);
+
+            const [ladderApiResponse] = await Promise.all([
+                p1Page.waitForResponse((res) => res.url().endsWith(`/api/v1/ladders/${ladderId}`)),
+                p1Page.goto(ladderUrl),
+            ]);
+            expect(ladderApiResponse.status()).toBe(404);
+            log("Group and its ladders confirmed deleted (API returns 404 for both)");
         }
-
-        const [groupApiResponse] = await Promise.all([
-            p1Page.waitForResponse((res) => res.url().endsWith(`/api/v1/groups/${groupId}`)),
-            p1Page.goto(groupUrl),
-        ]);
-        expect(groupApiResponse.status()).toBe(404);
-
-        const [ladderApiResponse] = await Promise.all([
-            p1Page.waitForResponse((res) => res.url().endsWith(`/api/v1/ladders/${ladderId}`)),
-            p1Page.goto(ladderUrl),
-        ]);
-        expect(ladderApiResponse.status()).toBe(404);
-        log("Group and its ladders confirmed deleted (API returns 404 for both)");
     }
 };

--- a/e2e-tests/ladders/ladders.spec.ts
+++ b/e2e-tests/ladders/ladders.spec.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ogsTest } from "@helpers";
+import { ladderVacationChallengeLimitTest } from "./ladder-vacation-challenge-limit";
+
+ogsTest.describe("@Ladder Tests", () => {
+    ogsTest(
+        "@Slow Games against players on vacation do not count toward the challenge limit",
+        ladderVacationChallengeLimitTest,
+    );
+});

--- a/src/views/Group/Group.tsx
+++ b/src/views/Group/Group.tsx
@@ -1359,14 +1359,16 @@ class _Group extends React.PureComponent<GroupProperties, GroupState> {
                         <Card className="ladders">
                             <div className="ladder-configuration">
                                 <table>
-                                    <tr>
-                                        <th>{_("Rules")}</th>
-                                        <td>{this.renderRules()}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>{_("Handicap")}</th>
-                                        <td>{this.renderHandicap()}</td>
-                                    </tr>
+                                    <tbody>
+                                        <tr>
+                                            <th>{_("Rules")}</th>
+                                            <td>{this.renderRules()}</td>
+                                        </tr>
+                                        <tr>
+                                            <th>{_("Handicap")}</th>
+                                            <td>{this.renderHandicap()}</td>
+                                        </tr>
+                                    </tbody>
                                 </table>
                             </div>
                             <div>

--- a/src/views/Ladder/Ladder.css
+++ b/src/views/Ladder/Ladder.css
@@ -97,18 +97,6 @@
             }
         }
 
-        &.on-vacation {
-            .Player,
-            .right {
-                opacity: 0.6;
-            }
-
-            /* Full strength so the marker stays readable on a dimmed row. */
-            .on-vacation-icon {
-                opacity: 1;
-            }
-        }
-
         &:hover {
             background-color: var(--shade4);
         }
@@ -176,8 +164,8 @@
 }
 
 /*
- * The vacation marker appears both in a ladder row and in the challenge
- * popover, which render in separate trees, so this sits at the top level.
+ * The vacation marker renders inside the challenge popover, which is a
+ * separate tree from the ladder rows, so this sits at the top level.
  */
 .on-vacation-icon {
     /* Clear of the rank label the Player component renders. */

--- a/src/views/Ladder/Ladder.css
+++ b/src/views/Ladder/Ladder.css
@@ -103,6 +103,7 @@
                 opacity: 0.6;
             }
 
+            /* Full strength so the marker stays readable on a dimmed row. */
             .on-vacation-icon {
                 opacity: 1;
             }
@@ -172,6 +173,16 @@
             }
         }
     }
+}
+
+/*
+ * The vacation marker appears both in a ladder row and in the challenge
+ * popover, which render in separate trees, so this sits at the top level.
+ */
+.on-vacation-icon {
+    /* Clear of the rank label the Player component renders. */
+    margin-left: 0.5rem;
+    color: #888;
 }
 
 .Ladder-challenge-details {

--- a/src/views/Ladder/Ladder.css
+++ b/src/views/Ladder/Ladder.css
@@ -84,14 +84,27 @@
         cursor: pointer;
 
         &.not-challengeable {
-            .Player, .right {
+            .Player,
+            .right {
                 color: #888 !important;
             }
         }
 
         &.challengeable {
-            .Player, .right {
+            .Player,
+            .right {
                 color: var(--link-color) !important;
+            }
+        }
+
+        &.on-vacation {
+            .Player,
+            .right {
+                opacity: 0.6;
+            }
+
+            .on-vacation-icon {
+                opacity: 1;
             }
         }
 
@@ -151,7 +164,8 @@
                     text-align: left;
                 }
 
-                .incoming, .outgoing {
+                .incoming,
+                .outgoing {
                     display: inline-block;
                     width: 1.2rem;
                 }
@@ -163,7 +177,9 @@
 .Ladder-challenge-details {
     box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.2);
     border: 1px solid transparent;
-    box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.16), 0px 2px 5px 0px rgba(0, 0, 0, 0.15);
+    box-shadow:
+        0px 2px 10px 0px rgba(0, 0, 0, 0.16),
+        0px 2px 5px 0px rgba(0, 0, 0, 0.15);
     background-color: var(--shade4);
     border-color: var(--shade3);
     color: var(--fg);

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -549,7 +549,6 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                 <div className="Ladder-challenge-details">
                     <h3>
                         <Player flag nochallenge user={row.player} />
-                        {row.on_vacation && <OnVacationIcon />}
                     </h3>
 
                     {row && row.can_challenge && (

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -31,6 +31,7 @@ import { alert } from "@/lib/swal_config";
 import { RouteComponentProps, rr6ClassShim } from "@/lib/ogs-rr6-shims";
 import { IdType } from "@/lib/types";
 import { PlayerCacheEntry } from "@/lib/player_cache";
+import { OnVacationIcon } from "./OnVacationIcon";
 import "./Ladder.css";
 
 type LadderProperties = RouteComponentProps<{
@@ -347,6 +348,7 @@ interface LadderRowState {
         outgoing_challenges: any;
         can_challenge: { challengeable: boolean };
         rank: number;
+        on_vacation: boolean;
         player: PlayerCacheEntry;
     };
 }
@@ -455,6 +457,7 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                 className={
                     "LadderRow " +
                     (row && row.rank === this.props.highlightRank ? " highlight " : "") +
+                    (row?.on_vacation ? " on-vacation " : "") +
                     row_class
                 }
             >
@@ -462,6 +465,8 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                     <span className="rank"># {(row && row.rank) || this.props.index + 1}</span>
 
                     {row && <Player flag nochallenge nolink user={row.player} />}
+
+                    {row?.on_vacation && <OnVacationIcon />}
 
                     <span className="right">
                         {(challenging || null) && (
@@ -534,6 +539,7 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                 <div className="Ladder-challenge-details">
                     <h3>
                         <Player flag nochallenge user={row.player} />
+                        {row.on_vacation && <OnVacationIcon />}
                     </h3>
 
                     {row && row.can_challenge && (
@@ -577,6 +583,7 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                                             #{challenge.player.ladder_rank}
                                         </span>
                                         <Player nolink user={challenge.player} />
+                                        {challenge.player.on_vacation && <OnVacationIcon />}
                                     </span>
                                 ))}
                             </span>
@@ -607,6 +614,7 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                                             #{challenge.player.ladder_rank}
                                         </span>
                                         <Player nolink user={challenge.player} />
+                                        {challenge.player.on_vacation && <OnVacationIcon />}
                                     </span>
                                 ))}
                             </span>
@@ -706,6 +714,11 @@ function canChallengeTooltip(obj: any): string | null {
                 return pgettext(
                     "Can't challenge player in ladder because: ",
                     "Player already has the maximum number of challenges",
+                );
+            case 0x009:
+                return pgettext(
+                    "Can't challenge player in ladder because: ",
+                    "Player is on vacation",
                 );
         }
     }

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -350,7 +350,6 @@ interface LadderRowState {
         outgoing_challenges: any;
         can_challenge: { challengeable: boolean };
         rank: number;
-        on_vacation: boolean;
         player: PlayerCacheEntry;
     };
 }
@@ -467,7 +466,6 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                 className={
                     "LadderRow " +
                     (row && row.rank === this.props.highlightRank ? " highlight " : "") +
-                    (row?.on_vacation ? " on-vacation " : "") +
                     row_class
                 }
             >
@@ -475,8 +473,6 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
                     <span className="rank"># {(row && row.rank) || this.props.index + 1}</span>
 
                     {row && <Player flag nochallenge nolink user={row.player} />}
-
-                    {row?.on_vacation && <OnVacationIcon />}
 
                     <span className="right">
                         {(challenging || null) && (

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -398,6 +398,14 @@ export class LadderRow extends React.Component<LadderRowProperties, LadderRowSta
         }
     }
 
+    componentDidMount() {
+        // The constructor starts a load whose result arrives after mount, and
+        // sync() drops that result when `unmounted` is set. React re-mounts the
+        // same instance in development, so the flag has to be cleared here or a
+        // remounted row discards its own data and renders empty forever.
+        this.unmounted = false;
+    }
+
     componentWillUnmount() {
         this.unmounted = true;
     }

--- a/src/views/Ladder/Ladder.tsx
+++ b/src/views/Ladder/Ladder.tsx
@@ -174,18 +174,20 @@ class _Ladder extends React.PureComponent<LadderProperties, LadderState> {
 
                         <div className="ladder-configuration">
                             <table>
-                                <tr>
-                                    <th>{_("Rules")}</th>
-                                    <td>{rulesText(this.state.ladder?.rules ?? "japanese")}</td>
-                                </tr>
-                                <tr>
-                                    <th>{_("Handicap")}</th>
-                                    <td>
-                                        {this.state.ladder?.handicap === -1
-                                            ? _("Automatic")
-                                            : _("None")}
-                                    </td>
-                                </tr>
+                                <tbody>
+                                    <tr>
+                                        <th>{_("Rules")}</th>
+                                        <td>{rulesText(this.state.ladder?.rules ?? "japanese")}</td>
+                                    </tr>
+                                    <tr>
+                                        <th>{_("Handicap")}</th>
+                                        <td>
+                                            {this.state.ladder?.handicap === -1
+                                                ? _("Automatic")
+                                                : _("None")}
+                                        </td>
+                                    </tr>
+                                </tbody>
                             </table>
                         </div>
 

--- a/src/views/Ladder/OnVacationIcon.tsx
+++ b/src/views/Ladder/OnVacationIcon.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+import { pgettext } from "@/lib/translate";
+
+/** Marks a ladder player who is currently on vacation. */
+export function OnVacationIcon(): React.ReactElement {
+    const label = pgettext("Ladder player status", "On vacation");
+
+    return <i className="fa fa-umbrella on-vacation-icon" title={label} aria-label={label} />;
+}


### PR DESCRIPTION
Frontend half of the ladder vacation change. Backend: online-go/ogs#2453.

Ladder players may have at most three open games they initiated. A game whose opponent is on vacation is paused, so it no longer counts toward that cap, and a player already on vacation cannot be challenged at all.

## Changes

- **New `0x009` tooltip case** in `canChallengeTooltip()` — "Player is on vacation". This is how a player finds out why a row is greyed out: click the row, read the reason.
- **`OnVacationIcon`**, a small co-located component, rendered next to each opponent in the challenge popover's "Challenging" and "Challenged by" lists. That is the one place a marker earns its keep: with four games listed, nothing else shows which one is paused and therefore not counting.

The ladder rows themselves are untouched. A player on vacation is always unchallengeable, so their row already renders with the existing grey `.not-challengeable` treatment — an extra icon and a second dimming layer on every affected row bought nothing and cluttered a view whose value is scanning ranks quickly. An earlier revision had both; seeing it in the browser settled it.

One accepted consequence: an anonymous or non-member viewer sees no vacation indication on the ladder, since `can_challenge` is null for them and there is neither grey nor tooltip. Both things the marker explains only matter to a logged-in participant.

## Two unrelated fixes, in separate commits so they can be dropped or cherry-picked

- **`a64c9c31d` — `LadderRow` never cleared its `unmounted` flag.** `componentWillUnmount` set it and nothing reset it, so an instance React remounts keeps it set; the load started in the constructor then resolves, `sync()` sees the stale flag and discards the row data, and the row renders its index with no player. React remounts components under StrictMode, so **every ladder row renders blank in development**. Production is unaffected. This is latent on `main` and worth landing regardless of the rest of this PR — it also made the e2e test below impossible until fixed.
- **`5a319e11e` — `<tbody>`** around the ladder and group config table rows, silencing a React DOM-nesting warning.

## Testing

New end-to-end test, `e2e-tests/ladders/` — the first in this suite for ladders. Six seeded players join a fresh group's ladder; the test then walks the whole rule:

- P6 reaches the cap and P4 reports `0x005`
- a player on vacation reports `0x009`
- an opponent going on vacation frees a slot and P4 becomes challengeable — the assertion the change exists for
- when everyone returns, P6 sits over the cap and nothing has been cancelled

It creates its own group per run so it runs against a clean ladder, and deletes it in a `finally`, confirming via the API that the group and its three auto-created ladders are really gone rather than trusting the redirect. Teardown also clears vacation from the shared seeded accounts, which a mid-flow failure would otherwise leave set for every later run.

Results: `@Ladder` 1 passed, `@Tournament` 3 passed (that suite shares the vacation settings pane and group-creation flow). `type-check`, `lint`, `prettier`, `cspell` and `yarn build` all clean.

Note the e2e directory is not covered by `yarn spellcheck`, which only scans `src/**`.

## Manual testing

Reviewed in the browser in both light and dark themes, which is what drove the decision to drop the row marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PDCmMoqZXTLL5mugZJvqo
