### PR TITLE
Make the AI review board toggle a gray marks icon with a switch

### DIFF
--- a/src/components/AIReview/AIReview.css
+++ b/src/components/AIReview/AIReview.css
@@ -246,23 +246,19 @@
             flex: 1.4;
             display: flex;
             justify-content: center;
+            align-items: center;
         }
 
         .right-section {
             flex: 0.8;
             display: flex;
             justify-content: flex-end;
+            align-items: center;
         }
 
         span {
             padding-left: 0.25rem;
             padding-right: 0.25rem;
-        }
-
-        /* The switches sit on the text baseline by default, a few pixels
-         * above the labels' center; center them on the row instead */
-        .Toggle {
-            vertical-align: middle;
         }
 
         .ai-summary-toggler {

--- a/src/components/AIReview/AIReviewBoardToggle.css
+++ b/src/components/AIReview/AIReviewBoardToggle.css
@@ -1,59 +1,29 @@
 .AIReviewBoardToggle {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    box-sizing: border-box;
-    width: 1.75rem;
-    height: 1.5rem;
-    margin: 0 0 0 0.75rem;
     padding: 0;
-    border: 1px solid var(--shade2);
-    border-radius: 0.25rem;
-    background: transparent;
-    box-shadow: none;
-    color: var(--fg);
-    cursor: pointer;
-    line-height: 0;
-    opacity: 0.6;
-    transition:
-        opacity 0.15s ease,
-        background-color 0.15s ease;
-
-    &:hover {
-        opacity: 1;
-    }
 
     svg {
         display: block;
         width: 1rem;
         height: 1rem;
         flex: 0 0 1rem;
+        margin-right: 0.25rem;
     }
 
-    circle {
+    .grid {
+        fill: none;
+        stroke: var(--shade2);
+        stroke-width: 1;
+    }
+
+    .stone {
         fill: var(--shade1);
     }
 
-    &.active {
-        opacity: 1;
-        background: var(--shade2);
-        border-color: var(--shade2);
-
-        circle.excellent {
-            fill: var(--move-quality-excellent);
-        }
-        circle.good {
-            fill: var(--move-quality-good);
-        }
-        /* The colored bottom row reads a touch left of the top row, so it
-         * is nudged right; the gray dots sit on the plain grid */
-        circle.inaccuracy {
-            fill: var(--move-quality-inaccuracy);
-            transform: translateX(0.5px);
-        }
-        circle.blunder {
-            fill: var(--move-quality-blunder);
-            transform: translateX(0.5px);
-        }
+    .ring {
+        fill: var(--bg);
+        stroke: var(--shade1);
+        stroke-width: 1;
     }
 }

--- a/src/components/AIReview/AIReviewBoardToggle.tsx
+++ b/src/components/AIReview/AIReviewBoardToggle.tsx
@@ -16,42 +16,37 @@
  */
 
 import * as React from "react";
+import { Toggle } from "@/components/Toggle";
 import { pgettext } from "@/lib/translate";
 import { usePreference } from "@/lib/preferences";
 import "./AIReviewBoardToggle.css";
 
 /**
- * Button that toggles the "ai-review-show-on-board" preference: whether the
+ * Switch that toggles the "ai-review-show-on-board" preference: whether the
  * AI review draws anything on the board (suggested moves, their score
- * differences, the move quality of the move played). The icon is four dots
- * in the excellent, good, inaccuracy and blunder colors.
+ * differences, the move quality of the move played). A gray icon of board
+ * marks on grid lines (circle, triangle in a hollow circle, blank, circle)
+ * sits to the left of the switch.
  */
 export function AIReviewBoardToggle(): React.ReactElement {
     const [show_on_board, setShowOnBoard] = usePreference("ai-review-show-on-board");
 
     return (
-        <button
-            className={"AIReviewBoardToggle" + (show_on_board ? " active" : "")}
-            aria-pressed={show_on_board}
-            onClick={() => setShowOnBoard(!show_on_board)}
-            title={
-                show_on_board
-                    ? pgettext(
-                          "Button that hides the AI review's marks on the board",
-                          "Hide AI review on the board",
-                      )
-                    : pgettext(
-                          "Button that shows the AI review's marks on the board",
-                          "Show AI review on the board",
-                      )
-            }
+        <span
+            className="AIReviewBoardToggle"
+            title={pgettext(
+                "Switch that shows or hides the AI review's marks on the board",
+                "Show AI review on the board",
+            )}
         >
             <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
-                <circle className="excellent" cx="4" cy="4" r="3" />
-                <circle className="good" cx="12" cy="4" r="3" />
-                <circle className="inaccuracy" cx="4" cy="12" r="3" />
-                <circle className="blunder" cx="12" cy="12" r="3" />
+                <path className="grid" d="M4 0v16M12 0v16M0 4h16M0 12h16" />
+                <circle className="stone" cx="4" cy="4" r="3" />
+                <circle className="ring" cx="12" cy="4" r="3" />
+                <polygon className="stone" points="12,2 14,5.5 10,5.5" />
+                <circle className="stone" cx="12" cy="12" r="3" />
             </svg>
-        </button>
+            <Toggle checked={show_on_board} onChange={(checked) => setShowOnBoard(checked)} />
+        </span>
     );
 }

--- a/src/components/AIReview/ScoreWinRateToggle.tsx
+++ b/src/components/AIReview/ScoreWinRateToggle.tsx
@@ -70,9 +70,7 @@ export function ScoreWinRateToggle({
                     {pgettext("Display the win % that the AI estimates", "Win %")}
                 </span>
 
-                <span>
-                    <Toggle checked={useScore} onChange={handleToggleChange} />
-                </span>
+                <Toggle checked={useScore} onChange={handleToggleChange} />
 
                 <span className="score-toggle" onClick={handleScoreToggleClick}>
                     {pgettext("Display the game score that the AI estimates", "Score")}
@@ -84,9 +82,7 @@ export function ScoreWinRateToggle({
                         <span>
                             <i className="fa fa-table"></i>
                         </span>
-                        <span>
-                            <Toggle checked={!tableHidden} onChange={handleTableToggleChange} />
-                        </span>
+                        <Toggle checked={!tableHidden} onChange={handleTableToggleChange} />
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Summary

The button that shows or hides the AI review's marks on the board used four quality-colored dots with its own pressed state. It is now a plain gray icon of board marks with a Toggle switch beside it, matching the other switches on the Win % / Score row.

The icon draws faint grid lines with a filled circle upper left, a triangle inside a hollow circle upper right, a bare intersection lower left, and a filled circle lower right.

## Changes

- `src/components/AIReview/AIReviewBoardToggle.tsx`: render a span with the gray SVG icon and a `Toggle` instead of a button. One title string replaces the show/hide pair.
- `src/components/AIReview/AIReviewBoardToggle.css`: drop the button border, background, hover, and quality color rules; style the grid, stones, and ring.
- `src/components/AIReview/ScoreWinRateToggle.tsx` and `AIReview.css`: the Win % / Score and table switches sat a pixel below their labels because they were wrapped in plain spans and aligned by the text baseline. The sections now center their items and the wrapper spans are gone, so all three switches share the row's center.

## Testing

- `yarn type-check`, `yarn lint`, and `yarn build` pass.
- Checked the real AI review panel in a browser against a beta game. The icon, all three switches, and both labels measure the same vertical center.
- Not yet checked on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7hpCcFMcUp7ndEhWxQ5jA
