### PR TITLE
Keep puzzles in puzzle mode when navigating with the move slider

### DIFF
--- a/src/components/GobanView/MoveNumberSlider.tsx
+++ b/src/components/GobanView/MoveNumberSlider.tsx
@@ -60,10 +60,11 @@ export function MoveNumberSlider(): React.ReactElement {
     // Puzzles save their solution as the move tree's trunk_next chain. Walking
     // it forward via `next()` would let the slider drag through unplayed
     // solution moves, spoiling the puzzle. Detect puzzle mode at mount time
-    // (the slider switches the goban to "analyze" on first navigation, so
-    // `goban.mode` isn't reliable later) and constrain the slider's max to a
-    // session high-water mark of the user's actual position. Reset whenever
-    // the goban changes so loading a new puzzle starts from move 0.
+    // (other navigation paths, e.g. the puzzle editor's keyboard shortcuts,
+    // may switch the goban to "analyze", so `goban.mode` isn't reliable
+    // later) and constrain the slider's max to a session high-water mark of
+    // the user's actual position. Reset whenever the goban changes so
+    // loading a new puzzle starts from move 0.
     //
     // Both the mode and the hwm need to be reset *synchronously* on goban
     // change, before the first render with the new goban — otherwise that

--- a/src/lib/GobanController.test.ts
+++ b/src/lib/GobanController.test.ts
@@ -82,4 +82,37 @@ describe("GobanController", () => {
         expect(controller.goban.engine.last_official_move).toBe(variation);
         expect(trunkTail).not.toBe(variation);
     });
+
+    it("stays in puzzle mode when navigating backward", () => {
+        const controller = new GobanController({
+            width: 9,
+            height: 9,
+            move_tree: {
+                x: -1,
+                y: -1,
+                trunk_next: {
+                    x: 3,
+                    y: 3,
+                    trunk_next: {
+                        x: 4,
+                        y: 3,
+                    },
+                },
+            },
+        });
+        const goban = controller.goban;
+        goban.setMode("puzzle");
+
+        const second_move = goban.engine.move_tree.trunk_next?.trunk_next;
+        if (!second_move) {
+            throw new Error("Expected test move tree to contain two trunk moves");
+        }
+        goban.engine.jumpTo(second_move);
+        expect(goban.engine.cur_move.move_number).toBe(2);
+
+        controller.previousMove();
+
+        expect(goban.engine.cur_move.move_number).toBe(1);
+        expect(goban.mode).toBe("puzzle");
+    });
 });

--- a/src/lib/GobanController.ts
+++ b/src/lib/GobanController.ts
@@ -624,13 +624,14 @@ export class GobanController extends EventEmitter<GobanControllerEvents> {
             return true;
         }
 
-        // Puzzle mode → analyze, without jumping to the last official move
-        // (puzzles have no official moves; jumping would reset the position
-        // the user is navigating from). Mirrors PuzzleNavigation so the
-        // controller-driven nav paths (slider, prev/next buttons) match the
-        // keyboard-shortcut path.
+        // Puzzle mode: navigate without leaving puzzle mode. Answer
+        // detection, the "Correct!"/"Incorrect" events, and the opponent's
+        // automatic responses only run while the goban is in "puzzle" mode,
+        // so switching to analyze here would silently disable the puzzle
+        // after any slider navigation. This matches the puzzle view's
+        // left-arrow/undo path; the puzzle editor's keyboard navigation
+        // enters analyze mode explicitly via PuzzleNavigation.
         if (this.goban.mode === "puzzle") {
-            this.goban.setMode("analyze", true);
             if (move) {
                 this.goban.engine.jumpTo(move);
             }

--- a/src/views/Puzzle/Puzzle.tsx
+++ b/src/views/Puzzle/Puzzle.tsx
@@ -23,7 +23,13 @@ import { get, post, put, del } from "@/lib/requests";
 import { KBShortcut } from "@/components/KBShortcut";
 import { errorAlerter, errorLogger, ignore } from "@/lib/misc";
 import { rankList } from "@/lib/rank_utils";
-import { GobanRendererConfig, GobanRenderer, PuzzleConfig, PuzzlePlacementSetting } from "goban";
+import {
+    GobanRendererConfig,
+    GobanRenderer,
+    MoveTree,
+    PuzzleConfig,
+    PuzzlePlacementSetting,
+} from "goban";
 import type { PlayerCacheEntry } from "@/lib/player_cache";
 import { GobanController } from "@/lib/GobanController";
 import { goban_view_mode, GobanView, GobanViewRef } from "@/components/GobanView";
@@ -255,6 +261,21 @@ export function Puzzle(): React.ReactElement {
         attemptsRef.current++;
     }, []);
 
+    // The move slider and its step buttons navigate without going through
+    // this view's undo handler, so clear the correct/incorrect banner on any
+    // backward navigation — it describes a position the user has left.
+    const lastMoveNumberRef = React.useRef(0);
+    const onCurMove = React.useCallback((move: MoveTree) => {
+        const receded = move.move_number < lastMoveNumberRef.current;
+        lastMoveNumberRef.current = move.move_number;
+        if (receded && (stateRef.current.show_wrong || stateRef.current.show_correct)) {
+            setState({
+                show_correct: false,
+                show_wrong: false,
+            });
+        }
+    }, []);
+
     const onCorrectAnswer = React.useCallback(() => {
         const pid = puzzleIdRef.current;
         const goban = gobanRef.current;
@@ -332,6 +353,8 @@ export function Puzzle(): React.ReactElement {
             goban.on("update", onUpdate);
             goban.on("puzzle-wrong-answer", onWrongAnswer);
             goban.on("puzzle-correct-answer", onCorrectAnswer);
+            lastMoveNumberRef.current = goban.engine.cur_move.move_number;
+            goban.on("cur_move", onCurMove);
             navigation.goban = goban;
         },
         [
@@ -341,6 +364,7 @@ export function Puzzle(): React.ReactElement {
             onUpdate,
             onWrongAnswer,
             onCorrectAnswer,
+            onCurMove,
             replacementSettingFunction,
         ],
     );


### PR DESCRIPTION
Fixes the bug reported in [Weird things on interactive puzzle page](https://forums.online-go.com/t/weird-things-on-interactive-puzzle-page/60697): after navigating backward with the new move-number slider, entering the correct solution still showed the red "Incorrect" banner.

## Root cause

The slider and its step buttons route through `GobanController.checkAndEnterAnalysis()`, which switched the goban from "puzzle" mode into "analyze" mode on any navigation. Answer detection, the `puzzle-correct-answer` / `puzzle-wrong-answer` events, and the opponent's automatic responses only run in "puzzle" mode, so one touch of the slider silently disabled the puzzle: later moves became plain analysis variations, no events fired, and the stale banner never cleared. The same switch also broke Joseki exploration after slider use, since Joseki keeps its goban in puzzle mode and relies on `puzzle-place` events.

## Changes

- `GobanController.checkAndEnterAnalysis()` now navigates without leaving puzzle mode, matching the puzzle view's left-arrow/undo path. The puzzle editor's keyboard navigation still enters analyze mode explicitly through `PuzzleNavigation`, which is unchanged.
- The Puzzle view clears the "Correct!" / "Incorrect" banner on any backward navigation (via the goban's `cur_move` event), so slider navigation behaves like the undo shortcut instead of leaving a banner that describes a position the user has left.
- Comment update in `MoveNumberSlider.tsx`; new regression test asserting backward navigation keeps the goban in puzzle mode.

## Testing

- `yarn type-check`, `yarn lint`, jest (472 tests), and `yarn build` all pass.
- Verified in the browser against the beta backend (puzzle 1555, same shape as the reported 99499 scenario): wrong move shows red "Incorrect"; stepping back with the slider clears the banner and stays in puzzle mode; playing the correct move shows green "Correct!" and fires the solution POST. Before the fix, the banner stayed red. Also confirmed the slider still cannot scrub forward into the unplayed solution after a reset.
- The "Try again returns to move 1" behavior discussed in the same thread was left as is, per the thread's conclusion that it is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAPkEyemwJszLkb7pQwS53