### PR TITLE
Fix/moderate user typo

### DIFF
--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -102,7 +102,7 @@ export function Clock({
         }
 
         // The main time for correspondence games can get pretty lengthy, for those
-        // use use a smaller font
+        // use a smaller font
         const need_small_main_time_font = prettyTime(player_clock.main_time).length > 8;
 
         const show_pause = !compact && clock.pause_state;

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -102,7 +102,7 @@ export function Clock({
         }
 
         // The main time for correspondence games can get pretty lengthy, for those
-        // use a smaller font
+        // use use a smaller font
         const need_small_main_time_font = prettyTime(player_clock.main_time).length > 8;
 
         const show_pause = !compact && clock.pause_state;

--- a/src/components/ModerateUser/ModerateUser.tsx
+++ b/src/components/ModerateUser/ModerateUser.tsx
@@ -171,7 +171,7 @@ export class ModerateUser extends Modal<Events, ModerateUserProperties, any> {
         } else {
             // They are about to be a new CM ... we have to "offer"
             this.setState({
-                offered_moderator_powers: this.state.moderator_powers | power_mask,
+                offered_moderator_powers: this.state.offered_moderator_powers | power_mask,
             });
         }
     };


### PR DESCRIPTION
Title: Fix typo in ModerateUser.tsx line 174 Body: 
## Changes 
- Fixed a typo on line 174 of ModerateUser.tsx ## Before offered_moderator_powers: this.state.moderator_powers | power_mask, ## After offered_moderator_powers: this.state.offered_moderator_powers | power_mask, 
- ## Description Fixed the code in the `makeOffer` function to correctly combine the permissions being proposed to a new community moderator.