### PR TITLE
Remove the request undo button from the action bar

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -38,22 +38,19 @@ import { GameActionArea } from "./GameActionArea";
 import { alert } from "@/lib/swal_config";
 import {
     useAnnulled,
-    useCanRequestUndo,
     useCurrentMoveNumber,
     useMode,
     useOfficialMoveNumber,
     usePauseControl,
     usePhase,
     useScorePopup,
-    useUndoRequestIsMine,
     useUserIsLivePlayerToMove,
     useUserIsParticipant,
     useViewMode,
     useZenMode,
 } from "./GameHooks";
-import { openGameInfo, requestUndo } from "./game_actions";
+import { openGameInfo } from "./game_actions";
 import { openGameLinkModal } from "./GameLinkModal";
-import { UndoIcon } from "./UndoIcon";
 import {
     GobanControllerContext,
     GobanView,
@@ -143,8 +140,6 @@ export function Game(): React.ReactElement | null {
     const cur_move_number = useCurrentMoveNumber(goban);
     const official_move_number = useOfficialMoveNumber(goban);
     const user_is_live_player_to_move = useUserIsLivePlayerToMove(goban);
-    const can_request_undo = useCanRequestUndo(goban);
-    const undo_request_is_mine = useUndoRequestIsMine(goban);
     const pause_control = usePauseControl(goban);
     const annulled = useAnnulled(goban_controller.current);
     const modal_context = React.useContext(ModalContext);
@@ -855,10 +850,6 @@ export function Game(): React.ReactElement | null {
     const is_browsing_history =
         analysis_disabled && mode === "play" && cur_move_number < official_move_number;
 
-    // Undo applies only while the user is actually playing a game that is
-    // still in progress.
-    const show_play_action_tabs = user_is_player && mode === "play" && phase === "play";
-
     // Toggle behavior: if the mode is already on, clicking exits back to play.
     // Reading the live `mode`/`estimating_score` for the `active` prop also
     // means anything else that exits the mode (Escape key, navigation,
@@ -1330,30 +1321,6 @@ export function Game(): React.ReactElement | null {
             {review_tab && <GobanView.Tab {...review_tab} />}
 
             {conditional_tab && <GobanView.Tab {...conditional_tab} />}
-
-            {/* Ask the opponent to take back the last move. The button stays
-             *  lit while your own request is pending, and pressing it again
-             *  withdraws that request. It greys out when an undo can't be
-             *  asked for right now (rengo, the opening move, the opponent's
-             *  request pending, a staged move). */}
-            {show_play_action_tabs && (
-                <GobanView.Tab
-                    id="game-undo"
-                    type="action"
-                    align="center"
-                    icon={<UndoIcon badge="question" />}
-                    title={
-                        undo_request_is_mine
-                            ? pgettext("Withdraw your own undo request", "Cancel undo request")
-                            : pgettext("Ask the opponent to undo the last move", "Request undo")
-                    }
-                    active={undo_request_is_mine}
-                    disabled={!undo_request_is_mine && !can_request_undo}
-                    onClick={() =>
-                        undo_request_is_mine ? goban!.cancelUndo() : requestUndo(goban!, user.id)
-                    }
-                />
-            )}
 
             {pause_tab && <GobanView.Tab {...pause_tab} />}
 

--- a/src/views/Game/PlayButtons.css
+++ b/src/views/Game/PlayButtons.css
@@ -93,7 +93,8 @@
         white-space: nowrap;
     }
 
-    .reject-undo-button {
+    .reject-undo-button,
+    .cancel-undo-button {
         white-space: nowrap;
     }
 

--- a/src/views/Game/PlayButtons.test.tsx
+++ b/src/views/Game/PlayButtons.test.tsx
@@ -214,7 +214,7 @@ describe("PlayButtons", () => {
         expect(screen.queryByText("Cancel Undo")).toBeNull();
     });
 
-    test("renders no undo response to the player who requested the undo", () => {
+    test('shows "Cancel Undo" to the player who requested the undo', () => {
         const controller = new GobanController({
             moves: [
                 [16, 3, 9136.12], // B
@@ -233,14 +233,13 @@ describe("PlayButtons", () => {
             controller.goban.engine.undo_requested = 4;
         });
 
-        // The requester withdraws from the action bar's undo button, so
-        // there is no undo response for them here — only resign.
         const { container } = render(
             <WrapTest controller={controller}>
                 <PlayButtons />
             </WrapTest>,
         );
 
+        expect(screen.getByText("Cancel Undo")).toBeDefined();
         expect(screen.queryByText("Accept Undo")).toBeNull();
         expect(screen.queryByText("Reject Undo")).toBeNull();
         expect(container.querySelector(".resign-button")).not.toBeNull();

--- a/src/views/Game/PlayButtons.tsx
+++ b/src/views/Game/PlayButtons.tsx
@@ -31,6 +31,7 @@ import {
     useResignMode,
     useShowSubmitButton,
     useSubmittingMove,
+    useUndoRequestIsMine,
     useUserIsParticipant,
 } from "./GameHooks";
 import { cancelOrResignGame } from "./game_actions";
@@ -240,10 +241,10 @@ export function PlayButtons(): React.ReactElement | null {
         };
     }, [goban]);
 
-    // Only the receiving side of an undo request is answered here. The
-    // requesting side withdraws from the action bar's undo button, which
-    // toggles off while their own request is pending.
+    // The receiving side of an undo request answers it here; the requesting
+    // side gets a button to withdraw it while it is still pending.
     const show_undo_response = useCanAnswerUndoRequest(goban);
+    const show_cancel_undo = useUndoRequestIsMine(goban);
 
     // Resign (or cancel, while the game is young enough) sits at the right
     // edge of this strip. It only applies to a player in a game that is
@@ -298,12 +299,13 @@ export function PlayButtons(): React.ReactElement | null {
         goban.isAnalysisDisabled() &&
         cur_move_number < official_move_number;
 
-    // Undo moved to the action bar; what is left here is the response to
-    // the opponent's undo request, the move controls, and resign.
-    // Collapse the strip entirely when none of them apply so it takes up
-    // no space.
+    // Requesting an undo lives in the More actions menu; what is left here
+    // is the response to the opponent's undo request, withdrawing your own,
+    // the move controls, and resign. Collapse the strip entirely when none
+    // of them apply so it takes up no space.
     if (
         !show_undo_response &&
+        !show_cancel_undo &&
         !show_pass &&
         !show_submit_button &&
         !show_back_to_game &&
@@ -323,6 +325,11 @@ export function PlayButtons(): React.ReactElement | null {
                         ref={accept_button}
                     >
                         {_("Accept Undo")}
+                    </button>
+                )}
+                {show_cancel_undo && (
+                    <button className="bold cancel-undo-button xs" onClick={() => cancelUndo()}>
+                        {_("Cancel Undo")}
                     </button>
                 )}
             </span>


### PR DESCRIPTION
## Summary

- Remove the request undo button from the game action bar. Requesting an undo is now done from the More actions ("...") menu only.
- Bring back the "Cancel Undo" button in the play-buttons strip for the player who requested the undo, since the action bar button was also how they withdrew a pending request. It sits in the left slot, where the opponent sees "Accept Undo".

## Testing

- `yarn test src/views/Game/PlayButtons.test.tsx` passes (12 tests), including the updated requester test that expects "Cancel Undo" and no Accept/Reject buttons.
- `yarn type-check`, `yarn lint`, `yarn prettier:file`, and `yarn build` all pass.
- Manual testing on mobile and desktop browsers is still needed, in particular the mobile strip layout with Cancel Undo beside the resign button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tu1jXaYS2H9h7sTXxmV6L6
