### PR TITLE
Rename MoveNumberSlider to MoveNumberControl and add a buttons mode

### DIFF
--- a/src/components/GobanView/GobanView.tsx
+++ b/src/components/GobanView/GobanView.tsx
@@ -26,7 +26,7 @@ import {
 } from "./GobanViewContext";
 import { GobanViewTab, GobanViewTabProps } from "./GobanViewTab";
 import { TabBar } from "./TabBar";
-import { MoveNumberSlider } from "./MoveNumberSlider";
+import { MoveNumberControl } from "./MoveNumberControl";
 import { goban_view_mode, goban_view_squashed, ViewMode } from "./util";
 import "./GobanView.css";
 
@@ -65,14 +65,14 @@ interface GobanViewProps {
     /** Open this takeover on initial mount. Only read once; subsequent
      *  renders ignore changes. Use the ref API for mid-lifetime control. */
     defaultActiveTakeover?: string;
-    /** Replace the built-in MoveNumberSlider. Renders unconditionally —
+    /** Replace the built-in MoveNumberControl. Renders unconditionally —
      *  including during takeovers — so consumers whose navigation model
      *  needs to remain visible across modes (e.g. joseki) keep a single
      *  control strip in the standard location. The "has-custom-slider"
      *  class is added to the GobanView root so portrait CSS can leave room
      *  for it above the tab bar. */
     customSlider?: React.ReactNode;
-    /** Leave out the built-in MoveNumberSlider. Has no effect when a
+    /** Leave out the built-in MoveNumberControl. Has no effect when a
      *  `customSlider` is given. Consumers use this to drop the strip when
      *  move navigation is not relevant, e.g. on mobile during live play. */
     hideSlider?: boolean;
@@ -320,7 +320,7 @@ function GobanViewComponent({
     // keeps its existing "hide during takeover" rule.
     const sliderSlot: React.ReactNode = customSlider
         ? customSlider
-        : !hasTakeover && !hideSlider && <MoveNumberSlider />;
+        : !hasTakeover && !hideSlider && <MoveNumberControl />;
 
     const customSliderClass = customSlider ? " has-custom-slider" : "";
 

--- a/src/components/GobanView/MoveNumberControl.css
+++ b/src/components/GobanView/MoveNumberControl.css
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-.MoveNumberSlider {
+.MoveNumberControl {
     --thumb-size: 1.4rem;
     --track-height: 0.35rem;
 
@@ -27,7 +27,7 @@
     border-top: 1px solid var(--shade3);
     background: var(--shade4);
 
-    .MoveNumberSlider-button {
+    .MoveNumberControl-button {
         display: flex;
         align-items: center;
         justify-content: center;
@@ -62,7 +62,7 @@
        height of the component is a hit target for the slider. The thin
        gray bar is hard to hit on its own; the negative margin cancels the
        strip's padding. */
-    .MoveNumberSlider-track {
+    .MoveNumberControl-track {
         flex-grow: 1;
         position: relative;
         display: flex;
@@ -85,9 +85,12 @@
         }
     }
 
-    .MoveNumberSlider-input {
+    .MoveNumberControl-input {
         appearance: none;
         -webkit-appearance: none;
+        /* The global input rule draws a bottom border; at full strip height
+           it would paint a line along the bottom edge of the strip. */
+        border: none;
         width: 100%;
         /* Fill the stretched track so clicks anywhere in the strip land on
            the input. The native thumb stays vertically centered in the
@@ -128,7 +131,7 @@
         }
     }
 
-    .MoveNumberSlider-knob {
+    .MoveNumberControl-knob {
         position: absolute;
         /* Sit above the native input (z-index: 1) so the bar doesn't
            cover the knob's lower edge. */
@@ -151,7 +154,7 @@
         transition: transform 0.1s ease;
     }
 
-    .MoveNumberSlider-knob-text {
+    .MoveNumberControl-knob-text {
         /* Same background as the knob so longer numbers (e.g. 100+) extend
            beyond the circle into a readable pill rather than overflowing
            onto the bar. */
@@ -165,8 +168,28 @@
         white-space: nowrap;
     }
 
-    .MoveNumberSlider-input:hover ~ .MoveNumberSlider-knob,
-    .MoveNumberSlider-input:active ~ .MoveNumberSlider-knob {
+    .MoveNumberControl-input:hover ~ .MoveNumberControl-knob,
+    .MoveNumberControl-input:active ~ .MoveNumberControl-knob {
         transform: translate(-50%, -50%) scale(1.08);
+    }
+
+    /* Buttons layout: the buttons and the move label spread across the
+       full width of the strip. */
+    &.MoveNumberControl-buttons {
+        justify-content: space-between;
+        gap: 0.25rem;
+
+        .MoveNumberControl-button {
+            font-size: 1.1rem;
+        }
+
+        .MoveNumberControl-move-number {
+            color: var(--fg);
+            font-size: 0.85rem;
+            line-height: 1;
+            font-variant-numeric: tabular-nums;
+            white-space: nowrap;
+            user-select: none;
+        }
     }
 }

--- a/src/components/GobanView/MoveNumberControl.tsx
+++ b/src/components/GobanView/MoveNumberControl.tsx
@@ -17,10 +17,11 @@
 
 import * as React from "react";
 import { GobanRenderer } from "goban";
-import { pgettext } from "@/lib/translate";
+import { interpolate, pgettext } from "@/lib/translate";
+import { usePreference } from "@/lib/preferences";
 import { useGobanController } from "./GobanViewContext";
 import { generateGobanHook } from "./hooks";
-import "./MoveNumberSlider.css";
+import "./MoveNumberControl.css";
 
 interface MoveBounds {
     current: number;
@@ -52,10 +53,18 @@ const useMoveBounds = generateGobanHook<MoveBounds, GobanRenderer | null>(
     ["cur_move", "last_official_move"],
 );
 
-export function MoveNumberSlider(): React.ReactElement {
+/**
+ * Move navigation strip rendered below the goban. Two layouts share the
+ * same navigation state: a draggable slider with prev/next/autoplay
+ * buttons, or a row of first / back 10 / back / autoplay / forward /
+ * forward 10 / last buttons around the move number. The layout is chosen
+ * by the "move-number-control-mode" preference.
+ */
+export function MoveNumberControl(): React.ReactElement {
     const controller = useGobanController();
     const goban = controller.goban;
     const { current, reachable } = useMoveBounds(goban);
+    const [mode] = usePreference("move-number-control-mode");
 
     // Puzzles save their solution as the move tree's trunk_next chain. Walking
     // it forward via `next()` would let the slider drag through unplayed
@@ -134,6 +143,22 @@ export function MoveNumberSlider(): React.ReactElement {
         controller.nextMove();
     }, [controller]);
 
+    const handleFirst = React.useCallback(() => {
+        controller.gotoFirstMove();
+    }, [controller]);
+
+    const handlePrev10 = React.useCallback(() => {
+        controller.previous10Moves();
+    }, [controller]);
+
+    const handleNext10 = React.useCallback(() => {
+        controller.forwardTenMoves();
+    }, [controller]);
+
+    const handleLast = React.useCallback(() => {
+        controller.gotoLastMove();
+    }, [controller]);
+
     const handleSliderChange = React.useCallback(
         (ev: React.ChangeEvent<HTMLInputElement>) => {
             const target = parseInt(ev.target.value, 10);
@@ -183,41 +208,111 @@ export function MoveNumberSlider(): React.ReactElement {
         [controller],
     );
 
+    const play_pause_button = !restrict_forward && (
+        <button
+            className="MoveNumberControl-button"
+            onClick={handlePlayPause}
+            disabled={at_end && !autoplaying}
+            title={
+                autoplaying
+                    ? pgettext("Move navigation: stop autoplay", "Pause autoplay")
+                    : pgettext("Move navigation: play through the moves", "Autoplay")
+            }
+        >
+            <i className={"fa " + (autoplaying ? "fa-pause" : "fa-play")} />
+        </button>
+    );
+
+    const prev_button = (
+        <button
+            className="MoveNumberControl-button"
+            onClick={handlePrev}
+            disabled={at_start}
+            title={pgettext("Move navigation: previous move", "Previous move")}
+        >
+            <i className="fa fa-step-backward" />
+        </button>
+    );
+
+    const next_button = (
+        <button
+            className="MoveNumberControl-button"
+            onClick={handleNext}
+            disabled={at_end}
+            title={pgettext("Move navigation: next move", "Next move")}
+        >
+            <i className="fa fa-step-forward" />
+        </button>
+    );
+
+    if (mode === "buttons") {
+        // In puzzle mode the forward-jumping buttons would walk into the
+        // saved solution, so only single-step forward navigation is offered.
+        return (
+            <div className="MoveNumberControl MoveNumberControl-buttons">
+                <button
+                    className="MoveNumberControl-button"
+                    onClick={handleFirst}
+                    disabled={at_start}
+                    title={pgettext("Move navigation: first move", "First move")}
+                >
+                    <i className="fa fa-fast-backward" />
+                </button>
+                <button
+                    className="MoveNumberControl-button"
+                    onClick={handlePrev10}
+                    disabled={at_start}
+                    title={pgettext("Move navigation: back 10 moves", "Back 10 moves")}
+                >
+                    <i className="fa fa-backward" />
+                </button>
+                {prev_button}
+                {play_pause_button}
+                {next_button}
+                {!restrict_forward && (
+                    <button
+                        className="MoveNumberControl-button"
+                        onClick={handleNext10}
+                        disabled={at_end}
+                        title={pgettext("Move navigation: forward 10 moves", "Forward 10 moves")}
+                    >
+                        <i className="fa fa-forward" />
+                    </button>
+                )}
+                {!restrict_forward && (
+                    <button
+                        className="MoveNumberControl-button"
+                        onClick={handleLast}
+                        disabled={at_end}
+                        title={pgettext("Move navigation: last move", "Last move")}
+                    >
+                        <i className="fa fa-fast-forward" />
+                    </button>
+                )}
+                <span className="MoveNumberControl-move-number">
+                    {interpolate(pgettext("Current move number", "Move {{move_number}}"), {
+                        move_number: knob_number,
+                    })}
+                </span>
+            </div>
+        );
+    }
+
     // The CSS lays out our custom knob using `--move-frac` (0..1) so it
     // tracks the (invisible) native slider thumb across the track — see the
     // calc() in the accompanying CSS for the formula.
     const knob_frac = max > 0 ? Math.min(1, current / max) : 0;
 
     return (
-        <div className="MoveNumberSlider">
-            <button
-                className="MoveNumberSlider-button"
-                onClick={handlePrev}
-                disabled={at_start}
-                title={pgettext("Move navigation: previous move", "Previous move")}
-            >
-                <i className="fa fa-step-backward" />
-            </button>
-            {!restrict_forward && (
-                <button
-                    className="MoveNumberSlider-button"
-                    onClick={handlePlayPause}
-                    disabled={at_end && !autoplaying}
-                    title={
-                        autoplaying
-                            ? pgettext("Move navigation: stop autoplay", "Pause autoplay")
-                            : pgettext("Move navigation: play through the moves", "Autoplay")
-                    }
-                >
-                    <i className={"fa " + (autoplaying ? "fa-pause" : "fa-play")} />
-                </button>
-            )}
+        <div className="MoveNumberControl MoveNumberControl-slider">
+            {prev_button}
+            {play_pause_button}
             <div
-                className="MoveNumberSlider-track"
+                className="MoveNumberControl-track"
                 style={{ "--move-frac": knob_frac } as React.CSSProperties}
             >
                 <input
-                    className="MoveNumberSlider-input"
+                    className="MoveNumberControl-input"
                     type="range"
                     min={0}
                     max={max}
@@ -226,18 +321,11 @@ export function MoveNumberSlider(): React.ReactElement {
                     onChange={handleSliderChange}
                     aria-label={pgettext("Move navigation slider", "Move number")}
                 />
-                <div className="MoveNumberSlider-knob" aria-hidden="true">
-                    <span className="MoveNumberSlider-knob-text">{knob_number}</span>
+                <div className="MoveNumberControl-knob" aria-hidden="true">
+                    <span className="MoveNumberControl-knob-text">{knob_number}</span>
                 </div>
             </div>
-            <button
-                className="MoveNumberSlider-button"
-                onClick={handleNext}
-                disabled={at_end}
-                title={pgettext("Move navigation: next move", "Next move")}
-            >
-                <i className="fa fa-step-forward" />
-            </button>
+            {next_button}
         </div>
     );
 }

--- a/src/components/GobanView/index.ts
+++ b/src/components/GobanView/index.ts
@@ -19,7 +19,7 @@ export { GobanView } from "./GobanView";
 export type { GobanViewRef, TabDefinition } from "./GobanView";
 export { GobanViewTab } from "./GobanViewTab";
 export type { GobanViewTabProps } from "./GobanViewTab";
-export { MoveNumberSlider } from "./MoveNumberSlider";
+export { MoveNumberControl } from "./MoveNumberControl";
 export {
     GobanControllerContext,
     useGobanController,

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -158,6 +158,7 @@ export const defaults = {
     "variations-in-chat-enabled": true,
     "start-in-zen-mode": false,
     "scroll-to-navigate": false,
+    "move-number-control-mode": "buttons" as "slider" | "buttons",
     "show-empty-chat-notification": true,
     "chat-subscribe-group-chat-unread": true,
     "chat-subscribe-group-mentions": true,

--- a/src/views/Game/Game.css
+++ b/src/views/Game/Game.css
@@ -346,7 +346,7 @@
 
         /* The slider strip keeps its own panel chrome (background + border),
          * which reads as a stray grey card on zen's transparent sidebar. */
-        .MoveNumberSlider {
+        .MoveNumberControl {
             background: transparent;
             border-top: none;
         }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1168,7 +1168,7 @@ export function Game(): React.ReactElement | null {
 
             {/* Left: settings + the two analysis tools that used to live in
              *  the More-actions takeover. Move navigation comes from
-             *  GobanView's built-in MoveNumberSlider above the tab bar. */}
+             *  GobanView's built-in MoveNumberControl above the tab bar. */}
             <GobanView.Tab
                 id="game-settings"
                 type="action"

--- a/src/views/Joseki/Joseki.tsx
+++ b/src/views/Joseki/Joseki.tsx
@@ -1166,7 +1166,7 @@ export function Joseki(): React.ReactElement {
                   </div>
               ));
 
-    // Reuses .MoveNumberSlider classes for visual parity with the standard
+    // Reuses .MoveNumberControl classes for visual parity with the standard
     // bar but is wired to joseki's own server-driven nav (back_stepping flag
     // + per-step fetch) rather than the controller's previousMove/nextMove.
     function renderMoveControls() {
@@ -1186,12 +1186,12 @@ export function Joseki(): React.ReactElement {
         return (
             <div
                 className={
-                    "Joseki-move-bar MoveNumberSlider" +
+                    "Joseki-move-bar MoveNumberControl" +
                     (played_mistake.current ? " highlight" : "")
                 }
             >
                 <button
-                    className="MoveNumberSlider-button"
+                    className="MoveNumberControl-button"
                     onClick={resetBoard}
                     disabled={at_start}
                     title={pgettext("Move navigation: reset to root", "Reset to root")}
@@ -1199,7 +1199,7 @@ export function Joseki(): React.ReactElement {
                     <i className="fa fa-refresh" />
                 </button>
                 <button
-                    className="MoveNumberSlider-button"
+                    className="MoveNumberControl-button"
                     onClick={backOneMove}
                     disabled={!can_back}
                     title={pgettext("Move navigation: previous move", "Previous move")}
@@ -1207,7 +1207,7 @@ export function Joseki(): React.ReactElement {
                     <i className="fa fa-step-backward" />
                 </button>
                 <div
-                    className="MoveNumberSlider-track"
+                    className="MoveNumberControl-track"
                     style={
                         {
                             "--move-frac": (slider_target ?? move_number) / Math.max(knob_max, 1),
@@ -1215,7 +1215,7 @@ export function Joseki(): React.ReactElement {
                     }
                 >
                     <input
-                        className="MoveNumberSlider-input"
+                        className="MoveNumberControl-input"
                         type="range"
                         min={0}
                         max={knob_max}
@@ -1229,8 +1229,8 @@ export function Joseki(): React.ReactElement {
                         }}
                         aria-label={pgettext("Move navigation slider", "Move number")}
                     />
-                    <div className="MoveNumberSlider-knob">
-                        <span className="MoveNumberSlider-knob-text">
+                    <div className="MoveNumberControl-knob">
+                        <span className="MoveNumberControl-knob-text">
                             {slider_target ?? move_number}
                         </span>
                     </div>
@@ -1239,7 +1239,7 @@ export function Joseki(): React.ReactElement {
                     </div>
                 </div>
                 <button
-                    className="MoveNumberSlider-button"
+                    className="MoveNumberControl-button"
                     onClick={forwardOneMove}
                     disabled={!can_forward}
                     title={pgettext("Move navigation: next move", "Next move")}

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -104,6 +104,9 @@ export function ThemePreferences(): React.ReactElement | null {
         usePreference("variation-stone-opacity");
     const [show_visit_counts, setShowVisitCounts] = usePreference("ai-review-show-visit-counts");
     const [animate_turn_clock, setAnimateTurnClock] = usePreference("animate-turn-clock");
+    const [move_number_control_mode, _setMoveNumberControlMode] = usePreference(
+        "move-number-control-mode",
+    );
 
     //const [show_move_numbers, _setShowMoveNumbers] = usePreference("show-move-numbers");
     const [show_variation_move_numbers, _setShowVariationMoveNumbers] = usePreference(
@@ -655,6 +658,33 @@ export function ThemePreferences(): React.ReactElement | null {
                 )}
             >
                 <Toggle checked={animate_turn_clock} onChange={setAnimateTurnClock} />
+            </PreferenceLine>
+
+            <PreferenceLine
+                title={pgettext("Theme preference title", "Move navigation control")}
+                description={pgettext(
+                    "Theme preference description",
+                    "Navigate moves with a slider, or with first, back 10, back, forward, forward 10, and last buttons.",
+                )}
+            >
+                <PreferenceDropdown
+                    value={move_number_control_mode}
+                    options={[
+                        {
+                            value: "buttons",
+                            label: pgettext("Move navigation control mode", "Buttons"),
+                        },
+                        {
+                            value: "slider",
+                            label: pgettext("Move navigation control mode", "Slider"),
+                        },
+                    ]}
+                    onChange={(value: string) => {
+                        if (value === "slider" || value === "buttons") {
+                            _setMoveNumberControlMode(value);
+                        }
+                    }}
+                />
             </PreferenceLine>
 
             <PreferenceLine


### PR DESCRIPTION
## Summary

- Rename `MoveNumberSlider` to `MoveNumberControl` (component, CSS, class names, and all references including the Joseki view's reused classes).
- Add a second layout, chosen by the new `move-number-control-mode` preference:
  - **buttons** (default): first, back 10, back, autoplay, forward, forward 10, last, spread across the strip, with a plain "Move N" label.
  - **slider**: the existing draggable slider with prev/next/autoplay.
- The preference lives in Themes & Visuals, so it also shows in the in-game settings "More options" panel.
- Both layouts share the same navigation state, puzzle forward restriction, AI review presentation handling, and autoplay wiring.
- Fix: the slider's range input picked up the global input bottom border, which painted a second line along the bottom edge of the strip. The border is now reset.

## Testing

- `yarn type-check`, `yarn lint`, `yarn prettier:check`, and `yarn build` pass.
- Checked in a browser against a finished game on beta: both layouts render, each button moves to the expected move with correct disabled states at the ends, the buttons row fits at a 320px width, and the extra line under the slider is gone in dark theme.
- Not yet checked: signed-in mobile analysis mode and puzzles. Please test on mobile and desktop before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbroSKrQNs5zFsTSzghNha
