### PR TITLE
Make the move comments box fill the sidebar width

### DIFF
--- a/src/views/Game/PlayControls.css
+++ b/src/views/Game/PlayControls.css
@@ -154,6 +154,18 @@
         }
     }
 
+    /* Match the move tree container's 0.5em margin so the comments box lines
+     * up with it and fills the remaining width of the sidebar. */
+    .move-comments {
+        margin: 0 0.5em;
+
+        textarea {
+            display: block;
+            width: 100%;
+            box-sizing: border-box;
+        }
+    }
+
     .btn-group {
         vertical-align: middle;
         display: inline-flex;

--- a/src/views/Game/PlayControls.tsx
+++ b/src/views/Game/PlayControls.tsx
@@ -508,7 +508,7 @@ export function ReviewControls({ review_id }: ReviewControlsProps) {
                         ref={goban_controller.setMoveTreeContainer}
                     />
 
-                    <div style={{ paddingLeft: "0.5em", paddingRight: "0.5em" }}>
+                    <div className="move-comments">
                         <textarea
                             id="game-move-node-text"
                             placeholder={_("Move comments...")}


### PR DESCRIPTION
When you review a game, the "Move comments..." textarea did not fill the width of the aside. The move tree above it did.

The textarea had no width rule, so it used the default `cols` width.

- Replace the inline padding wrapper with a `.move-comments` class.
- Give the class the same 0.5em horizontal margin as `#move-tree-container`.
- Make the textarea `display: block; width: 100%; box-sizing: border-box`.

The rule is scoped under `.PlayControls` because `src/views/Puzzle/Puzzle.tsx` uses the same `#game-move-node-text` id. The puzzle editor has the same problem, but it is out of scope here.

## Testing

- `yarn type-check`, `yarn lint`, and `yarn prettier:file` pass.
- Manual test in mobile and desktop browsers is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLAjMATZs6CuwUWzoJkhWk
