### PR TITLE
Shared game action area that pushes the board up on mobile

### DIFF
--- a/docs/game-action-area.md
+++ b/docs/game-action-area.md
@@ -1,0 +1,33 @@
+# Game action area
+
+The game page keeps the controls a player must reach without scrolling in
+one container, `GameActionArea` (`src/views/Game/GameActionArea.tsx`).
+
+## What it holds
+
+- Play phase, for a participant: the `PlayButtons` strip. Pass or Submit
+  in the center, Resign at the right, the undo response at the left. When
+  analysis is disabled and the user has stepped back through the game, the
+  center slot holds Back to Game instead.
+- Score estimation: the estimate and the Back to Board button.
+- Stone removal phase: Accept removed stones with its clock, Auto-score,
+  and Cancel and resume game. Each player card shows a check or cross badge
+  for whether that player has accepted. The sealing warning and the phase
+  explanation stay in `PlayControls`.
+
+It renders nothing when the current state has none of these.
+
+## Where it renders
+
+- Portrait (mobile): the Game view passes it to GobanView's `belowBoard`
+  slot, under the bottom player card. The slot is part of the board stage,
+  and the board is the only part of the stage that shrinks, so anything in
+  the area pushes the board up instead of falling below the fold. There is
+  no fixed height reservation to keep in sync.
+- Wider layouts: `PlayControls` renders it at the top of the sidebar.
+
+## Adding to it
+
+Put a control here only when a player must see it without scrolling and it
+fits in a row or two. Cards with explanatory text, such as the anti-grief
+cards, stay in `PlayControls`.

--- a/src/views/Game/Game.css
+++ b/src/views/Game/Game.css
@@ -370,18 +370,12 @@
  * for the other consumers. The extra .GobanView class outranks the
  * equal-specificity shared portrait rules regardless of import order. */
 .GobanView.MainGobanView.portrait {
-    /* The play buttons run edge to edge on portrait; keep them off the
-     * screen edges. */
-    .play-buttons {
+    /* The action area runs edge to edge under the bottom player card and
+     * reads as the top of the panel slab below it. */
+    .GameActionArea {
         box-sizing: border-box;
         padding: 0 0.5rem;
-    }
-
-    /* Leave room under the board stage for the play-buttons strip (2.6rem)
-     * plus the panel slab's and PlayControls' top padding (0.5rem each), so
-     * the strip lands on screen without scrolling. */
-    &.has-play-buttons .GobanView-stage {
-        max-height: calc(100% - 3.6rem);
+        background: var(--shade5);
     }
 
     .GobanView-mobile-panels {

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -959,7 +959,22 @@ export function Game(): React.ReactElement | null {
           }
         : null;
 
-    const menu_action_tabs = [analyze_tab, chat_tab, review_tab, conditional_tab].filter(
+    // Pause / resume the game clock. Rendered only for users allowed to
+    // change the pause state right now (participants in vacation-eligible
+    // games, moderators — see usePauseControl).
+    const pause_tab: GobanViewTabProps | null =
+        pause_control.action !== null
+            ? {
+                  id: "game-pause",
+                  type: "action",
+                  align: "center",
+                  icon: pause_control.paused ? "play" : "pause",
+                  title: pause_control.paused ? _("Resume game") : _("Pause game"),
+                  onClick: pause_control.togglePause,
+              }
+            : null;
+
+    const menu_action_tabs = [analyze_tab, chat_tab, review_tab, conditional_tab, pause_tab].filter(
         (tab): tab is GobanViewTabProps => tab !== null,
     );
 
@@ -1236,20 +1251,7 @@ export function Game(): React.ReactElement | null {
                 />
             )}
 
-            {/* Pause / resume the game clock. Rendered only for users
-             *  allowed to change the pause state right now (participants
-             *  in vacation-eligible games, moderators — see
-             *  usePauseControl). */}
-            {pause_control.action !== null && (
-                <GobanView.Tab
-                    id="game-pause"
-                    type="action"
-                    align="center"
-                    icon={pause_control.paused ? "play" : "pause"}
-                    title={pause_control.paused ? _("Resume game") : _("Pause game")}
-                    onClick={pause_control.togglePause}
-                />
-            )}
+            {pause_tab && <GobanView.Tab {...pause_tab} />}
 
             {/* Right group, in source order (visually left → right):
              *  1. Moderator toggle (gavel) — per-player controls + decide /

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -34,6 +34,7 @@ import { GameChat } from "./GameChat";
 import { goban_view_mode, user_color } from "./util";
 import { PlayerCard, PlayerCards } from "./PlayerCards";
 import { PlayControls, ReviewControls } from "./PlayControls";
+import { GameActionArea } from "./GameActionArea";
 import { alert } from "@/lib/swal_config";
 import {
     useCanRequestUndo,
@@ -889,11 +890,10 @@ export function Game(): React.ReactElement | null {
     // UX shape as the Analyze tab) so clicking it always switches *into*
     // the planner; clicking it again while in the planner exits to play.
     //
-    // useUserIsLivePlayerToMove treats a staged (not yet submitted) stone in
-    // submit-move / double-click mode as still the user's turn, so the tab
-    // hides until the move is submitted — entering the planner would
-    // silently discard the staged move. It derives a boolean so this
-    // component doesn't re-render on every move navigation event.
+    // useUserIsLivePlayerToMove follows the official branch, so walking
+    // through the game in analyze mode does not toggle the tab, and a
+    // staged (not yet submitted) stone still counts as the user's turn —
+    // entering the planner would silently discard the staged move.
     const is_planning_conditional = mode === "conditional";
     const show_conditional_tab =
         !review &&
@@ -1097,18 +1097,22 @@ export function Game(): React.ReactElement | null {
             ref={goban_view_ref}
             controller={goban_controller.current}
             className={
-                "Game MainGobanView" +
-                (is_mobile ? " mobile" : "") +
-                /* Mobile reserves room under the board stage for the play
-                 * buttons at the top of PlayControls, so the board shrinks
-                 * to keep them on screen along with both player cards. */
-                (is_mobile && show_play_action_tabs ? " has-play-buttons" : "") +
-                (zen_mode ? " zen" : "")
+                "Game MainGobanView" + (is_mobile ? " mobile" : "") + (zen_mode ? " zen" : "")
             }
             onWheel={onWheel}
             header={<GameStateHeader />}
             aboveBoard={is_mobile && renderMobilePlayerCard(top_color)}
-            belowBoard={is_mobile && renderMobilePlayerCard(bottom_color)}
+            /* The action area sits in the stage with the player cards, so
+             * the board gives up room for it instead of pushing it below
+             * the fold. */
+            belowBoard={
+                is_mobile && (
+                    <>
+                        {renderMobilePlayerCard(bottom_color)}
+                        <GameActionArea />
+                    </>
+                )
+            }
             /* On mobile the move slider only earns its row while analyzing;
              * during play it is dropped to leave the board and the controls
              * more room. */

--- a/src/views/Game/GameActionArea.css
+++ b/src/views/Game/GameActionArea.css
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.GameActionArea {
+    width: 100%;
+    flex-shrink: 0;
+
+    .score-estimate-buttons {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.3rem;
+        padding: 0.3rem 0;
+
+        .score-estimate {
+            font-weight: bold;
+        }
+    }
+
+    .stone-removal-buttons {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.3rem 0;
+
+        .secondary-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 0.5rem;
+        }
+
+        .autoscoring-in-progress {
+            font-size: 1.1rem;
+        }
+    }
+}

--- a/src/views/Game/GameActionArea.tsx
+++ b/src/views/Game/GameActionArea.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { _ } from "@/lib/translate";
+import { alert } from "@/lib/swal_config";
+import { Clock } from "@/components/Clock";
+import { useUser } from "@/lib/hooks";
+import { PlayButtons } from "./PlayButtons";
+import { EstimateScore } from "./fragments";
+import { useGobanController } from "./goban_context";
+import {
+    useAutoScoring,
+    useMode,
+    useNeedsSealing,
+    usePhase,
+    useStoneRemovalAccepted,
+    useUserIsParticipant,
+} from "./GameHooks";
+import "./GameActionArea.css";
+
+/**
+ * The controls a player must be able to reach without scrolling: pass and
+ * resign, the score estimate with its exit button, and the stone removal
+ * controls.
+ *
+ * On portrait the Game view renders this in GobanView's below-board slot,
+ * so whatever it holds pushes the board up instead of sitting below the
+ * fold. On wider layouts PlayControls renders it at the top of the sidebar.
+ * Renders nothing when the current state has no such controls.
+ */
+export function GameActionArea(): React.ReactElement | null {
+    const user = useUser();
+    const goban_controller = useGobanController();
+    const goban = goban_controller.goban;
+    const engine = goban.engine;
+    const mode = useMode(goban);
+    const phase = usePhase(goban);
+    const user_is_player = useUserIsParticipant(goban);
+    const needs_sealing = useNeedsSealing(goban);
+    const autoscoring = useAutoScoring(goban);
+    const black_accepted = useStoneRemovalAccepted(goban, "black");
+    const white_accepted = useStoneRemovalAccepted(goban, "white");
+
+    const show_play_buttons = mode === "play" && phase === "play" && user_is_player;
+    const show_score_estimate = mode === "score estimation";
+
+    const user_is_active_player = [engine.players.black.id, engine.players.white.id].includes(
+        user.id,
+    );
+    const show_accept = user_is_active_player || user.is_moderator;
+    const show_stone_removal = phase === "stone removal" && (show_accept || user_is_player);
+
+    if (!show_play_buttons && !show_score_estimate && !show_stone_removal) {
+        return null;
+    }
+
+    const need_to_seal = !!needs_sealing && needs_sealing.length > 0;
+    const user_accepted = engine.playerColor(user.id) === "black" ? black_accepted : white_accepted;
+    // Moderators see the accept button, with its timer, but can't press it.
+    const moderator_only = user.is_moderator && !user_is_active_player;
+    const accept_is_primary = !moderator_only && !need_to_seal && !autoscoring.in_progress;
+    const accept_disabled =
+        moderator_only ||
+        !!user_accepted ||
+        (autoscoring.in_progress && !autoscoring.taking_too_long);
+
+    const onStoneRemovalCancel = () => {
+        void alert
+            .fire({
+                text: _("Are you sure you want to resume the game?"),
+                showCancelButton: true,
+            })
+            .then(({ value: accept }) => {
+                if (accept) {
+                    goban.rejectRemovedStones();
+                }
+            });
+    };
+
+    return (
+        <div className="GameActionArea">
+            {show_play_buttons && <PlayButtons />}
+
+            {show_score_estimate && (
+                <div className="score-estimate-buttons">
+                    <div className="score-estimate">
+                        <EstimateScore />
+                    </div>
+                    <button
+                        className="sm primary bold"
+                        onClick={goban_controller.stopEstimatingScore}
+                    >
+                        {_("Back to Board")}
+                    </button>
+                </div>
+            )}
+
+            {show_stone_removal && (
+                <div className="stone-removal-buttons">
+                    {show_accept && (
+                        <button
+                            className={accept_is_primary ? "primary" : ""}
+                            disabled={accept_disabled}
+                            onClick={() => goban.acceptRemovedStones()}
+                        >
+                            {_("Accept removed stones")}
+                            <Clock goban={goban} color="stone-removal" />
+                        </button>
+                    )}
+                    {autoscoring.in_progress && (
+                        <div className="autoscoring-in-progress">
+                            <i className="fa fa-circle-o-notch rotating" /> {_("Scoring game")}
+                        </div>
+                    )}
+                    {user_is_player && (
+                        <div className="secondary-buttons">
+                            <button
+                                id="game-stone-removal-auto-score"
+                                onClick={() => goban.performStoneRemovalAutoScoring()}
+                            >
+                                {_("Auto-score")}
+                            </button>
+                            <button
+                                id="game-stone-removal-cancel"
+                                className={need_to_seal ? "primary" : ""}
+                                onClick={onStoneRemovalCancel}
+                            >
+                                {_("Cancel and resume game")}
+                            </button>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -22,6 +22,8 @@ import {
     GobanRenderer,
     JGOFClockWithTransmitting,
     JGOFPauseState,
+    JGOFSealingIntersection,
+    PlayerColor,
 } from "goban";
 import * as data from "@/lib/data";
 import * as preferences from "@/lib/preferences";
@@ -312,6 +314,90 @@ export const useCurrentMoveNumber = generateGobanHook(
 /** React hook that returns the phase */
 export const usePhase = generateGobanHook((goban: Goban | null) => goban?.engine.phase, ["phase"]);
 
+/** React hook that returns the move number of the last official move */
+export const useOfficialMoveNumber = generateGobanHook(
+    (goban: Goban | null) => goban?.engine.last_official_move?.move_number ?? -1,
+    ["last_official_move"],
+);
+
+/**
+ * Intersections the auto-scorer wants sealed before the stone removal
+ * phase can be scored correctly. Undefined when nothing needs sealing.
+ */
+export const useNeedsSealing = generateGobanHook(
+    (goban: Goban | null): JGOFSealingIntersection[] | undefined => goban?.engine.needs_sealing,
+    ["stone-removal.needs-sealing", "engine.updated"],
+);
+
+/**
+ * Whether `color` has accepted the current stone removal state. Undefined
+ * outside of the stone removal phase.
+ */
+export function useStoneRemovalAccepted(goban: Goban, color: PlayerColor): boolean | undefined {
+    const derive = React.useCallback(() => {
+        const engine = goban.engine;
+        if (engine.phase !== "stone removal") {
+            return undefined;
+        }
+        return engine.players[color].accepted_stones === engine.getStoneRemovalString();
+    }, [goban, color]);
+    const [accepted, setAccepted] = React.useState<boolean | undefined>(derive);
+
+    React.useEffect(() => {
+        const sync = () => setAccepted(derive());
+        sync();
+        return subscribeAllEvents(
+            goban,
+            ["phase", "mode", "outcome", "stone-removal.accepted", "stone-removal.updated"],
+            sync,
+        );
+    }, [goban, derive]);
+
+    return accepted;
+}
+
+/**
+ * Tracks the server's stone removal auto-scoring. `taking_too_long` turns
+ * on when a run has been going for two seconds, so the user is not left
+ * waiting on a stuck scorer before they can accept.
+ */
+export function useAutoScoring(goban: Goban): { in_progress: boolean; taking_too_long: boolean } {
+    const [in_progress, setInProgress] = React.useState(false);
+    const [taking_too_long, setTakingTooLong] = React.useState(false);
+
+    React.useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout> | null = null;
+        const onStarted = () => {
+            setInProgress(true);
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            timeout = setTimeout(() => {
+                setTakingTooLong(true);
+                timeout = null;
+            }, 2000);
+        };
+        const onComplete = () => {
+            setInProgress(false);
+            if (timeout) {
+                clearTimeout(timeout);
+                timeout = null;
+            }
+        };
+        goban.on("stone-removal.auto-scoring-started", onStarted);
+        goban.on("stone-removal.auto-scoring-complete", onComplete);
+        return () => {
+            goban.off("stone-removal.auto-scoring-started", onStarted);
+            goban.off("stone-removal.auto-scoring-complete", onComplete);
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+        };
+    }, [goban]);
+
+    return { in_progress, taking_too_long };
+}
+
 /**
  * Pause/resume control for the game clock. `action` is non-null only for
  * users allowed to change the pause state right now:
@@ -411,22 +497,20 @@ export const usePlayerToMoveOnOfficialBranch = generateGobanHook(
     ["cur_move", "last_official_move"],
 );
 
-/** React hook that returns true while it is the user's live turn to move,
- *  treating a staged (not yet submitted) move in submit-move / double-click mode
- *  as still the user's turn. Derives a boolean so consumers re-render only
- *  when the answer flips, not on every move navigation event. */
+/** React hook that returns true while it is the user's live turn to move.
+ *  It follows the official branch, so navigating the move tree in analyze
+ *  mode does not change the answer, and a staged (not yet submitted) move
+ *  still counts as the user's turn. Derives a boolean so consumers
+ *  re-render only when the answer flips. */
 export const useUserIsLivePlayerToMove = generateGobanHook(
     (goban: Goban | null) => {
         const user = data.get("user");
         if (!goban || !user) {
             return false;
         }
-        const engine = goban.engine;
-        const live_player_to_move =
-            goban.submit_move != null ? engine.playerNotToMove() : engine.playerToMove();
-        return live_player_to_move === user.id;
+        return goban.engine.playerToMoveOnOfficialBranch() === user.id;
     },
-    ["cur_move", "last_official_move", "submit_move"],
+    ["last_official_move"],
 );
 
 /** React hook that returns true if the title should be shown. */

--- a/src/views/Game/GameStateHeader.tsx
+++ b/src/views/Game/GameStateHeader.tsx
@@ -32,7 +32,6 @@ import {
     useViewMode,
     useWinner,
 } from "./GameHooks";
-import { EstimateScore } from "./fragments";
 import "./GameStateHeader.css";
 
 /**
@@ -96,25 +95,30 @@ export function GameStateHeader(): React.ReactElement | null {
 
     const sse = engine.stalling_score_estimate;
 
-    const isPlayPlay = mode === "play" && phase === "play";
-    const isStoneRemoval = mode === "play" && phase === "stone removal";
+    // Score estimation keeps the header content of the mode it was entered
+    // from; the estimate itself is shown in PlayControls above the
+    // "Back to Board" button.
+    const is_play_like = mode === "play" || mode === "score estimation";
+    const isPlayPlay = is_play_like && phase === "play";
+    const isStoneRemoval = is_play_like && phase === "stone removal";
     const isAnalyze = mode === "analyze";
     const isConditional = mode === "conditional";
-    const isScoreEstimation = mode === "score estimation";
-    const isFinished = mode === "play" && phase === "finished";
+    const isFinished = is_play_like && phase === "finished";
 
-    // Portrait drops the "Your move" style title during play to save
-    // vertical space for the board; the clocks already say whose turn it
-    // is. The undo request message stays since it needs a response.
+    // Portrait drops the mode and phase labels ("Your move", "Analyze
+    // Mode", "Stone Removal Phase", ...) to save vertical space for the
+    // board; the clocks and the lit action bar icons already say as much.
+    // The undo request message stays since it needs a response, and the
+    // final result stays since nothing else on screen shows it.
     const is_portrait = useViewMode(goban_controller) === "portrait";
-    const show_play_title = show_title && !engine.rengo && !is_portrait;
+    const show_labels = !is_portrait;
+    const show_play_title = show_title && !engine.rengo && show_labels;
     const has_play_content = isPlayPlay && (show_play_title || show_undo_requested);
+    const has_analyze_content = isAnalyze && (show_labels || show_undo_requested);
     const has_any_content =
         has_play_content ||
-        isStoneRemoval ||
-        isAnalyze ||
-        isConditional ||
-        isScoreEstimation ||
+        has_analyze_content ||
+        (show_labels && (isStoneRemoval || isConditional)) ||
         isFinished;
 
     if (!has_any_content) {
@@ -140,9 +144,9 @@ export function GameStateHeader(): React.ReactElement | null {
                 </span>
             )}
 
-            {isStoneRemoval && <span>{_("Stone Removal Phase")}</span>}
+            {isStoneRemoval && show_labels && <span>{_("Stone Removal Phase")}</span>}
 
-            {isAnalyze && (
+            {has_analyze_content && (
                 <span>
                     {show_undo_requested ? (
                         <span className="undo-requested-message" ref={undo_message_ref}>
@@ -160,9 +164,7 @@ export function GameStateHeader(): React.ReactElement | null {
                 </span>
             )}
 
-            {isConditional && <span>{_("Conditional Move Planner")}</span>}
-
-            {isScoreEstimation && <EstimateScore />}
+            {isConditional && show_labels && <span>{_("Conditional Move Planner")}</span>}
 
             {isFinished && (
                 <>

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -21,10 +21,10 @@ import { isLiveGame } from "@/components/TimeControl";
 import * as preferences from "@/lib/preferences";
 import { alert } from "@/lib/swal_config";
 import {
-    generateGobanHook,
     useCanAnswerUndoRequest,
     useCurrentMoveNumber,
     useMode,
+    useOfficialMoveNumber,
     usePhase,
     usePlayerToMove,
     hasStagedMove,
@@ -34,17 +34,13 @@ import {
     useUserIsParticipant,
 } from "./GameHooks";
 import { cancelOrResignGame } from "./game_actions";
+import { enableTouchAction } from "./touch_actions";
 import * as DynamicHelp from "react-dynamic-help";
 import { useGobanController } from "./goban_context";
 import { useUser } from "@/lib/hooks";
 import { sfx } from "@/lib/sfx";
 import { decodeMoves } from "goban";
 import "./PlayButtons.css";
-
-const useOfficialMoveNumber = generateGobanHook(
-    (goban) => goban!.engine.last_official_move?.move_number ?? -1,
-    ["last_official_move"],
-);
 
 function KeyboardCoordinateInput(): React.ReactElement | null {
     const goban_controller = useGobanController();
@@ -294,6 +290,14 @@ export function PlayButtons(): React.ReactElement | null {
         cur_move_number === official_move_number;
     const show_submit_button = show_submit;
 
+    // With analysis disabled, stepping back through the game only shows
+    // earlier positions; this is the way back to the live position.
+    const show_back_to_game =
+        mode === "play" &&
+        phase === "play" &&
+        goban.isAnalysisDisabled() &&
+        cur_move_number < official_move_number;
+
     // Undo moved to the action bar; what is left here is the response to
     // the opponent's undo request, the move controls, and resign.
     // Collapse the strip entirely when none of them apply so it takes up
@@ -302,6 +306,7 @@ export function PlayButtons(): React.ReactElement | null {
         !show_undo_response &&
         !show_pass &&
         !show_submit_button &&
+        !show_back_to_game &&
         !keyboard_coordinates_enabled &&
         !show_resign
     ) {
@@ -322,6 +327,17 @@ export function PlayButtons(): React.ReactElement | null {
                 )}
             </span>
             <span>
+                {show_back_to_game && (
+                    <button
+                        className="sm primary bold back-to-game-button"
+                        onClick={() => {
+                            enableTouchAction();
+                            goban.setModeDeferred("play");
+                        }}
+                    >
+                        {_("Back to Game")}
+                    </button>
+                )}
                 <KeyboardCoordinateInput />
                 {show_pass && (
                     <button className="sm primary bold pass-button" onClick={pass}>

--- a/src/views/Game/PlayControls.css
+++ b/src/views/Game/PlayControls.css
@@ -137,11 +137,6 @@
         }
     }
 
-    .autoscoring-in-progress {
-        margin-top: 0.5rem;
-        font-size: 1.2rem;
-    }
-
     .score-square {
         display: inline-block;
         width: 0.7rem;

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -18,26 +18,16 @@ import * as React from "react";
 import { useSearchParams } from "react-router-dom";
 import { _, interpolate, pgettext } from "@/lib/translate";
 import * as data from "@/lib/data";
-import {
-    Goban,
-    ConditionalMoveTree,
-    PlayerColor,
-    JGOFSealingIntersection,
-    GobanEngine,
-} from "goban";
-import { alert } from "@/lib/swal_config";
+import { Goban, ConditionalMoveTree } from "goban";
 import { challengeRematch } from "@/components/ChallengeModal";
-import { Clock } from "@/components/Clock";
 import { Link } from "react-router-dom";
 import { Resizable } from "@/components/Resizable";
 import { ChatMode } from "./GameChat";
 import { close_all_popovers } from "@/lib/popover";
 import { setExtraActionCallback, Player } from "@/components/Player";
-import { PlayButtons } from "./PlayButtons";
+import { GameActionArea } from "./GameActionArea";
 import {
     generateGobanHook,
-    subscribeAllEvents,
-    useCurrentMoveNumber,
     useUserIsParticipant,
     useVariationName,
     useSelectedChatLog,
@@ -46,15 +36,15 @@ import {
     usePhase,
     useZenMode,
     useStashedConditionalMoves,
+    useNeedsSealing,
+    useViewMode,
 } from "./GameHooks";
 import { useGobanController } from "./goban_context";
 import { is_valid_url } from "@/lib/url_validation";
-import { enableTouchAction } from "./touch_actions";
 import { ConditionalMoveTreeDisplay } from "./ConditionalMoveTreeDisplay";
 import { useUser } from "@/lib/hooks";
 import { AntiGrief } from "./AntiGrief";
 import { GobanAnalyzeButtonBar } from "@/components/GobanAnalyzeButtonBar/GobanAnalyzeButtonBar";
-
 import { EstimateScore } from "./fragments";
 import "./PlayControls.css";
 
@@ -77,13 +67,9 @@ export function PlayControls({ annulment_reason }: PlayControlsProps): React.Rea
     const [searchParams] = useSearchParams();
     const return_param = searchParams.get("return");
     const return_url = return_param && is_valid_url(return_param) ? return_param : null;
-    const [stone_removal_accept_disabled, setStoneRemovalAcceptDisabled] = React.useState(false);
-    const [needs_sealing, setNeedsSealing] = React.useState<JGOFSealingIntersection[] | undefined>(
-        engine?.needs_sealing,
-    );
+    const needs_sealing = useNeedsSealing(goban);
     const need_to_seal = needs_sealing && needs_sealing.length > 0;
-    const [autoscoring_in_progress, setAutoScoringInProgress] = React.useState(false);
-    const [autoscoring_taking_too_long, setAutoscoringTakingTooLong] = React.useState(false);
+    const is_portrait = useViewMode(goban_controller) === "portrait";
     const annulled = useAnnulled(goban_controller);
     const onVariationKeyPress = useOnVariationKeyPress();
     const zen_mode = useZenMode(goban_controller);
@@ -92,106 +78,9 @@ export function PlayControls({ annulment_reason }: PlayControlsProps): React.Rea
     const phase = usePhase(goban);
     const stashed_conditional_moves = useStashedConditionalMoves(goban_controller);
 
-    const user_is_active_player = [engine.players.black.id, engine.players.white.id].includes(
-        user.id,
-    );
-
-    const [black_accepted, set_black_accepted] = React.useState(
-        stoneRemovalAccepted(goban, "black"),
-    );
-    const [white_accepted, set_white_accepted] = React.useState(
-        stoneRemovalAccepted(goban, "white"),
-    );
-
-    // Setup: when there's a new goban in play, we need to make sure we have the current
-    // state of acceptance captured
-    React.useEffect(() => {
-        const syncStoneRemovalAcceptance = () => {
-            if (goban.engine.phase === "stone removal") {
-                set_black_accepted(stoneRemovalAccepted(goban, "black"));
-                set_white_accepted(stoneRemovalAccepted(goban, "white"));
-            }
-        };
-        syncStoneRemovalAcceptance();
-
-        return subscribeAllEvents(
-            goban,
-            ["phase", "mode", "outcome", "stone-removal.accepted", "stone-removal.updated"],
-            syncStoneRemovalAcceptance,
-        );
-    }, [goban]);
-
-    React.useEffect(() => {
-        const syncNeedsSealing = (locs?: JGOFSealingIntersection[]) => {
-            setNeedsSealing(locs);
-        };
-        const engineUpdated = (engine: GobanEngine) => {
-            syncNeedsSealing(engine.needs_sealing);
-        };
-
-        let autoscoring_timeout: any;
-        const onAutoScoringStarted = () => {
-            console.log("Auto-scoring started");
-            setAutoScoringInProgress(true);
-            if (autoscoring_timeout) {
-                clearTimeout(autoscoring_timeout);
-            }
-            autoscoring_timeout = setTimeout(() => {
-                setAutoscoringTakingTooLong(true);
-                autoscoring_timeout = null;
-            }, 2000);
-        };
-        const onAutoScoringComplete = () => {
-            console.log("Auto-scoring complete");
-            setAutoScoringInProgress(false);
-            if (autoscoring_timeout) {
-                clearTimeout(autoscoring_timeout);
-                autoscoring_timeout = null;
-            }
-        };
-
-        if (goban?.engine) {
-            engineUpdated(goban.engine);
-        } else {
-            console.error("No engine in PlayControls");
-        }
-        goban.on("stone-removal.needs-sealing", syncNeedsSealing);
-        goban.on("engine.updated", engineUpdated);
-        goban.on("stone-removal.auto-scoring-started", onAutoScoringStarted);
-        goban.on("stone-removal.auto-scoring-complete", onAutoScoringComplete);
-
-        return () => {
-            goban.off("engine.updated", engineUpdated);
-            goban.off("stone-removal.needs-sealing", syncNeedsSealing);
-            goban.off("stone-removal.auto-scoring-started", onAutoScoringStarted);
-            goban.off("stone-removal.auto-scoring-complete", onAutoScoringComplete);
-        };
-    }, [goban]);
-
-    /*
-    React.useEffect(() => {
-        setStoneRemovalAcceptDisabled(true);
-        const timeout = setTimeout(() => {
-            console.log("setting false");
-            setStoneRemovalAcceptDisabled(false);
-        }, 1500);
-
-        return () => clearTimeout(timeout);
-    }, [stone_removal_string]);
-    */
-
-    React.useEffect(() => {
-        const player_accepted =
-            goban.engine?.playerColor(user.id) === "black" ? black_accepted : white_accepted;
-
-        setStoneRemovalAcceptDisabled(player_accepted ?? false);
-    }, [black_accepted, white_accepted]);
-
     const paused = usePaused(goban);
-    const official_move_number = useOfficialMoveNumber(goban);
     const conditional_moves = useConditionalMoveTree(goban);
     const user_is_player = useUserIsParticipant(goban);
-    const cur_move_number = useCurrentMoveNumber(goban);
     const mode = useMode(goban);
 
     const goban_setMode_play = () => {
@@ -228,29 +117,10 @@ export function PlayControls({ annulment_reason }: PlayControlsProps): React.Rea
             goban.engine.config,
         );
     };
-    const onStoneRemovalCancel = () => {
-        void alert
-            .fire({
-                text: _("Are you sure you want to resume the game?"),
-                showCancelButton: true,
-            })
-            .then(({ value: accept }) => {
-                if (accept) {
-                    goban.rejectRemovedStones();
-                }
-            });
-        return false;
-    };
-    const onStoneRemovalAccept = (): void => {
-        goban.acceptRemovedStones();
-    };
-    const onStoneRemovalAutoScore = (): void => {
-        goban.performStoneRemovalAutoScoring();
-    };
 
     return (
         <div className="PlayControls">
-            {mode === "play" && phase === "play" && user_is_player && <PlayButtons />}
+            {!is_portrait && <GameActionArea />}
             {annulled && (
                 <div className="annulled-indicator">
                     {pgettext("Displayed to the user when the game is annulled", "Game Annulled")}
@@ -361,106 +231,6 @@ export function PlayControls({ annulment_reason }: PlayControlsProps): React.Rea
                                     <span>...</span>
                                 )}
                             </div>
-
-                            <div style={{ textAlign: "center" }}>
-                                {(user_is_player || null) && (
-                                    <button
-                                        id="game-stone-removal-cancel"
-                                        onClick={onStoneRemovalCancel}
-                                        className={need_to_seal ? "primary" : ""}
-                                    >
-                                        {_("Cancel and resume game")}
-                                    </button>
-                                )}
-                            </div>
-                        </div>
-                    )}
-                    <div>
-                        {(user_is_active_player || user.is_moderator || null) && ( // moderators see the button, with its timer, but can't press it
-                            <button
-                                className={
-                                    (user.is_moderator && !user_is_active_player) ||
-                                    need_to_seal ||
-                                    autoscoring_in_progress
-                                        ? ""
-                                        : "primary"
-                                }
-                                disabled={
-                                    (user.is_moderator && !user_is_active_player) ||
-                                    stone_removal_accept_disabled ||
-                                    (autoscoring_in_progress && !autoscoring_taking_too_long)
-                                }
-                                onClick={onStoneRemovalAccept}
-                            >
-                                {_("Accept removed stones")}
-                                <Clock goban={goban} color="stone-removal" />
-                            </button>
-                        )}
-
-                        {autoscoring_in_progress && (
-                            <div className="autoscoring-in-progress">
-                                <i className="fa fa-circle-o-notch rotating" /> {_("Scoring game")}
-                            </div>
-                        )}
-                    </div>
-                    <br />
-                    <div style={{ textAlign: "center" }}>
-                        <div style={{ textAlign: "left", display: "inline-block" }}>
-                            <div>
-                                {(black_accepted || null) && (
-                                    <i
-                                        className="fa fa-check"
-                                        style={{ color: "green", width: "1.5em" }}
-                                    ></i>
-                                )}
-                                {(!black_accepted || null) && (
-                                    <i
-                                        className="fa fa-times"
-                                        style={{ color: "red", width: "1.5em" }}
-                                    ></i>
-                                )}
-                                {engine.players.black.username}
-                            </div>
-                            <div>
-                                {(white_accepted || null) && (
-                                    <i
-                                        className="fa fa-check"
-                                        style={{ color: "green", width: "1.5em" }}
-                                    ></i>
-                                )}
-                                {(!white_accepted || null) && (
-                                    <i
-                                        className="fa fa-times"
-                                        style={{ color: "red", width: "1.5em" }}
-                                    ></i>
-                                )}
-                                {engine.players.white.username}
-                            </div>
-                        </div>
-                    </div>
-                    <br />
-
-                    <div style={{ textAlign: "center" }}>
-                        {(user_is_player || null) && (
-                            <button
-                                id="game-stone-removal-auto-score"
-                                onClick={onStoneRemovalAutoScore}
-                            >
-                                {_("Auto-score")}
-                            </button>
-                        )}
-                    </div>
-                    {!need_to_seal && (
-                        <div style={{ textAlign: "center" }}>
-                            {(user_is_player || null) && (
-                                <button
-                                    id="game-stone-removal-cancel"
-                                    onClick={onStoneRemovalCancel}
-                                    className={need_to_seal ? "primary" : ""}
-                                >
-                                    {_("Cancel and resume game")}
-                                </button>
-                            )}
                         </div>
                     )}
 
@@ -525,37 +295,6 @@ export function PlayControls({ annulment_reason }: PlayControlsProps): React.Rea
                             </div>
                         </div>
                     )}
-                </div>
-            )}
-            {((mode === "play" &&
-                phase === "play" &&
-                goban.isAnalysisDisabled() &&
-                cur_move_number < official_move_number) ||
-                null) && (
-                <div className="analyze-mode-buttons">
-                    <span>
-                        <button
-                            className="sm primary bold"
-                            onClick={() => {
-                                enableTouchAction();
-                                goban.setModeDeferred("play");
-                            }}
-                        >
-                            {_("Back to Game")}
-                        </button>
-                    </span>
-                </div>
-            )}
-            {(mode === "score estimation" || null) && (
-                <div className="analyze-mode-buttons">
-                    <span>
-                        <button
-                            className="sm primary bold"
-                            onClick={goban_controller.stopEstimatingScore}
-                        >
-                            {_("Back to Board")}
-                        </button>
-                    </span>
                 </div>
             )}
         </div>
@@ -855,19 +594,6 @@ function ShareAnalysisButton(props: ShareAnalysisButtonProperties): React.ReactE
     }
 }
 
-function stoneRemovalAccepted(goban: Goban, color: PlayerColor) {
-    const engine = goban.engine;
-
-    if (engine.phase !== "stone removal") {
-        return undefined;
-    }
-    return engine.players[color].accepted_stones === engine.getStoneRemovalString();
-}
-
-const useOfficialMoveNumber = generateGobanHook(
-    (goban) => goban!.engine.last_official_move?.move_number ?? -1,
-    ["last_official_move"],
-);
 const usePaused = generateGobanHook(
     (goban) => goban!.pause_control && !!goban!.pause_control.paused,
     ["paused"],

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -25,13 +25,14 @@ import { ChatPresenceIndicator } from "@/components/ChatPresenceIndicator";
 import { Clock, SGFClock } from "@/components/Clock";
 import { Player } from "@/components/Player";
 import { lookup, fetch } from "@/lib/player_cache";
-import { _, interpolate, ngettext } from "@/lib/translate";
+import { _, interpolate, ngettext, pgettext } from "@/lib/translate";
 import * as data from "@/lib/data";
 import {
     generateGobanHook,
     usePhase,
     usePlayerToMoveOnOfficialBranch,
     useScorePopup,
+    useStoneRemovalAccepted,
     useZenMode,
 } from "./GameHooks";
 import { get_network_latency, get_clock_drift } from "@/lib/sockets";
@@ -163,6 +164,7 @@ export function PlayerCard({
 
     const auto_resign_expiration = useAutoResignExpiration(goban, color);
     const score = useScore(goban)[color];
+    const stone_removal_accepted = useStoneRemovalAccepted(goban, color);
     const { game_id, review_id } = goban;
     const chat_channel = game_id ? `game-${game_id}` : `review-${review_id}`;
 
@@ -242,6 +244,25 @@ export function PlayerCard({
 
             {player && player.rank !== -1 && (
                 <div className={`${color} player-name-container`}>
+                    {stone_removal_accepted !== undefined && (
+                        <i
+                            className={
+                                "stone-removal-accepted fa " +
+                                (stone_removal_accepted ? "fa-check accepted" : "fa-times")
+                            }
+                            title={
+                                stone_removal_accepted
+                                    ? pgettext(
+                                          "Player card badge during the stone removal phase",
+                                          "Accepted the removed stones",
+                                      )
+                                    : pgettext(
+                                          "Player card badge during the stone removal phase",
+                                          "Has not accepted the removed stones yet",
+                                      )
+                            }
+                        />
+                    )}
                     <Player
                         user={player.id}
                         historical={(!engine.rengo && historical) || player}

--- a/src/views/Game/Players.css
+++ b/src/views/Game/Players.css
@@ -276,6 +276,15 @@
         margin-left: 0.4em;
     }
 
+    .stone-removal-accepted {
+        margin-right: 0.3rem;
+        color: var(--danger);
+
+        &.accepted {
+            color: var(--success);
+        }
+    }
+
     .player-name-container {
         overflow: hidden;
         text-align: left;


### PR DESCRIPTION
## Summary

- Adds `GameActionArea`, one container for the controls a player must reach without scrolling: the pass / resign strip, the score estimate stacked above Back to Board, and the stone removal controls (Accept removed stones with its clock, Auto-score, Cancel and resume game).
- On portrait it renders in GobanView's below-board slot under the bottom player card. The board stage already shrinks the goban to fit its slots, so the area pushes the board up by its own height. The fixed 3.6rem reservation and its per-state class toggle are removed. On wider layouts `PlayControls` renders it at the top of the sidebar.
- Player cards show a check or cross badge for stone removal acceptance, replacing the list in `PlayControls`.
- Back to Game (analysis disabled, stepped back through moves) moves into the play strip's center slot.
- On portrait the game state header drops every mode and phase label and keeps only the undo request message and the final result.
- The conditional move tab now follows the official branch, so walking through the game in analyze mode no longer toggles it.
- Shared hooks in `GameHooks.ts` for the official move number, sealing state, per-color stone removal acceptance, and auto-scoring progress. `docs/game-action-area.md` describes the container.

## Testing

- `yarn type-check`, `yarn lint`, `yarn build` pass. Game view unit tests pass (46).
- Portrait browser pass on the dev server at 400x800 and 400x560: the action area's bottom edge lands on the scroll container's bottom, and the board shrinks to make room for the estimate and for the stone removal controls.
- Stone removal was exercised by faking the phase and players client-side. Please test a real stone removal phase and the Back to Game case in a live no-analysis game on both a phone and a desktop browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwn4jv2UVe2UPfYaoBLk5M
