### PR TITLE
Strip the game sidebar down to the essentials in zen mode

### DIFF
--- a/src/components/GobanView/TabBar.tsx
+++ b/src/components/GobanView/TabBar.tsx
@@ -162,6 +162,7 @@ export function TabBar({ tabs }: TabBarProps): React.ReactElement {
         <button
             key={tab.id}
             className={`GobanView-tab-button ${isActive(tab) ? "active" : ""}`}
+            data-tab-id={tab.id}
             title={tab.title}
             disabled={tab.disabled}
             onClick={(e) => handleClick(tab, e)}

--- a/src/views/Game/Game.css
+++ b/src/views/Game/Game.css
@@ -324,10 +324,20 @@
         }
 
         /* The sidebar is transparent in zen, so the tab bar drops its own
-         * panel styling and reads as a bare row of glyphs. */
+         * panel styling. Pause / resume is the only button that stays: it
+         * is the one action a player must be able to reach without leaving
+         * zen. Without it, the bar has nothing to show and goes away. */
         .GobanView-tab-bar {
             background: transparent;
             border-top: none;
+
+            .GobanView-tab-button:not([data-tab-id="game-pause"]) {
+                display: none;
+            }
+
+            &:not(:has([data-tab-id="game-pause"])) {
+                display: none;
+            }
         }
 
         /* Stack the few items that remain — player cards, controls — so they
@@ -361,6 +371,30 @@
 
         .PlayControls {
             flex-grow: 0;
+        }
+
+        /* The only on-screen way out of zen: a quiet glyph pinned to the
+         * top right corner of the viewport, above the board and sidebar. */
+        .leave-zen-mode-button {
+            position: fixed;
+            top: 0.5rem;
+            right: 0.5rem;
+            z-index: var(--z-dock);
+            height: auto;
+            min-height: 0;
+            padding: 0.25rem;
+            border: none;
+            background: transparent;
+            box-shadow: none;
+            font-size: 2rem;
+            line-height: 1;
+            color: var(--shade3);
+            cursor: pointer;
+
+            &:hover,
+            &:focus-visible {
+                color: var(--fg);
+            }
         }
     }
 }

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -1171,8 +1171,9 @@ export function Game(): React.ReactElement | null {
             }
             /* On mobile the move slider only earns its row while analyzing;
              * during play it is dropped to leave the board and the controls
-             * more room. */
-            hideSlider={is_mobile && !is_analyzing}
+             * more room. Zen mode drops it everywhere: keyboard navigation
+             * still works, and the strip is not part of the focused view. */
+            hideSlider={(is_mobile && !is_analyzing) || zen_mode}
         >
             {game_id > 0 && (
                 <UIPush
@@ -1182,6 +1183,18 @@ export function Game(): React.ReactElement | null {
                 />
             )}
             <GameKeyboardShortcuts />
+
+            {zen_mode && (
+                <button
+                    type="button"
+                    className="leave-zen-mode-button"
+                    title={_("Exit zen mode")}
+                    aria-label={_("Exit zen mode")}
+                    onClick={goban_controller.current.toggleZenMode}
+                >
+                    <i className="ogs-zen-mode" />
+                </button>
+            )}
 
             <GobanView.Tab id="game-main" type="always">
                 {/* Mobile renders the two player cards in GobanView's

--- a/src/views/Game/GameSettingsPanel.tsx
+++ b/src/views/Game/GameSettingsPanel.tsx
@@ -30,10 +30,10 @@ import "./GameSidebarPanels.css";
 
 interface GameSettingsPanelProps {
     /** Called by actions that commit to a final state the user wants to see
-     *  applied (full screen). Toggles that the user is likely to flip
+     *  applied (zen mode). Toggles that the user is likely to flip
      *  multiple times (coordinates, AI review, volume) don't fire this. */
     onClose?: () => void;
-    /** Hide the Full screen toggle. The mobile (portrait) layout doesn't
+    /** Hide the Zen Mode toggle. The mobile (portrait) layout doesn't
      *  expose it — the viewport is already the full screen. */
     compact?: boolean;
     /** When provided, a "More options" item renders under the theme quick
@@ -144,12 +144,12 @@ export function GameSettingsPanel({
 
             {!compact && (
                 <div className="GameSidebarPanel-labeled-row">
-                    <label htmlFor="game-settings-full-screen">
+                    <label htmlFor="game-settings-zen-mode">
                         <i className="fa fa-expand" />
-                        <span>{_("Full screen")}</span>
+                        <span>{_("Zen Mode")}</span>
                     </label>
                     <Toggle
-                        id="game-settings-full-screen"
+                        id="game-settings-zen-mode"
                         checked={zen_mode}
                         onChange={() => {
                             goban_controller.toggleZenMode();

--- a/src/views/Game/GameStateHeader.tsx
+++ b/src/views/Game/GameStateHeader.tsx
@@ -31,6 +31,7 @@ import {
     useTitle,
     useViewMode,
     useWinner,
+    useZenMode,
 } from "./GameHooks";
 import "./GameStateHeader.css";
 
@@ -109,9 +110,13 @@ export function GameStateHeader(): React.ReactElement | null {
     // Mode", "Stone Removal Phase", ...) to save vertical space for the
     // board; the clocks and the lit action bar icons already say as much.
     // The undo request message stays since it needs a response, and the
-    // final result stays since nothing else on screen shows it.
+    // final result stays since nothing else on screen shows it. Zen mode
+    // drops the labels and the result too, so only the undo request can
+    // make the header appear.
     const is_portrait = useViewMode(goban_controller) === "portrait";
-    const show_labels = !is_portrait;
+    const zen_mode = useZenMode(goban_controller);
+    const show_labels = !is_portrait && !zen_mode;
+    const show_result = isFinished && !zen_mode;
     const show_play_title = show_title && !engine.rengo && show_labels;
     const has_play_content = isPlayPlay && (show_play_title || show_undo_requested);
     const has_analyze_content = isAnalyze && (show_labels || show_undo_requested);
@@ -119,7 +124,7 @@ export function GameStateHeader(): React.ReactElement | null {
         has_play_content ||
         has_analyze_content ||
         (show_labels && (isStoneRemoval || isConditional)) ||
-        isFinished;
+        show_result;
 
     if (!has_any_content) {
         return null;
@@ -166,7 +171,7 @@ export function GameStateHeader(): React.ReactElement | null {
 
             {isConditional && show_labels && <span>{_("Conditional Move Planner")}</span>}
 
-            {isFinished && (
+            {show_result && (
                 <>
                     <span style={{ textDecoration: annulled ? "line-through" : "none" }}>
                         {winner

--- a/src/views/Game/PlayControls.test.tsx
+++ b/src/views/Game/PlayControls.test.tsx
@@ -349,3 +349,30 @@ test("Pause buttons show up", () => {
     expect(screen.getByText("Game Paused")).toBeDefined();
     expect(screen.getByText("4 pauses left for Black")).toBeDefined();
 });
+
+test("Review list is hidden in zen mode", () => {
+    const controller = new GobanController({
+        game_id: 1234,
+        phase: "finished",
+        players: {
+            black: { id: 987, username: "someone" },
+            white: { id: 456, username: "test_user2" },
+        },
+    });
+    controller.review_list = [{ id: 1, owner: { id: 987, username: "someone" } }] as any;
+    data.set("user", TEST_USER);
+
+    render(
+        <WrapTest controller={controller}>
+            <PlayControls {...PLAY_CONTROLS_DEFAULTS} />
+        </WrapTest>,
+    );
+
+    expect(screen.getByText("Reviews")).toBeDefined();
+
+    act(() => {
+        controller.setZenMode(true);
+    });
+
+    expect(screen.queryByText("Reviews")).toBeNull();
+});

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -186,7 +186,7 @@ export function PlayControls({ annulment_reason }: PlayControlsProps): React.Rea
                             {_("Rematch")}
                         </button>
                     )}
-                    {(goban_controller.review_list.length > 0 || null) && (
+                    {((!zen_mode && goban_controller.review_list.length > 0) || null) && (
                         <div className="review-list">
                             <h3>{_("Reviews")}</h3>
                             {goban_controller.review_list.map((review, idx) => (

--- a/src/views/Game/Players.css
+++ b/src/views/Game/Players.css
@@ -525,6 +525,8 @@
     }
 
     .player-icons {
+        gap: 0.5rem;
+
         .player-container {
             justify-content: center;
             min-width: 150px;
@@ -537,6 +539,7 @@
 
         .Clock {
             min-height: 80px;
+            justify-content: center;
 
             .pause-text {
                 display: none;
@@ -564,24 +567,27 @@
             }
         }
 
+        /* The score row sits in the lower left corner of the card, out of
+         * the way of the centered clock. */
         .captures {
             display: flex;
-            justify-content: center;
-            flex-basis: 70%;
+            justify-content: flex-start;
+            flex-basis: auto;
         }
 
         .score-container {
             margin: 0px;
-            justify-content: center;
+            padding: 0 0.4rem 0.1rem;
+            justify-content: flex-start;
             flex-grow: 0;
         }
 
         .num-captures-container {
             display: flex;
             align-items: center;
-            justify-content: center;
+            justify-content: flex-start;
             flex-direction: row;
-            flex-grow: 1;
+            flex-grow: 0;
 
             .stone-image {
                 width: 14px;


### PR DESCRIPTION
## Summary

Zen mode now shows only the board, the two player cards, the pause / resume button and a zen glyph in the top right corner to leave it.

- The state header ("Black to move", "White wins by Resignation") is hidden. An undo request message still shows because it needs a response.
- The move slider strip is hidden. Keyboard move navigation still works.
- Every tab bar button except pause / resume is hidden. When there is no pause button the bar goes away. Tab bar buttons now carry a `data-tab-id` attribute so CSS can target them.
- The review list is hidden. A unit test covers this.
- The player cards get a small gap between them, the clock is centered and the score sits in the lower left corner of each card.
- A zen glyph pinned to the top right of the viewport exits zen mode.
- The quick settings toggle is labeled "Zen Mode" again instead of "Full screen".

## Test plan

- [x] `yarn test`, `yarn type-check`, `yarn lint`, `yarn build`
- [x] Desktop: live game and finished game in zen mode, light theme
- [ ] Desktop: dark theme
- [ ] Mobile: zen mode on a phone-width viewport
- [ ] Pause / resume button visible in zen mode as a game participant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011L1uZWufbpeGJe6cngWMKy
