### PR TITLE
Remove dead Safari min-height hack from the modal body

### DIFF
--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -82,7 +82,6 @@
         padding: 0.5rem;
         flex-grow: 1;
         overflow: auto;
-        /* min-height: 20rem; */
     }
 
     .buttons {
@@ -96,10 +95,4 @@
         min-height: 3em;
         border-color: var(--shade3);
     }
-}
-
-/* Safari is stupid and isn't auto-growing the body like every other browser, so
-this hack targets safari only */
-_::-webkit-:not(:root:root), .Modal .body {
-    min-height: 20rem;
 }


### PR DESCRIPTION
Fixes #3721.

The "Paste SGF" dialog renders broken on production online-go.com at shorter viewports: the textarea body is stuck at a 20rem minimum and the Cancel/Upload buttons overflow the modal card. It does not reproduce in the dev server (but I can force a repro by just setting `min-height: 20rem` unconditionally).

Root cause is a decade-old Safari hack in `Modal.css`:

```css
_::-webkit-:not(:root:root), .Modal .body {
    min-height: 20rem;
}
```

`_::-webkit-:not(:root:root)` is an invalid selector. Per CSS error handling, a selector list containing any invalid selector is discarded entirely, so this rule has never applied in any browser (Safari included) since it was added in 2017.

The Vite 8 upgrade (commit 3c18ee3c4 from July 31, 2026) switched the default CSS minifier from esbuild to lightningcss. lightningcss is the only minifier in the project's history that splits the selector list into two standalone rules, so the production bundle now contains a live `.Modal .body { min-height: 20rem }`. In height-constrained modals like this one (`height: 55dvh`), the body can no longer shrink to fit, so it overflows the flex column.

Deleting the hack restores the layout from before the Vite-8 upgrade.

NOTE: The 20rem floor has been live in production for roughly five weeks (since the Vite 8 bump). Removing it also removes that floor from other modals that do not set their own body height, so it's possible new modals introduced recently rely on this. I had Claude audit new modals added since then and it identified two, neither of which specified their own body height:
1. `GameKeyboardShortcutsModal`: https://github.com/online-go/online-go.com/pull/3700
2. `RengoTeamModal`: https://github.com/online-go/online-go.com/pull/3711

The first modal actually rendered improperly when the viewport vertical height was very small (see screenshots below), so this change fixed it. I wasn't able to test the Rengo modal in my dev setup, but I think this change should be safe for it as well.

Before the fix:

<img width="745" height="390" alt="image" src="https://github.com/user-attachments/assets/cad5d778-73ac-4e7a-9e57-1dbb4373e18f" />

After the fix:

<img width="747" height="387" alt="image" src="https://github.com/user-attachments/assets/7ab048f8-3126-4deb-9c21-06d264dfcb85" />