### PR TITLE
Connect the container dev server to the local OGS stack

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -111,9 +111,17 @@ const backend_url =
         ? "https://beta.online-go.com"
         : OGS_BACKEND === "PRODUCTION"
           ? "https://online-go.com"
-          : "http://127.0.0.1:1080"; // LOCAL
+          : process.env.OGS_CONTAINER
+            ? "http://loadbalancer"
+            : "http://127.0.0.1:1080";
 
 const PORT = process.env.OGS_PORT ? parseInt(process.env.OGS_PORT) : 8080;
+
+// Django trusts this origin for requests forwarded by the local dev server.
+const local_dev_headers = {
+    origin: "http://localhost:8080",
+    referer: "http://localhost:8080/",
+};
 
 const proxy: Record<string, ProxyOptions> = {};
 
@@ -138,6 +146,7 @@ for (const base_path of [
     proxy[base_path] = {
         target: backend_url,
         changeOrigin: true,
+        headers: OGS_BACKEND === "LOCAL" ? local_dev_headers : undefined,
         rewrite: (path: string) => {
             return backend_url + path;
         },
@@ -516,18 +525,10 @@ export default defineConfig({
  * meaningful against the local stack; against beta or production the admin
  * host is its own site.
  *
- * `Origin` and `Referer` are replaced with this dev server's own, because the
- * browser's names a host *with a port* — and Django's wildcard
- * `CSRF_TRUSTED_ORIGINS` entries cannot match one, so `admin.example.org:8080`
- * is refused with "Origin checking failed" on every POST while the same host
- * without the port is accepted. In production the interface and the API are
- * one origin and none of this arises. The apps/admin dev server presents a
- * trusted origin for the same reason.
+ * `Origin` and `Referer` use the origin Django trusts for local development.
  */
 function admin_host_proxy(): Plugin {
     const target = new URL(backend_url);
-    // In CSRF_TRUSTED_ORIGINS for every port this server runs on.
-    const dev_origin = `http://localhost:${PORT}`;
     return {
         name: "admin-host-proxy",
         configureServer(server: ViteDevServer) {
@@ -563,8 +564,7 @@ function admin_host_proxy(): Plugin {
                         path: req.url,
                         headers: {
                             ...req.headers,
-                            origin: dev_origin,
-                            referer: `${dev_origin}/`,
+                            ...local_dev_headers,
                         },
                     },
                     (answer) => {


### PR DESCRIPTION
The local Vite server needs to reach the OGS load balancer from inside Docker and accept browser requests made through a VM's external IP address.

Companion Compose and build infrastructure PR: https://github.com/online-go/ogs/pull/2471.

Use `http://loadbalancer` for the LOCAL backend when `OGS_CONTAINER` is set. Forward the trusted `http://localhost:8080` Origin and Referer on local REST and admin requests, so access does not depend on the VM's IP or hostname. Django still validates CSRF tokens; beta and production proxy settings are unchanged.

Validation:

- Passed `yarn type-check`, `yarn lint`, formatting of `vite.config.ts`, and the containerized `yarn build`.
- Checked desktop and mobile browser access through the VM IP. Authenticated requests with a valid CSRF token reach the endpoint; missing and incorrect tokens return 403.
- Graphify update was unavailable because the CLI is not installed.

Please also manually check desktop and mobile browsers before merging.
