### PR TITLE
Use the search-plus icon for the Review this game tab

### DIFF
--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -961,7 +961,7 @@ export function Game(): React.ReactElement | null {
               id: "game-review",
               type: "action",
               align: "center",
-              icon: "refresh",
+              icon: "search-plus",
               title: _("Review this game"),
               onClick: goban_controller.current.startReview,
           }


### PR DESCRIPTION
## Summary

The "Review this game" tab on the game page used the refresh glyph. It has done so since the first open source release, when it sat next to a text label in the old game dock. In the GobanView tab bar the glyph stands alone, and it reads as reload, not review.

- `Game.tsx`: the review tab icon changes from `refresh` to `search-plus`. It stays distinct from the `sitemap` Analyze tab and the `exchange` conditional-moves tab.
- The sync button in `PlayControls.tsx` keeps `refresh`. There it means resynchronize, which is a correct use.

## Testing

- `yarn type-check`, eslint and prettier pass on the changed file.
- Manual testing still needed in desktop and mobile layouts: open a finished game and a live game as a spectator, and confirm the review tab shows the magnifier-plus glyph in the bar and in the More actions menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LXVNYUXJHr7gCZfzpfsh1