### PR TITLE
Make zen mode work on mobile

### DIFF
--- a/src/components/GobanView/hooks.ts
+++ b/src/components/GobanView/hooks.ts
@@ -18,7 +18,6 @@
 import * as React from "react";
 import { Goban, GobanEvents } from "goban";
 import { GobanController } from "@/lib/GobanController";
-import * as preferences from "@/lib/preferences";
 import { ViewMode, goban_view_mode, stageFitsWithSlider } from "./util";
 
 /**
@@ -79,14 +78,15 @@ export function useViewMode(controller: GobanController | null): ViewMode {
 }
 
 export function useZenMode(controller: GobanController | null): boolean {
-    const [zen_mode, set_zen_mode] = React.useState(
-        controller?.zen_mode ?? preferences.get("start-in-zen-mode"),
-    );
+    const [zen_mode, set_zen_mode] = React.useState(controller?.zen_mode ?? false);
     React.useEffect(() => {
         if (!controller) {
             return;
         }
 
+        // The Game view stays mounted when it moves to another game, so the
+        // new controller's state replaces the state of the one before it.
+        set_zen_mode(controller.zen_mode);
         controller.on("zen_mode", set_zen_mode);
         return () => {
             controller.off("zen_mode", set_zen_mode);

--- a/src/lib/GobanController.ts
+++ b/src/lib/GobanController.ts
@@ -263,7 +263,7 @@ export class GobanController extends EventEmitter<GobanControllerEvents> {
     private _autoplaying: boolean = false;
     public analyze_pencil_color: string = preferences.get("analysis.pencil-color");
     private show_bot_detection_results: boolean = false;
-    private _zen_mode: boolean = preferences.get("start-in-zen-mode");
+    private _zen_mode: boolean = false;
     private _ai_review_enabled: boolean = preferences.get("ai-review-enabled");
     private autoplay_timer: ReturnType<typeof setTimeout> | null = null;
     private _variation_name: string = "";
@@ -896,14 +896,7 @@ export class GobanController extends EventEmitter<GobanControllerEvents> {
         }
     };
     toggleZenMode = () => {
-        const body = document.getElementsByTagName("body")[0];
-        if (this.zen_mode) {
-            body.classList.remove("zen"); //remove the class
-            this.setZenMode(false);
-        } else {
-            body.classList.add("zen"); //add the class
-            this.setZenMode(true);
-        }
+        this.setZenMode(!this.zen_mode);
         this.emit("view_mode", goban_view_mode());
         this.emit("resize");
     };

--- a/src/views/Game/Game.css
+++ b/src/views/Game/Game.css
@@ -408,6 +408,33 @@
             padding-bottom: 0;
         }
     }
+
+    /* Zen mode. Pinned to the top right corner, the exit button would
+     * cover the top player's clock, so it takes the place of the hidden
+     * tab bar as the last row of the column instead. The panels drop
+     * their slab, as the zen sidebar does in landscape. */
+    &.zen {
+        /* The free space goes above the board, which pushes the board and
+         * the player cards down near the thumb. When the column is too
+         * short, the auto margin becomes zero and the top stays in reach
+         * of the scroll. */
+        .GobanView-stage {
+            margin-top: auto;
+        }
+
+        .GobanView-mobile-panels {
+            flex-grow: 0;
+            background: transparent;
+        }
+
+        .leave-zen-mode-button {
+            position: static;
+            align-self: flex-end;
+            flex-shrink: 0;
+            margin: 0 calc(0.5rem + env(safe-area-inset-right))
+                calc(0.5rem + var(--safe-area-inset-bottom)) 0;
+        }
+    }
 }
 
 .chat-container {

--- a/src/views/Game/Game.tsx
+++ b/src/views/Game/Game.tsx
@@ -210,6 +210,15 @@ export function Game(): React.ReactElement | null {
         }
     }, [zen_mode]);
 
+    // `body.zen` hides the navbar, announcements and private chats. It
+    // follows the zen state here and not in GobanController, so a game that
+    // starts in zen mode gets it too, and the other views that make a
+    // controller do not.
+    React.useEffect(() => {
+        document.body.classList.toggle("zen", zen_mode);
+        return () => document.body.classList.remove("zen");
+    }, [zen_mode]);
+
     // The mobile chat renders at the bottom of the scroll area, usually well
     // below the fold, so toggling it on would otherwise appear to do
     // nothing. Bring it into view when it appears.
@@ -633,8 +642,11 @@ export function Game(): React.ReactElement | null {
                             game.height,
                         );
 
-                    if (!live) {
-                        goban_controller.current?.setZenMode(false);
+                    // Only live games start in zen mode. The controller starts
+                    // out of zen mode, so a correspondence game does not show
+                    // zen while this data loads.
+                    if (live && preferences.get("start-in-zen-mode")) {
+                        goban_controller.current?.setZenMode(true);
                     }
 
                     if (ladder_id.current) {
@@ -720,8 +732,6 @@ export function Game(): React.ReactElement | null {
             setExtraActionCallback(null as any);
             window.removeEventListener("focus", onFocus);
             window.document.title = "OGS";
-            const body = document.getElementsByTagName("body")[0];
-            body.classList.remove("zen"); //remove the class
 
             goban_div.current?.childNodes.forEach((node) => node.remove());
         };

--- a/src/views/Game/GameHooks.test.tsx
+++ b/src/views/Game/GameHooks.test.tsx
@@ -27,6 +27,7 @@ import {
     usePlayerToMoveOnOfficialBranch,
     useResignMode,
     useUndoRequestIsMine,
+    useZenMode,
 } from "./GameHooks";
 
 const LOGGED_IN_USER = {
@@ -418,5 +419,26 @@ describe("usePlayerToMoveOnOfficialBranch", () => {
         });
 
         expect(officialPlayerToMove()).toBe(OPPONENT.id);
+    });
+});
+
+describe("useZenMode", () => {
+    function ZenProbe({ controller }: { controller: GobanController }): React.ReactElement {
+        return <span data-testid="zen-mode">{useZenMode(controller) ? "on" : "off"}</span>;
+    }
+    const zenMode = () => screen.getByTestId("zen-mode").textContent;
+
+    test("follows the new controller when the Game view moves to another game", () => {
+        const correspondence_game = new GobanController(GAME_IN_PROGRESS);
+        correspondence_game.setZenMode(false);
+        const { rerender } = render(<ZenProbe controller={correspondence_game} />);
+
+        expect(zenMode()).toBe("off");
+
+        const live_game = new GobanController(GAME_IN_PROGRESS);
+        live_game.setZenMode(true);
+        rerender(<ZenProbe controller={live_game} />);
+
+        expect(zenMode()).toBe("on");
     });
 });

--- a/src/views/Game/GameSettingsPanel.test.tsx
+++ b/src/views/Game/GameSettingsPanel.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, fireEvent } from "@testing-library/react";
+import * as React from "react";
+import { GameSettingsPanel } from "./GameSettingsPanel";
+import { GobanControllerContext } from "./goban_context";
+import { GobanController } from "@/lib/GobanController";
+
+jest.mock("@/components/GobanThemePicker/GobanThemePicker", () => ({
+    GobanThemePicker: () => null,
+}));
+
+function renderPanel(
+    controller: GobanController,
+    props: React.ComponentProps<typeof GameSettingsPanel> = {},
+) {
+    return render(
+        <GobanControllerContext.Provider value={controller}>
+            <GameSettingsPanel {...props} />
+        </GobanControllerContext.Provider>,
+    );
+}
+
+test("the compact (mobile) panel turns on zen mode and closes", () => {
+    const controller = new GobanController({ game_id: 123456 });
+    const onClose = jest.fn();
+
+    const { container } = renderPanel(controller, { compact: true, onClose });
+
+    const zen_toggle = container.querySelector("#game-settings-zen-mode");
+    expect(zen_toggle).not.toBeNull();
+
+    fireEvent.click(zen_toggle!);
+
+    expect(controller.zen_mode).toBe(true);
+    expect(onClose).toHaveBeenCalled();
+});
+
+test("the compact (mobile) panel leaves out the landscape-only board alignment", () => {
+    const controller = new GobanController({ game_id: 123456 });
+
+    const { container } = renderPanel(controller, { compact: true });
+
+    expect(container.querySelector("#game-settings-board-alignment")).toBeNull();
+});

--- a/src/views/Game/GameSettingsPanel.tsx
+++ b/src/views/Game/GameSettingsPanel.tsx
@@ -33,8 +33,7 @@ interface GameSettingsPanelProps {
      *  applied (zen mode). Toggles that the user is likely to flip
      *  multiple times (coordinates, AI review, volume) don't fire this. */
     onClose?: () => void;
-    /** Hide the Zen Mode toggle. The mobile (portrait) layout doesn't
-     *  expose it — the viewport is already the full screen. */
+    /** Mobile (portrait) layout: leave out the landscape-only options. */
     compact?: boolean;
     /** When provided, a "More options" item renders under the theme quick
      *  select; clicking it fires this (the Game view opens the full
@@ -142,22 +141,20 @@ export function GameSettingsPanel({
                 />
             </div>
 
-            {!compact && (
-                <div className="GameSidebarPanel-labeled-row">
-                    <label htmlFor="game-settings-zen-mode">
-                        <i className="fa fa-expand" />
-                        <span>{_("Zen Mode")}</span>
-                    </label>
-                    <Toggle
-                        id="game-settings-zen-mode"
-                        checked={zen_mode}
-                        onChange={() => {
-                            goban_controller.toggleZenMode();
-                            onClose?.();
-                        }}
-                    />
-                </div>
-            )}
+            <div className="GameSidebarPanel-labeled-row">
+                <label htmlFor="game-settings-zen-mode">
+                    <i className="fa fa-expand" />
+                    <span>{_("Zen Mode")}</span>
+                </label>
+                <Toggle
+                    id="game-settings-zen-mode"
+                    checked={zen_mode}
+                    onChange={() => {
+                        goban_controller.toggleZenMode();
+                        onClose?.();
+                    }}
+                />
+            </div>
 
             <div className="GameSidebarPanel-labeled-row">
                 <label htmlFor="game-settings-coords">

--- a/src/views/Game/fragments.tsx
+++ b/src/views/Game/fragments.tsx
@@ -17,7 +17,14 @@
 
 import * as React from "react";
 import { useGobanController } from "./goban_context";
-import { useShowTitle, useTitle, useCurrentMove, useAIReviewEnabled, useMode } from "./GameHooks";
+import {
+    useShowTitle,
+    useTitle,
+    useCurrentMove,
+    useAIReviewEnabled,
+    useMode,
+    useZenMode,
+} from "./GameHooks";
 import { GAME_KEYBOARD_SHORTCUT_GROUPS } from "./game_keyboard_shortcuts";
 import { _, interpolate } from "@/lib/translate";
 import { rulesText } from "@/lib/misc";
@@ -81,19 +88,17 @@ export function GameInformation(): React.ReactElement | null {
     const goban_controller = useGobanController();
     const goban = goban_controller.goban;
     const [config, setConfig] = React.useState(goban?.engine?.config);
-    const [zen_mode, set_zen_mode] = React.useState(goban_controller.zen_mode);
+    const zen_mode = useZenMode(goban_controller);
 
     React.useEffect(() => {
         const handleUpdate = () => {
             setConfig(goban?.engine?.config);
         };
         goban?.on("load", handleUpdate);
-        goban_controller.on("zen_mode", set_zen_mode);
         return () => {
             goban?.off("load", handleUpdate);
-            goban_controller.off("zen_mode", set_zen_mode);
         };
-    }, [goban, goban_controller]);
+    }, [goban]);
 
     if (zen_mode) {
         return null;


### PR DESCRIPTION
Zen mode could not be turned on from the mobile layout, and the "Activate Zen Mode by default" preference did not work reliably on desktop or mobile.

## Mobile toggle and layout

- The Settings popover hid the Zen Mode toggle in portrait (`compact`). It now shows in both layouts. `compact` hides only the landscape-only Board alignment option.
- In portrait zen, the exit button pinned to the top right corner covered the top player's clock. It now takes the place of the hidden tab bar, as the last row of the column in the bottom right corner.
- The free space in portrait zen goes above the board, so the board and both player cards sit at the bottom of the screen, near the thumb. When the screen is too short, the space becomes zero and nothing is clipped.
- The empty panels under the board drop their grey slab in zen, as the zen sidebar does in landscape.

## "Activate Zen Mode by default"

The preference applies to live games only, as the Settings text says. Correspondence games do not start in zen mode (this is not changed).

- `useZenMode` kept the zen state of the first controller it saw. The Game view stays mounted when it moves to another game, so a live game opened from inside the app after a correspondence game did not start in zen mode, and the toggle needed two taps. The hook now reads the state of each new controller. `GameInformation` uses the hook instead of its own copy of the same logic.
- Only `toggleZenMode` added `body.zen`. A game that started in zen mode kept the navbar under the board, and did not hide announcements and private chats. The Game view now sets `body.zen` from its zen state. The controller does not touch the body, because other views (Kibitz, Puzzle, Joseki, MiniGoban) also create controllers.
- The controller started in zen mode from the preference, before the game data showed if the game was live. Correspondence games showed zen mode for about 0.25 s. With the body class change, that also hid the navbar for that time. The controller now starts out of zen mode, and the Game view turns zen on when the data shows a live game. As a result, reviews and demo boards no longer start in zen mode.

## Validation

- `yarn type-check`, `yarn lint`, `yarn prettier:file` and `yarn build` pass.
- The Game, GobanView and lib tests pass (218). New tests: the compact Settings panel turns zen mode on, and `useZenMode` follows a new controller. The second test failed before the fix.
- Browser checks, with the preference on and a game API response changed to a live time control (the local stack has only correspondence games):
    - A live game starts in zen at 1600x900 and 400x800, with `body.zen` set and the navbar hidden.
    - A correspondence game never gets `body.zen`.
    - An in-app move from a correspondence game to a live game enters zen, and the move back leaves it.
    - The exit button, Shift+Z and leaving the game work.
- Portrait zen layout at 400x800, 375x667, 360x640 and 360x480: the exit button never covers a card, and the top is not clipped. Desktop zen does not change.

## Manual testing needed

- Test in mobile and desktop browsers. On a real phone, check the bottom inset around the exit button and the height with browser toolbars.
- Test as a player in a live game. The play buttons move down with the board, but I could test only as a spectator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDAGYV5phwuAviW7mDvi72
