### PR TITLE
fix(chat_manager): stop double-wrapping ChatChannelProxy event payloads

### DIFF
--- a/src/lib/chat_manager.ts
+++ b/src/lib/chat_manager.ts
@@ -823,17 +823,22 @@ export class ChatChannelProxy extends TypedEventEmitter<Events> {
         this._destroy();
     }
 
+    // Re-emit the underlying channel's single-payload events as-is. The
+    // channel always emits (event, payload) - a single argument - so we
+    // must forward that same single argument, not wrap the captured
+    // (...args) rest-array in another array (which used to produce
+    // listeners receiving `[payload]` instead of `payload`).
     _onChat = (...args: any[]) => {
-        this.emit.apply(this, ["chat", args]);
+        this.emit("chat", args[0]);
     };
     _onTopic = (...args: any[]) => {
-        this.emit.apply(this, ["topic", args]);
+        this.emit("topic", args[0]);
     };
     _onJoin = (...args: any[]) => {
-        this.emit.apply(this, ["join", args]);
+        this.emit("join", args[0]);
     };
     _onPart = (...args: any[]) => {
-        this.emit.apply(this, ["part", args]);
+        this.emit("part", args[0]);
     };
     _onUserMetadataUpdate = (update?: { user: User; previous_user: User }) => {
         if (!update) {
@@ -842,10 +847,10 @@ export class ChatChannelProxy extends TypedEventEmitter<Events> {
         this.emit("user-metadata-update", update);
     };
     _onChatRemoved = (...args: any[]) => {
-        this.emit.apply(this, ["chat-removed", args]);
+        this.emit("chat-removed", args[0]);
     };
     _onUnreadChanged = (...args: any[]) => {
-        this.emit.apply(this, ["unread-count-changed", args]);
+        this.emit("unread-count-changed", args[0]);
     };
     _destroy() {
         this.channel.off("chat", this._onChat);

--- a/src/views/Kibitz/KibitzController.ts
+++ b/src/views/Kibitz/KibitzController.ts
@@ -983,15 +983,13 @@ export class KibitzController extends EventEmitter<KibitzControllerEvents> {
         this.setVariations(variations);
     };
 
-    // ChatChannelProxy._onChat / _onChatRemoved (chat_manager.ts:841-861)
-    // collect (...args) and re-emit with args wrapped in an array
-    // (`emit.apply(this, ["chat", args])`), so listeners can't trust the
-    // event payload — every other consumer in the codebase ignores it and
-    // re-derives from proxy.channel.chat_log. We do the same, but stay
-    // incremental by inspecting whether the log grew by one (the common
-    // path for both send and receive) vs. some other delta (initial sync,
-    // bulk clear via clearSystemMessages, etc.) which falls back to a full
-    // rebuild.
+    // ChatChannelProxy._onChat / _onChatRemoved (chat_manager.ts) now forward
+    // the underlying channel's single payload correctly, but we still
+    // re-derive from proxy.channel.chat_log rather than trust the payload
+    // shape, staying incremental by inspecting whether the log grew by one
+    // (the common path for both send and receive) vs. some other delta
+    // (initial sync, bulk clear via clearSystemMessages, etc.) which falls
+    // back to a full rebuild.
     private onChatMessage = (): void => {
         const proxy = this._active_chat_proxy;
         const room = this._active_room;


### PR DESCRIPTION
Summary
ChatChannelProxy's re-emit handlers (_onChat, _onTopic, _onJoin, _onPart, _onChatRemoved, _onUnreadChanged in src/lib/chat_manager.ts) captured the underlying channel's single-argument event as (...args: any[]) and re-emitted it with this.emit.apply(this, [event, args]).
Because args is already the collected rest-array (e.g. [payload]), emit.apply(this, [event, args]) is equivalent to this.emit(event, args) — it passes the array as the single positional argument to emit, so subscribers receive [payload] instead of payload.
This matches a real, currently-open upstream bug report: https://github.com/online-go/online-go.com/issues/3534.
Fix
Forward args[0] directly for each handler, matching how the channel actually emits (event, payload) and how _onUserMetadataUpdate already handled this correctly in the same class. Also updated a stale comment in KibitzController.ts that documented the old (buggy) behavior as an accepted workaround.

Files changed
src/lib/chat_manager.ts
src/views/Kibitz/KibitzController.ts (comment only, no logic change)