### PR TITLE
Make "Center beside sidebar" the default board alignment

### DIFF
--- a/src/components/GobanView/util.test.ts
+++ b/src/components/GobanView/util.test.ts
@@ -100,10 +100,12 @@ describe("boardAlignmentClass", () => {
         expect(boardAlignmentClass("group")).toBe("board-align-group");
     });
 
-    test("falls back to window centering for unknown stored values", () => {
-        expect(boardAlignmentClass("bogus" as GobanViewBoardAlignment)).toBe("board-align-window");
+    test("falls back to container centering for unknown stored values", () => {
+        expect(boardAlignmentClass("bogus" as GobanViewBoardAlignment)).toBe(
+            "board-align-container",
+        );
         expect(boardAlignmentClass(undefined as unknown as GobanViewBoardAlignment)).toBe(
-            "board-align-window",
+            "board-align-container",
         );
     });
 });

--- a/src/components/GobanView/util.ts
+++ b/src/components/GobanView/util.ts
@@ -59,9 +59,9 @@ export function boardAlignmentOptions(): BoardAlignmentOption[] {
     ];
 }
 
-/** Root class for the alignment; unknown stored values fall back to `window`. */
+/** Root class for the alignment; unknown stored values fall back to `container`. */
 export function boardAlignmentClass(alignment: GobanViewBoardAlignment): string {
-    const valid = GOBAN_VIEW_BOARD_ALIGNMENTS.includes(alignment) ? alignment : "window";
+    const valid = GOBAN_VIEW_BOARD_ALIGNMENTS.includes(alignment) ? alignment : "container";
     return `board-align-${valid}`;
 }
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -85,7 +85,7 @@ export const defaults = {
     "goban-theme-removal-graphic": "square" as "square" | "x",
     "goban-theme-removal-scale": 0.9,
     "goban-view-sidebar-width": null as number | null,
-    "goban-view-board-alignment": "window" as GobanViewBoardAlignment,
+    "goban-view-board-alignment": "container" as GobanViewBoardAlignment,
     "hide-ranks": false,
     "label-positioning": "all" as LabelPosition,
     "label-positioning-puzzles": "all" as LabelPosition,


### PR DESCRIPTION
## Summary

The board alignment preference for the landscape game layout now defaults to "Center beside sidebar" (`container`) instead of "Center in window".

- `src/lib/preferences.ts` sets the default for `goban-view-board-alignment` to `container`.
- `boardAlignmentClass` in `src/components/GobanView/util.ts` falls back to `container` for unknown stored values, so the fallback matches the default.
- The fallback unit test is updated to expect the new value.

Users who already chose an alignment keep their stored choice. Only users who never set one see the new default.

## Test plan

- [x] `yarn jest src/components/GobanView/util.test.ts`, `yarn type-check`, `yarn lint`
- [ ] Desktop: open a game with no stored alignment preference and confirm the board is centered beside the sidebar
- [ ] Desktop: confirm a previously stored alignment choice is still honored
- [ ] Mobile: confirm the portrait layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XECoT6eWNArTpYnMMEP5Qu
