### PR TITLE
Joseki: fix the position description being trapped in a tiny scroll box on mobile

### DIFF
--- a/src/views/Joseki/Joseki.css
+++ b/src/views/Joseki/Joseki.css
@@ -26,6 +26,28 @@
         padding-top: 0;
     }
 
+    /* Portrait puts the inline panels inside .GobanView-mobile-scroll, which is
+       already the scroll container for everything below the goban. Panels there
+       must size to their content and let that container do the scrolling. If
+       they keep the sidebar's "fill the available height and scroll inside"
+       rules, they shrink to the remaining space and trap the description and
+       the comments in inner scroll boxes only a few lines tall. */
+    &.portrait .GobanView-mobile-scroll > .GobanView-tab-panel {
+        flex-grow: 0;
+        flex-shrink: 0;
+
+        .explore-pane,
+        .discussion-lines,
+        .play-dashboard {
+            flex-shrink: 0;
+            overflow-y: visible;
+        }
+
+        .joseki-inline-comments {
+            max-height: none;
+        }
+    }
+
     /* ---- Move bar (reset / back / [knob] / forward / tenuki / throbber) ---- */
 
     .Joseki-move-bar {


### PR DESCRIPTION
Fixes #3586

## Problem

On mobile (portrait), the Joseki position description is clipped into an unreachable scroll box a few lines tall, and the area below the goban does not scroll. Turning comments on makes it worse. The reporter's screenshot shows "Knights Move" as the only visible line.

## Cause

`.Joseki .GobanView-tab-panel.always` is a full-height flex column that scrolls internally. That is correct for the desktop sidebar, which has a fixed height.

In portrait, `GobanView` renders the same panel inside `.GobanView-mobile-scroll`, which is already the scroll container for everything below the goban. The panel therefore shrank to the leftover space instead of growing past it. `.position-details` is `flex-shrink: 0`, so all of the shrinking landed on `.explore-pane`, whose `overflow-y: auto` turned it into a small inner scroller.

Measured at 412x915 on position 21748 ("Knight's Approach"):

```
.GobanView-mobile-scroll: clientH=301 scrollH=301   <- outer area never scrolled
.explore-pane:            clientH=81  scrollH=288   <- description trapped
```

## Change

In portrait only, panels inside the mobile scroll area size to their content and let that container do the scrolling. Same position after the change:

```
.GobanView-mobile-scroll: clientH=301 scrollH=507   <- scrolls
.explore-pane:            clientH=288 scrollH=288   <- no inner scroller
```

## Testing

Checked at 412x915 (portrait) and 1400x900 (desktop):

- Portrait: the full description renders; with comments on, the description and the comment thread stack and scroll together.
- Portrait: the Play tab (the other panel rendered inside the scroll area) and the filter takeover overlay behave as before.
- Desktop: the sidebar layout is unchanged.
- `yarn lint`, `yarn type-check`, `yarn prettier:file`, and `yarn build` pass.

Manual testing on a real mobile browser and on desktop is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rfd1arJafTb1geG7jCmNw