### PR TITLE
Add board alignment preference for the landscape game layout

### DIFF
--- a/src/components/GobanView/GobanView.css
+++ b/src/components/GobanView/GobanView.css
@@ -99,6 +99,31 @@
         }
     }
 
+    /* Board alignment preference (landscape only). `board-align-window` is
+     * the default described above and needs no extra rules. */
+
+    /* Center the board in the space beside the sidebar. */
+    &.board-align-container .GobanView-center {
+        padding-left: 0;
+    }
+
+    /* Center the board and the sidebar together: the center column hugs
+     * the square board (100cqh wide, shrinking when the sidebar is too
+     * wide) and the row is centered, so the empty space splits evenly
+     * between the far left and the far right. The left margin mirrors the
+     * sidebar's right margin. */
+    &.board-align-group {
+        justify-content: center;
+
+        .GobanView-center {
+            flex-grow: 0;
+            flex-basis: 50%;
+            flex-basis: 100cqh;
+            padding-left: 0;
+            margin-left: 0.3rem;
+        }
+    }
+
     /* The gap between the goban area and the sidebar, shared by all
      * GobanView consumers (game, puzzle, joseki). It doubles as the drag
      * handle for resizing the sidebar: a thin bar appears in the middle of

--- a/src/components/GobanView/GobanView.tsx
+++ b/src/components/GobanView/GobanView.tsx
@@ -28,7 +28,7 @@ import { GobanViewTab, GobanViewTabProps } from "./GobanViewTab";
 import { TabBar } from "./TabBar";
 import { MoveNumberControl } from "./MoveNumberControl";
 import { SidebarResizer } from "./SidebarResizer";
-import { goban_view_mode, goban_view_squashed, ViewMode } from "./util";
+import { boardAlignmentClass, goban_view_mode, goban_view_squashed, ViewMode } from "./util";
 import { usePreference } from "@/lib/preferences";
 import "./GobanView.css";
 
@@ -227,6 +227,7 @@ function GobanViewComponent({
     // release.
     const [savedSidebarWidth, setSavedSidebarWidth] = usePreference("goban-view-sidebar-width");
     const [dragSidebarWidth, setDragSidebarWidth] = React.useState<number | null>(null);
+    const [boardAlignment] = usePreference("goban-view-board-alignment");
     const sidebarWidth = dragSidebarWidth ?? savedSidebarWidth;
     const commitSidebarWidth = React.useCallback(
         (width: number | null) => {
@@ -411,7 +412,7 @@ function GobanViewComponent({
                 <div
                     ref={rootRef}
                     className={
-                        `GobanView ${viewMode}` +
+                        `GobanView ${viewMode} ${boardAlignmentClass(boardAlignment)}` +
                         (squashed ? " squashed" : "") +
                         (hasTakeover ? " has-takeover" : "") +
                         (sidebarWidth !== null ? " has-custom-sidebar-width" : "") +

--- a/src/components/GobanView/util.test.ts
+++ b/src/components/GobanView/util.test.ts
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { selectVisibleTabs, TabBarSlot } from "./util";
+import {
+    boardAlignmentClass,
+    GobanViewBoardAlignment,
+    selectVisibleTabs,
+    TabBarSlot,
+} from "./util";
 
 interface Tab extends TabBarSlot {
     id: string;
@@ -85,5 +90,20 @@ describe("selectVisibleTabs", () => {
         const reordered = [info, more, link, settings, estimate, analyze, undo];
         const width = group(3) + group(1) + group(3);
         expect(ids(selectVisibleTabs(reordered, width, BUTTON, GAP))).toEqual(ids(reordered));
+    });
+});
+
+describe("boardAlignmentClass", () => {
+    test("maps each alignment to its root class", () => {
+        expect(boardAlignmentClass("window")).toBe("board-align-window");
+        expect(boardAlignmentClass("container")).toBe("board-align-container");
+        expect(boardAlignmentClass("group")).toBe("board-align-group");
+    });
+
+    test("falls back to window centering for unknown stored values", () => {
+        expect(boardAlignmentClass("bogus" as GobanViewBoardAlignment)).toBe("board-align-window");
+        expect(boardAlignmentClass(undefined as unknown as GobanViewBoardAlignment)).toBe(
+            "board-align-window",
+        );
     });
 });

--- a/src/components/GobanView/util.ts
+++ b/src/components/GobanView/util.ts
@@ -15,7 +15,55 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { pgettext } from "@/lib/translate";
+
 export type ViewMode = "portrait" | "wide" | "square";
+
+/**
+ * Where the board sits in the landscape layout.
+ *
+ * - `window`: the board is centered in the window; the sidebar sits in
+ *   the space to its right.
+ * - `container`: the board is centered in the space beside the sidebar.
+ * - `group`: the board and the sidebar are centered together, as one
+ *   block, with equal empty space on both sides.
+ */
+export type GobanViewBoardAlignment = "window" | "container" | "group";
+
+export const GOBAN_VIEW_BOARD_ALIGNMENTS: readonly GobanViewBoardAlignment[] = [
+    "window",
+    "container",
+    "group",
+];
+
+export interface BoardAlignmentOption {
+    value: GobanViewBoardAlignment;
+    label: string;
+}
+
+/** Translated labels for the board alignment preference, in display order. */
+export function boardAlignmentOptions(): BoardAlignmentOption[] {
+    return [
+        {
+            value: "window",
+            label: pgettext("Board alignment on the game page", "Center in window"),
+        },
+        {
+            value: "container",
+            label: pgettext("Board alignment on the game page", "Center beside sidebar"),
+        },
+        {
+            value: "group",
+            label: pgettext("Board alignment on the game page", "Center with sidebar"),
+        },
+    ];
+}
+
+/** Root class for the alignment; unknown stored values fall back to `window`. */
+export function boardAlignmentClass(alignment: GobanViewBoardAlignment): string {
+    const valid = GOBAN_VIEW_BOARD_ALIGNMENTS.includes(alignment) ? alignment : "window";
+    return `board-align-${valid}`;
+}
 
 export function goban_view_mode(bar_width?: number): ViewMode {
     if (!bar_width) {

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -23,6 +23,7 @@ import { DataSchema } from "./data_schema";
 import { FollowedChannel } from "@/views/GoTV";
 import { getWindowWidth } from "./device";
 import { createGobanThemePreferenceDefaults } from "./goban_theme_defaults";
+import type { GobanViewBoardAlignment } from "@/components/GobanView/util";
 
 export const defaults = {
     "ai-review-enabled": true,
@@ -84,6 +85,7 @@ export const defaults = {
     "goban-theme-removal-graphic": "square" as "square" | "x",
     "goban-theme-removal-scale": 0.9,
     "goban-view-sidebar-width": null as number | null,
+    "goban-view-board-alignment": "window" as GobanViewBoardAlignment,
     "hide-ranks": false,
     "label-positioning": "all" as LabelPosition,
     "label-positioning-puzzles": "all" as LabelPosition,

--- a/src/views/Game/GameSettingsPanel.tsx
+++ b/src/views/Game/GameSettingsPanel.tsx
@@ -23,6 +23,7 @@ import type { LabelPosition } from "goban";
 import { Toggle } from "@/components/Toggle";
 import { GobanThemePicker } from "@/components/GobanThemePicker/GobanThemePicker";
 import { openACLModal } from "@/components/ACLModal";
+import { boardAlignmentOptions, GobanViewBoardAlignment } from "@/components/GobanView/util";
 import { useAIReviewEnabled, useZenMode } from "./GameHooks";
 import { useGobanController } from "./goban_context";
 import "./GameSidebarPanels.css";
@@ -102,6 +103,7 @@ export function GameSettingsPanel({
     const zen_mode = useZenMode(goban_controller);
 
     const [label_position, setLabelPositionPref] = usePreference("label-positioning");
+    const [board_alignment, setBoardAlignment] = usePreference("goban-view-board-alignment");
     // The preference is the source of truth; the goban needs an explicit
     // sync call since it doesn't subscribe to this specific preference.
     const setCoordinates = (pos: LabelPosition) => {
@@ -219,6 +221,32 @@ export function GameSettingsPanel({
                         {pgettext("Control who can access the game or review", "Access settings")}
                     </span>
                 </button>
+            )}
+
+            {/* Board alignment only applies to the landscape layout, so the
+                portrait (compact) panel leaves it out. */}
+            {!compact && (
+                <div className="GameSidebarPanel-labeled-row">
+                    <label htmlFor="game-settings-board-alignment">
+                        <i className="fa fa-arrows-h" />
+                        <span>
+                            {pgettext("Board alignment on the game page", "Board alignment")}
+                        </span>
+                    </label>
+                    <select
+                        id="game-settings-board-alignment"
+                        value={board_alignment}
+                        onChange={(e) =>
+                            setBoardAlignment(e.target.value as GobanViewBoardAlignment)
+                        }
+                    >
+                        {boardAlignmentOptions().map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
             )}
 
             <div className="GameSidebarPanel-section-header">

--- a/src/views/Settings/ThemePreferences.tsx
+++ b/src/views/Settings/ThemePreferences.tsx
@@ -36,6 +36,7 @@ import { MiniGoban } from "@/components/MiniGoban";
 import { GobanEngineConfig, setGobanRenderer } from "goban";
 import { Toggle } from "@/components/Toggle";
 import { GobanThemeImportExport } from "./GobanThemeImportExport";
+import { boardAlignmentOptions } from "@/components/GobanView/util";
 import "./ThemePreferences.css";
 
 const sample_board_data: GobanEngineConfig = {
@@ -56,6 +57,7 @@ const sample_board_data: GobanEngineConfig = {
 };
 
 export function ThemePreferences(): React.ReactElement | null {
+    const [board_alignment, setBoardAlignment] = usePreference("goban-view-board-alignment");
     const [stone_removal_graphic, _setStoneRemovalGraphic] = usePreference(
         "goban-theme-removal-graphic",
     );
@@ -252,6 +254,13 @@ export function ThemePreferences(): React.ReactElement | null {
                 <GobanThemeImportExport />
             </PreferenceLine>
 
+            <PreferenceLine title={pgettext("Board alignment on the game page", "Board alignment")}>
+                <PreferenceDropdown
+                    value={board_alignment}
+                    options={boardAlignmentOptions()}
+                    onChange={setBoardAlignment}
+                />
+            </PreferenceLine>
             <PreferenceLine title={_("Board label positioning")}>
                 <PreferenceDropdown
                     value={label_positioning}


### PR DESCRIPTION
## Summary

Adds a "Board alignment" preference that controls where the board sits in the landscape game layout. Three modes:

- **Center in window** (default, current behavior): the board is centered in the window and the sidebar sits in the space to its right.
- **Center beside sidebar**: the board is centered in the space beside the sidebar.
- **Center with sidebar**: the board and sidebar are centered together as one block, with equal empty space on both sides.

The modes are CSS modifier classes on the GobanView root, so no JS layout math changed. Portrait is unaffected.

The option is exposed in the game settings panel (above the Theme section, landscape only) and in Settings > Theme.

## Testing

- Unit tests for the preference-to-class mapping in `src/components/GobanView/util.test.ts`.
- Measured each mode in a live game at 1600 px wide, including a user-dragged sidebar width and an oversized sidebar that forces the board to shrink.
- `yarn type-check`, `yarn lint`, `yarn jest`, and `yarn build` pass.

Manual testing in mobile and desktop browsers is still recommended before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnhLJJn23NeTDc29Zq2d7M
