### PR TITLE
Restore the game chat font size

### DIFF
--- a/src/views/Game/GameChat.css
+++ b/src/views/Game/GameChat.css
@@ -291,33 +291,12 @@
     }
 }
 
-/* Desktop (landscape) sidebar: the chat inherits the root 1rem while the
- * surrounding chrome (player names, toggle buttons, condensed info) sits on
- * the small/metadata scale, so messages read louder than the title. Step
- * the log and input down to the sidebar's body scale and the timestamps to
- * the metadata scale. Portrait keeps the defaults — 16px is the right
- * reading size on phones and anything smaller makes iOS zoom the viewport
- * when the input is focused. */
+/* Center the single-line text and placeholder inside the 30px input box:
+ * 30px box - 1px bottom border - 19.2px line leaves ~10px of slack, split
+ * evenly (the default 3px top padding left the text riding high). */
 .GobanView:not(.portrait) .GameChat {
-    .chat-log {
-        font-size: 0.875rem;
-    }
-
-    .chat-line .Player {
-        font-size: inherit;
-    }
-
-    .timestamp {
-        font-size: 0.75rem;
-    }
-
     .chat-input-container textarea {
-        font-size: 0.875rem;
-        /* Center the single-line text and placeholder inside the 30px
-         * input box: 30px box − 1px bottom border − 16.8px line leaves
-         * ~11px of slack, split evenly (the default 3px top padding left
-         * the text riding ~3px high). */
-        padding-top: 6px;
+        padding-top: 5px;
         padding-bottom: 5px;
     }
 }


### PR DESCRIPTION
## What

The GobanView port (8411935e3, 2026-08-11) stepped the desktop/landscape game chat down to the sidebar's body scale. This puts it back.

Removed from `.GobanView:not(.portrait) .GameChat`:

- `.chat-log` — `0.875rem`
- `.timestamp` — `0.75rem`
- `.chat-line .Player` — `inherit`
- the `font-size: 0.875rem` on the input textarea

Kept the textarea vertical centering from that same commit, with the padding recomputed for the 16px line: `5px` top and bottom instead of `6px`/`5px`.

Portrait was never in the selector, so mobile does not change.

## Result

Measured on a game page at 1600x1000:

| | before | after |
|---|---|---|
| chat log / message body | 14px | 16px |
| timestamp | 12px | 13.33px (the original `10pt`) |
| player name | 14px | 13.33px (its own size) |
| input textarea | 14px | 16px, box height 30.19px |

## Testing

`yarn type-check`, `yarn lint` and `yarn prettier:file` pass. Sizes confirmed in the browser against the dev server.

Please check a game with real chat history in both a desktop and a mobile browser before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmQmai5vkPuSJ7C23rLRUW