### PR TITLE
docs: define where design artifacts live

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,29 @@ Before submitting a PR, remind the author to perform manual testing in both mobi
 
 - Follow the repository PR template at `.github/pull_request_template.md` when creating pull requests.
 
+## OGS-Wide Development Policy
+
+Applies to all OGS repositories: `ogs`, `ogs-ui`, `goban`, `moderator-ui`.
+
+### Design artifact storage
+
+Non-trivial work produces two kinds of document. They have different lifetimes. Keep them apart.
+
+**Working artifacts** — `docs/superpowers/specs/` and `docs/superpowers/plans/`
+
+- Name them `YYYY-MM-DD-<topic>-design.md` and `YYYY-MM-DD-<topic>.md`.
+- Commit each as its own `docs:` commit on the feature branch: spec first, plan second, then the implementation.
+- Amend them in place as the work teaches you things. A plan that no longer matches what was built is worse than no plan.
+- Put them in the repository the work is in. Work that spans repositories goes in the repository carrying most of it.
+
+**Durable documents** — `docs/<topic>.md`
+
+- Subject-named, undated, present tense. They say what the system does now, not what some change proposed.
+- Work that establishes a lasting capability, contract or convention must leave one behind. Open it during the work, not after.
+- Curate them. Delete what has become false instead of appending corrections.
+
+**A working artifact with no durable document behind it is scaffolding.** It can be deleted once the work has landed. If something in a spec is worth keeping, move it to the durable document.
+
 ## graphify
 
 This project has a graphify knowledge graph at graphify-out/.


### PR DESCRIPTION
## What

Adds an **OGS-Wide Development Policy** section to `AGENTS.md` (which `CLAUDE.md` symlinks to), setting out where design artifacts live.

## Why this section, in this file

`ogs/services/django/CLAUDE.md` already tells readers:

> **See [../ogs-ui/CLAUDE.md](../ogs-ui/CLAUDE.md#ogs-wide-development-policy)** for git workflow and other organization-wide policies that apply to all OGS repositories.

That anchor has never existed. This PR creates the section the backend has been pointing at.

## The policy describes what we already do

This is not a new convention. It is drawn from precedent set by **ogsai** and **anoek** in the `ogs` repository, and the two-class split falls straight out of that history:

**Working artifacts get amended during the work, not written once and frozen.** The nexus autoscaling spec was edited four times while the work happened — `Put the host reputation schema in the nexus scylla_schema.cql`, `Run the autoscaler against the Foreman and a provider`, `Serialize rentals, read the queue without workers, harden the kill switch`, `Require evidence before giving up an instance, and scope the backlog` — and its plan likewise (`Amend the autoscaling plan per review`, `Record plan amendments found during execution`).

**Durable subject documents are opened during the work and curated afterwards.** `docs/vast-ai-processors.md` was opened by `Document the vast.ai AI processor workflow` and then maintained across 14 commits running past the implementation. It is pruned for truth rather than appended to: `Stop shipping a benchmark table that will go stale`, `Drop the now-false multi-GPU LeelaZero known-gap bullet`, `Document the autoscaler, and stop citing a deleted survey`. `docs/streak.md` follows the same shape.

**Scaffolding with nothing durable behind it gets cleared away.** anoek's `9dd50b407 removed unimportant specs` deleted a spec and a 1,276-line plan that had been committed the same day — the one spec/plan pair with no accompanying subject document. The vast.ai and nexus pairs, which do have one, survive. That contrast is where the last rule in this section comes from.

## What is deliberately not in here

An earlier draft ended by requiring design artifacts to live inside a repository, which would have ruled out keeping them in the workspace root. That is a real change to current practice rather than a description of it, so it has been left out of this PR and can be argued separately.

## Notes for reviewers

- Markdown is not covered by CI (`prettier:check` and `lint` are both scoped to `src/`), and `AGENTS.md` already fails `prettier --check` on `main`. I have not reformatted it, to keep this diff to the 23 added lines.
- Two further stale references in these files are **not** fixed here, and each would need its own PR: the link above resolves to `ogs/services/ogs-ui/`, a path that has never existed; and `AGENTS.md` tells contributors to follow `.github/pull_request_template.md`, which is not in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PDCmMoqZXTLL5mugZJvqo
