### PR TITLE
Change answer for 4.24.12 from "Black" -> "seki"

### DIFF
--- a/src/views/LearningHub/Sections/BeginnerLevel1/Seki1.tsx
+++ b/src/views/LearningHub/Sections/BeginnerLevel1/Seki1.tsx
@@ -979,7 +979,7 @@ class Page12 extends LearningPage {
                 const selectedValue = event.target.value;
                 setValue(selectedValue);
 
-                if (selectedValue === "Black") {
+                if (selectedValue === "seki") {
                     props.onCorrectAnswer();
                 } else if (selectedValue !== "") {
                     props.onWrongAnswer();


### PR DESCRIPTION
The puzzle shown under Beginner Level 1 > Seki > #12 shows seki, but only accepts black as an answer.

<img width="718" height="452" alt="image" src="https://github.com/user-attachments/assets/ce3e8e84-70ef-44c1-81af-25ffa329c985" />

I'm a Go beginner, so there's always the chance I'm just wrong here, but I'm pretty confident that's seki.

Note: I didn't test this out locally (i.e. to make sure the casing of `"seki"` is right), but that matches other answers in this file.