### PR TITLE
Show the move timings with the fair play summary

### DIFF
--- a/src/components/AIReview/AIReview.tsx
+++ b/src/components/AIReview/AIReview.tsx
@@ -79,11 +79,10 @@ interface AIReviewProperties {
     onAIReviewSelected: (ai_review: JGOFAIReview) => void;
     simul_black?: boolean | null;
     simul_white?: boolean | null;
-    /** When true, shows the FairPlayGameSummary (bound to the moderator tools being open) */
+    /** When true, shows the FairPlayGameSummary with the per-move timings
+     *  (bound to the moderator tools being open) */
     showFairPlay?: boolean;
-    /** When true, shows GameTimings within FairPlayGameSummary */
-    showGameTimings?: boolean;
-    /** GameTimings props - required when showGameTimings is true */
+    /** GameTimings props, shown with the FairPlayGameSummary */
     moves?: GobanMovesArray;
     start_time?: number;
     end_time?: number;
@@ -107,7 +106,6 @@ export function AIReview({
     simul_black,
     simul_white,
     showFairPlay,
-    showGameTimings,
     moves,
     start_time,
     end_time,
@@ -621,18 +619,14 @@ export function AIReview({
                         white_player_id={gobanController.goban!.engine.config.white_player_id!}
                         board_size={gobanController.goban!.engine.width}
                         currentMoveNumber={move.move_number - 1}
-                        moves={showGameTimings ? moves : undefined}
-                        start_time={showGameTimings ? start_time : undefined}
-                        end_time={showGameTimings ? end_time : undefined}
-                        free_handicap_placement={
-                            showGameTimings ? free_handicap_placement : undefined
-                        }
-                        handicap={showGameTimings ? handicap : undefined}
-                        simul_black={showGameTimings ? simul_black : undefined}
-                        simul_white={showGameTimings ? simul_white : undefined}
-                        onFinalActionCalculated={
-                            showGameTimings ? onFinalActionCalculated : undefined
-                        }
+                        moves={moves}
+                        start_time={start_time}
+                        end_time={end_time}
+                        free_handicap_placement={free_handicap_placement}
+                        handicap={handicap}
+                        simul_black={simul_black}
+                        simul_white={simul_white}
+                        onFinalActionCalculated={onFinalActionCalculated}
                     />
                 )}
             </div>
@@ -751,19 +745,15 @@ export function AIReview({
                                         }
                                         board_size={gobanController.goban!.engine.width}
                                         currentMoveNumber={move.move_number - 1}
-                                        moves={showGameTimings ? moves : undefined}
-                                        start_time={showGameTimings ? start_time : undefined}
-                                        end_time={showGameTimings ? end_time : undefined}
-                                        free_handicap_placement={
-                                            showGameTimings ? free_handicap_placement : undefined
-                                        }
-                                        handicap={showGameTimings ? handicap : undefined}
-                                        simul_black={showGameTimings ? simul_black : undefined}
-                                        simul_white={showGameTimings ? simul_white : undefined}
+                                        moves={moves}
+                                        start_time={start_time}
+                                        end_time={end_time}
+                                        free_handicap_placement={free_handicap_placement}
+                                        handicap={handicap}
+                                        simul_black={simul_black}
+                                        simul_white={simul_white}
                                         ai_review_uuid={selectedAiReview?.uuid}
-                                        onFinalActionCalculated={
-                                            showGameTimings ? onFinalActionCalculated : undefined
-                                        }
+                                        onFinalActionCalculated={onFinalActionCalculated}
                                     />
                                 )}
                         </React.Fragment>

--- a/src/lib/GobanController.ts
+++ b/src/lib/GobanController.ts
@@ -52,7 +52,6 @@ import { isLiveGame } from "@/components/TimeControl";
 interface GobanControllerEvents {
     autoplaying: (autoplaying: boolean) => void;
     variation_name: (variation_name: string) => void;
-    show_game_timing: (show_game_timing: boolean) => void;
     show_bot_detection_results: (show_bot_detection_results: boolean) => void;
     zen_mode: (zen_mode: boolean) => void;
     copied_node: (copied_node: MoveTree | undefined) => void;
@@ -262,7 +261,6 @@ export class GobanController extends EventEmitter<GobanControllerEvents> {
     public readonly goban: GobanRenderer;
     private _autoplaying: boolean = false;
     public analyze_pencil_color: string = preferences.get("analysis.pencil-color");
-    private show_game_timing: boolean = false;
     private show_bot_detection_results: boolean = false;
     private _zen_mode: boolean = preferences.get("start-in-zen-mode");
     private _ai_review_enabled: boolean = preferences.get("ai-review-enabled");
@@ -856,11 +854,6 @@ export class GobanController extends EventEmitter<GobanControllerEvents> {
         preferences.set("label-positioning", label_position);
 
         this.goban.setLabelPosition(label_position);
-    };
-
-    toggleShowTiming = () => {
-        this.show_game_timing = !this.show_game_timing;
-        this.emit("show_game_timing", this.show_game_timing);
     };
 
     toggleShowBotDetectionResults = () => {

--- a/src/views/Game/FragAIReview.test.tsx
+++ b/src/views/Game/FragAIReview.test.tsx
@@ -21,6 +21,7 @@ import { FragAIReview } from "./fragments";
 import { GobanControllerContext } from "./goban_context";
 import * as data from "@/lib/data";
 import { GobanController } from "@/lib/GobanController";
+import { GobanMovesArray } from "goban";
 
 jest.mock("@/lib/requests", () => ({
     get: jest.fn(() => Promise.resolve([])),
@@ -30,9 +31,19 @@ jest.mock("@/lib/requests", () => ({
     patch: jest.fn(() => Promise.resolve({})),
 }));
 
+const fair_play_props = jest.fn();
+
 jest.mock("@moderator-ui/FairPlay", () => ({
-    FairPlayGameSummary: () => <div data-testid="fair-play-summary" />,
+    FairPlayGameSummary: (props: Record<string, unknown>) => {
+        fair_play_props(props);
+        return <div data-testid="fair-play-summary" />;
+    },
 }));
+
+const MOVES: GobanMovesArray = [
+    [3, 3, 1000],
+    [15, 15, 2000],
+];
 
 const MODERATOR = {
     anonymous: false,
@@ -70,6 +81,9 @@ function makeController(phase: "play" | "finished"): GobanController {
         phase,
         black_player_id: 987,
         white_player_id: 456,
+        start_time: 1000,
+        end_time: 5000,
+        moves: MOVES,
         players: {
             black: { id: 987, username: "someone" },
             white: { id: 456, username: "someone_else" },
@@ -87,6 +101,7 @@ function renderFragment(controller: GobanController, showFairPlay: boolean) {
 
 beforeEach(() => {
     data.set("user", MODERATOR);
+    fair_play_props.mockClear();
 });
 
 describe("fair play summary follows the moderator tools", () => {
@@ -95,9 +110,13 @@ describe("fair play summary follows the moderator tools", () => {
         expect(screen.queryByTestId("fair-play-summary")).toBeNull();
     });
 
-    test("ongoing game: shown while the moderator tools are on", () => {
+    test("ongoing game: shown with the move timings while the moderator tools are on", () => {
         renderFragment(makeController("play"), true);
         expect(screen.getByTestId("fair-play-summary")).toBeDefined();
+        const props = fair_play_props.mock.calls[0][0];
+        expect(props.moves).toBe(MOVES);
+        expect(props.start_time).toBe(1000);
+        expect(props.end_time).toBe(5000);
     });
 
     test("finished game: hidden while the moderator tools are off", async () => {
@@ -107,9 +126,13 @@ describe("fair play summary follows the moderator tools", () => {
         expect(screen.queryByTestId("fair-play-summary")).toBeNull();
     });
 
-    test("finished game: shown while the moderator tools are on", async () => {
+    test("finished game: shown with the move timings while the moderator tools are on", async () => {
         const controller = makeController("finished");
         renderFragment(controller, true);
         await screen.findByTestId("fair-play-summary");
+        const props = fair_play_props.mock.calls[0][0];
+        expect(props.moves).toBe(MOVES);
+        expect(props.start_time).toBe(1000);
+        expect(props.end_time).toBe(5000);
     });
 });

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -123,7 +123,6 @@ export function Game(): React.ReactElement | null {
         React.useState<rest_api.AnnulmentReason | null>(null);
     const [scroll_to_navigate] = React.useState(preferences.get("scroll-to-navigate"));
     const phase = usePhase(goban);
-    const [show_game_timing, set_show_game_timing] = React.useState(false);
     const [tournament, set_tournament] = React.useState<ActiveTournament>();
     const [, set_undo_requested] = React.useState<number | undefined>();
     const [bot_detection_results, set_bot_detection_results] = React.useState<any>(null);
@@ -315,16 +314,14 @@ export function Game(): React.ReactElement | null {
         }
         const controller = goban_controller.current;
 
-        controller.on("show_game_timing", set_show_game_timing);
         controller.on("show_bot_detection_results", set_show_bot_detection_results);
         controller.on("estimating_score", set_estimating_score);
 
         return () => {
-            controller.off("show_game_timing", set_show_game_timing);
             controller.off("show_bot_detection_results", set_show_bot_detection_results);
             controller.off("estimating_score", set_estimating_score);
         };
-    }, [goban_controller.current, set_show_game_timing, set_show_bot_detection_results]);
+    }, [goban_controller.current, set_show_bot_detection_results]);
 
     const onWheel: React.WheelEventHandler<HTMLDivElement> = React.useCallback(
         (event) => {
@@ -1243,7 +1240,6 @@ export function Game(): React.ReactElement | null {
                         simul_black={simul_black}
                         simul_white={simul_white}
                         showFairPlay={show_mod_tab && moderator_tab_visible}
-                        showGameTimings={show_game_timing}
                     />
                 )}
 

--- a/src/views/Game/GameModToolsPanel.tsx
+++ b/src/views/Game/GameModToolsPanel.tsx
@@ -68,7 +68,8 @@ export function GameModToolsPanel({
     const annulable = !annulled && engine.config.ranked;
     const unannulable = annulled && engine.config.ranked;
     const can_inspect_full = user_can_intervene || user_can_annul;
-    const show_icons = user_can_intervene || user_can_annul || user_detects_ai;
+    const show_bot_detection = (can_inspect_full || user_detects_ai) && ai_suspected;
+    const show_icons = can_inspect_full || show_bot_detection;
 
     const decide = (winner: string): void => {
         if (!game_id) {
@@ -188,7 +189,7 @@ export function GameModToolsPanel({
             .catch(errorAlerter);
     };
 
-    if (!user_can_intervene && !user_can_annul && !user_detects_ai && !superuser_ai_review_ready) {
+    if (!user_can_intervene && !user_can_annul && !show_icons && !superuser_ai_review_ready) {
         return null;
     }
 
@@ -267,15 +268,6 @@ export function GameModToolsPanel({
 
             {show_icons && (
                 <div className="GameModToolsPanel-icons" role="group" aria-label={_("Inspect")}>
-                    <button
-                        type="button"
-                        className="GameModToolsPanel-icon"
-                        onClick={goban_controller.toggleShowTiming}
-                        title={_("Timing")}
-                        aria-label={_("Timing")}
-                    >
-                        <i className="fa fa-clock-o" />
-                    </button>
                     {can_inspect_full && (
                         <>
                             <button
@@ -298,7 +290,7 @@ export function GameModToolsPanel({
                             </button>
                         </>
                     )}
-                    {ai_suspected && (
+                    {show_bot_detection && (
                         <button
                             type="button"
                             className="GameModToolsPanel-icon"

--- a/src/views/Game/GameModeratorAreaPanel.test.tsx
+++ b/src/views/Game/GameModeratorAreaPanel.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { GameModeratorAreaPanel } from "./GameModeratorAreaPanel";
+import { GobanControllerContext } from "./goban_context";
+import * as data from "@/lib/data";
+import { GobanController } from "@/lib/GobanController";
+import { MODERATOR_POWERS } from "@/lib/moderation";
+
+jest.mock("@/lib/requests", () => ({
+    get: jest.fn(() => Promise.resolve([])),
+    post: jest.fn(() => Promise.resolve({})),
+    put: jest.fn(() => Promise.resolve({})),
+    del: jest.fn(() => Promise.resolve({})),
+    patch: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock("@/components/Player", () => ({
+    Player: () => <span data-testid="player" />,
+}));
+
+const BASE_USER = {
+    anonymous: false,
+    id: 123,
+    username: "test_user",
+    registration_date: "2022-05-10 11:03:24.299562+00:00",
+    ratings: {
+        version: 5,
+        overall: { rating: 1500, deviation: 350, volatility: 0.06 },
+    },
+    country: "un",
+    professional: false,
+    ranking: 23,
+    provisional: 0,
+    can_create_tournaments: true,
+    is_moderator: false,
+    is_superuser: false,
+    moderator_powers: 0,
+    offered_moderator_powers: 0,
+    is_tournament_moderator: false,
+    supporter: true,
+    supporter_level: 4,
+    tournament_admin: false,
+    ui_class: "",
+    icon: "",
+    email: "",
+    email_validated: false,
+    is_announcer: false,
+    last_supporter_trial: "",
+} as const;
+
+const BLACK = { id: 987, username: "someone" };
+const WHITE = { id: 456, username: "someone_else" };
+
+function makeController(): GobanController {
+    return new GobanController({
+        game_id: 1234,
+        phase: "play",
+        black_player_id: BLACK.id,
+        white_player_id: WHITE.id,
+        players: { black: BLACK, white: WHITE },
+    });
+}
+
+function renderPanel(bot_detection_results: rest_api.BotDetectionResults | null) {
+    return render(
+        <GobanControllerContext.Provider value={makeController()}>
+            <GameModeratorAreaPanel
+                historical_black={BLACK as unknown as rest_api.games.Player}
+                historical_white={WHITE as unknown as rest_api.games.Player}
+                black_flags={null}
+                white_flags={null}
+                bot_detection_results={bot_detection_results}
+            />
+        </GobanControllerContext.Provider>,
+    );
+}
+
+describe("GameModeratorAreaPanel for community moderators", () => {
+    beforeEach(() => {
+        data.set("user", { ...BASE_USER, moderator_powers: MODERATOR_POWERS.AI_DETECTOR });
+    });
+
+    test("renders nothing when there is no flag to show", () => {
+        const { container } = renderPanel(null);
+        expect(container.querySelector(".GameModeratorAreaPanel")).toBeNull();
+    });
+
+    test("shows the AI suspected flag without the moderator controls", () => {
+        const { container, getByText } = renderPanel({
+            ai_suspected: [BLACK.id],
+        } as unknown as rest_api.BotDetectionResults);
+        expect(getByText("AI Suspected")).toBeDefined();
+        expect(container.querySelector(".PlayerModSection-controls")).toBeNull();
+    });
+});
+
+describe("GameModeratorAreaPanel for full moderators", () => {
+    test("always shows the per-player controls", () => {
+        data.set("user", { ...BASE_USER, is_moderator: true });
+        const { container } = renderPanel(null);
+        expect(container.querySelectorAll(".PlayerModSection-controls").length).toBe(2);
+    });
+});

--- a/src/views/Game/GameModeratorAreaPanel.tsx
+++ b/src/views/Game/GameModeratorAreaPanel.tsx
@@ -73,6 +73,20 @@ export function GameModeratorAreaPanel({
         historical_white?.id != null &&
         !!bot_detection_results?.ai_suspected?.includes(historical_white.id);
 
+    const show_controls = !hide_controls && user.is_moderator;
+    const has_flags =
+        !hide_flags &&
+        (black_ai_suspected ||
+            white_ai_suspected ||
+            Object.keys(black_flags ?? {}).length > 0 ||
+            Object.keys(white_flags ?? {}).length > 0);
+
+    // Community moderators get no per-player controls, so without a flag to
+    // show the rows would be bare player names.
+    if (!show_controls && !has_flags) {
+        return null;
+    }
+
     return (
         <div className="GameModeratorAreaPanel">
             <PlayerModSection
@@ -82,7 +96,7 @@ export function GameModeratorAreaPanel({
                 ai_suspected={black_ai_suspected}
                 flags={black_flags}
                 hide_flags={hide_flags}
-                hide_controls={hide_controls || !user.is_moderator}
+                hide_controls={!show_controls}
                 phase={phase}
                 game_id={game_id}
             />
@@ -93,7 +107,7 @@ export function GameModeratorAreaPanel({
                 ai_suspected={white_ai_suspected}
                 flags={white_flags}
                 hide_flags={hide_flags}
-                hide_controls={hide_controls || !user.is_moderator}
+                hide_controls={!show_controls}
                 phase={phase}
                 game_id={game_id}
             />

--- a/src/views/Game/fragments.tsx
+++ b/src/views/Game/fragments.tsx
@@ -150,7 +150,6 @@ interface FragAIReviewProps {
     simul_black?: boolean | null;
     simul_white?: boolean | null;
     showFairPlay?: boolean;
-    showGameTimings?: boolean;
 }
 
 export function FragAIReview(props: FragAIReviewProps): React.ReactElement | null {
@@ -188,7 +187,6 @@ export function FragAIReview(props: FragAIReviewProps): React.ReactElement | nul
                 simul_black={props.simul_black}
                 simul_white={props.simul_white}
                 showFairPlay={props.showFairPlay}
-                showGameTimings={props.showGameTimings}
                 moves={goban.engine.config.moves}
                 start_time={goban.engine.config.start_time}
                 end_time={goban.engine.config.end_time}
@@ -220,15 +218,13 @@ export function FragAIReview(props: FragAIReviewProps): React.ReactElement | nul
                 white_player_id={goban.engine.config.white_player_id}
                 board_size={goban.engine.width}
                 currentMoveNumber={cur_move.move_number - 1}
-                moves={props.showGameTimings ? goban.engine.config.moves : undefined}
-                start_time={props.showGameTimings ? goban.engine.config.start_time : undefined}
-                end_time={props.showGameTimings ? goban.engine.config.end_time : undefined}
-                free_handicap_placement={
-                    props.showGameTimings ? goban.engine.config.free_handicap_placement : undefined
-                }
-                handicap={props.showGameTimings ? goban.engine.config.handicap : undefined}
-                simul_black={props.showGameTimings ? props.simul_black : undefined}
-                simul_white={props.showGameTimings ? props.simul_white : undefined}
+                moves={goban.engine.config.moves}
+                start_time={goban.engine.config.start_time}
+                end_time={goban.engine.config.end_time}
+                free_handicap_placement={goban.engine.config.free_handicap_placement}
+                handicap={goban.engine.config.handicap}
+                simul_black={props.simul_black}
+                simul_white={props.simul_white}
             />
         );
     }


### PR DESCRIPTION
## Summary

- The per-move timing table now shows whenever the fair play summary shows, instead of behind its own Timing toggle in the gavel panel.
- Removes the Timing toggle, the `show_game_timing` controller event, and the `showGameTimings` prop from `AIReview` and `FragAIReview`.
- The gavel panel's inspect icon group and the per-player rows render only when they have content, so community moderators no longer see empty groups.

## Resulting rule

The fair play summary and the timing table show together while the gavel tab is open, on games only, outside zen mode, on 9x9, 13x13 or 19x19 boards with both player ids. Full moderators and AI detector community moderators see the gavel tab.

## Related

The reported game view in moderator-ui passed the removed prop. online-go/moderator-ui has a companion PR that drops it; merge that one alongside this.

## Test plan

- [x] `yarn type-check`, `yarn lint`, `yarn build`
- [x] `src/views/Game` jest suites pass, including the fragment test now asserting the timings reach the summary on ongoing and finished games
- [x] Dev server as a simulated AI detector community moderator: gavel tab present, Timing button gone, empty panels gone
- [ ] Manual check on a finished game with players, desktop and mobile, as a moderator and as an AI detector community moderator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHfQyohZUNjwomhuojCUkp
