### PR TITLE
Keep popovers inside the viewport by placing them from their rendered size

### DIFF
--- a/src/lib/popover.test.tsx
+++ b/src/lib/popover.test.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { act } from "react";
+import { popover, PopOver } from "./popover";
+
+type ResizeCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void;
+
+let last_observer: MockResizeObserver | null = null;
+
+class MockResizeObserver {
+    public observed: Element[] = [];
+    public disconnected = false;
+
+    constructor(private readonly callback: ResizeCallback) {
+        last_observer = this;
+    }
+
+    observe(elt: Element): void {
+        this.observed.push(elt);
+    }
+
+    unobserve(): void {}
+
+    disconnect(): void {
+        this.disconnected = true;
+    }
+
+    trigger(): void {
+        this.callback([], this as unknown as ResizeObserver);
+    }
+}
+
+const VIEWPORT_WIDTH = 1280;
+const VIEWPORT_HEIGHT = 800;
+const VIEWPORT_MARGIN = 16;
+
+function makeAnchor(rect: { left: number; top: number; width: number; height: number }) {
+    const button = document.createElement("button");
+    button.getBoundingClientRect = () =>
+        ({
+            left: rect.left,
+            top: rect.top,
+            right: rect.left + rect.width,
+            bottom: rect.top + rect.height,
+            width: rect.width,
+            height: rect.height,
+            x: rect.left,
+            y: rect.top,
+            toJSON: () => ({}),
+        }) as DOMRect;
+    document.body.appendChild(button);
+    return button;
+}
+
+function setRenderedSize(elt: HTMLElement, width: number, height: number): void {
+    Object.defineProperty(elt, "offsetWidth", { configurable: true, value: width });
+    Object.defineProperty(elt, "offsetHeight", { configurable: true, value: height });
+}
+
+describe("popover placement", () => {
+    let instance: PopOver | null = null;
+
+    beforeEach(() => {
+        (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+        (window as unknown as { ResizeObserver: unknown }).ResizeObserver = MockResizeObserver;
+        Object.defineProperty(window, "innerWidth", { configurable: true, value: VIEWPORT_WIDTH });
+        Object.defineProperty(window, "innerHeight", {
+            configurable: true,
+            value: VIEWPORT_HEIGHT,
+        });
+        last_observer = null;
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            instance?.close();
+        });
+        instance = null;
+        document.body.innerHTML = "";
+    });
+
+    function open(anchor: HTMLElement, minWidth: number): HTMLElement {
+        act(() => {
+            instance = popover({ elt: <div>content</div>, below: anchor, minWidth });
+        });
+        return instance!.container;
+    }
+
+    test("keeps a popover wider than its minWidth inside the viewport", () => {
+        // A gear button near the right side of a 1280px viewport. The
+        // caller declares minWidth 320 but the rendered content ends up
+        // 404px wide, which used to push the popover past the right edge.
+        const anchor = makeAnchor({ left: 886, top: 748, width: 40, height: 40 });
+        const container = open(anchor, 320);
+
+        setRenderedSize(container, 404, 453);
+        act(() => {
+            last_observer?.trigger();
+        });
+
+        const left = parseFloat(container.style.left);
+        expect(left + 404).toBeLessThanOrEqual(VIEWPORT_WIDTH - VIEWPORT_MARGIN);
+        expect(left).toBeGreaterThanOrEqual(0);
+    });
+
+    test("stays anchored to the element when there is room", () => {
+        const anchor = makeAnchor({ left: 100, top: 100, width: 40, height: 40 });
+        const container = open(anchor, 320);
+
+        setRenderedSize(container, 404, 453);
+        act(() => {
+            last_observer?.trigger();
+        });
+
+        expect(parseFloat(container.style.left)).toBe(100);
+        expect(parseFloat(container.style.top)).toBe(140);
+    });
+
+    test("flips above the anchor when the rendered height does not fit below", () => {
+        // Button 200px above the bottom edge: the declared minHeight (25)
+        // fits below, but the real 453px content does not.
+        const anchor = makeAnchor({ left: 100, top: 560, width: 40, height: 40 });
+        const container = open(anchor, 320);
+
+        setRenderedSize(container, 320, 453);
+        act(() => {
+            last_observer?.trigger();
+        });
+
+        expect(container.style.top).toBe("");
+        expect(parseFloat(container.style.bottom)).toBe(VIEWPORT_HEIGHT - 560);
+    });
+
+    test("stops observing when closed", async () => {
+        const anchor = makeAnchor({ left: 100, top: 100, width: 40, height: 40 });
+        open(anchor, 320);
+        const observer = last_observer;
+        expect(observer).not.toBeNull();
+
+        await act(async () => {
+            instance?.close();
+        });
+        instance = null;
+
+        expect(observer!.disconnected).toBe(true);
+    });
+});

--- a/src/lib/popover.tsx
+++ b/src/lib/popover.tsx
@@ -39,6 +39,9 @@ interface PopoverConfig {
     container_class?: string;
 }
 
+// Minimum gap between a popover and the edge of the viewport.
+const VIEWPORT_MARGIN = 16;
+
 let last_id = 0;
 const open_popovers: { [id: number]: PopOver } = {};
 
@@ -113,52 +116,51 @@ export function popover(config: PopoverConfig): PopOver {
 
     const minWidth: number = config.minWidth || 150;
     const minHeight: number = config.minHeight || 25;
-    let x = 0;
-    let y = 0;
+    container.style.minWidth = `${minWidth}px`;
+
     const scrollLeft =
         window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft || 0;
     const scrollTop =
         window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
-    const bounds = {
-        x: scrollLeft + window.innerWidth - 16,
-        y: scrollTop + window.innerHeight - 16,
-    };
 
+    // Anchor point in document coordinates: the popover's top-left corner
+    // goes here when it fits. For `below`, `flip_bottom` is where the
+    // popover's bottom edge goes when it has to sit above the element
+    // instead so it never covers what it was opened from.
+    let anchor_x = 0;
+    let anchor_y = 0;
+    let flip_bottom = 0;
     if (config.at) {
-        x = config.at.x;
-        y = config.at.y;
-
-        x = Math.min(x, bounds.x - minWidth);
-
-        if (y < bounds.y - minHeight) {
-            container.style.minWidth = `${minWidth}px`;
-            container.style.top = `${y}px`;
-            container.style.left = `${x}px`;
-        } else {
-            container.style.minWidth = `${minWidth}px`;
-            container.style.bottom = `${window.innerHeight - y}px`;
-            container.style.left = `${x}px`;
-        }
+        anchor_x = config.at.x;
+        anchor_y = config.at.y;
+        flip_bottom = config.at.y;
     } else if (config.below) {
         const rectangle = config.below.getBoundingClientRect();
-        x = rectangle.left + window.scrollX;
-        x = Math.min(x, bounds.x - minWidth);
-        console.log(bounds.x, x, minWidth);
-
-        y = rectangle.bottom + window.scrollY;
-
-        if (y < bounds.y - minHeight) {
-            container.style.minWidth = `${minWidth}px`;
-            container.style.top = `${y}px`;
-            container.style.left = `${x}px`;
-        } else {
-            // Don't overlap the element we were supposed to be below.
-            // If there is no space below, just go above it instead.
-            container.style.minWidth = `${minWidth}px`;
-            container.style.bottom = `${window.innerHeight - rectangle.top - window.scrollY}px`;
-            container.style.left = `${x}px`;
-        }
+        anchor_x = rectangle.left + scrollLeft;
+        anchor_y = rectangle.bottom + scrollTop;
+        flip_bottom = rectangle.top + scrollTop;
     }
+
+    // Place the container so that a popover of the given size stays inside
+    // the viewport (with a small margin). The caller's minWidth / minHeight
+    // are only a lower bound on the eventual rendered size, so this runs
+    // once up front and again whenever the rendered size changes.
+    const place = (width: number, height: number) => {
+        const max_x = scrollLeft + window.innerWidth - VIEWPORT_MARGIN - width;
+        const max_y = scrollTop + window.innerHeight - VIEWPORT_MARGIN;
+        const x = Math.max(scrollLeft, Math.min(anchor_x, max_x));
+        container.style.left = `${x}px`;
+
+        if (anchor_y + height <= max_y) {
+            container.style.top = `${anchor_y}px`;
+            container.style.bottom = "";
+        } else {
+            container.style.top = "";
+            container.style.bottom = `${window.innerHeight - flip_bottom}px`;
+        }
+    };
+
+    place(minWidth, minHeight);
 
     document.body.appendChild(backdrop);
     document.body.appendChild(container);
@@ -166,5 +168,15 @@ export function popover(config: PopoverConfig): PopOver {
     const root = ReactDOM.createRoot(container);
     root.render(<React.StrictMode>{config.elt}</React.StrictMode>);
 
-    return new PopOver(config, backdrop, container, root);
+    const observer = new ResizeObserver(() => {
+        place(
+            Math.max(container.offsetWidth, minWidth),
+            Math.max(container.offsetHeight, minHeight),
+        );
+    });
+    observer.observe(container);
+
+    const instance = new PopOver(config, backdrop, container, root);
+    instance.on("close", () => observer.disconnect());
+    return instance;
 }


### PR DESCRIPTION
## Summary

Opening the in-game Settings gear pushed the popover past the right edge of the viewport. On desktop this created a horizontal scrollbar (and a vertical one as a side effect); on mobile the panel was clipped.

**Root cause:** `src/lib/popover.tsx` reserved room only for the caller's declared `minWidth` / `minHeight`. The Settings panel declares 320px but renders ~404px wide (the stone theme rows carry a fixed 365px width), so it was anchored at the button's left edge and overflowed. The vertical flip decision had the same flaw, using a 25px minimum instead of the real height.

**Fix:** measure the popover container with a `ResizeObserver` and place it from the real dimensions. The left edge is clamped so the whole popover fits inside the viewport with the existing 16px margin, and the popover flips above its anchor when the real height does not fit below. The observer is disconnected on close. A stray 2018 debug `console.log` on the same path is removed.

This applies to every popover in the app, not only the Settings one.

## Testing

- New unit test `src/lib/popover.test.tsx` covers the overflow clamp, the anchored case, the height-based flip, and observer cleanup. Three cases failed before the fix and pass after.
- Verified in a browser at 1280x800: the popover's right edge moved from 1290px to 1264px and the document scroll width now matches the viewport.
- Verified at 390x844: the popover fills the viewport width with no clipping.
- `yarn type-check`, `yarn lint`, `yarn prettier:file`, and `yarn build` all pass.

Please also give it a manual pass on desktop and mobile browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EAqZWdrkn5y5uTQh4fBHD
