### PR TITLE
Truncate long tournament names in the game actions menu

### DIFF
--- a/src/views/Game/GameActionsPanel.tsx
+++ b/src/views/Game/GameActionsPanel.tsx
@@ -250,6 +250,7 @@ export function GameActionsPanel({
                     className="GameSidebarPanel-item"
                     href={`/tournament/${tournament_id}`}
                     onClick={navigateTo(`/tournament/${tournament_id}`)}
+                    title={tournament_name}
                 >
                     <i className="fa fa-trophy" />
                     <span>{tournament_name || _("Tournament")}</span>

--- a/src/views/Game/GameSidebarPanels.css
+++ b/src/views/Game/GameSidebarPanels.css
@@ -111,6 +111,7 @@
         }
 
         span {
+            min-width: 0;
             overflow: hidden;
             text-overflow: ellipsis;
         }
@@ -235,6 +236,13 @@
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
+}
+
+/* Cap each actions column so a long label (for example a tournament name)
+ * truncates with an ellipsis instead of stretching the popover. */
+.popover-container .GamePopover.GameMoreActionsPopover .GameSidebarPanel {
+    max-width: 22rem;
+    min-width: 0;
 }
 
 /* Moderator case: actions and mod-tools render as two columns side-by-side


### PR DESCRIPTION
## Summary

- Cap each panel column in the more-actions popover at 22rem so a long label truncates with an ellipsis instead of stretching the menu.
- Let label spans shrink inside their flex row so the existing ellipsis rules take effect.
- Add a hover title on the tournament link so the full name is still reachable.

## Test plan

- Open a game that belongs to a tournament with a very long name and open the "..." menu. The name should truncate with an ellipsis and the menu should stay a normal width.
- Hover the tournament row to see the full name in a tooltip.
- Check the settings popover is unchanged.
- Check on mobile and desktop browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FETFimg1xYpxkK2Nw1Q7SC