### PR TITLE
Drive pause and undo through the More-actions menu in e2e tests

### DIFF
--- a/e2e-tests/games/multi-move-undo.ts
+++ b/e2e-tests/games/multi-move-undo.ts
@@ -85,10 +85,15 @@ export const multiMoveUndoTest = async ({
     // Challenger is black. Black plays, white answers — black's turn again.
     await playMoves(challengerPage, acceptorPage, ["D4", "E5"], "9x9");
 
-    // Black requests an undo while it is black's turn.
-    const undoButton = challengerPage.getByTitle("Request undo");
-    await expect(undoButton).toBeEnabled();
-    await undoButton.click();
+    // Black requests an undo while it is black's turn. The undo request
+    // lives in the "More actions" (ellipsis) popover as a labeled item;
+    // the trigger is an icon-only tab labeled via its `title` attribute.
+    await challengerPage.locator('button.GobanView-tab-button[title="More actions"]').click();
+    const undoItem = challengerPage
+        .locator("button.GameSidebarPanel-item")
+        .filter({ hasText: "Request undo" });
+    await expect(undoItem).toBeEnabled();
+    await undoItem.click();
 
     // The opponent sees a request covering both moves...
     await expect(acceptorPage.getByText("Accept Undo")).toBeVisible({ timeout: 10000 });
@@ -145,9 +150,13 @@ export const multiMoveUndoWhiteRequesterTest = async ({
     // Three moves: B D4, W E5, B C3 — now it is white's turn.
     await playMoves(challengerPage, acceptorPage, ["D4", "E5", "C3"], "9x9");
 
-    const undoButton = acceptorPage.getByTitle("Request undo");
-    await expect(undoButton).toBeEnabled();
-    await undoButton.click();
+    // White requests the undo via the "More actions" popover item.
+    await acceptorPage.locator('button.GobanView-tab-button[title="More actions"]').click();
+    const undoItem = acceptorPage
+        .locator("button.GameSidebarPanel-item")
+        .filter({ hasText: "Request undo" });
+    await expect(undoItem).toBeEnabled();
+    await undoItem.click();
 
     await expect(challengerPage.getByText("Accept Undo")).toBeVisible({ timeout: 10000 });
     const seen_by_black = await undoEngineState(challengerPage);

--- a/e2e-tests/games/simul-pause-detection.ts
+++ b/e2e-tests/games/simul-pause-detection.ts
@@ -152,13 +152,20 @@ export const simulPauseDetectionTest = async (
 
     // === Challenger pauses game 1 BEFORE game 2 ends ===
     log("Challenger pausing game 1 BEFORE game 2 ends...");
-    // Click on the "Pause game" action tab in the game dock. It renders as a
-    // GobanView action tab: <button class="GobanView-tab-button" title="Pause game">.
-    const pauseLink = challengerGame1Page.locator(
-        'button.GobanView-tab-button[title="Pause game"]',
+    // Pause lives in the "More actions" (ellipsis) popover, not the action
+    // bar. The GobanView action tabs are icon-only buttons labelled via the
+    // `title` attribute, so the trigger is selected by title; the popover
+    // items are labelled buttons (GameActionsPanel).
+    const moreActions1 = challengerGame1Page.locator(
+        'button.GobanView-tab-button[title="More actions"]',
     );
-    await expect(pauseLink).toBeVisible();
-    await pauseLink.click();
+    await expect(moreActions1).toBeVisible();
+    await moreActions1.click();
+    const pauseItem = challengerGame1Page
+        .locator("button.GameSidebarPanel-item")
+        .filter({ hasText: "Pause game" });
+    await expect(pauseItem).toBeVisible();
+    await pauseItem.click();
     log("Pause game clicked");
 
     // Verify the pause took effect by checking for "Game Paused" indicator and "Resume" button

--- a/e2e-tests/tournaments/tournament-disable-vacation.ts
+++ b/e2e-tests/tournaments/tournament-disable-vacation.ts
@@ -254,12 +254,21 @@ export const tournamentDisableVacationTest = async ({
     const goban = player1Page.locator(".Goban[data-pointers-bound]");
     await goban.waitFor({ state: "visible", timeout: 30000 });
 
-    // The pause button should NOT be visible for a player in a disable-vacation game.
-    // It would render as a GobanView action tab: <button class="GobanView-tab-button"
-    // title="Pause game"> when pausing is allowed.
-    const pauseLink = player1Page.locator('button.GobanView-tab-button[title="Pause game"]');
-    await expect(pauseLink).not.toBeVisible();
-    log("Confirmed: Pause game button is NOT visible for player in disable-vacation game");
+    // Pause lives in the "More actions" (ellipsis) popover. For a player in
+    // a disable-vacation game, the "Pause game" item must not be offered
+    // there (usePauseControl gates on disable_vacation). Anchoring on a
+    // visible sibling item first proves the popover is populated, so the
+    // absence check cannot pass vacuously against an unopened menu.
+    const moreActions = player1Page.locator('button.GobanView-tab-button[title="More actions"]');
+    await expect(moreActions).toBeVisible();
+    await moreActions.click();
+    const menuItems = player1Page.locator("button.GameSidebarPanel-item");
+    await expect(menuItems.filter({ hasText: "Game information" })).toBeVisible();
+    await expect(menuItems.filter({ hasText: "Pause game" })).not.toBeVisible();
+    // The popover has no Escape handling; clicking its backdrop dismisses
+    // it. Click a corner so the click cannot land on the panel itself.
+    await player1Page.locator(".popover-backdrop").click({ position: { x: 5, y: 5 } });
+    log("Confirmed: Pause game is NOT offered to a player in a disable-vacation game");
 
     log("Checking player 1 vacation settings for disable-vacation warning...");
     await player1Page.goto("/user/settings");


### PR DESCRIPTION
## What

#3716 (`11ee36e81`) moved pause / resume out of the game action bar into the More-actions popover, and since PR CI does not run the Playwright e2e suite, two tests went stale on main:

- **`simul-pause-detection`** still clicked the removed action-bar tab (`button.GobanView-tab-button[title="Pause game"]`) and fails outright. It now opens the More-actions popover and clicks the labeled "Pause game" item (`GameSidebarPanel-item`), matching the idiom already used by `sgf-download-restrictions` and `demo-board-utils`.
- **`tournament-disable-vacation`** asserted the action-bar pause tab is *not* visible for a disable-vacation game — which now passes vacuously, since the tab is gone for everyone. It now opens the popover, anchors on the always-present "Game information" item (so the absence check cannot pass against an unopened menu), asserts "Pause game" is absent (`usePauseControl` gates on `disable_vacation`), and dismisses via the backdrop (the popover has no Escape handling).

- **`multi-move-undo`** (both "Undo on (white) requester's turn" variants): "Request undo" is likewise no longer a title-labeled play-area button but a labeled popover item, so `getByTitle` found nothing. Both variants now request the undo via the popover. The "Accept Undo" side still renders as a visible play-area button and is unchanged.

Test-only change; no app code touched.

## Testing

Both tests run green locally against the dev stack:

- `Paused games excluded from simul detection` — passed (58.6s), pause verified via the "Game Paused" indicator as before.
- `Disable-vacation tournament shows banner and warning in vacation settings` — passed (51.0s), including the new populated-menu absence check.
- `Undo on requester's turn covers the last two moves` — passed (25.4s).
- `Undo on white requester's turn covers the last two moves` — passed (25.1s).

`yarn type-check`, `yarn lint`, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXek6AzjoNpoo9ytnDrePS
