### PR TITLE
Dev server: reach the admin interface by its own hostname

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -531,12 +531,28 @@ function admin_host_proxy(): Plugin {
     return {
         name: "admin-host-proxy",
         configureServer(server: ViteDevServer) {
-            if (OGS_BACKEND !== "LOCAL") {
-                return;
-            }
             server.middlewares.use((req, res, next) => {
                 if (!/^admin[.-]/i.test(req.headers.host ?? "")) {
                     next();
+                    return;
+                }
+                // Say so rather than fall through. Falling through served
+                // this site's own index for an admin hostname, with a 200
+                // and no error anywhere: it looked like the admin interface
+                // was broken when the relay simply was not installed. The
+                // admin interface is only ever relayed to a local stack —
+                // it pauses live games and changes who is staff, and doing
+                // that against beta or production from a dev server is not
+                // something to reach by forgetting a variable.
+                if (OGS_BACKEND !== "LOCAL") {
+                    res.writeHead(503, { "content-type": "text/plain" });
+                    res.end(
+                        `This dev server is talking to ${OGS_BACKEND}, so it will not relay ` +
+                            `${req.headers.host}.\n\n` +
+                            `The admin interface is relayed to the local stack only. Restart ` +
+                            `with OGS_BACKEND=LOCAL, or open the stack's own admin host ` +
+                            `directly (admin.localhost:1080).\n`,
+                    );
                     return;
                 }
                 const upstream = http.request(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -512,12 +512,22 @@ export default defineConfig({
  * but the unified admin interface (ogs/apps/admin) is served by the stack's
  * termination-server for `admin.*` hosts, not by this client. So a request
  * whose Host starts with `admin.` is relayed to the local load balancer,
- * headers intact (the stack routes by Host), and never reaches Vite. Only
+ * Host intact (the stack routes by it), and never reaches Vite. Only
  * meaningful against the local stack; against beta or production the admin
  * host is its own site.
+ *
+ * `Origin` and `Referer` are replaced with this dev server's own, because the
+ * browser's names a host *with a port* — and Django's wildcard
+ * `CSRF_TRUSTED_ORIGINS` entries cannot match one, so `admin.example.org:8080`
+ * is refused with "Origin checking failed" on every POST while the same host
+ * without the port is accepted. In production the interface and the API are
+ * one origin and none of this arises. The apps/admin dev server presents a
+ * trusted origin for the same reason.
  */
 function admin_host_proxy(): Plugin {
     const target = new URL(backend_url);
+    // In CSRF_TRUSTED_ORIGINS for every port this server runs on.
+    const dev_origin = `http://localhost:${PORT}`;
     return {
         name: "admin-host-proxy",
         configureServer(server: ViteDevServer) {
@@ -535,7 +545,11 @@ function admin_host_proxy(): Plugin {
                         port: target.port || 80,
                         method: req.method,
                         path: req.url,
-                        headers: req.headers,
+                        headers: {
+                            ...req.headers,
+                            origin: dev_origin,
+                            referer: `${dev_origin}/`,
+                        },
                     },
                     (answer) => {
                         res.writeHead(answer.statusCode ?? 502, answer.headers);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -403,6 +403,7 @@ export default defineConfig({
                 return null;
             },
         },
+        admin_host_proxy(),
         ogs_vite_middleware(),
         react(),
         //circularDependency(),
@@ -503,6 +504,55 @@ export default defineConfig({
         },
     },
 });
+
+/**
+ * Hands requests for an `admin.*` hostname to the local OGS stack.
+ *
+ * On a development instance every public hostname lands on this dev server,
+ * but the unified admin interface (ogs/apps/admin) is served by the stack's
+ * termination-server for `admin.*` hosts, not by this client. So a request
+ * whose Host starts with `admin.` is relayed to the local load balancer,
+ * headers intact (the stack routes by Host), and never reaches Vite. Only
+ * meaningful against the local stack; against beta or production the admin
+ * host is its own site.
+ */
+function admin_host_proxy(): Plugin {
+    const target = new URL(backend_url);
+    return {
+        name: "admin-host-proxy",
+        configureServer(server: ViteDevServer) {
+            if (OGS_BACKEND !== "LOCAL") {
+                return;
+            }
+            server.middlewares.use((req, res, next) => {
+                if (!/^admin[.-]/i.test(req.headers.host ?? "")) {
+                    next();
+                    return;
+                }
+                const upstream = http.request(
+                    {
+                        host: target.hostname,
+                        port: target.port || 80,
+                        method: req.method,
+                        path: req.url,
+                        headers: req.headers,
+                    },
+                    (answer) => {
+                        res.writeHead(answer.statusCode ?? 502, answer.headers);
+                        answer.pipe(res);
+                    },
+                );
+                upstream.on("error", (err) => {
+                    if (!res.headersSent) {
+                        res.writeHead(502, { "content-type": "text/plain" });
+                    }
+                    res.end(`admin host proxy: ${err.message}`);
+                });
+                req.pipe(upstream);
+            });
+        },
+    };
+}
 
 /*
  * For historical reasons, OGS uses a custom index.html template system


### PR DESCRIPTION
Dev-server support for reaching the unified admin interface
([online-go/ogs#2467](https://github.com/online-go/ogs/pull/2467)) by its own
hostname on a development stack. `vite.config.ts` only; nothing ships.

The admin interface is a separate site served by the termination-server for
any `admin.*` hostname. On a development machine every such name resolves to
the same box, and this dev server holds the port they arrive on, so the
requests landed here and were answered with the ordinary online-go.com page.

## What it does

- Relays a request whose `Host` starts with `admin.` or `admin-` to the local
  stack, leaving the path, method, body and cookies alone.
- Presents an `Origin` and `Referer` Django already trusts. Its CSRF check
  compares the whole netloc including the port, and its wildcard entries
  cannot say "any port", so a POST from a dev port was refused outright.
- Answers 503 on those hostnames when the dev server is talking to anything
  but a LOCAL backend, naming the backend and how to fix it.

That last one is worth a word. The relay only installs against a LOCAL
backend and this server defaults to BETA, so started the ordinary way, admin
hostnames used to fall through to the SPA catch-all: a 200, this site's own
index, no error anywhere. It read as the admin interface being broken when
the relay simply was not there. Relaying only to a local stack is deliberate:
the admin interface pauses live games and changes who is staff, and reaching
beta or production with it should not be something a forgotten variable does
for you.

## Testing

Exercised against a local stack: `admin.<host>:8080` serves the admin
interface with its own assets, ordinary hostnames are untouched, and a
second dev server started on `OGS_BACKEND=BETA` returns the 503 with its
explanation. `type-check`, `eslint` and `prettier` pass on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
