### PR TITLE
Add a Keyboard shortcuts modal to the game's More actions menu

### DIFF
--- a/src/lib/device.test.ts
+++ b/src/lib/device.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isTouchOnlyDevice, onTouchOnlyDeviceChange } from "./device";
+
+type Listener = (ev: { matches: boolean }) => void;
+
+function installMatchMedia(matches: boolean) {
+    const listeners: Listener[] = [];
+    const matchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        addEventListener: (_: string, cb: Listener) => listeners.push(cb),
+        removeEventListener: (_: string, cb: Listener) => {
+            const i = listeners.indexOf(cb);
+            if (i >= 0) {
+                listeners.splice(i, 1);
+            }
+        },
+    }));
+    Object.defineProperty(window, "matchMedia", { configurable: true, value: matchMedia });
+    return { matchMedia, listeners };
+}
+
+afterEach(() => {
+    delete (window as { matchMedia?: unknown }).matchMedia;
+});
+
+test("assumes a keyboard when matchMedia is unavailable", () => {
+    expect(isTouchOnlyDevice()).toBe(false);
+    expect(typeof onTouchOnlyDeviceChange(() => {})).toBe("function");
+});
+
+test("reports touch-only devices from the hover and pointer media query", () => {
+    const { matchMedia } = installMatchMedia(true);
+    expect(isTouchOnlyDevice()).toBe(true);
+    expect(matchMedia).toHaveBeenCalledWith("(any-hover: none) and (any-pointer: coarse)");
+
+    installMatchMedia(false);
+    expect(isTouchOnlyDevice()).toBe(false);
+});
+
+test("notifies when a pointing device is attached and stops after unsubscribe", () => {
+    const { listeners } = installMatchMedia(true);
+    const callback = jest.fn();
+    const unsubscribe = onTouchOnlyDeviceChange(callback);
+
+    expect(listeners).toHaveLength(1);
+    listeners[0]({ matches: false });
+    expect(callback).toHaveBeenCalledWith(false);
+
+    unsubscribe();
+    expect(listeners).toHaveLength(0);
+});

--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -52,3 +52,44 @@ export function getEm10Width(): number {
     }
     return em10_width;
 }
+
+/**
+ * Matches devices whose only pointing input is a coarse one (touch) and where
+ * nothing can hover. Phones and tablets match in any orientation. Attaching a
+ * mouse or trackpad to a tablet makes the query stop matching, and desktops
+ * with touch screens never match because the mouse can hover.
+ */
+const TOUCH_ONLY_QUERY = "(any-hover: none) and (any-pointer: coarse)";
+
+function touchOnlyMediaQuery(): MediaQueryList | null {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+        return null;
+    }
+    return window.matchMedia(TOUCH_ONLY_QUERY);
+}
+
+/**
+ * True when the device is driven by touch alone, so a physical keyboard is
+ * unlikely to be present. Browsers give no direct way to detect a keyboard;
+ * a fine, hover-capable pointer such as a mouse or trackpad is the closest
+ * proxy. When media queries are unavailable the device is assumed to have a
+ * keyboard.
+ */
+export function isTouchOnlyDevice(): boolean {
+    return touchOnlyMediaQuery()?.matches ?? false;
+}
+
+/**
+ * Calls `callback` whenever `isTouchOnlyDevice()` changes, for example when a
+ * mouse is plugged into a tablet. Returns a function that removes the
+ * listener.
+ */
+export function onTouchOnlyDeviceChange(callback: (touch_only: boolean) => void): () => void {
+    const query = touchOnlyMediaQuery();
+    if (!query) {
+        return () => {};
+    }
+    const handler = (ev: MediaQueryListEvent) => callback(ev.matches);
+    query.addEventListener("change", handler);
+    return () => query.removeEventListener("change", handler);
+}

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -20,6 +20,7 @@ import * as data from "@/lib/data";
 import { DataSchema } from "./data_schema";
 import { Goban } from "goban";
 import { bot_event_emitter, bots_list, Bot } from "@/lib/bots";
+import { isTouchOnlyDevice, onTouchOnlyDeviceChange } from "@/lib/device";
 
 /**
  * React Hook that gives the value for a given key.  This should be preferred
@@ -85,6 +86,19 @@ export function useIsDesktop(): boolean {
     }, []);
 
     return isDesktop;
+}
+
+/**
+ * True on touch-only devices such as phones and tablets, where a physical
+ * keyboard is unlikely. Updates live when a pointing device is attached or
+ * removed. See `isTouchOnlyDevice` in `@/lib/device`.
+ */
+export function useIsTouchOnlyDevice(): boolean {
+    const [touch_only, setTouchOnly] = React.useState(isTouchOnlyDevice);
+
+    React.useEffect(() => onTouchOnlyDeviceChange(setTouchOnly), []);
+
+    return touch_only;
 }
 
 export function useBots() {

--- a/src/views/Game/GameActionsPanel.test.tsx
+++ b/src/views/Game/GameActionsPanel.test.tsx
@@ -23,10 +23,15 @@ import { BrowserRouter as Router } from "react-router-dom";
 import * as data from "@/lib/data";
 import { GobanController } from "@/lib/GobanController";
 import { openSGFCollectionModal } from "@/components/SGFCollectionModal";
+import { openGameKeyboardShortcutsModal } from "./GameKeyboardShortcutsModal";
 
 // Mock the SGF Collection Modal
 jest.mock("@/components/SGFCollectionModal", () => ({
     openSGFCollectionModal: jest.fn(),
+}));
+
+jest.mock("./GameKeyboardShortcutsModal", () => ({
+    openGameKeyboardShortcutsModal: jest.fn(),
 }));
 
 const TEST_USER = {
@@ -173,6 +178,38 @@ test("'Add to library' button is disabled for anonymous users", () => {
     expect(addToLibraryButton).toBeInTheDocument();
     expect(addToLibraryButton).toBeDisabled();
     expect(addToLibraryButton).toHaveClass("disabled");
+});
+
+test("clicking 'Keyboard shortcuts' opens the shortcuts modal and closes the menu", () => {
+    data.set("user", TEST_USER);
+    const gameController = new GobanController({ game_id: 456789 });
+    const onClose = jest.fn();
+
+    renderPanel(gameController, { onClose });
+
+    fireEvent.click(screen.getByText("Keyboard shortcuts"));
+
+    expect(openGameKeyboardShortcutsModal).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("'Keyboard shortcuts' is hidden on touch-only devices", () => {
+    data.set("user", TEST_USER);
+    const gameController = new GobanController({ game_id: 456789 });
+
+    const matchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: query === "(any-hover: none) and (any-pointer: coarse)",
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+    }));
+    Object.defineProperty(window, "matchMedia", { configurable: true, value: matchMedia });
+    try {
+        renderPanel(gameController);
+        expect(screen.queryByText("Keyboard shortcuts")).toBeNull();
+    } finally {
+        delete (window as { matchMedia?: unknown }).matchMedia;
+    }
 });
 
 const OPPONENT = { id: 456, username: "test_user2" };

--- a/src/views/Game/GameActionsPanel.tsx
+++ b/src/views/Game/GameActionsPanel.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { _, pgettext } from "@/lib/translate";
 import { browserHistory } from "@/lib/ogsHistory";
 import { api1 } from "@/lib/requests";
-import { useUser } from "@/lib/hooks";
+import { useIsTouchOnlyDevice, useUser } from "@/lib/hooks";
 import { alert } from "@/lib/swal_config";
 import { toast } from "@/lib/toast";
 import { openReport } from "@/components/Report";
@@ -40,6 +40,7 @@ import {
 import { useGobanController } from "./goban_context";
 import { openGameInfoModal } from "./GameInfoModal";
 import { openGameLinkModal } from "./GameLinkModal";
+import { openGameKeyboardShortcutsModal } from "./GameKeyboardShortcutsModal";
 import { cancelOrResignGame, requestUndo } from "./game_actions";
 import { UndoIcon } from "./UndoIcon";
 import "./GameSidebarPanels.css";
@@ -87,6 +88,9 @@ export function GameActionsPanel({
     const phase = usePhase(goban);
     const mode = useMode(goban);
     const user = useUser();
+    // Phones and tablets have no keyboard to speak of, so the shortcut list
+    // is only offered where a mouse or trackpad suggests one is present.
+    const touch_only_device = useIsTouchOnlyDevice();
     const { showModal } = React.useContext(ModalContext);
 
     const annulled = useAnnulled(goban_controller);
@@ -141,6 +145,7 @@ export function GameActionsPanel({
     };
 
     const showLinkModal = wrap(() => openGameLinkModal(goban));
+    const showKeyboardShortcuts = wrap(openGameKeyboardShortcutsModal);
 
     const showGameInfo = wrap(() => {
         const ec = goban.engine.config;
@@ -418,6 +423,13 @@ export function GameActionsPanel({
                     <i className="fa fa-download" />
                     <span>{_("SGF with comments")}</span>
                 </a>
+            )}
+
+            {!touch_only_device && (
+                <button className="GameSidebarPanel-item" onClick={showKeyboardShortcuts}>
+                    <i className="fa fa-keyboard-o" />
+                    <span>{_("Keyboard shortcuts")}</span>
+                </button>
             )}
         </div>
     );

--- a/src/views/Game/GameKeyboardShortcutsModal.css
+++ b/src/views/Game/GameKeyboardShortcutsModal.css
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+.GameKeyboardShortcutsModal.Modal {
+    width: 100%;
+    max-width: 36rem;
+
+    .body {
+        padding: 0.5rem 1.5rem 1rem 1.5rem;
+    }
+
+    .shortcut-group {
+        margin-top: 1rem;
+
+        &:first-child {
+            margin-top: 0.25rem;
+        }
+
+        h3 {
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--shade1);
+            margin: 0 0 0.35rem 0;
+            padding-bottom: 0.3rem;
+            border-bottom: 1px solid var(--shade4);
+        }
+
+        .shortcut-note {
+            font-size: 0.85rem;
+            color: var(--shade1);
+            margin: 0 0 0.35rem 0;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        td {
+            padding: 0.25rem 0;
+            vertical-align: middle;
+        }
+
+        .shortcut-keys {
+            width: 11rem;
+            white-space: nowrap;
+            padding-right: 1rem;
+        }
+
+        .shortcut-plus {
+            display: inline-block;
+            padding: 0 0.3rem;
+            color: var(--shade1);
+        }
+
+        .shortcut-description {
+            font-size: 0.95rem;
+        }
+    }
+
+    kbd {
+        display: inline-block;
+        min-width: 1.4em;
+        padding: 0.1rem 0.45rem;
+        font-family: inherit;
+        font-size: 0.85rem;
+        line-height: 1.4;
+        text-align: center;
+        color: var(--fg);
+        background-color: var(--shade5);
+        border: 1px solid var(--shade3);
+        border-bottom-width: 2px;
+        border-radius: 4px;
+    }
+}

--- a/src/views/Game/GameKeyboardShortcutsModal.test.tsx
+++ b/src/views/Game/GameKeyboardShortcutsModal.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { GameKeyboardShortcutsModal } from "./GameKeyboardShortcutsModal";
+import { GAME_KEYBOARD_SHORTCUT_GROUPS, shortcutKeyNames } from "./game_keyboard_shortcuts";
+
+test("lists every shortcut the Game page binds", () => {
+    const { container } = render(<GameKeyboardShortcutsModal />);
+
+    const rows = container.querySelectorAll("tbody tr");
+    const expected = GAME_KEYBOARD_SHORTCUT_GROUPS.flatMap((group) => group.shortcuts);
+    expect(rows.length).toBe(expected.length);
+
+    for (const entry of expected) {
+        const description = Array.from(container.querySelectorAll(".shortcut-description")).find(
+            (el) => el.textContent === entry.description(),
+        );
+        expect(description).toBeDefined();
+    }
+});
+
+test("renders modifier combinations as separate key caps", () => {
+    const { container } = render(<GameKeyboardShortcutsModal />);
+
+    const row = Array.from(container.querySelectorAll("tbody tr")).find(
+        (tr) => tr.querySelector(".shortcut-description")?.textContent === "Toggle zen mode",
+    );
+    expect(row).toBeDefined();
+
+    const keys = Array.from(row!.querySelectorAll("kbd")).map((kbd) => kbd.textContent);
+    expect(keys).toEqual(["Shift", "Z"]);
+});
+
+test("shortcutKeyNames maps tokens to readable names", () => {
+    expect(shortcutKeyNames("page-up")).toEqual(["Page Up"]);
+    expect(shortcutKeyNames("ctrl-c")).toEqual(["Ctrl", "C"]);
+    expect(shortcutKeyNames("f10")).toEqual(["F10"]);
+    expect(shortcutKeyNames("escape")).toEqual(["Esc"]);
+});

--- a/src/views/Game/GameKeyboardShortcutsModal.tsx
+++ b/src/views/Game/GameKeyboardShortcutsModal.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { _ } from "@/lib/translate";
+import { openModal, Modal } from "@/components/Modal";
+import { GAME_KEYBOARD_SHORTCUT_GROUPS, shortcutKeyNames } from "./game_keyboard_shortcuts";
+import "./GameKeyboardShortcutsModal.css";
+
+interface Events {}
+
+interface GameKeyboardShortcutsModalProperties {}
+
+/** Lists every keyboard shortcut that the Game page binds. */
+export class GameKeyboardShortcutsModal extends Modal<
+    Events,
+    GameKeyboardShortcutsModalProperties,
+    {}
+> {
+    constructor(props: GameKeyboardShortcutsModalProperties) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <div className="Modal GameKeyboardShortcutsModal">
+                <div className="header">
+                    <h2>{_("Keyboard shortcuts")}</h2>
+                </div>
+                <div className="body">
+                    {GAME_KEYBOARD_SHORTCUT_GROUPS.map((group) => (
+                        <section key={group.title()} className="shortcut-group">
+                            <h3>{group.title()}</h3>
+                            {group.note && <p className="shortcut-note">{group.note()}</p>}
+                            <table>
+                                <tbody>
+                                    {group.shortcuts.map((entry) => (
+                                        <tr key={entry.shortcut}>
+                                            <td className="shortcut-keys">
+                                                {shortcutKeyNames(entry.shortcut).map((name, i) => (
+                                                    <React.Fragment key={name}>
+                                                        {i > 0 && (
+                                                            <span className="shortcut-plus">+</span>
+                                                        )}
+                                                        <kbd>{name}</kbd>
+                                                    </React.Fragment>
+                                                ))}
+                                            </td>
+                                            <td className="shortcut-description">
+                                                {entry.description()}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </section>
+                    ))}
+                </div>
+                <div className="buttons">
+                    <button onClick={this.close}>{_("Close")}</button>
+                </div>
+            </div>
+        );
+    }
+}
+
+export function openGameKeyboardShortcutsModal(): void {
+    openModal(<GameKeyboardShortcutsModal fastDismiss />);
+}

--- a/src/views/Game/fragments.tsx
+++ b/src/views/Game/fragments.tsx
@@ -17,7 +17,8 @@
 
 import * as React from "react";
 import { useGobanController } from "./goban_context";
-import { useShowTitle, useTitle, useCurrentMove, useAIReviewEnabled } from "./GameHooks";
+import { useShowTitle, useTitle, useCurrentMove, useAIReviewEnabled, useMode } from "./GameHooks";
+import { GAME_KEYBOARD_SHORTCUT_GROUPS } from "./game_keyboard_shortcuts";
 import { _, interpolate } from "@/lib/translate";
 import { rulesText } from "@/lib/misc";
 import { KBShortcut } from "@/components/KBShortcut";
@@ -119,72 +120,32 @@ export function GameInformation(): React.ReactElement | null {
 export function GameKeyboardShortcuts(): React.ReactElement | null {
     const goban_controller = useGobanController();
     const goban = goban_controller.goban;
+    const mode = useMode(goban);
+
+    // The list is rebuilt when the goban changes mode so `when` guards, such
+    // as F10 only applying in analysis mode, are re-evaluated.
+    const bindings = React.useMemo(
+        () =>
+            GAME_KEYBOARD_SHORTCUT_GROUPS.flatMap((group) =>
+                group.shortcuts
+                    .filter((entry) => !entry.when || entry.when(goban_controller))
+                    .map((entry) => ({
+                        shortcut: entry.shortcut,
+                        action: () => entry.action(goban_controller),
+                    })),
+            ),
+        [goban_controller, mode],
+    );
 
     return (
         <div>
-            <KBShortcut shortcut="up" action={goban_controller.nextBranchUp} />
-            <KBShortcut shortcut="down" action={goban_controller.nextBranchDown} />
-            <KBShortcut shortcut="left" action={goban_controller.previousMove} />
-            <KBShortcut shortcut="right" action={goban_controller.nextMove} />
-            <KBShortcut shortcut="page-up" action={goban_controller.previous10Moves} />
-            <KBShortcut shortcut="page-down" action={goban_controller.forwardTenMoves} />
-            <KBShortcut shortcut="space" action={goban_controller.togglePlayPause} />
-            <KBShortcut shortcut="home" action={goban_controller.gotoFirstMove} />
-            <KBShortcut shortcut="end" action={goban_controller.gotoLastMove} />
-            <KBShortcut shortcut="escape" action={goban_controller.handleEscapeKey} />
-            <KBShortcut
-                shortcut="f1"
-                action={() => goban_controller.setAnalyzeTool("stone", "alternate")}
-            />
-            <KBShortcut
-                shortcut="f2"
-                action={() => goban_controller.setAnalyzeTool("stone", "black")}
-            />
-            <KBShortcut
-                shortcut="f4"
-                action={() => goban_controller.setAnalyzeTool("label", "triangle")}
-            />
-            <KBShortcut
-                shortcut="f5"
-                action={() => goban_controller.setAnalyzeTool("label", "square")}
-            />
-            <KBShortcut
-                shortcut="f6"
-                action={() => goban_controller.setAnalyzeTool("label", "circle")}
-            />
-            <KBShortcut
-                shortcut="f7"
-                action={() => goban_controller.setAnalyzeTool("label", "letters")}
-            />
-            <KBShortcut
-                shortcut="f8"
-                action={() => goban_controller.setAnalyzeTool("label", "numbers")}
-            />
-            <KBShortcut shortcut="ctrl-c" action={goban_controller.copyBranch} />
-            <KBShortcut shortcut="ctrl-v" action={goban_controller.pasteBranch} />
-            <KBShortcut
-                shortcut="f9"
-                action={() =>
-                    goban_controller.setAnalyzeTool("draw", goban_controller.analyze_pencil_color)
-                }
-            />
-            {goban?.mode === "analyze" && (
-                <KBShortcut shortcut="f10" action={goban_controller.clearAndSync} />
-            )}
-            <KBShortcut shortcut="del" action={goban_controller.deleteBranch} />
-            <KBShortcut shortcut="shift-z" action={goban_controller.toggleZenMode} />
-            <KBShortcut shortcut="shift-c" action={goban_controller.toggleCoordinates} />
-            <KBShortcut shortcut="shift-i" action={goban_controller.toggleAIReview} />
-            <KBShortcut shortcut="shift-a" action={goban_controller.gameAnalyze} />
-            <KBShortcut shortcut="shift-r" action={goban_controller.startReview} />
-            <KBShortcut shortcut="shift-e" action={goban_controller.estimateScore} />
-            <KBShortcut
-                shortcut="shift-p"
-                action={() => goban_controller.goban.setModeDeferred("play")}
-            />
+            {bindings.map(({ shortcut, action }) => (
+                <KBShortcut key={shortcut} shortcut={shortcut} action={action} />
+            ))}
         </div>
     );
 }
+
 interface FragAIReviewProps {
     simul_black?: boolean | null;
     simul_white?: boolean | null;

--- a/src/views/Game/game_keyboard_shortcuts.ts
+++ b/src/views/Game/game_keyboard_shortcuts.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { pgettext } from "@/lib/translate";
+import { GobanController } from "@/lib/GobanController";
+
+/**
+ * One keyboard shortcut on the Game page.
+ *
+ * The same entry drives both the live `KBShortcut` binding and the row in the
+ * "Keyboard shortcuts" modal, so the two cannot drift apart.
+ */
+export interface GameKeyboardShortcut {
+    /** Key combination in `KBShortcut` syntax, e.g. "shift-z" or "page-up". */
+    shortcut: string;
+    /** Translated, human readable description of what the shortcut does. */
+    description: () => string;
+    /** What the shortcut does when pressed. */
+    action: (controller: GobanController) => void;
+    /** When given, the shortcut is only bound while this returns true. */
+    when?: (controller: GobanController) => boolean;
+}
+
+export interface GameKeyboardShortcutGroup {
+    /** Translated group heading shown in the modal. */
+    title: () => string;
+    /** Optional translated note shown under the group heading. */
+    note?: () => string;
+    shortcuts: GameKeyboardShortcut[];
+}
+
+export const GAME_KEYBOARD_SHORTCUT_GROUPS: GameKeyboardShortcutGroup[] = [
+    {
+        title: () => pgettext("Keyboard shortcut group", "Navigation"),
+        shortcuts: [
+            {
+                shortcut: "left",
+                description: () => pgettext("Keyboard shortcut description", "Previous move"),
+                action: (c) => c.previousMove(),
+            },
+            {
+                shortcut: "right",
+                description: () => pgettext("Keyboard shortcut description", "Next move"),
+                action: (c) => c.nextMove(),
+            },
+            {
+                shortcut: "page-up",
+                description: () => pgettext("Keyboard shortcut description", "Back 10 moves"),
+                action: (c) => c.previous10Moves(),
+            },
+            {
+                shortcut: "page-down",
+                description: () => pgettext("Keyboard shortcut description", "Forward 10 moves"),
+                action: (c) => c.forwardTenMoves(),
+            },
+            {
+                shortcut: "home",
+                description: () => pgettext("Keyboard shortcut description", "Go to first move"),
+                action: (c) => c.gotoFirstMove(),
+            },
+            {
+                shortcut: "end",
+                description: () => pgettext("Keyboard shortcut description", "Go to last move"),
+                action: (c) => c.gotoLastMove(),
+            },
+            {
+                shortcut: "up",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Previous variation branch"),
+                action: (c) => c.nextBranchUp(),
+            },
+            {
+                shortcut: "down",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Next variation branch"),
+                action: (c) => c.nextBranchDown(),
+            },
+            {
+                shortcut: "space",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Play or pause move autoplay"),
+                action: (c) => c.togglePlayPause(),
+            },
+        ],
+    },
+    {
+        title: () => pgettext("Keyboard shortcut group", "Modes and display"),
+        shortcuts: [
+            {
+                shortcut: "shift-a",
+                description: () => pgettext("Keyboard shortcut description", "Analyze game"),
+                action: (c) => c.gameAnalyze(),
+            },
+            {
+                shortcut: "shift-p",
+                description: () => pgettext("Keyboard shortcut description", "Return to play mode"),
+                action: (c) => c.goban.setModeDeferred("play"),
+            },
+            {
+                shortcut: "shift-r",
+                description: () => pgettext("Keyboard shortcut description", "Start a review"),
+                action: (c) => c.startReview(),
+            },
+            {
+                shortcut: "shift-e",
+                description: () => pgettext("Keyboard shortcut description", "Estimate score"),
+                action: (c) => c.estimateScore(),
+            },
+            {
+                shortcut: "shift-i",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Show or hide the AI review"),
+                action: (c) => c.toggleAIReview(),
+            },
+            {
+                shortcut: "shift-c",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Show or hide board coordinates"),
+                action: (c) => c.toggleCoordinates(),
+            },
+            {
+                shortcut: "shift-z",
+                description: () => pgettext("Keyboard shortcut description", "Toggle zen mode"),
+                action: (c) => c.toggleZenMode(),
+            },
+            {
+                shortcut: "escape",
+                description: () =>
+                    pgettext(
+                        "Keyboard shortcut description",
+                        "Cancel a staged move, stop score estimation, leave analysis, or exit zen mode",
+                    ),
+                action: (c) => c.handleEscapeKey(),
+            },
+        ],
+    },
+    {
+        title: () => pgettext("Keyboard shortcut group", "Variations"),
+        shortcuts: [
+            {
+                shortcut: "ctrl-c",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Copy the current branch"),
+                action: (c) => c.copyBranch(),
+            },
+            {
+                shortcut: "ctrl-v",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Paste the copied branch"),
+                action: (c) => c.pasteBranch(),
+            },
+            {
+                shortcut: "del",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Delete the current branch"),
+                action: (c) => c.deleteBranch(),
+            },
+        ],
+    },
+    {
+        title: () => pgettext("Keyboard shortcut group", "Analysis tools"),
+        note: () =>
+            pgettext(
+                "Note shown in the keyboard shortcuts list",
+                "Function keys must be enabled in Settings, under Game Preferences.",
+            ),
+        shortcuts: [
+            {
+                shortcut: "f1",
+                description: () =>
+                    pgettext("Keyboard shortcut description", "Place alternating stones"),
+                action: (c) => c.setAnalyzeTool("stone", "alternate"),
+            },
+            {
+                shortcut: "f2",
+                description: () => pgettext("Keyboard shortcut description", "Place black stones"),
+                action: (c) => c.setAnalyzeTool("stone", "black"),
+            },
+            {
+                shortcut: "f4",
+                description: () => pgettext("Keyboard shortcut description", "Triangle labels"),
+                action: (c) => c.setAnalyzeTool("label", "triangle"),
+            },
+            {
+                shortcut: "f5",
+                description: () => pgettext("Keyboard shortcut description", "Square labels"),
+                action: (c) => c.setAnalyzeTool("label", "square"),
+            },
+            {
+                shortcut: "f6",
+                description: () => pgettext("Keyboard shortcut description", "Circle labels"),
+                action: (c) => c.setAnalyzeTool("label", "circle"),
+            },
+            {
+                shortcut: "f7",
+                description: () => pgettext("Keyboard shortcut description", "Letter labels"),
+                action: (c) => c.setAnalyzeTool("label", "letters"),
+            },
+            {
+                shortcut: "f8",
+                description: () => pgettext("Keyboard shortcut description", "Number labels"),
+                action: (c) => c.setAnalyzeTool("label", "numbers"),
+            },
+            {
+                shortcut: "f9",
+                description: () => pgettext("Keyboard shortcut description", "Pencil"),
+                action: (c) => c.setAnalyzeTool("draw", c.analyze_pencil_color),
+            },
+            {
+                shortcut: "f10",
+                description: () =>
+                    pgettext(
+                        "Keyboard shortcut description",
+                        "Clear the analysis and sync with the game",
+                    ),
+                action: (c) => c.clearAndSync(),
+                when: (c) => c.goban?.mode === "analyze",
+            },
+        ],
+    },
+];
+
+/**
+ * Human readable key names for the modal.
+ *
+ * Keys are the tokens produced by splitting a `KBShortcut` string on "-".
+ * Anything not listed is shown upper-cased, which covers letters.
+ */
+const KEY_NAMES: { [token: string]: () => string } = {
+    left: () => pgettext("Keyboard key name", "Left arrow"),
+    right: () => pgettext("Keyboard key name", "Right arrow"),
+    up: () => pgettext("Keyboard key name", "Up arrow"),
+    down: () => pgettext("Keyboard key name", "Down arrow"),
+    "page-up": () => pgettext("Keyboard key name", "Page Up"),
+    "page-down": () => pgettext("Keyboard key name", "Page Down"),
+    home: () => pgettext("Keyboard key name", "Home"),
+    end: () => pgettext("Keyboard key name", "End"),
+    space: () => pgettext("Keyboard key name", "Space"),
+    escape: () => pgettext("Keyboard key name", "Esc"),
+    del: () => pgettext("Keyboard key name", "Delete"),
+    shift: () => pgettext("Keyboard key name", "Shift"),
+    ctrl: () => pgettext("Keyboard key name", "Ctrl"),
+    alt: () => pgettext("Keyboard key name", "Alt"),
+};
+
+/** Splits a `KBShortcut` string into display names, one per key cap. */
+export function shortcutKeyNames(shortcut: string): string[] {
+    if (shortcut in KEY_NAMES) {
+        return [KEY_NAMES[shortcut]()];
+    }
+    return shortcut.split("-").map((token) => {
+        if (token in KEY_NAMES) {
+            return KEY_NAMES[token]();
+        }
+        return token.toUpperCase();
+    });
+}


### PR DESCRIPTION
## Summary

- The "..." menu on the Game page gains a **Keyboard shortcuts** entry that opens a modal listing every shortcut the page binds, grouped into Navigation, Modes and display, Variations, and Analysis tools. Keys render as key caps, and the function-key group notes that F-keys must be enabled in Settings.
- The shortcut definitions move out of the JSX in `fragments.tsx` into `game_keyboard_shortcuts.ts`. Both the live `KBShortcut` bindings and the modal read from that one list, so they cannot drift apart. The F10 binding keeps its analyze-mode guard and now re-evaluates on mode changes instead of only on re-render.
- The entry is hidden on touch-only devices, where a keyboard is unlikely. `device.ts` gains `isTouchOnlyDevice` and `onTouchOnlyDeviceChange`, based on the `(any-hover: none) and (any-pointer: coarse)` media query. It matches phones and tablets in any orientation, stops matching when a mouse or trackpad is attached, and never matches a desktop with a touchscreen. `hooks.ts` wraps them in `useIsTouchOnlyDevice`. A tablet with only a Bluetooth keyboard still looks touch-only, since browsers give no way to detect a keyboard.

## Testing

- `yarn type-check`, `yarn lint`, `yarn jest src/views/Game src/lib/device.test.ts`, and `yarn build` pass.
- New tests cover the modal listing every bound shortcut, the key cap rendering, the menu entry opening the modal and closing the popover, the entry being absent on touch-only devices, and the device helpers including the no-`matchMedia` fallback.
- Modal checked in Chromium in both light and dark themes. Left arrow still steps back through moves after the bindings moved to the shared list.
- Not yet checked on a real phone or tablet. Please confirm the entry is absent there and present on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm55UmFadscpZao4bxadUE
