### PR TITLE
Show the mobile move slider during play when the board stage has room

### DIFF
--- a/docs/game-action-area.md
+++ b/docs/game-action-area.md
@@ -26,6 +26,19 @@ It renders nothing when the current state has none of these.
   no fixed height reservation to keep in sync.
 - Wider layouts: `PlayControls` renders it at the top of the sidebar.
 
+## The move slider on portrait
+
+The move slider (`MoveNumberControl`) sits above the tab bar, outside the
+scroll area, so its row comes out of the room the stage has. During play the
+Game view passes `hideSlider="when-cramped"` to GobanView: the slider only
+takes its row when the player cards, the action area and the board at its
+full width still fit on screen next to it. On a shorter screen the row goes
+to the board instead. While analyzing, or stepping back through a game with
+analysis disabled, the slider is always shown and the board shrinks to make
+room. GobanView measures this with a ResizeObserver (`useSliderFits`), so a
+control added to the action area can push the slider off a screen that was
+just tall enough.
+
 ## Adding to it
 
 Put a control here only when a player must see it without scrolling and it

--- a/src/components/GobanView/GobanView.tsx
+++ b/src/components/GobanView/GobanView.tsx
@@ -30,6 +30,7 @@ import { MoveNumberControl } from "./MoveNumberControl";
 import { SidebarResizer } from "./SidebarResizer";
 import { boardAlignmentClass, goban_view_mode, goban_view_squashed, ViewMode } from "./util";
 import { usePreference } from "@/lib/preferences";
+import { useSliderFits } from "./hooks";
 import "./GobanView.css";
 
 export interface TabDefinition {
@@ -77,8 +78,13 @@ interface GobanViewProps {
     customSlider?: React.ReactNode;
     /** Leave out the built-in MoveNumberControl. Has no effect when a
      *  `customSlider` is given. Consumers use this to drop the strip when
-     *  move navigation is not relevant, e.g. on mobile during live play. */
-    hideSlider?: boolean;
+     *  move navigation is not relevant, e.g. on mobile during live play.
+     *
+     *  "when-cramped" drops the strip only in portrait and only when the
+     *  board stage (the `aboveBoard` and `belowBoard` slots and the board at
+     *  its full width) would no longer fit on screen with the strip's row
+     *  taken out; in landscape the strip is always shown. */
+    hideSlider?: boolean | "when-cramped";
     /** Optional title bar rendered at the top of the sidebar (landscape) or
      *  above the goban (portrait). Stays visible across takeovers so
      *  consumers can use it to label the current view. */
@@ -220,6 +226,10 @@ function GobanViewComponent({
     activeTakeoverRef.current = activeTakeover;
     const rootRef = React.useRef<HTMLDivElement>(null);
     const sidebarRef = React.useRef<HTMLDivElement>(null);
+    const scrollRef = React.useRef<HTMLDivElement>(null);
+    const aboveRef = React.useRef<HTMLDivElement>(null);
+    const centerRef = React.useRef<HTMLDivElement>(null);
+    const belowRef = React.useRef<HTMLDivElement>(null);
 
     // Landscape sidebar width chosen by the user, in px; null means the
     // automatic width computed in CSS. While a drag is in progress the live
@@ -284,6 +294,13 @@ function GobanViewComponent({
     const isPortrait = viewMode === "portrait";
     const hasTakeover = activeTakeover !== null;
 
+    const sliderFits = useSliderFits(
+        { root: rootRef, scroll: scrollRef, above: aboveRef, center: centerRef, below: belowRef },
+        isPortrait && hideSlider === "when-cramped",
+    );
+    const sliderHidden =
+        hideSlider === "when-cramped" ? isPortrait && !sliderFits : hideSlider === true;
+
     const { inlinePanels, takeoverPanels } = React.useMemo(
         () => ({
             inlinePanels: tabs.filter((t) => t.type === "toggle" || t.type === "always"),
@@ -341,7 +358,7 @@ function GobanViewComponent({
     // keeps its existing "hide during takeover" rule.
     const sliderSlot: React.ReactNode = customSlider
         ? customSlider
-        : !hasTakeover && !hideSlider && <MoveNumberControl />;
+        : !hasTakeover && !sliderHidden && <MoveNumberControl />;
 
     const customSliderClass = customSlider ? " has-custom-slider" : "";
 
@@ -373,12 +390,14 @@ function GobanViewComponent({
                             so the whole column — board included — scrolls as
                             one. Only the header, slider and tab bar stay
                             pinned. */}
-                        <div className="GobanView-mobile-scroll">
+                        <div className="GobanView-mobile-scroll" ref={scrollRef}>
                             <div className="GobanView-stage">
                                 {aboveBoard && (
-                                    <div className="GobanView-above-board">{aboveBoard}</div>
+                                    <div className="GobanView-above-board" ref={aboveRef}>
+                                        {aboveBoard}
+                                    </div>
                                 )}
-                                <div className="GobanView-center">
+                                <div className="GobanView-center" ref={centerRef}>
                                     <GobanContainer
                                         onResize={onResize}
                                         onWheel={onWheel}
@@ -386,7 +405,9 @@ function GobanViewComponent({
                                     />
                                 </div>
                                 {belowBoard && (
-                                    <div className="GobanView-below-board">{belowBoard}</div>
+                                    <div className="GobanView-below-board" ref={belowRef}>
+                                        {belowBoard}
+                                    </div>
                                 )}
                             </div>
                             <div className="GobanView-mobile-panels">

--- a/src/components/GobanView/hooks.ts
+++ b/src/components/GobanView/hooks.ts
@@ -19,7 +19,7 @@ import * as React from "react";
 import { Goban, GobanEvents } from "goban";
 import { GobanController } from "@/lib/GobanController";
 import * as preferences from "@/lib/preferences";
-import { ViewMode, goban_view_mode } from "./util";
+import { ViewMode, goban_view_mode, stageFitsWithSlider } from "./util";
 
 /**
  * Generates a custom react hook that returns a prop derived from a goban object.
@@ -93,4 +93,90 @@ export function useZenMode(controller: GobanController | null): boolean {
         };
     }, [controller]);
     return zen_mode;
+}
+
+export interface SliderFitRefs {
+    /** The GobanView root; the rendered slider strip is found under it. */
+    root: React.RefObject<HTMLDivElement | null>;
+    /** The portrait scroll area, whose height the slider row is taken from. */
+    scroll: React.RefObject<HTMLDivElement | null>;
+    above: React.RefObject<HTMLDivElement | null>;
+    /** The board column; its width is the board's full size. */
+    center: React.RefObject<HTMLDivElement | null>;
+    below: React.RefObject<HTMLDivElement | null>;
+}
+
+/** Height of the MoveNumberControl strip in rem, used until the strip has
+ *  been rendered and measured. Matches the room GobanView.css reserves for
+ *  the strip above a takeover; a slight overestimate only errs towards
+ *  hiding the strip. */
+const SLIDER_FALLBACK_HEIGHT_REM = 2.6;
+
+/**
+ * Portrait only: whether the board stage (the above/below slots and the
+ * board at its full width) still fits in the scroll area, without the board
+ * shrinking, when the move slider takes its row above the tab bar.
+ *
+ * The layout is measured with a ResizeObserver, so the answer follows
+ * viewport changes and content changes in the slots. Showing the slider
+ * moves its height out of the scroll area, so the measurement adds it back
+ * and the answer is the same whether the slider is currently shown or not.
+ * The slider's height is read from the strip once it has been rendered;
+ * before that a fallback matching its CSS is used.
+ */
+export function useSliderFits(refs: SliderFitRefs, enabled: boolean): boolean {
+    const [fits, set_fits] = React.useState(false);
+    const measured_slider_height = React.useRef<number | null>(null);
+
+    React.useLayoutEffect(() => {
+        if (!enabled) {
+            return;
+        }
+
+        const measure = () => {
+            const root = refs.root.current;
+            const scroll = refs.scroll.current;
+            const center = refs.center.current;
+            if (!root || !scroll || !center) {
+                return;
+            }
+
+            const slider = root.querySelector<HTMLElement>(":scope > .MoveNumberControl");
+            if (slider) {
+                measured_slider_height.current = Math.max(
+                    measured_slider_height.current ?? 0,
+                    slider.offsetHeight,
+                );
+            }
+            const slider_height =
+                measured_slider_height.current ??
+                SLIDER_FALLBACK_HEIGHT_REM *
+                    parseFloat(getComputedStyle(document.documentElement).fontSize);
+
+            const next = stageFitsWithSlider({
+                available: scroll.clientHeight + (slider?.offsetHeight ?? 0),
+                slider: slider_height,
+                slots:
+                    (refs.above.current?.offsetHeight ?? 0) +
+                    (refs.below.current?.offsetHeight ?? 0),
+                board: center.offsetWidth,
+            });
+            set_fits((prev) => (prev === next ? prev : next));
+        };
+
+        measure();
+        if (typeof ResizeObserver === "undefined") {
+            return;
+        }
+
+        const observer = new ResizeObserver(measure);
+        for (const ref of [refs.root, refs.scroll, refs.above, refs.center, refs.below]) {
+            if (ref.current) {
+                observer.observe(ref.current);
+            }
+        }
+        return () => observer.disconnect();
+    }, [enabled]);
+
+    return enabled && fits;
 }

--- a/src/components/GobanView/util.test.ts
+++ b/src/components/GobanView/util.test.ts
@@ -19,6 +19,7 @@ import {
     boardAlignmentClass,
     GobanViewBoardAlignment,
     selectVisibleTabs,
+    stageFitsWithSlider,
     TabBarSlot,
 } from "./util";
 
@@ -106,6 +107,20 @@ describe("boardAlignmentClass", () => {
         );
         expect(boardAlignmentClass(undefined as unknown as GobanViewBoardAlignment)).toBe(
             "board-align-container",
+        );
+    });
+});
+
+describe("stageFitsWithSlider", () => {
+    test("fits when the slots, the full board and the slider all have room", () => {
+        expect(stageFitsWithSlider({ available: 700, slider: 36, slots: 264, board: 400 })).toBe(
+            true,
+        );
+    });
+
+    test("does not fit when the slider would make the board shrink", () => {
+        expect(stageFitsWithSlider({ available: 699, slider: 36, slots: 264, board: 400 })).toBe(
+            false,
         );
     });
 });

--- a/src/components/GobanView/util.ts
+++ b/src/components/GobanView/util.ts
@@ -81,6 +81,26 @@ export function goban_view_mode(bar_width?: number): ViewMode {
     return "wide";
 }
 
+export interface StageMeasurements {
+    /** Height of the portrait scroll area with no slider row taken out. */
+    available: number;
+    /** Height of the move slider row. */
+    slider: number;
+    /** Combined height of the above-board and below-board slots. */
+    slots: number;
+    /** Height of the board at its full width. */
+    board: number;
+}
+
+/**
+ * Whether the portrait stage (the two board-adjacent slots and the board at
+ * full width) fits in the scroll area together with the move slider, so the
+ * slider can take its row without the board having to shrink.
+ */
+export function stageFitsWithSlider(m: StageMeasurements): boolean {
+    return m.slots + m.board + m.slider <= m.available;
+}
+
 export function goban_view_squashed(): boolean {
     /* This value needs to match the "dock-inline-height" found in Dock.css */
     return window.innerHeight <= 500;

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -879,11 +879,11 @@ export function Game(): React.ReactElement | null {
     // and rendered twice: as icons in the action bar and as labeled items at
     // the top of the More-actions menu.
     //
-    // On mobile the move slider is hidden during play, so with analysis
-    // disabled the greyed-out analyze button would leave no way to look at
-    // earlier moves. Swap it for a "Previous move" button that steps back
-    // and thereby brings up the slider. Desktop keeps the disabled analyze
-    // button since its slider is always visible.
+    // On a cramped mobile screen the move slider is hidden during play, so
+    // with analysis disabled the greyed-out analyze button would leave no
+    // way to look at earlier moves. Swap it for a "Previous move" button
+    // that steps back and thereby brings up the slider. Desktop keeps the
+    // disabled analyze button since its slider is always visible.
     const swap_analyze_for_step_back = is_mobile && analysis_disabled;
     const analyze_tab: GobanViewTabProps | null = !game
         ? null
@@ -1196,13 +1196,21 @@ export function Game(): React.ReactElement | null {
                     </>
                 )
             }
-            /* On mobile the move slider only earns its row while analyzing,
+            /* On mobile the move slider always gets its row while analyzing,
              * or while stepping back through played moves in a game with
-             * analysis disabled; during play it is dropped to leave the board
-             * and the controls more room. Zen mode drops it everywhere:
-             * keyboard navigation still works, and the strip is not part of
-             * the focused view. */
-            hideSlider={(is_mobile && !is_analyzing && !is_browsing_history) || zen_mode}
+             * analysis disabled. During play it only gets the row when the
+             * board at full width, the player cards and the play buttons
+             * still fit on screen beside it; on a cramped screen it is
+             * dropped to leave the board and the controls the room. Zen mode
+             * drops it everywhere: keyboard navigation still works, and the
+             * strip is not part of the focused view. */
+            hideSlider={
+                zen_mode
+                    ? true
+                    : is_mobile && !is_analyzing && !is_browsing_history
+                      ? "when-cramped"
+                      : false
+            }
         >
             {game_id > 0 && (
                 <UIPush


### PR DESCRIPTION
## Summary

On mobile the move slider was hidden during play. On a tall phone that leaves an empty band below the play buttons while the slider would have fit.

- GobanView's `hideSlider` prop accepts a third value, `"when-cramped"`. In portrait it measures the scroll area, the above-board and below-board slots, and the board's full width with a ResizeObserver. The slider takes its row only when the board at full width, the player cards and the play buttons still fit on screen with it. In landscape the value shows the slider as before.
- The Game view passes `"when-cramped"` during mobile play. Analyzing, stepping back with analysis disabled, and zen mode keep their current rules.
- The "Previous move" button that replaces the analyze button on mobile with analysis disabled stays. It is still needed on a cramped screen.
- `docs/game-action-area.md` describes the rule.

## Testing

- `yarn type-check`, `yarn lint`, `yarn prettier:file`, and `yarn build` pass.
- New unit test for the stage-fit arithmetic in `src/components/GobanView/util.test.ts`.
- Checked in a browser on a game page: at 390x844 and 390x640 the slider shows and the board stays at full width; at 390x600 the slider is hidden and the board stays at full width; at 1400x900 the sidebar slider is unchanged.
- Manual testing still to do on a real phone and a desktop browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1nPtRKQ1985XYtSvQp62W
