### PR TITLE
game chat: make input controls match the input height

### DIFF
--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -175,13 +175,18 @@
         /* max-width: 100%; */
         /* width: 100%; */
         /* overflow: hidden; */
-        align-items: flex-end;
+        /* The textarea gets taller when the message has more lines.
+           Stretch makes the controls on each side as tall as the row. */
+        align-items: stretch;
         /* flex-direction: column; */
         border-top: 1px solid var(--shade3);
 
         button {
             flex-shrink: 0;
-            height: 30px;
+            /* This overrides the global 2em button height. A definite
+               height stops a flex item from stretching. */
+            height: auto;
+            min-height: 30px;
         }
 
         .chat-input-chat-log-toggle {
@@ -199,6 +204,8 @@
         }
 
         .qc-toggle {
+            display: flex;
+            align-items: center;
             background-color: transparent;
             border-right: 1px solid #000;
             padding: 0rem 0.5rem 0rem 0.5rem;
@@ -206,7 +213,7 @@
             background-color: var(--default-button);
             color: var(--default-button-color);
             transition: background-color 0.3s ease;
-            height: 30px;
+            min-height: 30px;
 
             &:hover,
             &:focus {


### PR DESCRIPTION
This is minor polish - currently, the chat box appears to break apart a bit when multiline text is entered.  This PR stretches all elements next to the text input so it looks more cohesive.

### Screenshots

| Before  | After |
| ------------- | ------------- |
| <img width="417" height="86" alt="Screenshot 2026-09-05 at 1 57 12 PM" src="https://github.com/user-attachments/assets/40cceb67-1f68-4379-9c39-b282877fed42" /> | <img width="418" height="85" alt="Screenshot 2026-09-05 at 1 57 48 PM" src="https://github.com/user-attachments/assets/fdd65325-160a-4c81-aaf2-ec303b236bde" /> |

### Testing

  - Checked by hand in a desktop browser against the beta backend (see "after" screenshot)
  - I did not add a screenshot test because there are no component-level screenshots in this repo.  E2E Playwright tests felt a bit heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W684wbWsQq1AERajhKGXV