### PR TITLE
Fix Kibitz Create Room reload on live move

### DIFF
--- a/src/components/GameList/GameList.test.tsx
+++ b/src/components/GameList/GameList.test.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { GameList } from "./GameList";
+
+type TestMiniGobanProps = {
+    game_id?: number;
+    width?: number;
+    json?: {
+        game_id?: number;
+        moves?: unknown[];
+        move_tree?: { id?: number | string };
+    };
+    onSelectGameId?: (gameId: number) => void;
+    miniGobanSnapshotOverrides?: unknown;
+};
+
+type TestSnapshotMiniGobanProps = TestMiniGobanProps & {
+    snapshot?: TestMiniGobanProps["json"] | null;
+};
+
+jest.mock("@/components/MiniGoban", () => ({
+    __esModule: true,
+    MiniGoban: (props: TestMiniGobanProps) => {
+        const gobanConfig = { game_id: props.game_id, ...props.json };
+        return (
+            <button
+                type="button"
+                data-testid={`mini-goban-${props.game_id}`}
+                data-game-id={String(props.game_id)}
+                data-width={String(props.width)}
+                data-snapshot-game-id={String(props.json?.game_id)}
+                data-controller-game-id={String(gobanConfig.game_id)}
+                data-move-count={String(props.json?.moves?.length || 0)}
+                data-snapshot-move-tree-id={String(props.json?.move_tree?.id)}
+                data-has-snapshot-override-prop={String(
+                    props.miniGobanSnapshotOverrides !== undefined,
+                )}
+                onClick={() => props.onSelectGameId?.(props.game_id as number)}
+            >
+                {props.game_id}
+            </button>
+        );
+    },
+}));
+
+jest.mock("./SnapshotMiniGoban", () => ({
+    __esModule: true,
+    SnapshotMiniGoban: (props: TestSnapshotMiniGobanProps) => (
+        <button
+            type="button"
+            data-testid={`mini-goban-${props.game_id}`}
+            data-game-id={String(props.game_id)}
+            data-snapshot-game-id={String(props.snapshot?.game_id)}
+            data-controller-game-id="undefined"
+            data-move-count={String(props.snapshot?.moves?.length || 0)}
+            data-snapshot-move-tree-id={String(props.snapshot?.move_tree?.id)}
+            data-has-snapshot-override-prop={String(props.miniGobanSnapshotOverrides !== undefined)}
+            onClick={() => props.onSelectGameId?.(props.game_id as number)}
+        >
+            {props.game_id}
+        </button>
+    ),
+}));
+
+function makeGame(id: number) {
+    return {
+        id,
+        name: `Game ${id}`,
+        black: { id: 10, username: "black" },
+        white: { id: 11, username: "white" },
+        width: 19,
+        height: 19,
+    };
+}
+
+describe("GameList thumbnail snapshots", () => {
+    it("keeps ordinary gamelist entries on the existing live path", () => {
+        render(
+            <GameList
+                list={[makeGame(456)]}
+                miniGobanProps={{ noText: true }}
+                lineSummaryMode="both-players"
+            />,
+        );
+
+        const ordinaryGame = screen.getByTestId("mini-goban-456");
+        expect(ordinaryGame).toHaveAttribute("data-game-id", "456");
+        expect(ordinaryGame).toHaveAttribute("data-snapshot-game-id", "undefined");
+        expect(ordinaryGame).toHaveAttribute("data-controller-game-id", "456");
+        expect(ordinaryGame).toHaveAttribute("data-move-count", "0");
+        expect(ordinaryGame).toHaveAttribute("data-snapshot-move-tree-id", "undefined");
+    });
+
+    it("preserves ordinary MiniGoban prop precedence and selection resolution", () => {
+        const miniGobanOnSelect = jest.fn();
+        const outerOnSelect = jest.fn();
+
+        render(
+            <GameList
+                list={[makeGame(456)]}
+                miniGobanProps={{
+                    game_id: 999,
+                    width: 13,
+                    onSelectGameId: miniGobanOnSelect,
+                }}
+                onSelectGameId={outerOnSelect}
+                lineSummaryMode="both-players"
+            />,
+        );
+
+        const ordinaryGame = screen.getByTestId("mini-goban-999");
+        expect(ordinaryGame).toHaveAttribute("data-game-id", "999");
+        expect(ordinaryGame).toHaveAttribute("data-width", "13");
+
+        fireEvent.click(ordinaryGame);
+        expect(outerOnSelect).toHaveBeenCalledWith(999);
+        expect(miniGobanOnSelect).not.toHaveBeenCalled();
+    });
+
+    it("keeps the targeted current game disconnected while its snapshot is pending", () => {
+        render(
+            <GameList
+                list={[makeGame(123)]}
+                miniGobanProps={{
+                    miniGobanSnapshotOverrides: new Map([[123, null]]),
+                }}
+                lineSummaryMode="both-players"
+            />,
+        );
+
+        const currentGame = screen.getByTestId("mini-goban-123");
+        expect(currentGame).toHaveAttribute("data-game-id", "123");
+        expect(currentGame).toHaveAttribute("data-controller-game-id", "undefined");
+        expect(currentGame).toHaveAttribute("data-snapshot-move-tree-id", "undefined");
+    });
+
+    it("applies a detached snapshot only to the matching game", () => {
+        const onSelectGameId = jest.fn();
+        const snapshotConfig = {
+            game_id: undefined,
+            move_tree: { id: "official-tree" },
+            moves: [[3, 3]],
+        };
+
+        render(
+            <GameList
+                list={[makeGame(123), makeGame(456)]}
+                miniGobanProps={{
+                    miniGobanSnapshotOverrides: new Map([[123, snapshotConfig]]),
+                }}
+                onSelectGameId={onSelectGameId}
+                lineSummaryMode="both-players"
+            />,
+        );
+
+        const currentGame = screen.getByTestId("mini-goban-123");
+        expect(currentGame).toHaveAttribute("data-game-id", "123");
+        expect(currentGame).toHaveAttribute("data-snapshot-game-id", "undefined");
+        expect(currentGame).toHaveAttribute("data-controller-game-id", "undefined");
+        expect(currentGame).toHaveAttribute("data-move-count", "1");
+        expect(currentGame).toHaveAttribute("data-snapshot-move-tree-id", "official-tree");
+
+        fireEvent.click(currentGame);
+        expect(onSelectGameId).toHaveBeenCalledWith(123);
+
+        const ordinaryGame = screen.getByTestId("mini-goban-456");
+        expect(ordinaryGame).toHaveAttribute("data-game-id", "456");
+        expect(ordinaryGame).toHaveAttribute("data-controller-game-id", "456");
+        expect(ordinaryGame).toHaveAttribute("data-snapshot-move-tree-id", "undefined");
+    });
+
+    it("does not leak the snapshot map control to MiniGoban", () => {
+        render(
+            <GameList
+                list={[makeGame(123)]}
+                miniGobanProps={{
+                    miniGobanSnapshotOverrides: new Map([[123, { move_tree: { id: "tree" } }]]),
+                }}
+                lineSummaryMode="both-players"
+            />,
+        );
+
+        expect(screen.getByTestId("mini-goban-123")).toHaveAttribute(
+            "data-has-snapshot-override-prop",
+            "false",
+        );
+    });
+
+    it("does not mutate the supplied snapshot config", () => {
+        const snapshotConfig = {
+            game_id: undefined,
+            move_tree: { id: "official-tree" },
+        };
+
+        render(
+            <GameList
+                list={[makeGame(123)]}
+                miniGobanProps={{
+                    miniGobanSnapshotOverrides: new Map([[123, snapshotConfig]]),
+                }}
+                lineSummaryMode="both-players"
+            />,
+        );
+
+        expect(snapshotConfig).toEqual({
+            game_id: undefined,
+            move_tree: { id: "official-tree" },
+        });
+    });
+});

--- a/src/components/GameList/GameList.test.tsx
+++ b/src/components/GameList/GameList.test.tsx
@@ -100,7 +100,7 @@ describe("GameList thumbnail snapshots", () => {
         expect(ordinaryGame).toHaveAttribute("data-snapshot-move-tree-id", "undefined");
     });
 
-    it("preserves ordinary MiniGoban prop precedence and selection resolution", () => {
+    it("lets per-game props win over shared miniGobanProps for ordinary MiniGobans", () => {
         const miniGobanOnSelect = jest.fn();
         const outerOnSelect = jest.fn();
 
@@ -117,12 +117,12 @@ describe("GameList thumbnail snapshots", () => {
             />,
         );
 
-        const ordinaryGame = screen.getByTestId("mini-goban-999");
-        expect(ordinaryGame).toHaveAttribute("data-game-id", "999");
-        expect(ordinaryGame).toHaveAttribute("data-width", "13");
+        const ordinaryGame = screen.getByTestId("mini-goban-456");
+        expect(ordinaryGame).toHaveAttribute("data-game-id", "456");
+        expect(ordinaryGame).toHaveAttribute("data-width", "19");
 
         fireEvent.click(ordinaryGame);
-        expect(outerOnSelect).toHaveBeenCalledWith(999);
+        expect(outerOnSelect).toHaveBeenCalledWith(456);
         expect(miniGobanOnSelect).not.toHaveBeenCalled();
     });
 

--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -577,13 +577,13 @@ function MiniGobanList(
                 ) : (
                     <MiniGoban
                         key={game.id}
+                        {...forwardedMiniGobanProps}
                         game_id={game.id}
                         width={game.width}
                         height={game.height}
-                        onGobanCreated={gobanCreated}
                         player={player}
-                        {...forwardedMiniGobanProps}
                         onSelectGameId={onSelectGameId ?? miniGobanProps?.onSelectGameId}
+                        onGobanCreated={gobanCreated}
                     />
                 );
                 if (withNames) {

--- a/src/components/GameList/GameList.tsx
+++ b/src/components/GameList/GameList.tsx
@@ -32,6 +32,7 @@ import {
     AdHocPackedMove,
     GobanRenderer,
 } from "goban";
+import { SnapshotMiniGoban } from "./SnapshotMiniGoban";
 import "./GameList.css";
 
 interface UserType {
@@ -64,13 +65,18 @@ interface GameListProps {
     player?: { id: number };
     emptyMessage?: string;
     disableSort?: boolean;
-    miniGobanProps?: any;
+    miniGobanProps?: GameListMiniGobanProps;
     namesByGobans?: boolean;
     forceList?: boolean;
     forceMiniGoban?: boolean;
     lineSummaryMode: LineSummaryTableMode;
     onSelectGameId?: (gameId: number) => void;
 }
+
+type GameListMiniGobanProps = MiniGobanProps & {
+    /** Render selected list thumbnails from detached snapshots without subscribing. */
+    miniGobanSnapshotOverrides?: ReadonlyMap<number, MiniGobanProps["json"] | null>;
+};
 
 type SortOrder = "clock" | "move-number" | "name" | "opponent" | "opponent-clock" | "size";
 type DescendingSortOrder = `-${SortOrder}`;
@@ -542,23 +548,41 @@ function MiniGobanList(
     withNames: boolean,
     onGobanCreated: (game: GameType, goban: GobanRenderer) => void,
     player?: { id: number },
-    miniGobanProps?: MiniGobanProps,
+    miniGobanProps?: GameListMiniGobanProps,
     onSelectGameId?: (gameId: number) => void,
 ): React.ReactElement {
+    const { miniGobanSnapshotOverrides, ...forwardedMiniGobanProps } = miniGobanProps || {};
+
     return (
         <div className="GameList">
             {games.map((game) => {
-                const miniGoban = (
-                    <MiniGoban
-                        key={!withNames ? game.id : undefined}
+                const hasSnapshotOverride = miniGobanSnapshotOverrides?.has(game.id) ?? false;
+                const snapshot = hasSnapshotOverride
+                    ? (miniGobanSnapshotOverrides?.get(game.id) ?? null)
+                    : undefined;
+                const gobanCreated = (goban_controller: { goban: GobanRenderer }) =>
+                    onGobanCreated(game, goban_controller.goban);
+                const miniGoban = hasSnapshotOverride ? (
+                    <SnapshotMiniGoban
+                        key={game.id}
+                        {...forwardedMiniGobanProps}
                         game_id={game.id}
                         width={game.width}
                         height={game.height}
-                        onGobanCreated={(goban_controller) =>
-                            onGobanCreated(game, goban_controller.goban)
-                        }
                         player={player}
-                        {...(miniGobanProps || {})}
+                        snapshot={snapshot}
+                        onSelectGameId={onSelectGameId ?? miniGobanProps?.onSelectGameId}
+                        onGobanCreated={gobanCreated}
+                    />
+                ) : (
+                    <MiniGoban
+                        key={game.id}
+                        game_id={game.id}
+                        width={game.width}
+                        height={game.height}
+                        onGobanCreated={gobanCreated}
+                        player={player}
+                        {...forwardedMiniGobanProps}
                         onSelectGameId={onSelectGameId ?? miniGobanProps?.onSelectGameId}
                     />
                 );

--- a/src/components/GameList/SnapshotMiniGoban.test.tsx
+++ b/src/components/GameList/SnapshotMiniGoban.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { restoreGobanToOfficialTail } from "@/lib/GobanController";
+import type { GobanController } from "@/lib/GobanController";
+import { SnapshotMiniGoban } from "./SnapshotMiniGoban";
+
+const mockLifecycle: string[] = [];
+const mockLoad = jest.fn((snapshot: unknown) => {
+    mockLifecycle.push("load");
+    return snapshot;
+});
+const mockController = {
+    goban: {
+        load: mockLoad,
+    },
+} as unknown as GobanController;
+
+jest.mock("@/components/MiniGoban", () => ({
+    __esModule: true,
+    MiniGoban: (props: {
+        game_id?: number;
+        json?: { game_id?: number };
+        onGobanCreated?: (controller: GobanController) => void;
+    }) => {
+        React.useEffect(() => {
+            mockLifecycle.push("listener-setup");
+            props.onGobanCreated?.(mockController);
+        }, []);
+
+        return (
+            <div
+                data-testid="mini-goban"
+                data-ui-game-id={String(props.game_id)}
+                data-constructor-game-id={String(props.json?.game_id)}
+            />
+        );
+    },
+}));
+
+jest.mock("@/lib/GobanController", () => ({
+    __esModule: true,
+    restoreGobanToOfficialTail: jest.fn(() => {
+        mockLifecycle.push("restore");
+    }),
+}));
+
+describe("SnapshotMiniGoban", () => {
+    beforeEach(() => {
+        mockLifecycle.length = 0;
+        mockLoad.mockClear();
+        jest.mocked(restoreGobanToOfficialTail).mockClear();
+    });
+
+    it("hydrates only after the detached child has installed its listeners", async () => {
+        const { rerender } = render(<SnapshotMiniGoban game_id={123} snapshot={null} />);
+
+        expect(screen.getByTestId("mini-goban")).toHaveAttribute("data-ui-game-id", "123");
+        expect(screen.getByTestId("mini-goban")).toHaveAttribute(
+            "data-constructor-game-id",
+            "undefined",
+        );
+        expect(mockLoad).not.toHaveBeenCalled();
+
+        const snapshot = { game_id: undefined, move_tree: { move_number: 2 } };
+        rerender(<SnapshotMiniGoban game_id={123} snapshot={snapshot} />);
+
+        await waitFor(() => {
+            expect(mockLoad).toHaveBeenCalledWith(snapshot);
+        });
+        expect(mockLifecycle).toEqual(["listener-setup", "load", "restore"]);
+    });
+
+    it("loads a newer snapshot without remounting the consumer", async () => {
+        const firstSnapshot = { game_id: undefined, move_tree: { move_number: 1 } };
+        const secondSnapshot = { game_id: undefined, move_tree: { move_number: 2 } };
+        const { rerender } = render(<SnapshotMiniGoban game_id={123} snapshot={firstSnapshot} />);
+
+        await waitFor(() => {
+            expect(mockLoad).toHaveBeenCalledTimes(1);
+        });
+        rerender(<SnapshotMiniGoban game_id={123} snapshot={secondSnapshot} />);
+
+        await waitFor(() => {
+            expect(mockLoad).toHaveBeenCalledTimes(2);
+        });
+        expect(mockLoad.mock.calls.map(([snapshot]) => snapshot)).toEqual([
+            firstSnapshot,
+            secondSnapshot,
+        ]);
+        expect(mockLifecycle).toEqual(["listener-setup", "load", "restore", "load", "restore"]);
+    });
+});

--- a/src/components/GameList/SnapshotMiniGoban.tsx
+++ b/src/components/GameList/SnapshotMiniGoban.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { MiniGoban, type MiniGobanProps } from "@/components/MiniGoban";
+import { restoreGobanToOfficialTail, type GobanController } from "@/lib/GobanController";
+
+interface SnapshotMiniGobanProps extends Omit<
+    MiniGobanProps,
+    "game_id" | "json" | "onGobanCreated"
+> {
+    game_id: number;
+    snapshot: MiniGobanProps["json"] | null;
+    onGobanCreated?: (goban_controller: GobanController) => void;
+}
+
+export function SnapshotMiniGoban(props: SnapshotMiniGobanProps): React.ReactElement {
+    const [controller, setController] = React.useState<GobanController | null>(null);
+    const { snapshot, onGobanCreated, ...miniGobanProps } = props;
+
+    React.useEffect(() => {
+        if (!controller || !snapshot) {
+            return;
+        }
+
+        controller.goban.load(snapshot);
+        restoreGobanToOfficialTail(controller.goban);
+    }, [controller, snapshot]);
+
+    return (
+        <MiniGoban
+            {...miniGobanProps}
+            game_id={props.game_id}
+            json={{ game_id: undefined }}
+            onGobanCreated={(nextController) => {
+                setController(nextController);
+                onGobanCreated?.(nextController);
+            }}
+        />
+    );
+}

--- a/src/lib/GobanController.ts
+++ b/src/lib/GobanController.ts
@@ -232,6 +232,21 @@ export function getMoveTreeTrunkTail(moveTree: MoveTree | null | undefined): Mov
     return cursor;
 }
 
+export function restoreGobanToOfficialTail(goban: GobanRenderer): MoveTree | null {
+    const officialTail = getMoveTreeTrunkTail(goban.engine.move_tree);
+
+    if (!officialTail || officialTail.move_number <= 0) {
+        return null;
+    }
+
+    goban.engine.jumpTo(officialTail);
+    goban.engine.setLastOfficialMove();
+    goban.jumpToLastOfficialMove();
+    goban.redraw(true);
+
+    return officialTail;
+}
+
 export interface ReviewListEntry {
     owner: PlayerCacheEntry;
     id: number;

--- a/src/views/Kibitz/KibitzGamePickerOverlay.test.tsx
+++ b/src/views/Kibitz/KibitzGamePickerOverlay.test.tsx
@@ -19,11 +19,33 @@ import * as React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { KibitzRoomSummary, KibitzWatchedGame } from "@/models/kibitz";
 import { KibitzGamePickerOverlay } from "./KibitzGamePickerOverlay";
+import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
 import { get } from "@/lib/requests";
 
 jest.mock("./KibitzBoard", () => ({
     __esModule: true,
-    KibitzBoard: () => <div data-testid="KibitzBoard" />,
+    KibitzBoard: (props: {
+        role?: string;
+        gameId?: number;
+        width?: number;
+        height?: number;
+        moveTree?: unknown;
+        movePath?: string;
+        restoreToOfficialTailOnLoad?: boolean;
+        connectToGame?: boolean;
+    }) => (
+        <div
+            data-testid="KibitzBoard"
+            data-role={props.role}
+            data-game-id={props.gameId}
+            data-width={props.width}
+            data-height={props.height}
+            data-move-tree-present={String(Boolean(props.moveTree))}
+            data-move-path={props.movePath}
+            data-restore-to-official-tail={String(props.restoreToOfficialTailOnLoad)}
+            data-connect-to-game={String(props.connectToGame)}
+        />
+    ),
 }));
 
 jest.mock("./KibitzUserAvatar", () => ({
@@ -33,10 +55,38 @@ jest.mock("./KibitzUserAvatar", () => ({
 
 jest.mock("@/components/ObserveGamesComponent", () => ({
     __esModule: true,
-    ObserveGamesComponent: ({ onSelectGameId }: { onSelectGameId: (gameId: number) => void }) => (
-        <div data-testid="ObserveGamesComponent">
+    ObserveGamesComponent: ({
+        onSelectGameId,
+        miniGobanProps,
+    }: {
+        onSelectGameId: (gameId: number) => void;
+        miniGobanProps?: {
+            miniGobanSnapshotOverrides?: ReadonlyMap<
+                number,
+                { game_id?: number; move_tree?: { id?: number | string } } | null
+            >;
+        };
+    }) => (
+        <div
+            data-testid="ObserveGamesComponent"
+            data-current-game-id={String(
+                miniGobanProps?.miniGobanSnapshotOverrides?.keys().next().value,
+            )}
+            data-snapshot-game-id={String(
+                miniGobanProps?.miniGobanSnapshotOverrides?.values().next().value?.game_id,
+            )}
+            data-snapshot-move-tree-id={String(
+                miniGobanProps?.miniGobanSnapshotOverrides?.values().next().value?.move_tree?.id,
+            )}
+            data-snapshot-ready={String(
+                Boolean(miniGobanProps?.miniGobanSnapshotOverrides?.values().next().value),
+            )}
+        >
             <button type="button" onClick={() => onSelectGameId(1234)}>
                 Select game
+            </button>
+            <button type="button" onClick={() => onSelectGameId(456)}>
+                Select another game
             </button>
         </div>
     ),
@@ -149,9 +199,9 @@ function makeRoom(currentGameId: number): KibitzRoomSummary {
     };
 }
 
-function makeGameDetails() {
+function makeGameDetails(gameId = 1234, moves: Array<{ x: number; y: number }> = []) {
     return {
-        id: 1234,
+        id: gameId,
         width: 19,
         height: 19,
         name: "Selected game",
@@ -177,7 +227,7 @@ function makeGameDetails() {
             },
         },
         gamedata: {
-            moves: [],
+            moves,
             private: false,
             disable_analysis: false,
         },
@@ -189,6 +239,62 @@ describe("KibitzGamePickerOverlay", () => {
         mockedGet.mockReset();
         installMatchMedia(false);
         installRequestAnimationFrame();
+    });
+
+    it("provides the current game's authoritative snapshot to picker thumbnails", () => {
+        const snapshot = {
+            gameId: 123,
+            roomId: "room-1",
+            trunkTailMoveNumber: 4,
+            moveTreeId: "official-tree",
+            movePath: "abcd",
+            source: "main-board",
+            config: {
+                game_id: 123,
+                move_tree: { id: "official-tree" },
+            },
+        } as unknown as KibitzCurrentGameBaseSnapshot;
+
+        render(
+            <KibitzGamePickerOverlay
+                mode="create-room"
+                rooms={[]}
+                currentRoom={makeRoom(123)}
+                currentGameBaseSnapshot={snapshot}
+                canOpenCreateRoomFlow={true}
+                signInHref="/sign-in#/kibitz"
+                onClose={jest.fn()}
+                onCreateRoom={jest.fn()}
+                onChangeBoard={jest.fn()}
+                onJoinRoom={jest.fn()}
+            />,
+        );
+
+        const picker = screen.getByTestId("ObserveGamesComponent");
+        expect(picker).toHaveAttribute("data-current-game-id", "123");
+        expect(picker).toHaveAttribute("data-snapshot-game-id", "undefined");
+        expect(picker).toHaveAttribute("data-snapshot-move-tree-id", "official-tree");
+        expect(picker).toHaveAttribute("data-snapshot-ready", "true");
+    });
+
+    it("keeps the current game in the detached snapshot map while pending", () => {
+        render(
+            <KibitzGamePickerOverlay
+                mode="create-room"
+                rooms={[]}
+                currentRoom={makeRoom(123)}
+                canOpenCreateRoomFlow={true}
+                signInHref="/sign-in#/kibitz"
+                onClose={jest.fn()}
+                onCreateRoom={jest.fn()}
+                onChangeBoard={jest.fn()}
+                onJoinRoom={jest.fn()}
+            />,
+        );
+
+        const picker = screen.getByTestId("ObserveGamesComponent");
+        expect(picker).toHaveAttribute("data-current-game-id", "123");
+        expect(picker).toHaveAttribute("data-snapshot-ready", "false");
     });
 
     it("disables create room while the submit request is in flight", async () => {
@@ -225,6 +331,83 @@ describe("KibitzGamePickerOverlay", () => {
         await waitFor(() => {
             expect(screen.getByRole("button", { name: "Create room" })).toBeEnabled();
         });
+    });
+
+    it("hydrates the desktop selected preview from the resolved game details", async () => {
+        mockedGet.mockResolvedValue(
+            makeGameDetails(1234, [
+                { x: 3, y: 4 },
+                { x: 15, y: 14 },
+            ]),
+        );
+
+        render(
+            <KibitzGamePickerOverlay
+                mode="create-room"
+                rooms={[]}
+                canOpenCreateRoomFlow={true}
+                signInHref="/sign-in#/kibitz"
+                onClose={jest.fn()}
+                onCreateRoom={jest.fn()}
+                onChangeBoard={jest.fn()}
+                onJoinRoom={jest.fn()}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText("Game ID"), { target: { value: "1234" } });
+        fireEvent.click(screen.getByRole("button", { name: "Load" }));
+
+        const board = await screen.findByTestId("KibitzBoard");
+        expect(board).toHaveAttribute("data-role", "preview");
+        expect(board).toHaveAttribute("data-game-id", "1234");
+        expect(board).toHaveAttribute("data-width", "19");
+        expect(board).toHaveAttribute("data-height", "19");
+        expect(board).toHaveAttribute("data-move-tree-present", "true");
+        expect(board).toHaveAttribute("data-restore-to-official-tail", "true");
+        expect(board).toHaveAttribute("data-connect-to-game", "undefined");
+        expect(mockedGet).toHaveBeenCalledTimes(1);
+        expect(mockedGet).toHaveBeenCalledWith("games/1234");
+    });
+
+    it("switches the desktop selected preview to the newly resolved game", async () => {
+        mockedGet
+            .mockResolvedValueOnce(makeGameDetails(1234, [{ x: 3, y: 4 }]))
+            .mockResolvedValueOnce(
+                makeGameDetails(456, [
+                    { x: 10, y: 10 },
+                    { x: 11, y: 11 },
+                ]),
+            );
+
+        render(
+            <KibitzGamePickerOverlay
+                mode="create-room"
+                rooms={[]}
+                canOpenCreateRoomFlow={true}
+                signInHref="/sign-in#/kibitz"
+                onClose={jest.fn()}
+                onCreateRoom={jest.fn()}
+                onChangeBoard={jest.fn()}
+                onJoinRoom={jest.fn()}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText("Game ID"), { target: { value: "1234" } });
+        fireEvent.click(screen.getByRole("button", { name: "Load" }));
+        const firstBoard = await screen.findByTestId("KibitzBoard");
+        expect(firstBoard).toHaveAttribute("data-game-id", "1234");
+        const firstMovePath = firstBoard.getAttribute("data-move-path");
+        expect(firstMovePath).not.toBeNull();
+
+        fireEvent.change(screen.getByLabelText("Game ID"), { target: { value: "456" } });
+        fireEvent.click(screen.getByRole("button", { name: "Load" }));
+        await waitFor(() => {
+            expect(screen.getByTestId("KibitzBoard")).toHaveAttribute("data-game-id", "456");
+        });
+        expect(mockedGet).toHaveBeenCalledTimes(2);
+        const secondBoard = screen.getByTestId("KibitzBoard");
+        expect(secondBoard).toHaveAttribute("data-move-tree-present", "true");
+        expect(secondBoard.getAttribute("data-move-path")).not.toBe(firstMovePath);
     });
 
     it("disables change board while the submit request is in flight", async () => {

--- a/src/views/Kibitz/KibitzGamePickerOverlay.tsx
+++ b/src/views/Kibitz/KibitzGamePickerOverlay.tsx
@@ -33,6 +33,11 @@ import {
 } from "./kibitzAnalysisPolicyText";
 import { parseGameId } from "./parseGameId";
 import { useCurrentKibitzUser } from "./useCurrentKibitzUser";
+import {
+    buildCurrentGameBaseSnapshotFromGameDetails,
+    createCurrentGameMiniGobanSnapshotOverrides,
+} from "./kibitzCurrentGameBaseSnapshot";
+import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
 import "./KibitzGamePickerOverlay.css";
 
 type KibitzGamePickerOverlayMode = "create-room" | "change-board";
@@ -54,6 +59,7 @@ interface KibitzGamePickerOverlayProps {
     ) => Promise<string | null> | string | null;
     onChangeBoard: (game: KibitzWatchedGame) => Promise<boolean> | boolean;
     onJoinRoom: (roomId: string) => void;
+    currentGameBaseSnapshot?: KibitzCurrentGameBaseSnapshot | null;
 }
 
 interface SelectedGameState {
@@ -150,6 +156,7 @@ export function KibitzGamePickerOverlay({
     onCreateRoom,
     onChangeBoard,
     onJoinRoom,
+    currentGameBaseSnapshot,
 }: KibitzGamePickerOverlayProps): React.ReactElement {
     const resolveGameRequestIdRef = React.useRef(0);
     const [selectedGame, setSelectedGame] = React.useState<SelectedGameState | null>(null);
@@ -183,6 +190,25 @@ export function KibitzGamePickerOverlay({
     }, []);
 
     const currentGameId = currentRoom?.current_game?.game_id ?? null;
+    const miniGobanSnapshotOverrides = React.useMemo(
+        () => createCurrentGameMiniGobanSnapshotOverrides(currentGameBaseSnapshot, currentGameId),
+        [currentGameBaseSnapshot, currentGameId],
+    );
+    const selectedGamePreviewSnapshot = React.useMemo(() => {
+        if (!selectedGame) {
+            return null;
+        }
+
+        try {
+            return buildCurrentGameBaseSnapshotFromGameDetails({
+                details: selectedGame.details,
+                gameId: selectedGame.game.game_id,
+                requiredSnapshotMoveNumber: selectedGame.game.move_number,
+            });
+        } catch {
+            return null;
+        }
+    }, [selectedGame]);
     const existingRoom = React.useMemo(() => {
         if (!selectedGame) {
             return null;
@@ -558,7 +584,7 @@ export function KibitzGamePickerOverlay({
                         </div>
                     </div>
                 )}
-                {showBoardPreview && !hidePickerGamePreviews ? (
+                {showBoardPreview && !hidePickerGamePreviews && selectedGamePreviewSnapshot ? (
                     <div
                         className={
                             "KibitzGamePickerOverlay-boardWrap" +
@@ -568,6 +594,11 @@ export function KibitzGamePickerOverlay({
                         <KibitzBoard
                             role="preview"
                             gameId={selectedGameSummary.game_id}
+                            width={selectedGame.details.width}
+                            height={selectedGame.details.height}
+                            moveTree={selectedGamePreviewSnapshot.config.move_tree}
+                            movePath={selectedGamePreviewSnapshot.movePath}
+                            restoreToOfficialTailOnLoad={true}
                             className="KibitzGamePickerOverlay-board"
                         />
                     </div>
@@ -757,6 +788,9 @@ export function KibitzGamePickerOverlay({
                                 updateTitle={false}
                                 channel=""
                                 initialMiniGoban={true}
+                                miniGobanProps={{
+                                    miniGobanSnapshotOverrides,
+                                }}
                                 onSelectGameId={onSelectGameId}
                             />
                         )}
@@ -906,6 +940,9 @@ export function KibitzGamePickerOverlay({
                             updateTitle={false}
                             channel=""
                             initialMiniGoban={true}
+                            miniGobanProps={{
+                                miniGobanSnapshotOverrides,
+                            }}
                             onSelectGameId={onSelectGameId}
                         />
                     )}

--- a/src/views/Kibitz/KibitzInner.snapshot.test.tsx
+++ b/src/views/Kibitz/KibitzInner.snapshot.test.tsx
@@ -18,7 +18,7 @@
 /* cspell:ignore refetches */
 
 import * as React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { KibitzController } from "./KibitzController";
 import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
 import type { KibitzRoom, KibitzRoomSummary, KibitzWatchedGame } from "@/models/kibitz";
@@ -95,7 +95,11 @@ jest.mock("./KibitzDebugPanel", () => ({
 
 jest.mock("./KibitzRoomList", () => ({
     __esModule: true,
-    KibitzRoomList: () => null,
+    KibitzRoomList: ({ onCreateRoom }: { onCreateRoom: () => void }) => (
+        <button type="button" onClick={onCreateRoom}>
+            Open create room
+        </button>
+    ),
 }));
 
 jest.mock("./KibitzRoomStage", () => ({
@@ -189,7 +193,15 @@ jest.mock("./KibitzMobileComparePanel", () => ({
 
 jest.mock("./KibitzGamePickerOverlay", () => ({
     __esModule: true,
-    KibitzGamePickerOverlay: () => null,
+    KibitzGamePickerOverlay: ({ mode }: { mode: string }) =>
+        mode ? (
+            <div role="dialog">
+                <label>
+                    Room name
+                    <input aria-label="Room name" defaultValue="initial room name" />
+                </label>
+            </div>
+        ) : null,
 }));
 
 jest.mock("./KibitzMobileGamePicker", () => ({
@@ -547,6 +559,7 @@ describe("KibitzInner current-game base snapshot fetch", () => {
 
     beforeEach(() => {
         mockedGet.mockReset();
+        mockedUseNavigate.mockReset();
         mockedGobanController.mockClear();
         mockedCaptureCurrentGameBaseSnapshotFromController.mockClear();
         mockedLogKibitzVariationDebug.mockClear();
@@ -876,6 +889,51 @@ describe("KibitzInner current-game base snapshot fetch", () => {
             expect(mockedGet).toHaveBeenCalledTimes(2);
             expect(mockedGet).toHaveBeenNthCalledWith(2, "games/2");
         });
+    });
+
+    it("keeps create-room open through a same-room live move update", async () => {
+        mockedGet.mockResolvedValue({
+            id: 1,
+            width: 19,
+            height: 19,
+            name: "Game 1",
+            ended: false,
+            players: {
+                black: makeUser(11, "black"),
+                white: makeUser(12, "white"),
+            },
+            gamedata: {
+                moves: Array.from({ length: 10 }, () => ({ x: 0, y: 0 })),
+                private: false,
+                disable_analysis: false,
+            },
+        });
+
+        const controller = makeController(makeRoom({ current_game: makeGame(1, 10) }));
+        render(<KibitzInner controller={controller} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Open create room" }));
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        fireEvent.change(screen.getByRole("textbox", { name: "Room name" }), {
+            target: { value: "edited room name" },
+        });
+        expect(screen.getByRole("textbox", { name: "Room name" })).toHaveValue("edited room name");
+
+        act(() => {
+            const mutableController = controller as unknown as {
+                active_room: KibitzRoom;
+            };
+            mutableController.active_room = makeRoom({ current_game: makeGame(1, 11) });
+            controller.emit("room-changed", mutableController.active_room);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole("dialog")).toBeInTheDocument();
+            expect(screen.getByRole("textbox", { name: "Room name" })).toHaveValue(
+                "edited room name",
+            );
+        });
+        expect(mockedUseNavigate).not.toHaveBeenCalled();
     });
 });
 

--- a/src/views/Kibitz/KibitzInner.tsx
+++ b/src/views/Kibitz/KibitzInner.tsx
@@ -3670,6 +3670,7 @@ export function KibitzInner({ controller }: KibitzInnerProps): React.ReactElemen
                 setPickerMode(null);
                 void navigate(`/kibitz/${nextRoomId}`);
             }}
+            currentGameBaseSnapshot={currentGameBaseSnapshot}
         />
     ) : null;
 
@@ -3941,6 +3942,7 @@ export function KibitzInner({ controller }: KibitzInnerProps): React.ReactElemen
                                                 mode={mobileOverlayMode}
                                                 rooms={rooms}
                                                 currentRoom={resolvedRoom}
+                                                currentGameBaseSnapshot={currentGameBaseSnapshot}
                                                 canOpenCreateRoomFlow={canOpenCreateRoomFlow}
                                                 signInHref={createRoomSignInHref}
                                                 onClose={onCloseMobileOverlay}

--- a/src/views/Kibitz/KibitzMobileGamePicker.test.tsx
+++ b/src/views/Kibitz/KibitzMobileGamePicker.test.tsx
@@ -7,11 +7,34 @@
 import * as React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { KibitzMobileGamePicker } from "./KibitzMobileGamePicker";
+import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
+import type { KibitzRoomSummary } from "@/models/kibitz";
 import { get } from "@/lib/requests";
 
 jest.mock("./KibitzBoard", () => ({
     __esModule: true,
-    KibitzBoard: () => <div data-testid="KibitzBoard" />,
+    KibitzBoard: (props: {
+        role?: string;
+        gameId?: number;
+        width?: number;
+        height?: number;
+        moveTree?: unknown;
+        movePath?: string;
+        restoreToOfficialTailOnLoad?: boolean;
+        connectToGame?: boolean;
+    }) => (
+        <div
+            data-testid="KibitzBoard"
+            data-role={props.role}
+            data-game-id={props.gameId}
+            data-width={props.width}
+            data-height={props.height}
+            data-move-tree-present={String(Boolean(props.moveTree))}
+            data-move-path={props.movePath}
+            data-restore-to-official-tail={String(props.restoreToOfficialTailOnLoad)}
+            data-connect-to-game={String(props.connectToGame)}
+        />
+    ),
 }));
 
 jest.mock("./KibitzUserAvatar", () => ({
@@ -21,8 +44,33 @@ jest.mock("./KibitzUserAvatar", () => ({
 
 jest.mock("@/components/ObserveGamesComponent", () => ({
     __esModule: true,
-    ObserveGamesComponent: ({ onSelectGameId }: { onSelectGameId: (gameId: number) => void }) => (
-        <div data-testid="ObserveGamesComponent">
+    ObserveGamesComponent: ({
+        onSelectGameId,
+        miniGobanProps,
+    }: {
+        onSelectGameId: (gameId: number) => void;
+        miniGobanProps?: {
+            miniGobanSnapshotOverrides?: ReadonlyMap<
+                number,
+                { game_id?: number; move_tree?: { id?: number | string } } | null
+            >;
+        };
+    }) => (
+        <div
+            data-testid="ObserveGamesComponent"
+            data-current-game-id={String(
+                miniGobanProps?.miniGobanSnapshotOverrides?.keys().next().value,
+            )}
+            data-snapshot-game-id={String(
+                miniGobanProps?.miniGobanSnapshotOverrides?.values().next().value?.game_id,
+            )}
+            data-snapshot-move-tree-id={String(
+                miniGobanProps?.miniGobanSnapshotOverrides?.values().next().value?.move_tree?.id,
+            )}
+            data-snapshot-ready={String(
+                Boolean(miniGobanProps?.miniGobanSnapshotOverrides?.values().next().value),
+            )}
+        >
             <button type="button" onClick={() => onSelectGameId(1234)}>
                 Select game
             </button>
@@ -98,9 +146,9 @@ function installMatchMedia(matches = false): void {
     });
 }
 
-function makeGameDetails() {
+function makeGameDetails(gameId = 1234, moves: Array<{ x: number; y: number }> = []) {
     return {
-        id: 1234,
+        id: gameId,
         width: 19,
         height: 19,
         name: "Selected game",
@@ -126,7 +174,7 @@ function makeGameDetails() {
             },
         },
         gamedata: {
-            moves: [],
+            moves,
             private: false,
             disable_analysis: false,
         },
@@ -137,6 +185,31 @@ describe("KibitzMobileGamePicker", () => {
     beforeEach(() => {
         mockedGet.mockReset();
         installMatchMedia(true);
+    });
+
+    it("keeps the current game in the detached snapshot map while pending", () => {
+        const currentRoom = {
+            id: "room-1",
+            current_game: { game_id: 123 },
+        } as unknown as KibitzRoomSummary;
+
+        render(
+            <KibitzMobileGamePicker
+                mode="create-room"
+                rooms={[]}
+                currentRoom={currentRoom}
+                canOpenCreateRoomFlow={true}
+                signInHref="/sign-in#/kibitz"
+                onClose={jest.fn()}
+                onCreateRoom={jest.fn()}
+                onChangeBoard={jest.fn()}
+                onJoinRoom={jest.fn()}
+            />,
+        );
+
+        const picker = screen.getByTestId("ObserveGamesComponent");
+        expect(picker).toHaveAttribute("data-current-game-id", "123");
+        expect(picker).toHaveAttribute("data-snapshot-ready", "false");
     });
 
     it("shows a login-required state for anonymous create-room direct entry", () => {
@@ -162,13 +235,26 @@ describe("KibitzMobileGamePicker", () => {
     });
 
     it("renders the normal create flow for logged-in users", async () => {
-        mockedGet.mockResolvedValue(makeGameDetails());
+        mockedGet.mockResolvedValue(makeGameDetails(1234, [{ x: 3, y: 4 }]));
         const onCreateRoom = jest.fn(() => Promise.resolve("room-2"));
+        const currentRoom = {
+            id: "room-1",
+            current_game: { game_id: 123 },
+        } as unknown as KibitzRoomSummary;
+        const currentGameBaseSnapshot = {
+            gameId: 123,
+            config: {
+                game_id: 123,
+                move_tree: { id: "official-tree" },
+            },
+        } as unknown as KibitzCurrentGameBaseSnapshot;
 
         render(
             <KibitzMobileGamePicker
                 mode="create-room"
                 rooms={[]}
+                currentRoom={currentRoom}
+                currentGameBaseSnapshot={currentGameBaseSnapshot}
                 canOpenCreateRoomFlow={true}
                 signInHref="/sign-in#/kibitz"
                 onClose={jest.fn()}
@@ -178,10 +264,48 @@ describe("KibitzMobileGamePicker", () => {
             />,
         );
 
+        const picker = screen.getByTestId("ObserveGamesComponent");
+        expect(picker).toHaveAttribute("data-current-game-id", "123");
+        expect(picker).toHaveAttribute("data-snapshot-game-id", "undefined");
+        expect(picker).toHaveAttribute("data-snapshot-move-tree-id", "official-tree");
+        expect(picker).toHaveAttribute("data-snapshot-ready", "true");
+
         fireEvent.click(screen.getByRole("button", { name: "Select game" }));
 
         await waitFor(() => {
             expect(screen.getByRole("button", { name: "Create room" })).toBeInTheDocument();
         });
+    });
+
+    it("moves to the mobile preview with the selected game's detached move tree", async () => {
+        mockedGet.mockResolvedValue(
+            makeGameDetails(1234, [
+                { x: 3, y: 4 },
+                { x: 15, y: 14 },
+            ]),
+        );
+
+        render(
+            <KibitzMobileGamePicker
+                mode="create-room"
+                rooms={[]}
+                canOpenCreateRoomFlow={true}
+                signInHref="/sign-in#/kibitz"
+                onClose={jest.fn()}
+                onCreateRoom={jest.fn()}
+                onChangeBoard={jest.fn()}
+                onJoinRoom={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Select game" }));
+
+        const board = await screen.findByTestId("KibitzBoard");
+        expect(board).toHaveAttribute("data-role", "preview");
+        expect(board).toHaveAttribute("data-game-id", "1234");
+        expect(board).toHaveAttribute("data-move-tree-present", "true");
+        expect(board).toHaveAttribute("data-move-path");
+        expect(board).toHaveAttribute("data-restore-to-official-tail", "true");
+        expect(board).toHaveAttribute("data-connect-to-game", "undefined");
     });
 });

--- a/src/views/Kibitz/KibitzMobileGamePicker.tsx
+++ b/src/views/Kibitz/KibitzMobileGamePicker.tsx
@@ -33,6 +33,11 @@ import {
 } from "./kibitzAnalysisPolicyText";
 import { parseGameId } from "./parseGameId";
 import { useCurrentKibitzUser } from "./useCurrentKibitzUser";
+import {
+    buildCurrentGameBaseSnapshotFromGameDetails,
+    createCurrentGameMiniGobanSnapshotOverrides,
+} from "./kibitzCurrentGameBaseSnapshot";
+import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
 
 type KibitzGamePickerMode = "create-room" | "change-board";
 type PickerSourceMode = "ongoing" | "game-id";
@@ -54,6 +59,7 @@ interface KibitzMobileGamePickerProps {
     onChangeBoard: (game: KibitzWatchedGame) => Promise<boolean> | boolean;
     onJoinRoom: (roomId: string) => void;
     onBackToMenu?: () => void;
+    currentGameBaseSnapshot?: KibitzCurrentGameBaseSnapshot | null;
 }
 
 interface SelectedGameState {
@@ -151,6 +157,7 @@ export function KibitzMobileGamePicker({
     onChangeBoard,
     onJoinRoom,
     onBackToMenu,
+    currentGameBaseSnapshot,
 }: KibitzMobileGamePickerProps): React.ReactElement {
     const resolveGameRequestIdRef = React.useRef(0);
     const [selectedGame, setSelectedGame] = React.useState<SelectedGameState | null>(null);
@@ -184,6 +191,25 @@ export function KibitzMobileGamePicker({
     }, []);
 
     const currentGameId = currentRoom?.current_game?.game_id ?? null;
+    const miniGobanSnapshotOverrides = React.useMemo(
+        () => createCurrentGameMiniGobanSnapshotOverrides(currentGameBaseSnapshot, currentGameId),
+        [currentGameBaseSnapshot, currentGameId],
+    );
+    const selectedGamePreviewSnapshot = React.useMemo(() => {
+        if (!selectedGame) {
+            return null;
+        }
+
+        try {
+            return buildCurrentGameBaseSnapshotFromGameDetails({
+                details: selectedGame.details,
+                gameId: selectedGame.game.game_id,
+                requiredSnapshotMoveNumber: selectedGame.game.move_number,
+            });
+        } catch {
+            return null;
+        }
+    }, [selectedGame]);
     const existingRoom = React.useMemo(() => {
         if (!selectedGame) {
             return null;
@@ -538,7 +564,7 @@ export function KibitzMobileGamePicker({
                             "Switching board...",
                         )}
                     </div>
-                ) : (
+                ) : selectedGamePreviewSnapshot ? (
                     <div
                         className={
                             "KibitzGamePickerOverlay-boardWrap" +
@@ -548,10 +574,15 @@ export function KibitzMobileGamePicker({
                         <KibitzBoard
                             role="preview"
                             gameId={selectedGameSummary.game_id}
+                            width={selectedGame.details.width}
+                            height={selectedGame.details.height}
+                            moveTree={selectedGamePreviewSnapshot.config.move_tree}
+                            movePath={selectedGamePreviewSnapshot.movePath}
+                            restoreToOfficialTailOnLoad={true}
                             className="KibitzGamePickerOverlay-board"
                         />
                     </div>
-                )}
+                ) : null}
                 {selectionErrorMessage ? (
                     <div className="KibitzGamePickerOverlay-error">{selectionErrorMessage}</div>
                 ) : null}
@@ -660,6 +691,9 @@ export function KibitzMobileGamePicker({
                             updateTitle={false}
                             channel=""
                             initialMiniGoban={true}
+                            miniGobanProps={{
+                                miniGobanSnapshotOverrides,
+                            }}
                             onSelectGameId={onSelectGameId}
                             compactControls={true}
                         />

--- a/src/views/Kibitz/KibitzRoomStage.test.ts
+++ b/src/views/Kibitz/KibitzRoomStage.test.ts
@@ -29,7 +29,6 @@ import {
     buildSelectedGameBaseSnapshotFromDetails,
     clearDraftBaseAppliedState,
     clearInstalledSecondaryVariationBaseState,
-    buildSnapshotFromEngine,
     decideSecondaryVariationReloadAction,
     getSameGameVariationBaseSnapshotState,
     getCurrentSecondaryVariationBaseTreeIdentity,
@@ -63,6 +62,7 @@ import {
     selectedGameSnapshotFailureKey,
     type SelectedGameBaseSnapshotFailure,
 } from "./KibitzRoomStage";
+import { buildSnapshotFromEngine } from "./kibitzCurrentGameBaseSnapshot";
 import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
 
 function makeUser(id: number, username: string) {

--- a/src/views/Kibitz/KibitzRoomStage.tsx
+++ b/src/views/Kibitz/KibitzRoomStage.tsx
@@ -18,14 +18,7 @@
 /* cspell:ignore unhydrated */
 
 import * as React from "react";
-import {
-    GobanEngine,
-    type GobanConfig,
-    type GobanEngineConfig,
-    type GobanModes,
-    type MoveTree,
-    type MoveTreeJson,
-} from "goban";
+import { type GobanConfig, type GobanModes, type MoveTree, type MoveTreeJson } from "goban";
 import { Resizable } from "@/components/Resizable";
 import { KBShortcut } from "@/components/KBShortcut";
 import { GobanController, getMoveTreeTrunkTail } from "@/lib/GobanController";
@@ -41,6 +34,7 @@ import type {
     KibitzWatchedGame,
 } from "@/models/kibitz";
 import {
+    buildCurrentGameBaseSnapshotFromGameDetails,
     cloneOfficialTrunkMoveTreeJson,
     hydrateMainBoardFromRoomBaseSnapshot,
     restoreMainBoardToOfficialTail,
@@ -318,41 +312,6 @@ export function buildSelectedGameSnapshotFailureFromError(params: {
     };
 }
 
-export function buildSnapshotFromEngine({
-    engine,
-    gameId,
-    roomId,
-    source,
-    requiredSnapshotMoveNumber,
-}: {
-    engine: GobanEngine;
-    gameId: number;
-    roomId: string | null | undefined;
-    source: KibitzCurrentGameBaseSnapshot["source"];
-    requiredSnapshotMoveNumber: number;
-}): KibitzCurrentGameBaseSnapshot | null {
-    const officialTail = getMoveTreeTrunkTail(engine.move_tree);
-    if (!officialTail || officialTail.move_number < requiredSnapshotMoveNumber) {
-        return null;
-    }
-
-    return {
-        gameId,
-        roomId: roomId ?? null,
-        trunkTailMoveNumber: officialTail.move_number,
-        moveTreeId: engine.move_tree?.id ?? null,
-        movePath: officialTail.getMoveStringToThisPoint(),
-        source,
-        fetchedMoveCount: null,
-        config: {
-            ...(engine.config as Record<string, unknown>),
-            game_id: gameId,
-            moves: undefined,
-            move_tree: cloneOfficialTrunkMoveTreeJson(engine.move_tree),
-        },
-    };
-}
-
 export function isSelectedGameBaseSnapshotFreshEnough(
     snapshot: KibitzCurrentGameBaseSnapshot | null | undefined,
     selectedGameId: number | null | undefined,
@@ -482,17 +441,34 @@ export function buildSelectedGameBaseSnapshotFromDetails({
         };
     }
 
-    let engine: GobanEngine;
-
     try {
-        const engineConfig = {
-            ...details.gamedata,
-            game_id: gameId,
-            width: details.width,
-            height: details.height,
-            moves: details.gamedata.moves,
-        } as unknown as GobanEngineConfig;
-        engine = new GobanEngine(engineConfig);
+        const snapshot = buildCurrentGameBaseSnapshotFromGameDetails({
+            details,
+            gameId,
+            roomId,
+            source: "selected-game-details",
+            requiredSnapshotMoveNumber,
+        });
+
+        if (!snapshot) {
+            return {
+                kind: "failure",
+                failure: {
+                    kind: "not-fresh-enough",
+                    retryAfter: Date.now() + SELECTED_GAME_NOT_FRESH_RETRY_MS,
+                    details: {
+                        trunkTailMoveNumber: details.gamedata.moves.length,
+                        requiredMoveNumber: requiredSnapshotMoveNumber,
+                    },
+                },
+            };
+        }
+
+        snapshot.fetchedMoveCount = details.gamedata.moves.length;
+        return {
+            kind: "ready",
+            snapshot,
+        };
     } catch (error) {
         return {
             kind: "failure",
@@ -505,34 +481,6 @@ export function buildSelectedGameBaseSnapshotFromDetails({
             },
         };
     }
-
-    const snapshot = buildSnapshotFromEngine({
-        engine,
-        gameId,
-        roomId,
-        source: "selected-game-details",
-        requiredSnapshotMoveNumber,
-    });
-
-    if (!snapshot) {
-        return {
-            kind: "failure",
-            failure: {
-                kind: "not-fresh-enough",
-                retryAfter: Date.now() + SELECTED_GAME_NOT_FRESH_RETRY_MS,
-                details: {
-                    trunkTailMoveNumber: getMoveTreeTrunkTail(engine.move_tree)?.move_number ?? 0,
-                    requiredMoveNumber: requiredSnapshotMoveNumber,
-                },
-            },
-        };
-    }
-
-    snapshot.fetchedMoveCount = details.gamedata.moves.length;
-    return {
-        kind: "ready",
-        snapshot,
-    };
 }
 
 async function fetchSelectedGameBaseSnapshot({

--- a/src/views/Kibitz/kibitzCurrentGameBaseSnapshot.test.ts
+++ b/src/views/Kibitz/kibitzCurrentGameBaseSnapshot.test.ts
@@ -15,14 +15,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type { GobanController } from "@/lib/GobanController";
+import {
+    GobanController,
+    getMoveTreeTrunkTail,
+    restoreGobanToOfficialTail,
+} from "@/lib/GobanController";
 import type { KibitzWatchedGame } from "@/models/kibitz";
 import {
     canHydrateMainBoardFromRoomBaseSnapshot,
+    buildCurrentGameBaseSnapshotFromGameDetails,
     captureCurrentGameBaseSnapshotFromController,
     chooseFresherCurrentGameBaseSnapshot,
+    createCurrentGameMiniGobanSnapshotOverrides,
     hydrateMainBoardFromRoomBaseSnapshot,
 } from "./kibitzCurrentGameBaseSnapshot";
+import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
 
 function makeGame(gameId: number, moveNumber: number): KibitzWatchedGame {
     return {
@@ -116,6 +123,7 @@ function makeController(moveTree: TestMoveTree): GobanController {
                 controller.goban.engine.config = config;
             }),
             redraw: jest.fn(),
+            jumpToLastOfficialMove: jest.fn(),
             engine: {
                 config: {},
                 move_tree: moveTree,
@@ -171,7 +179,89 @@ describe("chooseFresherCurrentGameBaseSnapshot", () => {
     });
 });
 
+describe("buildCurrentGameBaseSnapshotFromGameDetails", () => {
+    it("builds an official detached trunk from REST game details", () => {
+        const moves = [
+            { x: 3, y: 4 },
+            { x: 15, y: 14 },
+        ];
+        const snapshot = buildCurrentGameBaseSnapshotFromGameDetails({
+            details: {
+                width: 19,
+                height: 19,
+                gamedata: {
+                    moves,
+                },
+            },
+            gameId: 4321,
+        });
+
+        expect(snapshot?.gameId).toBe(4321);
+        expect(snapshot?.trunkTailMoveNumber).toBe(2);
+        expect(snapshot?.config.move_tree).toBeDefined();
+        expect(snapshot?.config.move_tree?.trunk_next?.trunk_next).toBeDefined();
+    });
+
+    it("creates a valid root snapshot for a zero-move game", () => {
+        const snapshot = buildCurrentGameBaseSnapshotFromGameDetails({
+            details: {
+                width: 13,
+                height: 9,
+                gamedata: { moves: [] },
+            },
+            gameId: 4321,
+        });
+
+        expect(snapshot).toEqual(
+            expect.objectContaining({
+                gameId: 4321,
+                trunkTailMoveNumber: 0,
+                config: expect.objectContaining({
+                    width: 13,
+                    height: 9,
+                    move_tree: expect.any(Object),
+                }),
+            }),
+        );
+    });
+});
+
 describe("main board broker hydration", () => {
+    it("positions a snapshot renderer at the official trunk tail", () => {
+        const controller = new GobanController({
+            width: 9,
+            height: 9,
+            move_tree: {
+                x: -1,
+                y: -1,
+                trunk_next: {
+                    x: 3,
+                    y: 3,
+                    trunk_next: {
+                        x: 4,
+                        y: 3,
+                    },
+                },
+            },
+        });
+        const { engine } = controller.goban;
+        const redraw = jest.spyOn(controller.goban, "redraw");
+        let observedMoveNumber = 0;
+        controller.goban.on("update", () => {
+            observedMoveNumber = controller.goban.engine.cur_move.move_number;
+        });
+
+        expect(getMoveTreeTrunkTail(engine.move_tree)?.move_number).toBe(2);
+        expect(engine.cur_move.move_number).toBe(0);
+        expect(engine.last_official_move.move_number).toBe(0);
+
+        expect(restoreGobanToOfficialTail(controller.goban)?.move_number).toBe(2);
+        expect(engine.cur_move.move_number).toBe(2);
+        expect(engine.last_official_move.move_number).toBe(2);
+        expect(observedMoveNumber).toBe(2);
+        expect(redraw).toHaveBeenCalledWith(true);
+    });
+
     it("accepts a fresh current-room snapshot for a root-only main board", () => {
         const controller = makeController(makeMoveTree(0));
         const roomBaseSnapshot = {
@@ -231,6 +321,7 @@ describe("main board broker hydration", () => {
         );
         expect(controller.goban.engine.jumpTo).toHaveBeenCalled();
         expect(controller.goban.engine.setLastOfficialMove).toHaveBeenCalled();
+        expect(controller.goban.jumpToLastOfficialMove).toHaveBeenCalled();
         expect(controller.goban.redraw).toHaveBeenCalledWith(true);
     });
 
@@ -410,5 +501,81 @@ describe("captureCurrentGameBaseSnapshotFromController", () => {
                 "room-base-broker",
             ),
         ).toBeNull();
+    });
+});
+
+describe("createCurrentGameMiniGobanSnapshotOverrides", () => {
+    it("keeps the current game detached while its snapshot is pending", () => {
+        expect(createCurrentGameMiniGobanSnapshotOverrides(null, 123)).toEqual(
+            new Map([[123, null]]),
+        );
+    });
+
+    it("clones the matching snapshot and suppresses only its internal game id", () => {
+        const snapshot = {
+            gameId: 123,
+            roomId: "room-1",
+            trunkTailMoveNumber: 2,
+            moveTreeId: "tree-1",
+            movePath: "ab",
+            source: "main-board",
+            config: {
+                game_id: 123,
+                move_tree: { id: "tree-1" },
+            },
+        } as unknown as KibitzCurrentGameBaseSnapshot;
+
+        const overrides = createCurrentGameMiniGobanSnapshotOverrides(snapshot, 123);
+        const config = overrides?.get(123);
+
+        expect(config?.game_id).toBeUndefined();
+        expect(config?.move_tree).toEqual({ id: "tree-1" });
+        expect(config?.move_tree).not.toBe(snapshot.config.move_tree);
+        expect(snapshot.config.game_id).toBe(123);
+    });
+
+    it("does not serialize live renderer references in the snapshot config", () => {
+        const circularSocket: Record<string, unknown> = {};
+        circularSocket.events = { context: circularSocket };
+        const boardDiv = document.createElement("div");
+        const snapshot = {
+            gameId: 123,
+            config: {
+                game_id: 123,
+                board_div: boardDiv,
+                connect_to_chat: true,
+                server_socket: circularSocket,
+                move_tree: {
+                    id: "tree-1",
+                    move_number: 2,
+                    trunk_next: undefined,
+                },
+            },
+        } as unknown as KibitzCurrentGameBaseSnapshot;
+
+        const config = createCurrentGameMiniGobanSnapshotOverrides(snapshot, 123)?.get(123);
+
+        expect(config).toEqual(
+            expect.objectContaining({
+                connect_to_chat: false,
+                game_id: undefined,
+                move_tree: expect.objectContaining({ id: "tree-1" }),
+                server_socket: undefined,
+            }),
+        );
+        expect(config).not.toHaveProperty("board_div");
+        expect(snapshot.config.server_socket).toBe(circularSocket);
+        expect(snapshot.config.board_div).toBe(boardDiv);
+    });
+
+    it("does not create an override for a different game", () => {
+        const snapshot = {
+            gameId: 123,
+            config: {},
+        } as unknown as KibitzCurrentGameBaseSnapshot;
+
+        expect(createCurrentGameMiniGobanSnapshotOverrides(snapshot, 456)).toEqual(
+            new Map([[456, null]]),
+        );
     });
 });

--- a/src/views/Kibitz/kibitzCurrentGameBaseSnapshot.ts
+++ b/src/views/Kibitz/kibitzCurrentGameBaseSnapshot.ts
@@ -15,10 +15,66 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type MoveTree, type MoveTreeJson } from "goban";
-import { getMoveTreeTrunkTail, type GobanController } from "@/lib/GobanController";
+import { GobanEngine, type GobanEngineConfig, type MoveTree, type MoveTreeJson } from "goban";
+import {
+    getMoveTreeTrunkTail,
+    restoreGobanToOfficialTail,
+    type GobanController,
+} from "@/lib/GobanController";
 import type { KibitzWatchedGame } from "@/models/kibitz";
 import type { KibitzCurrentGameBaseSnapshot } from "./kibitzCurrentGameBaseSnapshotTypes";
+
+export function createCurrentGameMiniGobanSnapshotOverrides(
+    snapshot: KibitzCurrentGameBaseSnapshot | null | undefined,
+    currentGameId: number | null | undefined,
+): ReadonlyMap<number, KibitzCurrentGameBaseSnapshot["config"] | null> | undefined {
+    if (currentGameId == null) {
+        return undefined;
+    }
+
+    if (!snapshot || snapshot.gameId !== currentGameId) {
+        return new Map([[currentGameId, null]]);
+    }
+
+    return new Map([[currentGameId, cloneMiniGobanSnapshotConfig(snapshot.config)]]);
+}
+
+function cloneMiniGobanSnapshotConfig(
+    source: KibitzCurrentGameBaseSnapshot["config"],
+): KibitzCurrentGameBaseSnapshot["config"] {
+    const {
+        board_div: _boardDiv,
+        title_div: _titleDiv,
+        move_tree_container: _moveTreeContainer,
+        move_tree: moveTree,
+        server_socket: _serverSocket,
+        ...serializableSource
+    } = source;
+    const seen = new WeakSet<object>();
+    const config = JSON.parse(
+        JSON.stringify(serializableSource, (_key, value: unknown) => {
+            if (typeof value === "function") {
+                return undefined;
+            }
+            if (value && typeof value === "object") {
+                if (seen.has(value)) {
+                    return undefined;
+                }
+                seen.add(value);
+            }
+            return value;
+        }),
+    ) as KibitzCurrentGameBaseSnapshot["config"];
+
+    return {
+        ...config,
+        connect_to_chat: false,
+        game_id: undefined,
+        moves: undefined,
+        move_tree: moveTree ? cloneMoveTreeJson(moveTree) : undefined,
+        server_socket: undefined,
+    };
+}
 
 export function cloneOfficialTrunkMoveTreeJson(moveTree: MoveTree): MoveTreeJson {
     const { branches: _branches, ...json } = moveTree.toJson();
@@ -30,23 +86,99 @@ export function cloneOfficialTrunkMoveTreeJson(moveTree: MoveTree): MoveTreeJson
     return json;
 }
 
+export interface KibitzGameDetailsForSnapshot {
+    width: number;
+    height: number;
+    gamedata?: {
+        moves?: unknown;
+    };
+}
+
+export function buildSnapshotFromEngine({
+    engine,
+    gameId,
+    roomId,
+    source,
+    requiredSnapshotMoveNumber,
+}: {
+    engine: GobanEngine;
+    gameId: number;
+    roomId: string | null | undefined;
+    source: KibitzCurrentGameBaseSnapshot["source"];
+    requiredSnapshotMoveNumber: number;
+}): KibitzCurrentGameBaseSnapshot | null {
+    const officialTail = getMoveTreeTrunkTail(engine.move_tree);
+    if (!officialTail || officialTail.move_number < requiredSnapshotMoveNumber) {
+        return null;
+    }
+
+    return {
+        gameId,
+        roomId: roomId ?? null,
+        trunkTailMoveNumber: officialTail.move_number,
+        moveTreeId: engine.move_tree?.id ?? null,
+        movePath: officialTail.getMoveStringToThisPoint(),
+        source,
+        fetchedMoveCount: null,
+        config: {
+            ...(engine.config as Record<string, unknown>),
+            game_id: gameId,
+            moves: undefined,
+            move_tree: cloneOfficialTrunkMoveTreeJson(engine.move_tree),
+        },
+    };
+}
+
+export function buildCurrentGameBaseSnapshotFromGameDetails({
+    details,
+    gameId,
+    roomId,
+    requiredSnapshotMoveNumber,
+    source = "selected-game-details",
+}: {
+    details: KibitzGameDetailsForSnapshot;
+    gameId: number;
+    roomId?: string | null;
+    requiredSnapshotMoveNumber?: number;
+    source?: KibitzCurrentGameBaseSnapshot["source"];
+}): KibitzCurrentGameBaseSnapshot | null {
+    const moves = details?.gamedata?.moves;
+    if (!Array.isArray(moves)) {
+        return null;
+    }
+
+    if (
+        !Number.isFinite(details.width) ||
+        !Number.isFinite(details.height) ||
+        details.width <= 0 ||
+        details.height <= 0
+    ) {
+        return null;
+    }
+
+    const engine = new GobanEngine({
+        ...details.gamedata,
+        game_id: gameId,
+        width: details.width,
+        height: details.height,
+        moves,
+    } as unknown as GobanEngineConfig);
+
+    return buildSnapshotFromEngine({
+        engine,
+        gameId,
+        roomId,
+        source,
+        requiredSnapshotMoveNumber: requiredSnapshotMoveNumber ?? moves.length,
+    });
+}
+
 function cloneMoveTreeJson(moveTree: MoveTreeJson): MoveTreeJson {
     return JSON.parse(JSON.stringify(moveTree)) as MoveTreeJson;
 }
 
 export function restoreMainBoardToOfficialTail(controller: GobanController): MoveTree | null {
-    const { engine } = controller.goban;
-    const officialTail = getMoveTreeTrunkTail(engine.move_tree);
-
-    if (!officialTail || officialTail.move_number <= 0) {
-        return null;
-    }
-
-    engine.jumpTo(officialTail);
-    engine.setLastOfficialMove();
-    controller.goban.redraw(true);
-
-    return officialTail;
+    return restoreGobanToOfficialTail(controller.goban);
 }
 
 export function canHydrateMainBoardFromRoomBaseSnapshot({


### PR DESCRIPTION
Fixes a Kibitz bug where opening Create Room while already watching a game could cause the page to reload when that game received its next move.
The picker could mount a second MiniGoban for the room's current game. Because the game subscription is shared, that late-joining Goban could receive incremental live events without first receiving the state those events were based on. Goban's synchronization-error handling could then reload the page.
This change keeps that one duplicate thumbnail detached from the live game subscription and hydrates it from the authoritative Kibitz board snapshot instead. Hydration happens after MiniGoban has installed its normal update listeners, so player/score metadata follows the normal Goban lifecycle.
Selected-game confirmation previews are also kept detached and hydrated from the `games/{id}` response that the picker already fetches, rather than opening another live consumer.
Ordinary Observe game thumbnails are unchanged and remain live.
Tested on desktop and mobile, including waiting for real moves while the Create Room form is open. The form remains open and retains edits without a document reload.
Validation: 127 focused tests across the affected Kibitz/GameList paths, plus TypeScript, ESLint, Prettier and `git diff --check`.