### PR TITLE
Fix analysis being enabled for players in no-analysis games after a stale session load

### DIFF
--- a/src/lib/configure-goban.test.ts
+++ b/src/lib/configure-goban.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { configure_goban } from "./configure-goban";
+import * as data from "@/lib/data";
+import { callbacks, GobanEngine } from "goban";
+import type { GobanBase, GobanEngineConfig } from "goban";
+
+const BLACK_ID = 111;
+const WHITE_ID = 222;
+const SPECTATOR_ID = 999;
+
+const BASE_USER = {
+    anonymous: false,
+    id: BLACK_ID,
+    username: "test_user",
+    registration_date: "2022-05-10 11:03:24.299562+00:00",
+    ratings: {
+        version: 5,
+        overall: { rating: 1500, deviation: 350, volatility: 0.06 },
+    },
+    country: "un",
+    professional: false,
+    ranking: 23,
+    provisional: 0,
+    can_create_tournaments: true,
+    is_moderator: false,
+    is_superuser: false,
+    moderator_powers: 0,
+    offered_moderator_powers: 0,
+    is_tournament_moderator: false,
+    supporter: false,
+    supporter_level: 0,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "",
+    email: "",
+    email_validated: false,
+    is_announcer: false,
+    last_supporter_trial: "",
+} as const;
+
+function setUser(id: number, anonymous: boolean = false) {
+    data.set("user", { ...BASE_USER, id, anonymous });
+}
+
+function makeGoban(config: GobanEngineConfig = {}): GobanBase {
+    const engine = new GobanEngine({
+        width: 9,
+        height: 9,
+        players: {
+            black: { id: BLACK_ID, username: "black-player" },
+            white: { id: WHITE_ID, username: "white-player" },
+        },
+        disable_analysis: true,
+        phase: "play",
+        ...config,
+    });
+    return { engine } as unknown as GobanBase;
+}
+
+function isAnalysisDisabled(goban: GobanBase, perGameSettingAppliesToNonPlayers = false): boolean {
+    if (!callbacks.isAnalysisDisabled) {
+        throw new Error("isAnalysisDisabled callback was not configured");
+    }
+    return callbacks.isAnalysisDisabled(goban, perGameSettingAppliesToNonPlayers);
+}
+
+beforeAll(() => {
+    configure_goban();
+});
+
+beforeEach(() => {
+    delete (window as { user?: unknown }).user;
+});
+
+describe("isAnalysisDisabled", () => {
+    test("disables analysis for a participant in a no-analysis game", () => {
+        setUser(BLACK_ID);
+        window.user = data.get("user");
+        const goban = makeGoban();
+
+        expect(isAnalysisDisabled(goban)).toBe(true);
+    });
+
+    test("allows analysis for a spectator in a no-analysis game", () => {
+        setUser(SPECTATOR_ID);
+        window.user = data.get("user");
+        const goban = makeGoban();
+
+        expect(isAnalysisDisabled(goban)).toBe(false);
+    });
+
+    test("disables analysis for a participant even when the engine was constructed before the user was loaded (issue #1765)", () => {
+        // Simulate a fresh session: window.user and the data store still hold
+        // the anonymous placeholder while the engine is constructed...
+        setUser(0, true);
+        window.user = data.get("user");
+        const goban = makeGoban();
+
+        // ...and the real logged-in user arrives afterwards (ui/config fetch).
+        setUser(BLACK_ID);
+        window.user = data.get("user");
+
+        expect(isAnalysisDisabled(goban)).toBe(true);
+    });
+
+    test("allows analysis for a participant once the game is finished", () => {
+        setUser(BLACK_ID);
+        window.user = data.get("user");
+        const goban = makeGoban({ phase: "finished" });
+
+        expect(isAnalysisDisabled(goban)).toBe(false);
+    });
+
+    test("allows analysis for a participant when the game does not disable it", () => {
+        setUser(BLACK_ID);
+        window.user = data.get("user");
+        const goban = makeGoban({ disable_analysis: false });
+
+        expect(isAnalysisDisabled(goban)).toBe(false);
+    });
+
+    test("per-game setting applies to spectators when requested (SGF download)", () => {
+        setUser(SPECTATOR_ID);
+        window.user = data.get("user");
+        const goban = makeGoban();
+
+        expect(isAnalysisDisabled(goban, true)).toBe(true);
+    });
+});

--- a/src/lib/configure-goban.test.ts
+++ b/src/lib/configure-goban.test.ts
@@ -84,14 +84,9 @@ beforeAll(() => {
     configure_goban();
 });
 
-beforeEach(() => {
-    delete (window as { user?: unknown }).user;
-});
-
 describe("isAnalysisDisabled", () => {
     test("disables analysis for a participant in a no-analysis game", () => {
         setUser(BLACK_ID);
-        window.user = data.get("user");
         const goban = makeGoban();
 
         expect(isAnalysisDisabled(goban)).toBe(true);
@@ -99,7 +94,6 @@ describe("isAnalysisDisabled", () => {
 
     test("allows analysis for a spectator in a no-analysis game", () => {
         setUser(SPECTATOR_ID);
-        window.user = data.get("user");
         const goban = makeGoban();
 
         expect(isAnalysisDisabled(goban)).toBe(false);
@@ -107,18 +101,15 @@ describe("isAnalysisDisabled", () => {
 
     test("disables analysis for a participant even when the engine was constructed before the user was loaded", () => {
         setUser(0, true);
-        window.user = data.get("user");
         const goban = makeGoban();
 
         setUser(BLACK_ID);
-        window.user = data.get("user");
 
         expect(isAnalysisDisabled(goban)).toBe(true);
     });
 
     test("allows analysis for a participant once the game is finished", () => {
         setUser(BLACK_ID);
-        window.user = data.get("user");
         const goban = makeGoban({ phase: "finished" });
 
         expect(isAnalysisDisabled(goban)).toBe(false);
@@ -126,7 +117,6 @@ describe("isAnalysisDisabled", () => {
 
     test("allows analysis for a participant when the game does not disable it", () => {
         setUser(BLACK_ID);
-        window.user = data.get("user");
         const goban = makeGoban({ disable_analysis: false });
 
         expect(isAnalysisDisabled(goban)).toBe(false);
@@ -134,7 +124,6 @@ describe("isAnalysisDisabled", () => {
 
     test("per-game setting applies to spectators when requested (SGF download)", () => {
         setUser(SPECTATOR_ID);
-        window.user = data.get("user");
         const goban = makeGoban();
 
         expect(isAnalysisDisabled(goban, true)).toBe(true);

--- a/src/lib/configure-goban.test.ts
+++ b/src/lib/configure-goban.test.ts
@@ -105,14 +105,11 @@ describe("isAnalysisDisabled", () => {
         expect(isAnalysisDisabled(goban)).toBe(false);
     });
 
-    test("disables analysis for a participant even when the engine was constructed before the user was loaded (issue #1765)", () => {
-        // Simulate a fresh session: window.user and the data store still hold
-        // the anonymous placeholder while the engine is constructed...
+    test("disables analysis for a participant even when the engine was constructed before the user was loaded", () => {
         setUser(0, true);
         window.user = data.get("user");
         const goban = makeGoban();
 
-        // ...and the real logged-in user arrives afterwards (ui/config fetch).
         setUser(BLACK_ID);
         window.user = data.get("user");
 

--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -94,14 +94,11 @@ export function configure_goban() {
             if (perGameSettingAppliesToNonPlayers) {
                 // This is used for the SGF download which is disabled even for users that are not
                 // participating in the game (or not signed in)
-                return !!goban.engine.config.original_disable_analysis;
+                return !!goban.engine.config.disable_analysis;
             } else {
-                // The per-game setting applies only to participants, spectators may always
-                // analyze. Participation must be evaluated at call time; the engine clears
-                // its own disable_analysis at construction when window.user is not a
-                // participant, and window.user may not be loaded yet at that point.
+                // The per-game setting applies only to participants, spectators may always analyze.
                 return (
-                    !!goban.engine.config.original_disable_analysis &&
+                    !!goban.engine.config.disable_analysis &&
                     goban.engine.isParticipant(data.get("user")?.id || 0)
                 );
             }

--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -97,8 +97,9 @@ export function configure_goban() {
                 return !!goban.engine.config.original_disable_analysis;
             } else {
                 // The per-game setting applies only to participants, spectators may always
-                // analyze. Participation must be evaluated at call time; the engine's own
-                // disable_analysis is computed once at construction and can be stale.
+                // analyze. Participation must be evaluated at call time; the engine clears
+                // its own disable_analysis at construction when window.user is not a
+                // participant, and window.user may not be loaded yet at that point.
                 return (
                     !!goban.engine.config.original_disable_analysis &&
                     goban.engine.isParticipant(data.get("user")?.id || 0)

--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -96,11 +96,9 @@ export function configure_goban() {
                 // participating in the game (or not signed in)
                 return !!goban.engine.config.original_disable_analysis;
             } else {
-                // The per-game setting applies only to participants; spectators may always
-                // analyze. Participation is evaluated here at call time rather than trusting
-                // engine.config.disable_analysis, which is computed once at engine construction
-                // and can be wrong when the engine was constructed before the logged-in user
-                // had finished loading (issue #1765).
+                // The per-game setting applies only to participants, spectators may always
+                // analyze. Participation must be evaluated at call time; the engine's own
+                // disable_analysis is computed once at construction and can be stale.
                 return (
                     !!goban.engine.config.original_disable_analysis &&
                     goban.engine.isParticipant(data.get("user")?.id || 0)

--- a/src/lib/configure-goban.tsx
+++ b/src/lib/configure-goban.tsx
@@ -96,7 +96,15 @@ export function configure_goban() {
                 // participating in the game (or not signed in)
                 return !!goban.engine.config.original_disable_analysis;
             } else {
-                return !!goban.engine.config.disable_analysis;
+                // The per-game setting applies only to participants; spectators may always
+                // analyze. Participation is evaluated here at call time rather than trusting
+                // engine.config.disable_analysis, which is computed once at engine construction
+                // and can be wrong when the engine was constructed before the logged-in user
+                // had finished loading (issue #1765).
+                return (
+                    !!goban.engine.config.original_disable_analysis &&
+                    goban.engine.isParticipant(data.get("user")?.id || 0)
+                );
             }
         },
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -278,14 +278,6 @@ player_cache.update(user);
 data.set("user", user);
 window.user = user;
 
-/* The goban engine reads window.user when it is constructed, so it must be
- * kept in sync when the logged-in user finishes loading after startup. */
-data.watch("config.user", (updated_user) => {
-    if (updated_user) {
-        window.user = updated_user;
-    }
-});
-
 /***
  * Test if local storage is disabled for some reason (Either because the user
  * turned it off, the browser doesn't support it, or because the user is using

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -278,10 +278,8 @@ player_cache.update(user);
 data.set("user", user);
 window.user = user;
 
-/* The goban engine reads window.user when it is constructed, so keep it in
- * sync when the logged-in user finishes loading after startup (e.g. the
- * ui/config fetch on a session whose localStorage cache was empty or stale).
- * See https://github.com/online-go/online-go.com/issues/1765 */
+/* The goban engine reads window.user when it is constructed, so it must be
+ * kept in sync when the logged-in user finishes loading after startup. */
 data.watch("config.user", (updated_user) => {
     if (updated_user) {
         window.user = updated_user;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -278,6 +278,16 @@ player_cache.update(user);
 data.set("user", user);
 window.user = user;
 
+/* The goban engine reads window.user when it is constructed, so keep it in
+ * sync when the logged-in user finishes loading after startup (e.g. the
+ * ui/config fetch on a session whose localStorage cache was empty or stale).
+ * See https://github.com/online-go/online-go.com/issues/1765 */
+data.watch("config.user", (updated_user) => {
+    if (updated_user) {
+        window.user = updated_user;
+    }
+});
+
 /***
  * Test if local storage is disabled for some reason (Either because the user
  * turned it off, the browser doesn't support it, or because the user is using

--- a/src/views/Game/GameInfoModal.tsx
+++ b/src/views/Game/GameInfoModal.tsx
@@ -391,7 +391,7 @@ export class GameInfoModal extends Modal<Events, GameInfoModalProperties, GameIn
                         </dd>
                         <dt>{_("Analysis")}</dt>
                         <dd>
-                            {config.original_disable_analysis
+                            {config.disable_analysis
                                 ? _("Analysis and conditional moves disabled")
                                 : _("Analysis and conditional moves enabled")}
                         </dd>


### PR DESCRIPTION
Fixes #1765. The engine-side fix (online-go/goban#263) is merged; this PR bumps the goban submodule to the goban main tip that includes it.

## Problem

Players sometimes get the analysis and score-estimator tools in games where analysis is disabled; a refresh restores the correct state. The reporter's 2022 diagnosis was correct: `GobanEngine` decided the "spectators may always analyze" exemption by reading `window.user` once at construction. When the engine was constructed before the logged-in user finished loading (localStorage cache empty or stale, real user arriving via the async `ui/config` fetch), the player was mistaken for a spectator and `disable_analysis` was permanently cleared.

## Fix

With online-go/goban#263 merged, the engine no longer reads `window.user` and never mutates `disable_analysis`; mode changes are gated through the `isAnalysisDisabled` callback, evaluated at call time.

This PR provides the app-side policy and adopts the new goban:

- `src/lib/configure-goban.tsx`: the `isAnalysisDisabled` callback now implements the spectator exemption itself — analysis is disabled when the game disables it **and** the current user is a participant, evaluated fresh on every call.
- `src/views/Game/GameInfoModal.tsx`: reads `config.disable_analysis` directly now that it is never munged.
- `submodules/goban`: bumped to goban main (`98f37bd5`).
- `src/lib/configure-goban.test.ts`: tests covering participant/spectator/finished/per-game-setting behavior, including the engine-constructed-before-user-loaded scenario.

## Testing

- `yarn jest` — 471 tests pass.
- `yarn type-check`, `yarn lint`, `yarn prettier:file`, `yarn build` all clean.
- Manual testing in desktop and mobile browsers still recommended, particularly the original repro: clear localStorage while keeping a valid session, then navigate directly to one of your own no-analysis games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015d6fFFvu5MQMWMEDAfJFqi