### PR TITLE
Recenter the goban after its game data loads

### DIFF
--- a/src/components/GobanContainer/GobanContainer.test.tsx
+++ b/src/components/GobanContainer/GobanContainer.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { EventEmitter } from "eventemitter3";
+import { GobanRenderer } from "goban";
+import { GobanContainer } from "./GobanContainer";
+
+const CONTAINER_WIDTH = 1249;
+const CONTAINER_HEIGHT = 797;
+
+/**
+ * The parts of a goban that GobanContainer touches. Like the real goban, it
+ * starts out as a 19x19 board and recomputes its square size from the last
+ * display width when its game data loads.
+ */
+class FakeGoban extends EventEmitter {
+    board_size = 19;
+    square_size = 0;
+    display_width = 0;
+    config: { board_div: HTMLDivElement };
+
+    constructor() {
+        super();
+        this.config = { board_div: document.createElement("div") };
+        this.on("load", () => this.setSquareSizeBasedOnDisplayWidth(this.display_width));
+    }
+
+    setSquareSizeBasedOnDisplayWidth(display_width: number): void {
+        this.display_width = display_width;
+        this.square_size = Math.floor(display_width / (this.board_size + 2));
+    }
+
+    computeMetrics(): { width: number; height: number } {
+        const side = this.square_size * (this.board_size + 2);
+        return { width: side, height: side };
+    }
+
+    setLastMoveOpacity(): void {}
+}
+
+let offset_width: PropertyDescriptor | undefined;
+let offset_height: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+    offset_width = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+    offset_height = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetHeight");
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+        configurable: true,
+        get: () => CONTAINER_WIDTH,
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+        configurable: true,
+        get: () => CONTAINER_HEIGHT,
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    if (offset_width) {
+        Object.defineProperty(HTMLElement.prototype, "offsetWidth", offset_width);
+    }
+    if (offset_height) {
+        Object.defineProperty(HTMLElement.prototype, "offsetHeight", offset_height);
+    }
+});
+
+function expectCentered(goban: FakeGoban): void {
+    const side = goban.computeMetrics().width;
+    expect(goban.config.board_div.style.left).toBe(`${Math.ceil((CONTAINER_WIDTH - side) / 2)}px`);
+    expect(goban.config.board_div.style.top).toBe(`${Math.ceil((CONTAINER_HEIGHT - side) / 2)}px`);
+}
+
+test("recenters the board when the loaded game changes the board size", () => {
+    const goban = new FakeGoban();
+    render(<GobanContainer goban={goban as unknown as GobanRenderer} respectContainerBounds />);
+
+    expect(goban.square_size).toBe(37);
+    expectCentered(goban);
+
+    act(() => {
+        goban.board_size = 9;
+        goban.emit("load", {});
+    });
+
+    expect(goban.square_size).toBe(72);
+    expectCentered(goban);
+});

--- a/src/components/GobanContainer/GobanContainer.tsx
+++ b/src/components/GobanContainer/GobanContainer.tsx
@@ -229,6 +229,23 @@ export function GobanContainer({
         onResize(/* no_debounce */ true, /* do_cb */ true);
     }, [goban, goban_div, ref_goban_container.current, onResize]);
 
+    /* A new goban is a 19x19 board until its game or review data arrives.
+     * Loading that data can change the board size, and with it the square
+     * size the goban derives from the last display width, but the container
+     * does not resize, so nothing else recenters the board. Sizing again on
+     * load keeps the board centered no matter which arrives first, the data
+     * or the container's debounced resize. */
+    React.useEffect(() => {
+        if (!goban) {
+            return;
+        }
+        const onLoad = () => onResizeRef.current(/* no_debounce */ true, /* do_cb */ false);
+        goban.on("load", onLoad);
+        return () => {
+            goban.off("load", onLoad);
+        };
+    }, [goban]);
+
     React.useEffect(() => cancelPendingInitialResizeRetry, [cancelPendingInitialResizeRetry]);
 
     if (!goban || !goban_div) {


### PR DESCRIPTION
## Summary

When switching between a game and its review, for example with the browser back and forward buttons, the board sometimes ended up a few pixels right and down from where it should be. It reads as a small size change at the corners.

A new goban is a 19x19 board until its game or review data arrives. The `GobanContainer` centered it for a 19x19 board right away, and the goban's own `load` handler then recomputed the square size for the real board and redrew it, but nothing recentered it. Whether the board ended up centered depended on whether the container's debounced resize callback ran before or after the data loaded. On a fresh page load the data usually arrives late, so it worked. On back/forward the socket is warm and the layout is stable, so it became a coin flip.

The container now runs its sizing pass again on the goban's `load` event, so the board is centered no matter which arrives first.

## Testing

- New unit test in `GobanContainer.test.tsx` with a fake goban that starts 19x19 and becomes 9x9 on load. It failed before the fix and passes now.
- Reproduced in Playwright Firefox against the dev server on a 9x9 game and its review: every back/forward cycle left the board at the 19x19 offsets. After the fix, 16 of 16 cycles are centered.
- `yarn type-check`, `yarn lint`, `yarn build` and the GobanView and Game unit tests pass.

Manual testing in mobile and desktop browsers is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWniDPE7VbrYWCA7gXWE3x
