### PR TITLE
Keep chat input visible above the on-screen keyboard on mobile

### DIFF
--- a/src/components/PrivateChat/PrivateChat.css
+++ b/src/components/PrivateChat/PrivateChat.css
@@ -20,7 +20,9 @@
 .private-chat-window {
     position: fixed;
     display: inline-block;
-    bottom: 0;
+    /* Docked above the on-screen keyboard rather than behind it; see
+       lib/visual_viewport.ts. */
+    bottom: var(--visual-viewport-bottom);
     right: 0;
     border: 1px solid #4e697a;
     border-radius: 4px;
@@ -146,6 +148,7 @@
 .private-chat-window.open {
     /* background-color: @ogs-private-chat-bg; */
     height: 26rem;
+    max-height: var(--visual-viewport-height);
     display: flex;
     flex-direction: column;
     background-color: var(--card-background-color);

--- a/src/global_styl/01_variables.css
+++ b/src/global_styl/01_variables.css
@@ -40,6 +40,15 @@
        Android), where padding by it would reserve the strip twice. */
     --safe-area-inset-bottom: env(safe-area-inset-bottom);
 
+    /* Where the visual viewport sits inside the layout viewport. Both insets
+       stay 0 unless the on-screen keyboard shrinks the visual viewport
+       without resizing the layout viewport (Safari on iOS), in which case
+       lib/visual_viewport.ts keeps them current so fixed elements can pin
+       themselves to the visible region. */
+    --visual-viewport-top: 0px;
+    --visual-viewport-bottom: 0px;
+    --visual-viewport-height: 100dvh;
+
     /* Chat */
     --channel-utils-height: 8.4rem;
     --channel-width: 20%;

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,10 @@
 
         <meta http-equiv="Cache-control" content="no-cache" />
         <meta http-equiv="Expires" content="-1" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
+        />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="format-detection" content="telephone=no" />
         <meta name="application-name" content="Online-Go.com" />

--- a/src/lib/visual_viewport.test.ts
+++ b/src/lib/visual_viewport.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { visual_viewport_insets } from "./visual_viewport";
+
+describe("visual_viewport_insets", () => {
+    test("reports no insets when the visual viewport covers the layout viewport", () => {
+        /* Desktop, and Chrome/Android with interactive-widget=resizes-content:
+         * the keyboard shrinks the layout viewport itself, so the two match. */
+        expect(visual_viewport_insets(508, 0, 508, 1)).toEqual({ top: 0, bottom: 0, height: 508 });
+    });
+
+    test("reports the pan as a top inset when Safari scrolls to the focused input", () => {
+        /* Measured on iOS Safari: the layout viewport stays 714pt tall, the
+         * keyboard leaves 377pt visible and Safari pans all the way down. */
+        expect(visual_viewport_insets(714, 337, 377, 1)).toEqual({
+            top: 337,
+            bottom: 0,
+            height: 377,
+        });
+    });
+
+    test("reports the keyboard as a bottom inset when the page is not panned", () => {
+        expect(visual_viewport_insets(714, 0, 377, 1)).toEqual({
+            top: 0,
+            bottom: 337,
+            height: 377,
+        });
+    });
+
+    test("splits a partial pan between the two insets", () => {
+        expect(visual_viewport_insets(714, 100, 377, 1)).toEqual({
+            top: 100,
+            bottom: 237,
+            height: 377,
+        });
+    });
+
+    test("ignores pinch zoom", () => {
+        /* Zoomed in, the visual viewport is a small window onto the page.
+         * Following it would make the chat chase the zoom, so treat it as
+         * covering the layout viewport. */
+        expect(visual_viewport_insets(714, 200, 300, 2.5)).toEqual({
+            top: 0,
+            bottom: 0,
+            height: 714,
+        });
+    });
+
+    test("tolerates the tiny scale drift browsers report", () => {
+        expect(visual_viewport_insets(714, 337, 377, 1.0000001)).toEqual({
+            top: 337,
+            bottom: 0,
+            height: 377,
+        });
+    });
+
+    test("clamps subpixel overshoot to zero", () => {
+        expect(visual_viewport_insets(714, 337.4, 377, 1)).toEqual({
+            top: 337,
+            bottom: 0,
+            height: 377,
+        });
+    });
+
+    test("survives unmeasurable metrics", () => {
+        expect(visual_viewport_insets(714, NaN, NaN, NaN)).toEqual({
+            top: 0,
+            bottom: 0,
+            height: 714,
+        });
+    });
+});

--- a/src/lib/visual_viewport.test.ts
+++ b/src/lib/visual_viewport.test.ts
@@ -77,6 +77,17 @@ describe("visual_viewport_insets", () => {
         });
     });
 
+    test("does not let overscroll inflate the bottom inset", () => {
+        /* Safari reports a negative offset while the page rubber-bands past
+         * its top edge. The keyboard is still 337pt tall, so the bottom
+         * inset must not grow with the overscroll. */
+        expect(visual_viewport_insets(714, -20, 377, 1)).toEqual({
+            top: 0,
+            bottom: 337,
+            height: 377,
+        });
+    });
+
     test("survives unmeasurable metrics", () => {
         expect(visual_viewport_insets(714, NaN, NaN, NaN)).toEqual({
             top: 0,

--- a/src/lib/visual_viewport.ts
+++ b/src/lib/visual_viewport.ts
@@ -71,8 +71,11 @@ export function visual_viewport_insets(
         return { top: 0, bottom: 0, height: layout_height };
     }
 
-    const top = Math.max(0, Math.round(offset_top));
-    const bottom = Math.max(0, Math.round(layout_height - offset_top - height));
+    /* Safari reports a negative offset during rubber-band overscroll; treat
+     * that as no pan so the bottom inset does not grow past the keyboard. */
+    const clamped_top = Math.max(0, offset_top);
+    const top = Math.round(clamped_top);
+    const bottom = Math.max(0, Math.round(layout_height - clamped_top - height));
     return { top, bottom, height: Math.round(height) };
 }
 

--- a/src/lib/visual_viewport.ts
+++ b/src/lib/visual_viewport.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Mobile browsers do not agree on what the on-screen keyboard does to the
+ * page. Chrome on Android honours `interactive-widget=resizes-content` in the
+ * viewport meta tag and shrinks the layout viewport, so `position: fixed;
+ * bottom: 0` lands above the keyboard on its own. Safari on iOS ignores that
+ * key: the layout viewport keeps its full height, only the visual viewport
+ * shrinks, and Safari pans the visual viewport down to show the focused
+ * input. Anything fixed to the top of the layout viewport pans out of view,
+ * and anything fixed to its bottom sits behind the keyboard until the pan
+ * brings it back.
+ *
+ * This module publishes the visual viewport's position within the layout
+ * viewport as CSS variables so that a fixed element can pin itself to the
+ * visible region instead:
+ *
+ *   --visual-viewport-top     distance from the top of the layout viewport
+ *                             to the top of the visual viewport
+ *   --visual-viewport-bottom  distance from the bottom of the visual viewport
+ *                             to the bottom of the layout viewport
+ *   --visual-viewport-height  height of the visual viewport
+ *
+ * Both insets are 0 wherever the two viewports coincide, so layouts that use
+ * them behave exactly as before on desktop and on browsers that resize the
+ * layout viewport.
+ */
+
+/** Scale drift below this is treated as "not zoomed". */
+const SCALE_TOLERANCE = 0.01;
+
+export interface VisualViewportInsets {
+    top: number;
+    bottom: number;
+    height: number;
+}
+
+/**
+ * Where the visual viewport sits inside the layout viewport, in CSS pixels.
+ *
+ * Pinch zoom also shrinks the visual viewport, but following it there would
+ * make pinned elements chase the zoom around the page, so a zoomed viewport
+ * is reported as covering the whole layout viewport. Unmeasurable inputs are
+ * treated the same way, so a browser without the API loses nothing.
+ */
+export function visual_viewport_insets(
+    layout_height: number,
+    offset_top: number,
+    height: number,
+    scale: number,
+): VisualViewportInsets {
+    const measurable = isFinite(offset_top) && isFinite(height) && isFinite(scale);
+    const zoomed = Math.abs(scale - 1) > SCALE_TOLERANCE;
+
+    if (!measurable || zoomed) {
+        return { top: 0, bottom: 0, height: layout_height };
+    }
+
+    const top = Math.max(0, Math.round(offset_top));
+    const bottom = Math.max(0, Math.round(layout_height - offset_top - height));
+    return { top, bottom, height: Math.round(height) };
+}
+
+export function update_visual_viewport_variables(): void {
+    const vv = window.visualViewport;
+    if (!vv) {
+        return;
+    }
+
+    const insets = visual_viewport_insets(
+        document.documentElement.clientHeight,
+        vv.offsetTop,
+        vv.height,
+        vv.scale,
+    );
+
+    const style = document.documentElement.style;
+    style.setProperty("--visual-viewport-top", `${insets.top}px`);
+    style.setProperty("--visual-viewport-bottom", `${insets.bottom}px`);
+    style.setProperty("--visual-viewport-height", `${insets.height}px`);
+}
+
+export function init_visual_viewport_variables(): void {
+    const vv = window.visualViewport;
+    if (!vv) {
+        return;
+    }
+
+    let scheduled = false;
+    const schedule = () => {
+        if (scheduled) {
+            return;
+        }
+        scheduled = true;
+        window.requestAnimationFrame(() => {
+            scheduled = false;
+            update_visual_viewport_variables();
+        });
+    };
+
+    update_visual_viewport_variables();
+    vv.addEventListener("resize", schedule);
+    vv.addEventListener("scroll", schedule);
+    window.addEventListener("resize", schedule);
+    window.addEventListener("orientationchange", schedule);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -208,6 +208,7 @@ import { routes } from "./routes";
 import { errorAlerter } from "@/lib/misc";
 import { close_all_popovers } from "@/lib/popover";
 import { init_safe_area_variables } from "@/lib/safe_area";
+import { init_visual_viewport_variables } from "@/lib/visual_viewport";
 import * as sockets from "@/lib/sockets";
 import { _, setCurrentLanguage } from "@/lib/translate";
 
@@ -378,6 +379,7 @@ if (user.anonymous) {
 }
 
 init_safe_area_variables();
+init_visual_viewport_variables();
 
 /* Initialization done, render!! */
 const svg_loader = document.getElementById("loading-svg-container");

--- a/src/views/ChatView/ChatView.css
+++ b/src/views/ChatView/ChatView.css
@@ -16,8 +16,10 @@
  */
 .ChatView {
     position: fixed;
-    top: calc(var(--navbar-height) + 0.2rem);
-    bottom: 0;
+    /* Pinned to the visible region so the on-screen keyboard cannot cover
+       the input or pan the header away; see lib/visual_viewport.ts. */
+    top: max(calc(var(--navbar-height) + 0.2rem), var(--visual-viewport-top));
+    bottom: var(--visual-viewport-bottom);
     left: 0;
     right: 0;
     display: flex;
@@ -25,7 +27,8 @@
     max-width: 100dvw;
     flex-direction: row;
 
-    .ChatChannelList, .ChatUsersList {
+    .ChatChannelList,
+    .ChatUsersList {
         flex-basis: 20%;
         flex-shrink: 0;
         flex-grow: 0;
@@ -68,7 +71,8 @@
 }
 
 .ChatHeader {
-    .fa-list, .fa-users {
+    .fa-list,
+    .fa-users {
         display: none;
     }
 }
@@ -95,7 +99,8 @@
     }
 
     .ChatHeader {
-        .fa-list, .fa-users {
+        .fa-list,
+        .fa-users {
             display: inline-flex;
         }
     }


### PR DESCRIPTION
## Summary

On mobile, the global chat page and private chat windows could not show the input or the latest lines while the on-screen keyboard was open.

Both mobile browsers keep the layout viewport at full height when the keyboard opens and only shrink the visual viewport. The chat view and the private chat window are `position: fixed; bottom: 0`, so they kept their full height and their bottom part, including the input, sat behind the keyboard. The browser then panned to the focused input, pushing the header and the latest chat lines off the top of the screen.

## Changes

- **Android Chrome:** the viewport meta now declares `interactive-widget=resizes-content`, so Chrome shrinks the layout viewport with the keyboard (the pre-Chrome-108 behaviour). This applies site-wide, so any page on Android now resizes when the keyboard opens.
- **iOS Safari** ignores that key. New `src/lib/visual_viewport.ts` listens to `visualViewport` resize and scroll events and publishes where the visible region sits inside the layout viewport as CSS variables: `--visual-viewport-top`, `--visual-viewport-bottom`, `--visual-viewport-height`. The chat view pins its top and bottom to them; the private chat window docks its bottom to them and caps its height to the visible height. The variables are 0 wherever the two viewports coincide, so desktop and Android layouts are unchanged. Pinch zoom is deliberately ignored.
- Unit tests for the inset calculation in `src/lib/visual_viewport.test.ts`.

## Testing

- Android emulator (Pixel, Chrome 133): global chat header, lines and input all visible above the keyboard; sent a message to confirm. Private chat window docks above the keyboard with its textarea visible.
- iPhone 17 simulator (iOS 26.5, Safari): same result for global chat and private chat. Layout follows the visible region as the keyboard opens and closes.
- `yarn type-check`, `yarn lint`, prettier, `yarn build` and `yarn test` for the touched libs are clean.

Still worth a pass on real Android and iOS devices before merging, since simulators cannot cover every keyboard variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYgExWKKGXVS617wtsG2g2
