### PR TITLE
Show rengo teams as a count on the player card with a team list modal

### DIFF
--- a/src/components/RengoTeamModal/RengoTeamModal.css
+++ b/src/components/RengoTeamModal/RengoTeamModal.css
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.RengoTeamModal.Modal {
+    width: 20rem;
+    max-width: 100%;
+
+    .body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        padding: 0.5rem 1rem;
+    }
+
+    .rengo-team-modal-row {
+        display: flex;
+        align-items: center;
+        padding: 0.3rem 0.5rem;
+        border-radius: 0.4em;
+        background-color: var(--other-player-background);
+    }
+
+    .rengo-team-modal-marker {
+        display: inline-flex;
+        justify-content: center;
+        flex-shrink: 0;
+        width: 1.2rem;
+        margin-right: 0.3rem;
+    }
+
+    .rengo-team-modal-you {
+        color: var(--primary);
+    }
+}

--- a/src/components/RengoTeamModal/RengoTeamModal.test.tsx
+++ b/src/components/RengoTeamModal/RengoTeamModal.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import * as React from "react";
+import { BrowserRouter as Router } from "react-router-dom";
+import * as data from "@/lib/data";
+import { RengoTeamModal } from "./RengoTeamModal";
+
+const TEST_USER = {
+    anonymous: false,
+    id: 123,
+    username: "test_user",
+    registration_date: "2022-05-10 11:03:24.299562+00:00",
+    ratings: {
+        version: 5,
+        overall: { rating: 1500, deviation: 350, volatility: 0.06 },
+    },
+    country: "un",
+    professional: false,
+    ranking: 23,
+    provisional: 0,
+    can_create_tournaments: true,
+    is_moderator: false,
+    is_superuser: false,
+    moderator_powers: 0,
+    offered_moderator_powers: 0,
+    is_tournament_moderator: false,
+    supporter: true,
+    supporter_level: 4,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "",
+    email: "",
+    email_validated: false,
+    is_announcer: false,
+    last_supporter_trial: "",
+} as const;
+
+const PLAYERS = [
+    { id: 1, username: "alice", rank: 10 },
+    { id: 2, username: "bob", rank: 11 },
+    { id: 3, username: "carol", rank: 12 },
+];
+
+function setUser(id: number, username: string) {
+    data.set("user", { ...TEST_USER, id, username });
+}
+
+function renderModal() {
+    return render(
+        <Router>
+            <RengoTeamModal color="black" players={PLAYERS} />
+        </Router>,
+    );
+}
+
+test("lists the team members in the order given", () => {
+    setUser(999, "someone_else");
+
+    const { container } = renderModal();
+    const rows = Array.from(container.querySelectorAll(".rengo-team-modal-row"));
+
+    expect(rows.map((row) => row.textContent)).toEqual(
+        expect.arrayContaining([
+            expect.stringContaining("alice"),
+            expect.stringContaining("bob"),
+            expect.stringContaining("carol"),
+        ]),
+    );
+    expect(rows[0]).toHaveTextContent("alice");
+    expect(rows[1]).toHaveTextContent("bob");
+    expect(rows[2]).toHaveTextContent("carol");
+});
+
+test("marks the current user's row with a chevron", () => {
+    setUser(2, "bob");
+
+    const { container } = renderModal();
+    const rows = container.querySelectorAll(".rengo-team-modal-row");
+
+    expect(rows[0].querySelector(".rengo-team-modal-you")).toBeNull();
+    expect(rows[1].querySelector(".rengo-team-modal-you")).not.toBeNull();
+    expect(rows[2].querySelector(".rengo-team-modal-you")).toBeNull();
+});
+
+test("shows no chevron when the current user is not on the team", () => {
+    setUser(999, "someone_else");
+
+    const { container } = renderModal();
+
+    expect(container.querySelector(".rengo-team-modal-you")).toBeNull();
+});

--- a/src/components/RengoTeamModal/RengoTeamModal.tsx
+++ b/src/components/RengoTeamModal/RengoTeamModal.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+import { GobanEnginePlayerEntry } from "goban";
+import { _, pgettext } from "@/lib/translate";
+import { Modal, openModal } from "@/components/Modal";
+import { Player } from "@/components/Player";
+import * as data from "@/lib/data";
+import "./RengoTeamModal.css";
+
+interface Events {}
+
+interface RengoTeamModalProperties {
+    color: "black" | "white";
+    /** Team members in turn order. The first entry is the player whose turn it is. */
+    players: GobanEnginePlayerEntry[];
+}
+
+/** Lists the members of one rengo team in turn order and marks the current user. */
+export class RengoTeamModal extends Modal<Events, RengoTeamModalProperties, {}> {
+    render() {
+        const user_id: number | undefined = data.get("user")?.id;
+        const title =
+            this.props.color === "black"
+                ? pgettext("Rengo team list modal title", "Black team")
+                : pgettext("Rengo team list modal title", "White team");
+
+        return (
+            <div className="Modal RengoTeamModal">
+                <div className="header">
+                    <h2>{title}</h2>
+                </div>
+                <div className="body">
+                    {this.props.players.map((player) => (
+                        <div className="rengo-team-modal-row" key={player.id}>
+                            <span className="rengo-team-modal-marker">
+                                {player.id === user_id && (
+                                    <i
+                                        className="rengo-team-modal-you fa fa-chevron-right"
+                                        title={pgettext(
+                                            "Marks the current user in a rengo team list",
+                                            "You",
+                                        )}
+                                    />
+                                )}
+                            </span>
+                            <Player user={player} icon rank />
+                        </div>
+                    ))}
+                </div>
+                <div className="buttons">
+                    <button onClick={this.close}>{_("Close")}</button>
+                </div>
+            </div>
+        );
+    }
+}
+
+export function openRengoTeamModal(
+    color: "black" | "white",
+    players: GobanEnginePlayerEntry[],
+): void {
+    openModal(<RengoTeamModal color={color} players={players} fastDismiss />);
+}

--- a/src/components/RengoTeamModal/index.ts
+++ b/src/components/RengoTeamModal/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from "./RengoTeamModal";

--- a/src/views/Game/PlayerCards.test.tsx
+++ b/src/views/Game/PlayerCards.test.tsx
@@ -16,7 +16,7 @@
 import "@/lib/data";
 import "@/lib/sockets";
 
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import * as React from "react";
 import { PlayerCard } from "./PlayerCards";
@@ -24,6 +24,11 @@ import { GobanControllerContext } from "./goban_context";
 import { BrowserRouter as Router } from "react-router-dom";
 import * as data from "@/lib/data";
 import { GobanController } from "../../lib/GobanController";
+import { openRengoTeamModal } from "@/components/RengoTeamModal";
+
+jest.mock("@/components/RengoTeamModal", () => ({
+    openRengoTeamModal: jest.fn(),
+}));
 
 const TEST_USER = {
     anonymous: false,
@@ -106,4 +111,57 @@ test("make sure komi is not displayed for black", () => {
     if (divElement) {
         expect(divElement).toBeEmptyDOMElement();
     }
+});
+
+const RENGO_PLAYERS = {
+    alice: { id: 1, username: "alice", rank: 10 },
+    bob: { id: 2, username: "bob", rank: 11 },
+    carol: { id: 3, username: "carol", rank: 12 },
+    dave: { id: 4, username: "dave", rank: 13 },
+};
+
+function renderRengoCard(color: "black" | "white") {
+    data.set("user", TEST_USER);
+    data.set("preferences.moderator.hide-flags", false);
+    data.set("preferences.moderator.hide-player-card-mod-controls", false);
+
+    const { alice, bob, carol, dave } = RENGO_PLAYERS;
+    const gameController = new GobanController({
+        game_id: 123456,
+        rengo: true,
+        players: { black: alice, white: dave },
+        rengo_teams: { black: [alice, bob, carol], white: [dave] },
+    });
+    const goban = gameController.goban;
+    const props = { goban, ...BASE_PROPS, color };
+
+    return render(
+        <Router>
+            <GobanControllerContext.Provider value={gameController}>
+                <PlayerCard {...props} />
+            </GobanControllerContext.Provider>
+        </Router>,
+    );
+}
+
+test("rengo card shows the number of other team members instead of the full list", () => {
+    const { container } = renderRengoCard("black");
+
+    expect(container.querySelector(".rengo-team-count")).toHaveTextContent("+ 2");
+    expect(container.querySelector(".rengo-team-members")).toBeNull();
+});
+
+test("rengo card hides the team count when the team has one player", () => {
+    const { container } = renderRengoCard("white");
+
+    expect(container.querySelector(".rengo-team-count")).toBeNull();
+});
+
+test("clicking the rengo team count opens the team modal with the current player first", () => {
+    const { container } = renderRengoCard("black");
+    const { alice, bob, carol } = RENGO_PLAYERS;
+
+    fireEvent.click(container.querySelector(".rengo-team-count")!);
+
+    expect(openRengoTeamModal).toHaveBeenCalledWith("black", [alice, bob, carol]);
 });

--- a/src/views/Game/PlayerCards.tsx
+++ b/src/views/Game/PlayerCards.tsx
@@ -38,6 +38,7 @@ import {
 import { get_network_latency, get_clock_drift } from "@/lib/sockets";
 import { useGobanController } from "./goban_context";
 import { player_is_ignored } from "@/components/BlockPlayer";
+import { openRengoTeamModal } from "@/components/RengoTeamModal";
 
 type PlayerType = rest_api.games.Player;
 
@@ -195,6 +196,7 @@ export function PlayerCard({
      * stays on the player the server clock is running for while the user
      * views an earlier move or stages (but has not yet submitted) a stone. */
     const their_turn = phase === "play" && player_to_move === player.id;
+    const rengo_team = engine.rengo && engine.rengo_teams ? engine.rengo_teams[color] : null;
     const highlight_their_turn = their_turn ? `their-turn` : "";
 
     const show_points =
@@ -268,6 +270,18 @@ export function PlayerCard({
                         historical={(!engine.rengo && historical) || player}
                         gameId={goban.game_id}
                     />
+                    {rengo_team && rengo_team.length > 1 && (
+                        <button
+                            className="rengo-team-count"
+                            title={pgettext(
+                                "Button on a rengo player card that opens the team list",
+                                "Show the other team members",
+                            )}
+                            onClick={() => openRengoTeamModal(color, rengo_team)}
+                        >
+                            {"+ " + (rengo_team.length - 1)}
+                        </button>
+                    )}
                 </div>
             )}
 
@@ -307,15 +321,6 @@ export function PlayerCard({
                     <ScorePopup goban={goban} color={color} show={show_score_breakdown} />
                 </div>
             </div>
-            {!!(engine.rengo && engine.rengo_teams) && (
-                <div className={"rengo-team-members player-name-container " + color}>
-                    {engine.rengo_teams[color].slice(1).map((player) => (
-                        <div className={"rengo-team-member"} key={player.id}>
-                            {<Player user={player} icon rank />}
-                        </div>
-                    ))}
-                </div>
-            )}
         </div>
     );
 }

--- a/src/views/Game/Players.css
+++ b/src/views/Game/Players.css
@@ -43,26 +43,6 @@
     background-color: var(--shade4);
 }
 
-.MainGobanView .players {
-    .rengo-team-members {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        flex-grow: 1;
-        margin: 0.3rem;
-
-        .rengo-team-member {
-            border-radius: 0.4em;
-            padding: 0.3rem;
-            padding-bottom: 0.1rem;
-            width: 100%;
-            box-sizing: border-box;
-            text-align: left;
-            background-color: var(--other-player-background);
-        }
-    }
-}
-
 .MainGobanView .player-icons {
     flex-shrink: 0;
     flex-grow: 0;
@@ -286,8 +266,32 @@
     }
 
     .player-name-container {
+        display: flex;
+        align-items: center;
         overflow: hidden;
         text-align: left;
+
+        /* The Player component wraps its link in a plain span. Let that
+         * span shrink so the username ellipsizes instead of pushing the
+         * team-count button out of the clipped row. */
+        > * {
+            min-width: 0;
+        }
+
+        .rengo-team-count {
+            flex-shrink: 0;
+            height: auto;
+            margin: 0 0 0 0.4rem;
+            padding: 0 0.4rem;
+            border: 0;
+            border-radius: 0.4em;
+            box-shadow: none;
+            font-size: 0.85em;
+            line-height: 1.4;
+            color: inherit;
+            background-color: var(--other-player-background);
+            cursor: pointer;
+        }
     }
 
     .player-name {


### PR DESCRIPTION
## Summary

Replaces the persistent list of rengo team members under each player card on the game page with a compact `+ N` button next to the active player's name, where N is the number of other players on the team.

Clicking the button opens a modal that lists the team in turn order, current player first. If the viewer is on the team, a chevron on the left marks their row.

## Changes

- `src/views/Game/PlayerCards.tsx`: render the `+ N` button in the name row when the team has more than one player; pass the engine's rotated team list to the modal.
- `src/components/RengoTeamModal/`: new modal component, CSS, and tests.
- `src/views/Game/Players.css`: button styling under `.player-icons` so it applies to both the desktop and mobile layouts; the name row is now a flex row so a long username ellipsizes instead of pushing the button out of the clipped row. The button inherits the card's foreground color so it stays readable on both cards in both themes.
- `src/views/Game/PlayerCards.test.tsx`: tests for the count label, the single-player case, and the modal order.

## Testing

- `yarn type-check`, `yarn lint`, `yarn build`, and the affected jest suites pass.
- Checked in a browser against a live 6v7 rengo game on desktop and at 360px wide, in light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpQvkktnnYhdsp1fAoV66Q
