### PR TITLE
Add Game Preferences to the game More options panel and fix iOS dropdown taps

### DIFF
--- a/src/lib/SettingsCommon.test.tsx
+++ b/src/lib/SettingsCommon.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { PreferenceDropdown } from "./SettingsCommon";
+
+const OPTIONS = [
+    { value: "a", label: "Alpha" },
+    { value: "b", label: "Beta" },
+];
+
+function Harness(): React.ReactElement {
+    const [, bump] = React.useState(0);
+    return (
+        <div>
+            <button onClick={() => bump((x) => x + 1)}>rerender</button>
+            <PreferenceDropdown value="a" options={OPTIONS} onChange={() => {}} />
+        </div>
+    );
+}
+
+/* Safari on iOS delivers touchend and the resulting click to the element
+ * that was under the finger at touchstart. If a parent re-render replaces
+ * the option elements while the menu is open, a tap between touchstart and
+ * touchend lands on a detached node and is lost. */
+test("keeps open menu option elements mounted across a parent re-render", () => {
+    const { container } = render(<Harness />);
+    const control = container.querySelector(".ogs-react-select__control");
+    if (!control) {
+        throw new Error("control not rendered");
+    }
+    fireEvent.mouseDown(control, { button: 0 });
+    const option = screen.getByText("Beta");
+    expect(option.classList.contains("PreferenceDropdown-option")).toBe(true);
+
+    fireEvent.click(screen.getByText("rerender"));
+
+    expect(document.body.contains(option)).toBe(true);
+    expect(screen.getByText("Beta")).toBe(option);
+});

--- a/src/lib/SettingsCommon.tsx
+++ b/src/lib/SettingsCommon.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import Select from "react-select";
+import Select, { SelectComponentsConfig } from "react-select";
 
 import { usePreference } from "@/lib/preferences";
 import { ValidPreference } from "@/lib/preferences";
@@ -85,41 +85,51 @@ export interface PreferenceDropdownProps {
     onChange: (value: any) => void;
 }
 
+type PreferenceOption = { value: any; label: string };
+
+/* The custom parts are defined once at module scope. Defining them inline
+ * in the render function gives react-select a new component type on every
+ * parent re-render, which remounts every option element while the menu is
+ * open. On iOS Safari a tap whose touchstart target is replaced before
+ * touchend never becomes a click, so the options could not be selected
+ * anywhere the parent re-renders often, such as the game view. */
+const PREFERENCE_DROPDOWN_COMPONENTS: SelectComponentsConfig<PreferenceOption, false, never> = {
+    Option: ({ innerRef, innerProps, isFocused, isSelected, data }) => (
+        <div
+            ref={innerRef}
+            {...innerProps}
+            className={
+                "PreferenceDropdown-option " +
+                (isFocused ? "focused " : "") +
+                (isSelected ? "selected" : "")
+            }
+        >
+            {data.label}
+        </div>
+    ),
+    SingleValue: ({ innerProps, data }) => (
+        <span {...innerProps} className="PreferenceDropdown-value">
+            {data.label}
+        </span>
+    ),
+    ValueContainer: ({ children }) => (
+        <div className="PreferenceDropdown-value-container">{children}</div>
+    ),
+};
+
 export function PreferenceDropdown(props: PreferenceDropdownProps): React.ReactElement {
     return (
-        <Select
+        <Select<PreferenceOption, false, never>
             className="PreferenceDropdown"
             classNamePrefix="ogs-react-select"
             value={props.options.filter((opt) => opt.value === props.value)[0]}
             getOptionValue={(data) => data.value}
-            onChange={(data: any) => props.onChange(data.value)}
+            onChange={(data) => props.onChange(data?.value)}
             options={props.options}
             isClearable={false}
             isSearchable={false}
             blurInputOnSelect={true}
-            components={{
-                Option: ({ innerRef, innerProps, isFocused, isSelected, data }) => (
-                    <div
-                        ref={innerRef}
-                        {...innerProps}
-                        className={
-                            "PreferenceDropdown-option " +
-                            (isFocused ? "focused " : "") +
-                            (isSelected ? "selected" : "")
-                        }
-                    >
-                        {data.label}
-                    </div>
-                ),
-                SingleValue: ({ innerProps, data }) => (
-                    <span {...innerProps} className="PreferenceDropdown-value">
-                        {data.label}
-                    </span>
-                ),
-                ValueContainer: ({ children }) => (
-                    <div className="PreferenceDropdown-value-container">{children}</div>
-                ),
-            }}
+            components={PREFERENCE_DROPDOWN_COMPONENTS}
         />
     );
 }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -65,7 +65,7 @@ import { ActiveTournament } from "@/lib/types";
 import { GobanController } from "@/lib/GobanController";
 import { FragAIReview, GameInformation, GameKeyboardShortcuts, RengoHeader } from "./fragments";
 import { GameSettingsPanel } from "./GameSettingsPanel";
-import { GameThemeSettingsPanel } from "./GameThemeSettingsPanel";
+import { GameMoreSettingsPanel } from "./GameMoreSettingsPanel";
 import { GameActionsPanel } from "./GameActionsPanel";
 import { GameModToolsPanel } from "./GameModToolsPanel";
 import { GameModeratorAreaPanel } from "./GameModeratorAreaPanel";
@@ -162,10 +162,10 @@ export function Game(): React.ReactElement | null {
     //     on desktop (chat is always visible there if the feature is on).
     const [chat_enabled] = usePreference("game.chat-enabled");
     const [mobile_chat_visible, set_mobile_chat_visible] = React.useState(false);
-    // Whether the Themes & Visuals takeover is showing. Synced from the
+    // Whether the full settings takeover is showing. Synced from the
     // takeover tab's onToggle (the authoritative open/close signal), and
     // used to light up the settings gear while it's open.
-    const [theme_settings_open, set_theme_settings_open] = React.useState(false);
+    const [more_settings_open, set_more_settings_open] = React.useState(false);
     // Bumped when the goban must be rebuilt from scratch (switching
     // between the SVG and canvas renderers); the constructor effect below
     // lists it as a dependency.
@@ -1003,7 +1003,7 @@ export function Game(): React.ReactElement | null {
                                 onClose={close}
                                 compact={is_mobile}
                                 onShowThemeSettings={() =>
-                                    goban_view_ref.current?.setActiveTakeover("game-theme-settings")
+                                    goban_view_ref.current?.setActiveTakeover("game-more-settings")
                                 }
                             />
                         </div>
@@ -1194,9 +1194,9 @@ export function Game(): React.ReactElement | null {
                 align="left"
                 icon="gear"
                 title={_("Settings")}
-                active={theme_settings_open}
+                active={more_settings_open}
                 onClick={(event) => {
-                    if (theme_settings_open) {
+                    if (more_settings_open) {
                         goban_view_ref.current?.setActiveTakeover(null);
                     } else {
                         openSettings(event);
@@ -1204,19 +1204,19 @@ export function Game(): React.ReactElement | null {
                 }}
             />
 
-            {/* Full Themes & Visuals settings, opened from the Settings
-             *  popover's "More options" item. Hidden from the tab bar —
-             *  the gear icon doubles as its lit-up toggle, and the panel
-             *  has a Done button, so it needs no close button. */}
+            {/* Full Themes & Visuals and Game Preferences settings, opened
+             *  from the Settings popover's "More options" item. Hidden from
+             *  the tab bar — the gear icon doubles as its lit-up toggle, and
+             *  the panel has a Done button, so it needs no close button. */}
             <GobanView.Tab
-                id="game-theme-settings"
+                id="game-more-settings"
                 type="takeover"
                 hideFromBar
                 hideCloseButton
-                title={_("Themes & Visuals")}
-                onToggle={set_theme_settings_open}
+                title={_("Settings")}
+                onToggle={set_more_settings_open}
             >
-                <GameThemeSettingsPanel
+                <GameMoreSettingsPanel
                     onClose={() => goban_view_ref.current?.setActiveTakeover(null)}
                 />
             </GobanView.Tab>

--- a/src/views/Game/GameMoreSettingsPanel.css
+++ b/src/views/Game/GameMoreSettingsPanel.css
@@ -15,17 +15,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-.GameThemeSettingsPanel {
+.GameMoreSettingsPanel {
     flex-grow: 1;
     min-height: 0;
 
-    .GameThemeSettingsPanel-content {
+    .GameMoreSettingsPanel-content {
         flex-grow: 1;
         min-height: 0;
         overflow-y: auto;
         overflow-x: hidden;
         /* The Settings page disables selection page-wide; keep that here. */
         user-select: none;
+
+        /* The panel has no title of its own, so the first section header
+         * sits flush with the top. */
+        > .GameSidebarPanel-section-header:first-child {
+            margin-top: 0;
+        }
 
         /* Each PreferenceLine is a two column grid: the title text sits in
          * the first row and the description in the second. The title span
@@ -167,7 +173,7 @@
         }
     }
 
-    .GameThemeSettingsPanel-buttons {
+    .GameMoreSettingsPanel-buttons {
         flex-shrink: 0;
         display: flex;
         justify-content: center;

--- a/src/views/Game/GameMoreSettingsPanel.tsx
+++ b/src/views/Game/GameMoreSettingsPanel.tsx
@@ -17,34 +17,35 @@
 
 import * as React from "react";
 import { _ } from "@/lib/translate";
+import { GamePreferences } from "@/views/Settings/GamePreferences";
 import { ThemePreferences } from "@/views/Settings/ThemePreferences";
-import "./GameThemeSettingsPanel.css";
+import "./GameMoreSettingsPanel.css";
 
-interface GameThemeSettingsPanelProps {
+interface GameMoreSettingsPanelProps {
     /** Fired by the Done button at the bottom of the panel. */
     onClose?: () => void;
 }
 
 /**
- * Sidebar takeover hosting the full "Themes & Visuals" settings component
- * from the Settings page. Opened from the game Settings popover's
- * "More options" item; closed by the Done button, or by clicking the
- * settings gear again (wired in Game.tsx).
+ * Sidebar takeover hosting the full "Themes & Visuals" and "Game
+ * Preferences" settings components from the Settings page. Opened from
+ * the game Settings popover's "More options" item; closed by the Done
+ * button, or by clicking the settings gear again (wired in Game.tsx).
  *
  * The inner wrapper carries the `.Settings` class so the PreferenceLine
  * styles from Settings.css (scoped under `.Settings`) apply here; the
  * panel's own CSS compacts them to sidebar width.
  */
-export function GameThemeSettingsPanel({
-    onClose,
-}: GameThemeSettingsPanelProps): React.ReactElement {
+export function GameMoreSettingsPanel({ onClose }: GameMoreSettingsPanelProps): React.ReactElement {
     return (
-        <div className="GameSidebarPanel GameThemeSettingsPanel">
-            <h3 className="GameSidebarPanel-title">{_("Themes & Visuals")}</h3>
-            <div className="Settings GameThemeSettingsPanel-content">
+        <div className="GameSidebarPanel GameMoreSettingsPanel">
+            <div className="Settings GameMoreSettingsPanel-content">
+                <h4 className="GameSidebarPanel-section-header">{_("Themes & Visuals")}</h4>
                 <ThemePreferences />
+                <h4 className="GameSidebarPanel-section-header">{_("Game Preferences")}</h4>
+                <GamePreferences />
             </div>
-            <div className="GameThemeSettingsPanel-buttons">
+            <div className="GameMoreSettingsPanel-buttons">
                 <button className="primary" onClick={onClose}>
                     {_("Done")}
                 </button>


### PR DESCRIPTION
## Summary

- The game's "More options" settings takeover now shows both **Themes & Visuals** and **Game Preferences**, under section headers, with no panel title of its own. The component is renamed from `GameThemeSettingsPanel` to `GameMoreSettingsPanel`.
- Fixes react-select dropdown options not being tappable on iOS Safari inside the game view. `PreferenceDropdown` defined its custom react-select components inline, so every parent re-render remounted the option elements. Safari sends touchend and the click to the element under the finger at touchstart, so a tap during a re-render hit a detached node and was dropped. Chrome re-hit-tests at tap end, which is why Android worked. The components are now defined once at module scope.
- Adds a regression test that opens the menu, re-renders the parent, and asserts the option element is the same node.

## Testing

- `yarn type-check`, `yarn lint`, `yarn jest src/lib/SettingsCommon.test.tsx`, and `yarn build` pass.
- Panel checked in Chromium at 1600x900 and 400x800.
- Dropdown fix confirmed on an iPad in portrait, where option taps failed before and select correctly now.

## Follow-up

Other `Select` usages also pass inline `components={{ ... }}` (ReviewSelector, QuickMatch, Settings, SoundPreferences). They have the same latent remount behaviour and would fail the same way anywhere the parent re-renders during a tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiXXtuZzkuK1N6hjeZQTzX
