### PR TITLE
Move pause / resume out of the action bar into the More actions menu

### DIFF
--- a/src/views/Game/Game.css
+++ b/src/views/Game/Game.css
@@ -304,15 +304,14 @@
     &.zen {
         background-color: var(--bg);
 
-        /* Hide the chat, analyze toolbar, move tree, and full-page AI review
-         * in zen mode — they aren't part of the focused view. The tab bar
-         * stays: it holds the only route to undo, resign, settings and the
-         * other game actions. */
+        /* Hide the chat, analyze toolbar, move tree, tab bar and full-page
+         * AI review in zen mode — they aren't part of the focused view. */
         .chat-container,
         .game-analyze-button-bar,
         #move-tree-container,
         .AIReview,
-        .condensed-game-information {
+        .condensed-game-information,
+        .GobanView-tab-bar {
             display: none;
         }
 
@@ -321,23 +320,6 @@
             border-radius: 0;
             box-shadow: none;
             margin: 0;
-        }
-
-        /* The sidebar is transparent in zen, so the tab bar drops its own
-         * panel styling. Pause / resume is the only button that stays: it
-         * is the one action a player must be able to reach without leaving
-         * zen. Without it, the bar has nothing to show and goes away. */
-        .GobanView-tab-bar {
-            background: transparent;
-            border-top: none;
-
-            .GobanView-tab-button:not([data-tab-id="game-pause"]) {
-                display: none;
-            }
-
-            &:not(:has([data-tab-id="game-pause"])) {
-                display: none;
-            }
         }
 
         /* Stack the few items that remain — player cards, controls — so they

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -980,17 +980,18 @@ export function Game(): React.ReactElement | null {
           }
         : null;
 
-    // Pause / resume the game clock. Rendered only for users allowed to
-    // change the pause state right now (participants in vacation-eligible
-    // games, moderators — see usePauseControl).
+    // Pause / resume the game clock. Listed only in the More-actions menu,
+    // and only for users allowed to change the pause state right now
+    // (participants in vacation-eligible games, moderators — see
+    // usePauseControl).
     const pause_tab: GobanViewTabProps | null =
         pause_control.action !== null
             ? {
                   id: "game-pause",
                   type: "action",
                   align: "center",
-                  icon: pause_control.paused ? "play" : "pause",
-                  title: pause_control.paused ? _("Resume game") : _("Pause game"),
+                  icon: pause_control.action === "resume" ? "play" : "pause",
+                  title: pause_control.action === "resume" ? _("Resume game") : _("Pause game"),
                   onClick: pause_control.togglePause,
               }
             : null;
@@ -1330,8 +1331,6 @@ export function Game(): React.ReactElement | null {
             {review_tab && <GobanView.Tab {...review_tab} />}
 
             {conditional_tab && <GobanView.Tab {...conditional_tab} />}
-
-            {pause_tab && <GobanView.Tab {...pause_tab} />}
 
             {/* Right group, in source order (visually left → right):
              *  1. Moderator toggle (gavel) — per-player controls + decide /

--- a/src/views/Game/GameHooks.test.tsx
+++ b/src/views/Game/GameHooks.test.tsx
@@ -18,10 +18,12 @@
 import * as React from "react";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import * as data from "@/lib/data";
+import { JGOFClockWithTransmitting } from "goban";
 import { GobanControllerContext } from "./goban_context";
 import { GobanController } from "../../lib/GobanController";
 import {
     useCanRequestUndo,
+    usePauseControl,
     usePlayerToMoveOnOfficialBranch,
     useResignMode,
     useUndoRequestIsMine,
@@ -75,8 +77,10 @@ function Probe({ controller }: { controller: GobanController }): React.ReactElem
     const undo_request_is_mine = useUndoRequestIsMine(controller.goban);
     const resign_mode = useResignMode(controller.goban);
     const official_player_to_move = usePlayerToMoveOnOfficialBranch(controller.goban);
+    const pause_control = usePauseControl(controller.goban);
     return (
         <div>
+            <span data-testid="pause-action">{pause_control.action ?? "none"}</span>
             <span data-testid="official-player-to-move">{official_player_to_move}</span>
             <span data-testid="can-request-undo">{can_request_undo ? "yes" : "no"}</span>
             <span data-testid="undo-request-is-mine">{undo_request_is_mine ? "yes" : "no"}</span>
@@ -98,6 +102,65 @@ const undoRequestIsMine = () => screen.getByTestId("undo-request-is-mine").textC
 const resignMode = () => screen.getByTestId("resign-mode").textContent;
 const officialPlayerToMove = () =>
     parseInt(screen.getByTestId("official-player-to-move").textContent ?? "", 10);
+const pauseAction = () => screen.getByTestId("pause-action").textContent;
+
+/** Feeds the hook a clock update carrying only the pause state. */
+function emitPauseState(
+    controller: GobanController,
+    pause_state: JGOFClockWithTransmitting["pause_state"],
+) {
+    act(() => {
+        controller.goban.emit("clock", { pause_state } as JGOFClockWithTransmitting);
+    });
+}
+
+const GAME_IN_PROGRESS = {
+    moves: [
+        [16, 3, 9136],
+        [3, 2, 18978.5],
+    ] as [number, number, number][],
+    players: { black: ME, white: OPPONENT },
+};
+
+describe("usePauseControl", () => {
+    test("offers 'pause' to a participant in an unpaused game", () => {
+        renderProbe(new GobanController(GAME_IN_PROGRESS));
+
+        expect(pauseAction()).toBe("pause");
+    });
+
+    test("still offers 'pause' during a weekend pause", () => {
+        const controller = new GobanController(GAME_IN_PROGRESS);
+        renderProbe(controller);
+
+        emitPauseState(controller, { weekend: true });
+
+        expect(pauseAction()).toBe("pause");
+    });
+
+    test("offers 'resume' once a player has paused", () => {
+        const controller = new GobanController(GAME_IN_PROGRESS);
+        renderProbe(controller);
+
+        emitPauseState(controller, { player: { player_id: String(OPPONENT.id), pauses_left: 3 } });
+
+        expect(pauseAction()).toBe("resume");
+    });
+
+    test("offers nothing to a spectator", () => {
+        const controller = new GobanController({
+            ...GAME_IN_PROGRESS,
+            players: { black: { id: 987, username: "someone" }, white: OPPONENT },
+        });
+        renderProbe(controller);
+
+        expect(pauseAction()).toBe("none");
+
+        emitPauseState(controller, { player: { player_id: String(OPPONENT.id), pauses_left: 3 } });
+
+        expect(pauseAction()).toBe("none");
+    });
+});
 
 describe("useResignMode", () => {
     test("is 'cancel' in the first 6 moves", () => {

--- a/src/views/Game/GameHooks.ts
+++ b/src/views/Game/GameHooks.ts
@@ -406,8 +406,10 @@ export function useAutoScoring(goban: Goban): { in_progress: boolean; taking_too
  *     still in progress, or for a moderator;
  *   - paused by a player → "resume" for participants and moderators;
  *   - paused by a moderator → "resume" for moderators only;
- *   - any other pause (weekend, vacation, server, stone removal) is not
- *     user-resumable, so `action` is null.
+ *   - paused for any other reason (weekend, vacation, server, stone
+ *     removal) → "pause" for the same users as when unpaused. Those
+ *     pauses are not user-resumable, but a player pause stacks on top of
+ *     them and outlives them, so the affordance stays available.
  *
  * Moderators bypass the vacation / participant gating that applies to
  * players — `disable_vacation` only constrains player-side pauses, and
@@ -446,12 +448,13 @@ export function usePauseControl(goban: GobanRenderer | null): {
     }, [goban]);
 
     const paused = !!pause_state;
+    const user_paused = !!pause_state?.player || !!pause_state?.moderator;
     const can_resume = pause_state?.player
         ? user_is_player || !!user?.is_moderator
         : pause_state?.moderator
           ? !!user?.is_moderator
           : false;
-    const action: "pause" | "resume" | null = paused
+    const action: "pause" | "resume" | null = user_paused
         ? can_resume
             ? "resume"
             : null
@@ -463,7 +466,7 @@ export function usePauseControl(goban: GobanRenderer | null): {
         if (!goban) {
             return;
         }
-        if (paused) {
+        if (action === "resume") {
             goban.resumeGame();
         } else {
             goban.pauseGame();


### PR DESCRIPTION
## Summary

The pause / resume button is removed from the game action bar. It stays in the "..." More actions menu as a labeled item, for the same users who could see it before.

- `Game.tsx` no longer renders the pause tab in the bar. The tab definition still feeds the More actions menu. The menu label and icon now follow the pause action, so a weekend-paused game reads "Pause game" rather than "Resume game".
- `usePauseControl` returned no action while a game was paused for a reason the user cannot undo (weekend, vacation, server, stone removal). That hid the menu item on every correspondence game over the weekend. A player pause stacks on those pauses, so the hook now offers "pause" in that state. "Resume" still applies only to player pauses, and to moderator pauses for moderators.
- Zen mode hid every action bar button except pause. With pause gone from the bar, the whole bar is hidden in zen. There is no pause affordance in zen now.
- Four new tests cover `usePauseControl`: unpaused, weekend-paused, player-paused, and spectator. The weekend case fails against the old hook.

## Testing

- `yarn type-check`, `yarn lint`, `yarn build` and the Game jest suite pass.
- Checked in the local dev server on a weekend-paused game with a moderator flag faked client-side: no pause tab in the bar, "Pause game" listed in the More actions menu.
- Manual testing still needed on a real account, in desktop and mobile layouts: pause and resume from the More actions menu as a participant, and as a moderator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HN3rdMnC2XkgyJQSBZLiWv
